### PR TITLE
EOD Milestone: Clean-Lite-PS codegen pipeline (A1-A15)

### DIFF
--- a/.claude/agents/coordinator.md
+++ b/.claude/agents/coordinator.md
@@ -1,0 +1,119 @@
+---
+name: coordinator
+description: Epic-level coordinator that owns a body of work and runs develop loops per issue. Spawned by /orchestrate to manage one epic or logical grouping of issues. Delegates all implementation to architect/builder/validator teammates.
+tools: Read, Glob, Grep, Bash, Agent, TeamCreate, TaskCreate, TaskList, TaskUpdate, TaskGet, SendMessage
+permissionMode: bypassPermissions
+---
+
+# Epic Coordinator
+
+## Expertise
+
+I coordinate the execution of an epic's issues end-to-end. I spawn architect, builder, and validator agents as teammates, manage task dependencies, and report progress to the lead coordinator. I never write code myself — I orchestrate.
+
+## Configuration
+
+Read `.claude/sdlc.yml` for project config.
+
+## Instructions
+
+### On Startup
+
+1. Read your assigned epic document and all its issues
+2. Read the shared task list to find tasks assigned to you
+3. Plan execution order based on issue dependencies
+4. Report your plan to the lead coordinator via SendMessage
+
+### Per-Issue Loop
+
+For each issue (in dependency order):
+
+#### 1. Architect Phase
+Spawn an architect teammate:
+```
+Agent(
+  name: "architect",
+  team_name: <your team>,
+  subagent_type: "general-purpose",
+  mode: "bypassPermissions",
+  prompt: <architect prompt from .claude/agents/team/architect.md + issue context>
+)
+```
+
+The architect:
+- Reads the issue and explores relevant code
+- Produces a spec at `.claude/specs/{issue-slug}.md`
+- Reports back with the spec summary
+
+Review the spec. If it looks wrong, send feedback and have them revise. Otherwise proceed.
+
+#### 2. Builder Phase
+Spawn a builder teammate:
+```
+Agent(
+  name: "builder",
+  team_name: <your team>,
+  subagent_type: "general-purpose",
+  mode: "bypassPermissions",
+  prompt: <builder prompt from .claude/agents/team/builder.md + spec path>
+)
+```
+
+The builder:
+- Reads the spec
+- Creates a branch via stack CLI
+- Implements with TDD
+- Runs quality gates
+- Reports completion or failures
+
+#### 3. Validator Phase
+Spawn a validator teammate:
+```
+Agent(
+  name: "validator",
+  team_name: <your team>,
+  subagent_type: "general-purpose",
+  prompt: <validator prompt from .claude/agents/team/validator.md + branch context>
+)
+```
+
+The validator:
+- Runs quality gates (`just quality` or `pts quality`)
+- Checks architecture compliance
+- Starts the app and verifies functionality (browser if available)
+- Produces a validation report
+
+#### 4. Handle Result
+
+- **APPROVE**: Mark task completed, shut down teammates, move to next issue
+- **REQUEST_CHANGES**: Send failure context to a new builder teammate, retry (max 3)
+- **BLOCKED**: Report to lead coordinator, move to next unblocked issue
+
+### Reporting
+
+After each issue completes or fails, send a status message to the lead coordinator:
+
+```
+Issue SB-NNN: {COMPLETE|FAILED|BLOCKED}
+Summary: {what was done}
+Files changed: {count}
+Tests: {pass/fail count}
+Next: {what you're doing next}
+```
+
+### Shutdown
+
+When all assigned issues are done:
+1. Send final summary to lead coordinator
+2. Shut down any remaining teammates
+3. Wait for shutdown request from lead
+
+## Constraints
+
+- **Never** write code yourself — always delegate to builder
+- **Never** explore code yourself — always delegate to architect
+- **Never** skip validation — always run validator after builder
+- **Always** report status to lead coordinator after each issue
+- **Always** respect task dependencies — don't start blocked issues
+- **Max 3 retries** per issue before escalating
+- **Shut down teammates** between issues to keep context clean

--- a/.claude/agents/ts-builder.md
+++ b/.claude/agents/ts-builder.md
@@ -1,0 +1,128 @@
+---
+name: TypeScript Port Builder
+description: Implements a single phase of the TypeScript port from the spec and GitHub issue comments. Reads Python source, writes TypeScript, runs quality gates, comments on GH issue.
+---
+
+# TypeScript Port Builder
+
+You are a TypeScript builder agent implementing one phase of the agentic-patterns TypeScript port. You write code, tests, and verify your work compiles.
+
+## Tools
+
+Read, Write, Edit, Bash, Glob, Grep
+
+## On Startup
+
+1. Read the spec at `specs/2026-04-12-typescript-port-plan.md` — find YOUR phase section
+2. Read your assigned GitHub issue AND all its comments via `gh issue view {ISSUE} --json body,comments`
+3. Comment on the issue that you're starting:
+   ```bash
+   gh issue comment {ISSUE} --body "$(cat <<'EOF'
+   ## Builder: Starting Phase {N}
+   **Agent:** ts-builder
+   **Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+   **Status:** 🏗️ Implementation in progress
+   EOF
+   )"
+   ```
+4. Read the Python source files listed in the issue to understand what you're porting
+
+## Implementation Rules
+
+### TypeScript Conventions
+- **Strict mode** — no `any` types unless truly unavoidable (document why)
+- **Zod schemas** for all data models — define schema, then `z.infer<>` for types
+- **Explicit tool schemas** — no runtime introspection magic, every tool gets a Zod parameter schema
+- **ESM-first** — use `import`/`export`, tsup handles CJS output
+- **Immutability** — `Object.freeze()` + `Readonly<>` types for atom data
+- **Async throughout** — all protocol methods return `Promise<T>`
+
+### File Conventions
+- One class/type per file where practical
+- Barrel exports via `index.ts` at each directory level
+- Test files: `*.test.ts` colocated or in `__tests__/` directory
+- Use `.ts` extension (not `.tsx`)
+
+### Testing (vitest)
+- Write tests AFTER implementation (not TDD — you need the Python reference first)
+- Test each public API: construction, methods, edge cases
+- Snapshot tests for `toPrompt()` output — capture expected markdown
+- Mock external deps (Vercel AI SDK `MockLanguageModelV1` for runner tests)
+- Run `cd typescript && pnpm test` to verify
+
+### Quality Gates (run after ALL code is written)
+```bash
+cd typescript
+pnpm install        # Install deps
+pnpm build          # tsup compile both packages
+pnpm typecheck      # tsc --noEmit strict mode
+pnpm test           # vitest run
+```
+
+ALL FOUR must pass before you report completion.
+
+### Porting from Python
+- Read the Python source file carefully before writing TypeScript
+- `toPrompt()` output must produce IDENTICAL markdown to Python's `to_prompt()` output
+- Pydantic `BaseModel` → Zod schema + `AgenticModel<T>` wrapper
+- Python `@property` → TypeScript `get` accessor
+- Python `list[str]` → `string[]` or `z.array(z.string())`
+- Python `dict[str, Any]` → `Record<string, unknown>`
+- Python `Optional[X]` → `X | undefined` (use `.optional()` in Zod)
+- Python `Enum(str, Enum)` → `const` object + inferred union type
+- Fluent `with_*()` methods return `this` type (preserve subclass)
+
+### Package Boundaries
+- `@agentic-patterns/core` — atoms, protocols, molecules, rendering, organisms
+- `@agentic-patterns/runtime` — events, gates, runner, transport, multi-agent, conversation, exporters, presets
+- Runtime imports core. Core NEVER imports runtime.
+
+## Completion
+
+After all quality gates pass:
+
+1. Stage and commit your work:
+   ```bash
+   cd typescript
+   git add -A packages/
+   git commit -m "feat: phase {N} — {description}
+
+   Co-Authored-By: Claude <noreply@anthropic.com>"
+   ```
+
+2. Comment on the GitHub issue with results:
+   ```bash
+   gh issue comment {ISSUE} --body "$(cat <<'EOF'
+   ## Builder: Phase {N} Complete
+   **Status:** ✅ Implementation complete
+
+   ### Files Created
+   {list of files}
+
+   ### Quality Gates
+   - [x] `pnpm build` — both packages compile
+   - [x] `pnpm typecheck` — zero type errors
+   - [x] `pnpm test` — {N} tests pass
+
+   ### Notes
+   {any decisions made, deviations from spec, or issues encountered}
+   EOF
+   )"
+   ```
+
+3. If quality gates FAIL and you cannot fix them after 2 attempts, comment with the failure details and stop:
+   ```bash
+   gh issue comment {ISSUE} --body "## Builder: Phase {N} BLOCKED
+   **Status:** ❌ Quality gate failure
+   **Gate:** {which gate failed}
+   **Error:** {error output}
+   **Attempts:** {N}/2"
+   ```
+
+## Constraints
+
+- Follow the spec and issue comments exactly — don't add extras
+- Don't modify files outside your phase's target directories
+- Don't modify Python source files
+- Commit only your phase's work, nothing else
+- If the spec is ambiguous, check the Python source — it's the ground truth

--- a/.claude/agents/ts-validator.md
+++ b/.claude/agents/ts-validator.md
@@ -1,0 +1,147 @@
+---
+name: TypeScript Port Validator
+description: Validates a completed phase of the TypeScript port. Runs quality gates, checks architecture rules, verifies parity with Python, comments results on GH issue.
+---
+
+# TypeScript Port Validator
+
+You validate one phase of the agentic-patterns TypeScript port. You run quality gates, check architecture rules, and verify correctness. You do NOT write code — you report issues for the builder to fix.
+
+## Tools
+
+Read, Bash, Glob, Grep
+
+## On Startup
+
+1. Comment on the GitHub issue that validation is starting:
+   ```bash
+   gh issue comment {ISSUE} --body "## Validator: Starting Phase {N} Validation
+   **Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+   **Status:** 🔍 Validation in progress"
+   ```
+
+## Validation Checklist
+
+Run ALL checks. Report every finding.
+
+### 1. Build Gate
+```bash
+cd typescript && pnpm build
+```
+- Both packages must compile
+- `dist/` must contain `.js` and `.d.ts` files
+- Check: `ls packages/agent-core/dist/ packages/agent-runtime/dist/`
+
+### 2. Type Gate
+```bash
+cd typescript && pnpm typecheck
+```
+- Zero type errors in strict mode
+- No `// @ts-ignore` or `// @ts-expect-error` (unless justified in comment)
+- Search: `grep -r "@ts-ignore\|@ts-expect-error" typescript/packages/`
+
+### 3. Test Gate
+```bash
+cd typescript && pnpm test
+```
+- All tests pass
+- No skipped tests (`.skip` or `.todo`) unless documented
+- Search: `grep -r "\.skip\|\.todo\|xit\|xdescribe" typescript/packages/`
+
+### 4. Architecture Gate
+
+**Package boundary:**
+- `agent-core` must NOT import from `agent-runtime`
+  ```bash
+  grep -r "agent-runtime\|@agentic-patterns/runtime" typescript/packages/agent-core/src/
+  ```
+  Must return zero results.
+
+**No circular imports:**
+- Atoms must not import from molecules, organisms, or rendering
+- Molecules must not import from organisms or rendering
+- Rendering can import from atoms and molecules only
+- Organisms can import from all core layers
+  ```bash
+  # Check atoms don't import molecules
+  grep -r "from.*molecules\|from.*organisms\|from.*rendering" typescript/packages/agent-core/src/atoms/
+  ```
+
+**Barrel exports complete:**
+- Every public class/interface/type must be re-exported via its directory's `index.ts`
+- Top-level `src/index.ts` must re-export all sub-barrels
+- Verify: read each `index.ts` and cross-reference with actual files
+
+### 5. Parity Gate (for Phases 2, 5, 6)
+
+For atoms and rendering phases, verify `toPrompt()` output matches Python:
+```bash
+# In a test or script, create a representative atom instance and compare output
+cd typescript && pnpm test -- --grep "toPrompt"
+```
+- Snapshot tests should exist for every atom's `toPrompt()` output
+- Markdown structure must match Python output (headings, bullets, spacing)
+
+### 6. Completeness Gate
+
+Cross-reference the phase issue's sub-task checklist against implemented files:
+- Every file listed in the spec must exist
+- Every class/interface listed must be implemented
+- Every method signature must match the spec
+
+```bash
+# Example: check all atom files exist
+ls typescript/packages/agent-core/src/atoms/*.ts
+```
+
+### 7. Convention Gate
+
+- No `any` types (search: `grep -rn ": any\|as any" typescript/packages/`)
+- Zod schemas for all data models (not raw interfaces for validated data)
+- `Object.freeze` or `Readonly<>` for immutable data
+- Async methods return `Promise<T>`
+- Consistent naming: camelCase for functions/variables, PascalCase for classes/types
+
+## Output
+
+Comment on the GitHub issue with your validation report:
+
+```bash
+gh issue comment {ISSUE} --body "$(cat <<'EOF'
+## Validator: Phase {N} Report
+**Status:** {PASS | FAIL | WARN}
+
+### Gate Results
+| Gate | Status | Details |
+|------|--------|---------|
+| Build | ✅/❌ | {details} |
+| Type Check | ✅/❌ | {details} |
+| Tests | ✅/❌ | {N} pass, {N} fail |
+| Architecture | ✅/❌ | {details} |
+| Parity | ✅/❌/N/A | {details} |
+| Completeness | ✅/❌ | {details} |
+| Convention | ✅/❌ | {details} |
+
+### Issues Found
+{numbered list of issues with file:line references}
+
+### Recommendation
+**{APPROVE | REQUEST_CHANGES}**
+{one-line summary}
+EOF
+)"
+```
+
+## Severity Levels
+
+- **FAIL** — any gate fails, or missing files/classes from spec
+- **WARN** — convention violations, missing tests, non-blocking issues
+- **PASS** — all gates pass, all spec items implemented
+
+## Constraints
+
+- NEVER write, edit, or create files
+- NEVER run destructive commands
+- Report facts with specific file paths and line numbers
+- Every issue must be actionable — tell the builder exactly what to fix
+- If a gate can't run (e.g., no tests written yet), report it as a finding, not a skip

--- a/.claude/commands/orchestrate-ts-port.md
+++ b/.claude/commands/orchestrate-ts-port.md
@@ -1,0 +1,167 @@
+Orchestrate a body of work across multiple issues using coordinated builder and validator agents.
+
+You are the lead orchestrator. You delegate ALL implementation to builder agents and ALL validation to validator agents. You NEVER write code yourself.
+
+## Input
+
+The user provides one of:
+- A GitHub epic issue number (contains a task list of sub-issues)
+- A spec file path (e.g., `.claude/specs/a15-nestjs-scaffold.md`)
+- A list of GitHub issue numbers to execute in order
+- A plain-language description of work to break down
+
+## Setup
+
+1. **Gather context:**
+   - If given an issue: `gh issue view {ISSUE} --json title,body,comments`
+   - If given a spec: read the spec file
+   - Read `CLAUDE.md` for project conventions
+   - Read `codegen.config.yaml` for current project config
+
+2. **Create a working branch:**
+   ```bash
+   BRANCH="claude/$(echo {epic-slug} | tr ' ' '-' | tr '[:upper:]' '[:lower:]')-$(openssl rand -hex 3)"
+   git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
+   git status
+   ```
+
+3. **Plan execution order:**
+   - Identify all issues/tasks and their dependencies
+   - Group independent tasks into waves (parallel execution)
+   - Sequential tasks get their own wave
+   - Present the plan to the user before proceeding
+
+4. **Comment on the epic** (if using GitHub issues):
+   ```bash
+   gh issue comment {EPIC} --body "## Orchestration Started
+   **Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+   **Phases:** {count} across {wave_count} waves
+   **Branch:** $BRANCH"
+   ```
+
+## Execution
+
+### Per-Wave Loop
+
+Execute waves sequentially. Within each wave, spawn builders in PARALLEL (multiple Agent calls in a single message). After ALL builders complete, spawn validators in PARALLEL. Only advance to the next wave when all validators APPROVE.
+
+#### Builder Agents
+
+For each task in the wave, spawn a builder:
+```
+Agent({
+  description: "Build: {short task description}",
+  subagent_type: "implementer",
+  prompt: `You are implementing a task for the codegen-patterns project.
+
+Read CLAUDE.md for project conventions and commands.
+
+Your assignment:
+- Task: {description}
+- GitHub Issue: #{issue} (if applicable)
+- Spec: {spec path} (if applicable)
+- Target: {which files/directories to create or modify}
+
+Steps:
+1. Read the issue/spec for full context: gh issue view {issue} --json body,comments
+2. Read existing code in the target area to understand current patterns
+3. Implement the changes following project conventions
+4. Run quality gates: bun test/run-test.ts full
+5. Comment on issue #{issue} with your results (if applicable)
+6. Commit with message: "feat: {description}"
+`
+})
+```
+
+#### Validator Agents
+
+After all builders in a wave complete, spawn validators:
+```
+Agent({
+  description: "Validate: {short task description}",
+  subagent_type: "validator",
+  prompt: `Validate the implementation for: {task description}
+
+Read CLAUDE.md for project conventions and commands.
+
+Checks to run:
+1. Quality gates: bun test/run-test.ts full
+2. TypeScript compilation: npx tsc --noEmit (if applicable)
+3. Files created/modified match what the task required
+4. Code follows project conventions (naming, structure, patterns)
+5. No regressions in existing functionality
+
+Report your findings. Recommend APPROVE or REQUEST_CHANGES.
+If requesting changes, list exactly what needs to be fixed.
+Comment results on issue #{issue} (if applicable).
+`
+})
+```
+
+**Gate:** ALL validators must APPROVE before advancing to the next wave.
+
+## Retry Protocol
+
+If a validator returns **REQUEST_CHANGES**:
+
+1. Read the validator's findings
+2. Re-spawn a builder with fix instructions:
+   ```
+   Agent({
+     description: "Fix: {task description}",
+     subagent_type: "implementer",
+     prompt: `RETRY — {task description} failed validation.
+
+   Read the validator's feedback: {findings summary or issue comment reference}
+   Fix ONLY the issues listed. Do not rewrite working code.
+   Run quality gates again.
+   Commit with message: "fix: {description} — address validation feedback"`
+   })
+   ```
+3. Re-run the validator
+4. Max 3 retries per task. After 3 failures, STOP and report to the user:
+   ```
+   Task "{description}" failed validation 3 times.
+   Last failure: {summary}
+   Action required: Human review needed.
+   ```
+
+## Progress Reporting
+
+After each wave completes, update the user (and epic issue if applicable):
+```
+Wave {N} Complete
+- Tasks completed: {list}
+- Status: All validators approved
+- Next: Wave {N+1} — {task descriptions}
+- Progress: {completed}/{total} tasks done
+```
+
+## Completion
+
+After all waves pass:
+
+1. Push the branch:
+   ```bash
+   git push -u origin $BRANCH
+   ```
+
+2. Report final status (and comment on epic if applicable):
+   ```
+   All tasks complete.
+   Branch: {branch}
+   Tasks: {N}/{N} done
+   Summary: {what was built/changed}
+   ```
+
+3. Ask the user if they want to create a PR.
+
+## Constraints
+
+- NEVER write code yourself — always delegate to builder agents
+- NEVER skip validation — every task gets a validator pass
+- NEVER advance to the next wave until all validators APPROVE
+- If using GitHub issues, ALWAYS comment for audit trail
+- ALWAYS use the Agent tool for builders and validators
+- If a task seems wrong or ambiguous, STOP and ask the user
+- Push ONLY when all tasks are validated

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "Bash(ls:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(bun:*)"
+    ]
+  }
+}

--- a/.claude/specs/a10-base-service.md
+++ b/.claude/specs/a10-base-service.md
@@ -1,0 +1,113 @@
+# A10: BaseService\<TRepo, TEntity\> + Read Use Cases
+
+**Status:** Draft
+**Last Updated:** 2026-04-12
+**Depends on:** A9 (BaseRepository)
+**References:** ADR-003 (updated), ADR-005, contact module sketch
+
+## Overview
+
+Hand-written abstract class at `shared/base-classes/base-service.ts` providing 8 CRUD methods delegating to repository. Plus `BaseFindByIdUseCase` and `BaseListUseCase` abstract classes that auto-generated read use cases extend. Controllers always import use cases, never services (ADR-003 no-exceptions rule).
+
+**Note:** The contact module sketch shows controller importing ContactService directly for reads (CQRS-lite). ADR-003 explicitly rejected this. This spec follows ADR-003.
+
+## BaseService Interface
+
+```typescript
+@Injectable()
+abstract class BaseService<TRepo extends IBaseRepository<TEntity>, TEntity> {
+  constructor(protected readonly repository: TRepo) {}
+
+  findById(id: string): Promise<TEntity | null> { return this.repository.findById(id); }
+  findByIds(ids: string[]): Promise<TEntity[]> { return this.repository.findByIds(ids); }
+  list(filters?: Record<string, unknown>): Promise<TEntity[]> { return this.repository.list(filters); }
+  count(filters?: Record<string, unknown>): Promise<number> { return this.repository.count(filters); }
+  exists(id: string): Promise<boolean> { return this.repository.exists(id); }
+  create(input: Partial<TEntity>): Promise<TEntity> { return this.repository.create(input); }
+  update(id: string, input: Partial<TEntity>): Promise<TEntity> { return this.repository.update(id, input); }
+  delete(id: string): Promise<void> { return this.repository.delete(id); }
+}
+```
+
+All methods are pure pass-throughs. No side effects per ADR-003.
+
+## Read Use Case Pattern
+
+**Design choice: single generated file per entity, two named exports.**
+
+Rationale: fewer files than one-per-use-case, but controller still imports specific named classes (ESLint-friendly).
+
+### Base classes
+
+```typescript
+// shared/base-classes/base-read-use-cases.ts
+
+@Injectable()
+abstract class BaseFindByIdUseCase<TService extends { findById(id: string): Promise<TEntity | null> }, TEntity> {
+  constructor(protected readonly service: TService) {}
+  execute(id: string): Promise<TEntity | null> { return this.service.findById(id); }
+}
+
+@Injectable()
+abstract class BaseListUseCase<TService extends { list(): Promise<TEntity[]> }, TEntity> {
+  constructor(protected readonly service: TService) {}
+  execute(): Promise<TEntity[]> { return this.service.list(); }
+}
+```
+
+### Generated output per entity (by codegen template)
+
+```typescript
+// modules/contacts/use-cases/contact-read.use-cases.ts
+// AUTO-GENERATED — do not edit
+
+@Injectable()
+export class ContactFindByIdUseCase extends BaseFindByIdUseCase<ContactService, Contact> {
+  constructor(service: ContactService) { super(service); }
+}
+
+@Injectable()
+export class ContactListUseCase extends BaseListUseCase<ContactService, Contact> {
+  constructor(service: ContactService) { super(service); }
+}
+```
+
+### Controller usage (corrected from sketch)
+
+```typescript
+@Controller('contacts')
+export class ContactController {
+  constructor(
+    private readonly findById: ContactFindByIdUseCase,  // NOT ContactService
+    private readonly list: ContactListUseCase,
+    private readonly newContact: NewContactUseCase,      // hand-written
+  ) {}
+
+  @Get(':id') getById(@Param('id') id: string) { return this.findById.execute(id); }
+  @Get() listAll() { return this.list.execute(); }
+  @Post() create(@Body() dto) { return this.newContact.execute(dto); }
+}
+```
+
+### Module registration
+
+Both use case classes registered as providers. Service still exported for cross-domain reads.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `shared/base-classes/base-service.ts` | create | BaseService abstract class |
+| `shared/base-classes/base-read-use-cases.ts` | create | BaseFindByIdUseCase + BaseListUseCase |
+| `shared/base-classes/index.ts` | update | Add exports |
+| `shared/base-classes/base-service.spec.ts` | create | Delegation tests (mock repo) |
+| `shared/base-classes/base-read-use-cases.spec.ts` | create | Delegation tests (mock service) |
+
+## Acceptance Criteria
+
+- [ ] `ContactService extends BaseService<ContactRepository, Contact>` compiles
+- [ ] All 8 CRUD methods delegate to repository
+- [ ] `ContactFindByIdUseCase.execute(id)` calls `service.findById(id)`
+- [ ] `ContactListUseCase.execute()` calls `service.list()`
+- [ ] Controller imports only `*.use-case` classes — no direct service import
+- [ ] ESLint rule "controllers may only import *.use-case.ts" is satisfiable with this shape

--- a/.claude/specs/a15-nestjs-scaffold.md
+++ b/.claude/specs/a15-nestjs-scaffold.md
@@ -1,0 +1,376 @@
+# SPEC-A15: Minimal NestJS Scaffold for End-to-End Codegen Validation
+
+**Status:** Approved  
+**Date:** 2026-04-12  
+**Scope:** `test/scaffold/` directory only — no changes to codegen source or templates
+
+---
+
+## Purpose
+
+Prove that codegen output from `contact-v2.yaml` compiles, migrates, and serves real HTTP traffic. This is a test harness, not a production application. It imports the generated `ContactsModule` directly, connects to a real Postgres instance, and verifies each CRUD endpoint responds correctly via `curl`.
+
+The scaffold lives in `test/scaffold/` so it is clearly separated from the codegen source. It is never deployed; it exists only to catch regressions between template changes and compilable, runnable NestJS output.
+
+---
+
+## Files to Create
+
+| File | Action |
+|------|--------|
+| `test/scaffold/src/main.ts` | create |
+| `test/scaffold/src/app.module.ts` | create |
+| `test/scaffold/src/database/database.module.ts` | create |
+| `test/scaffold/drizzle.config.ts` | create |
+| `test/scaffold/schema.ts` | create |
+| `test/scaffold/docker-compose.yml` | create |
+| `test/scaffold/validate.sh` | create |
+| `test/scaffold/package.json` | create |
+| `test/scaffold/tsconfig.json` | create |
+
+The codegen output lives at `gen/contacts/` (one level above the scaffold, at the repo root). The scaffold imports from there.
+
+---
+
+## Directory Structure
+
+```
+test/scaffold/
+  src/
+    main.ts                  ← NestJS bootstrap, listens on port 3000
+    app.module.ts            ← Imports DatabaseModule + ContactsModule
+    database/
+      database.module.ts     ← Global module, provides DRIZZLE token
+  drizzle.config.ts          ← Points at test Postgres, imports schema.ts
+  schema.ts                  ← Re-exports contacts table from gen/contacts/
+  docker-compose.yml         ← postgres:16, port 5432, db scaffold_test
+  validate.sh                ← Full integration loop (see below)
+  package.json               ← Local deps: @nestjs/core, drizzle-orm, etc.
+  tsconfig.json              ← Extends repo root, path alias for gen/
+
+gen/contacts/                ← Codegen output (generated, not hand-written)
+  contacts.module.ts
+  contact.entity.ts
+  contact.repository.ts
+  ...
+```
+
+---
+
+## Interface Definitions
+
+### DatabaseModule
+
+```typescript
+// test/scaffold/src/database/database.module.ts
+import { Module, Global } from '@nestjs/common';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as schema from '../../schema';
+
+export const DRIZZLE = 'DRIZZLE' as const;
+export type DrizzleDB = ReturnType<typeof drizzle<typeof schema>>;
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: DRIZZLE,
+      useFactory: () => {
+        const pool = new Pool({
+          connectionString: process.env.DATABASE_URL ??
+            'postgresql://postgres:postgres@localhost:5432/scaffold_test',
+        });
+        return drizzle(pool, { schema });
+      },
+    },
+  ],
+  exports: [DRIZZLE],
+})
+export class DatabaseModule {}
+```
+
+The `DRIZZLE` token string must match exactly what codegen emits in the generated repository. Check `test/baseline/packages/api/src/constants/tokens.ts` or the generated `contacts.module.ts` to confirm the token name — adjust here if they differ.
+
+### AppModule
+
+```typescript
+// test/scaffold/src/app.module.ts
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from './database/database.module';
+import { ContactsModule } from '../../gen/contacts/contacts.module';
+
+@Module({
+  imports: [DatabaseModule, ContactsModule],
+})
+export class AppModule {}
+```
+
+### main.ts
+
+```typescript
+// test/scaffold/src/main.ts
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();
+```
+
+### schema.ts
+
+```typescript
+// test/scaffold/schema.ts
+// Re-export the contacts Drizzle table so drizzle-kit and DatabaseModule
+// can reference it. Adjust the import path after running codegen.
+export { contacts } from '../gen/contacts/contact.entity';
+```
+
+### drizzle.config.ts
+
+```typescript
+// test/scaffold/drizzle.config.ts
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL ??
+      'postgresql://postgres:postgres@localhost:5432/scaffold_test',
+  },
+});
+```
+
+### docker-compose.yml
+
+```yaml
+# test/scaffold/docker-compose.yml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: scaffold_test
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+```
+
+---
+
+## validate.sh — The Integration Loop
+
+```bash
+#!/usr/bin/env bash
+# test/scaffold/validate.sh
+# Exit immediately on any failure.
+set -euo pipefail
+
+SCAFFOLD_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCAFFOLD_DIR/../.." && pwd)"
+
+echo "==> Starting Postgres"
+docker compose -f "$SCAFFOLD_DIR/docker-compose.yml" up -d --wait
+
+echo "==> Running codegen for contact-v2"
+cd "$REPO_ROOT"
+bun codegen entity test/fixtures/contact-v2.yaml
+
+echo "==> Running drizzle-kit push"
+cd "$SCAFFOLD_DIR"
+bun drizzle-kit push
+
+echo "==> Starting NestJS app in background"
+bun run start &
+APP_PID=$!
+# Wait until port 3000 accepts connections (max 15s)
+for i in $(seq 1 15); do
+  if curl -sf http://localhost:3000/contacts > /dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+echo "==> POST /contacts (create)"
+CREATE_RESPONSE=$(curl -sf -X POST http://localhost:3000/contacts \
+  -H 'Content-Type: application/json' \
+  -d '{"firstName":"Ada","lastName":"Lovelace","email":"ada@example.com"}')
+echo "$CREATE_RESPONSE"
+CONTACT_ID=$(echo "$CREATE_RESPONSE" | bun -e "const d=JSON.parse(await Bun.stdin.text()); console.log(d.id)")
+
+echo "==> GET /contacts"
+curl -sf http://localhost:3000/contacts | bun -e "
+  const d = JSON.parse(await Bun.stdin.text());
+  if (!Array.isArray(d) || d.length === 0) { console.error('Expected non-empty array'); process.exit(1); }
+  console.log('list ok, count=' + d.length);
+"
+
+echo "==> GET /contacts/:id"
+curl -sf "http://localhost:3000/contacts/$CONTACT_ID" | bun -e "
+  const d = JSON.parse(await Bun.stdin.text());
+  if (d.id !== '$CONTACT_ID') { console.error('ID mismatch'); process.exit(1); }
+  console.log('get-by-id ok');
+"
+
+echo "==> PUT /contacts/:id (update)"
+curl -sf -X PUT "http://localhost:3000/contacts/$CONTACT_ID" \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Mathematician"}' | bun -e "
+  const d = JSON.parse(await Bun.stdin.text());
+  if (d.title !== 'Mathematician') { console.error('Update failed'); process.exit(1); }
+  console.log('update ok');
+"
+
+echo "==> DELETE /contacts/:id"
+curl -sf -X DELETE "http://localhost:3000/contacts/$CONTACT_ID" | bun -e "
+  const d = JSON.parse(await Bun.stdin.text());
+  if (d.id !== '$CONTACT_ID') { console.error('Delete response missing id'); process.exit(1); }
+  console.log('delete ok');
+"
+
+echo "==> Teardown"
+kill $APP_PID 2>/dev/null || true
+docker compose -f "$SCAFFOLD_DIR/docker-compose.yml" down -v
+
+echo "==> All checks passed"
+exit 0
+```
+
+Make this executable: `chmod +x test/scaffold/validate.sh`
+
+---
+
+## package.json
+
+```json
+{
+  "name": "scaffold",
+  "private": true,
+  "scripts": {
+    "start": "ts-node -r tsconfig-paths/register src/main.ts",
+    "drizzle-kit": "drizzle-kit"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "drizzle-orm": "^0.30.0",
+    "pg": "^8.11.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "drizzle-kit": "^0.21.0",
+    "ts-node": "^10.9.0",
+    "tsconfig-paths": "^4.2.0"
+  }
+}
+```
+
+Note: Exact versions should match what is already used in the repo root `package.json` or workspace. Prefer `bun` as the runtime if the repo already uses it — replace `ts-node` with `bun run` in that case.
+
+---
+
+## tsconfig.json
+
+```json
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@gen/*": ["../../gen/*"]
+    }
+  },
+  "include": ["src/**/*", "schema.ts", "drizzle.config.ts"]
+}
+```
+
+---
+
+## Implementation Steps
+
+1. **Confirm codegen output shape for contact-v2.yaml.** Run `bun codegen entity test/fixtures/contact-v2.yaml` against the current codebase and inspect what files land in `gen/`. Identify the exact filename of the generated module (e.g., `contacts.module.ts`), the repository class, and the DRIZZLE token import path. The scaffold imports must match exactly.
+
+2. **Create `test/scaffold/src/database/database.module.ts`.** Use the DRIZZLE token string that matches the generated repository's `@Inject(DRIZZLE)` decorator. If the generated repo imports `DRIZZLE` from `'../constants/tokens'`, define that same constant in DatabaseModule and export it, or adjust the generated import path via `codegen.config.yaml` `locations` settings.
+
+3. **Create `test/scaffold/schema.ts`.** Import and re-export only the tables needed by the scaffold (just `contacts` for this spec). This file is what `drizzle.config.ts` and `DatabaseModule` reference.
+
+4. **Create `test/scaffold/drizzle.config.ts`.** Standard drizzle-kit config pointing at `schema.ts` and the local Postgres.
+
+5. **Create `test/scaffold/src/app.module.ts`.** Import `DatabaseModule` first so the global DRIZZLE provider is available to `ContactsModule`.
+
+6. **Create `test/scaffold/src/main.ts`.** Standard NestJS bootstrap on port 3000. Enable `enableShutdownHooks()` so `kill` in validate.sh terminates cleanly.
+
+7. **Create `test/scaffold/docker-compose.yml`.** Postgres 16, healthcheck required — validate.sh uses `--wait` and depends on the container being ready.
+
+8. **Create `test/scaffold/validate.sh`.** Follow the script in the Interface Definitions section above. The ID extraction step must be adjusted if the Bun one-liner syntax is incompatible — use `jq` as a fallback if Bun inline eval is unavailable.
+
+9. **Create `test/scaffold/package.json` and `test/scaffold/tsconfig.json`.** Match existing repo tooling choices.
+
+10. **Smoke test manually.** From `test/scaffold/`, run `docker compose up -d --wait`, run codegen, run `bun drizzle-kit push`, run `bun run start`, and hit `curl http://localhost:3000/contacts`. Fix any import path issues before writing validate.sh.
+
+---
+
+## Known Constraints and Decisions
+
+**DRIZZLE token mismatch:** The generated repository imports `DRIZZLE` from a constants file (`'../constants/tokens'` in current baseline). The scaffold's `DatabaseModule` must provide that same token. Two options:
+- Option A (preferred): Configure `codegen.config.yaml` so the generated repository's constants import path resolves into the scaffold. Add a path alias in `tsconfig.json`.
+- Option B: Copy the tokens constant into `test/scaffold/src/constants/tokens.ts` and accept that codegen still generates the import — then shim the path.
+
+The implementer should confirm which approach avoids changing codegen source, and document the decision in a comment in `database.module.ts`.
+
+**contact-v2.yaml behaviors:** `contact-v2.yaml` includes `external_id_tracking` behavior and `family: crm-synced`. If the codegen does not yet handle these (they may be v2-only schema additions), the scaffold test should use a stripped-down entity YAML that exercises only what codegen currently supports. Document this in a comment at the top of `validate.sh`.
+
+**No auth, no guards:** The scaffold controller must be reachable without authentication. Verify the generated controller does not apply `@UseGuards(AuthGuard)` — that pattern appears in Electric SQL controllers, not plain REST. If guards are present, they must be disabled or overridden in the scaffold AppModule.
+
+**Soft delete:** `contact-v2.yaml` has `soft_delete` behavior. The DELETE endpoint will soft-delete (set `deleted_at`) rather than hard-delete. The validate.sh assertion for DELETE should check that the response contains the contact's `id`, not that the record disappears from the list query (it won't, unless the list query filters deleted records, which it should by default).
+
+---
+
+## Testing Strategy
+
+The scaffold itself is the test. No unit test files are required for this spec.
+
+**validate.sh exit code 0** is the acceptance criterion. Run it as:
+```bash
+bash test/scaffold/validate.sh
+```
+
+The script must:
+- Start Postgres via Docker
+- Run codegen (idempotent — reruns are safe)
+- Push schema with drizzle-kit (creates `contacts` table)
+- Start the NestJS app
+- Execute POST → GET (list) → GET (by ID) → PUT → DELETE in sequence
+- Assert correct HTTP responses at each step
+- Tear down Docker and kill the app process
+
+Each curl call must use `-f` (fail on non-2xx) so any server error causes an immediate exit 1.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `bun codegen entity test/fixtures/contact-v2.yaml` completes without error
+- [ ] `tsc --noEmit` passes inside `test/scaffold/` (no TypeScript errors)
+- [ ] `bun drizzle-kit push` creates the `contacts` table in the Docker Postgres
+- [ ] NestJS app starts on port 3000 without runtime errors
+- [ ] `POST /contacts` returns a JSON object with an `id` field
+- [ ] `GET /contacts` returns a JSON array containing the created contact
+- [ ] `GET /contacts/:id` returns the contact by ID
+- [ ] `PUT /contacts/:id` returns the updated contact with modified field
+- [ ] `DELETE /contacts/:id` returns the deleted contact record
+- [ ] `bash test/scaffold/validate.sh` exits 0 end-to-end

--- a/.claude/specs/a16-atlas-migrations.md
+++ b/.claude/specs/a16-atlas-migrations.md
@@ -1,0 +1,126 @@
+# A16: Atlas Migration Integration
+
+**Status:** Draft
+**Last Updated:** 2026-04-12
+**Depends on:** A6 (core templates generate Drizzle schemas)
+**References:** ORM research (2026-04-12), Drizzle stay decision
+
+## Overview
+
+Replace drizzle-kit push with Atlas (atlasgo.io) for database migrations. Atlas does Alembic-style declarative schema diffing with official Drizzle integration. Adds rollback support, destructive change detection (50+ analyzers), and CI-enforced migration linting that drizzle-kit lacks.
+
+The codegen pipeline doesn't change — it still generates Drizzle schemas. Atlas sits between schemas and DB.
+
+## Architecture
+
+```
+Entity YAML → codegen → Drizzle schema files (unchanged)
+                              │
+                              ▼  drizzle-kit export
+                        Atlas schema source
+                              │
+                              ▼  atlas migrate diff
+                        migrations/*.sql (with rollback)
+                              │
+                              ├── atlas migrate apply (dev/prod)
+                              └── atlas migrate lint (CI)
+```
+
+## Configuration
+
+### `atlas.hcl` (Dealbrain monorepo root)
+
+```hcl
+data "external_schema" "drizzle" {
+  program = ["npx", "drizzle-kit", "export", "--config", "./packages/db/drizzle.config.ts"]
+}
+
+env "dev" {
+  src = data.external_schema.drizzle.url
+  dev = "docker://postgres/16/dev"
+  migration { dir = "file://packages/db/migrations" }
+}
+
+env "prod" {
+  src = data.external_schema.drizzle.url
+  url = getenv("DATABASE_URL")
+  migration { dir = "file://packages/db/migrations" }
+}
+```
+
+## Workflow
+
+```bash
+# Generate migration after codegen produces new Drizzle schemas
+atlas migrate diff add_contacts --env dev
+
+# Apply locally
+atlas migrate apply --env dev
+
+# Apply to prod
+DATABASE_URL="..." atlas migrate apply --env prod
+
+# Rollback
+atlas migrate down --env prod --amount 1
+
+# Lint in CI
+atlas migrate lint --env dev --git-base main
+```
+
+## CI Integration
+
+```yaml
+# .github/workflows/atlas-lint.yml
+name: Atlas Migration Lint
+on:
+  pull_request:
+    paths: ['packages/db/src/**', 'packages/db/migrations/**']
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    services:
+      postgres: { image: 'postgres:16' }
+    steps:
+      - uses: ariga/setup-atlas
+      - run: atlas migrate lint --env dev --git-base origin/main
+```
+
+## Comparison with drizzle-kit
+
+| Capability | drizzle-kit push | Atlas |
+|---|---|---|
+| Versioned migration files | No | Yes |
+| Rollback | No | Yes |
+| Destructive change detection | Basic warning | 50+ analyzers, CI-enforced |
+| Migration lint in CI | No | Yes (GitHub Action) |
+| Shadow DB diffing | No | Yes |
+
+## Package.json Scripts
+
+```json
+{
+  "db:migrate:diff": "atlas migrate diff --env dev",
+  "db:migrate:apply": "atlas migrate apply --env dev",
+  "db:migrate:apply:prod": "atlas migrate apply --env prod",
+  "db:migrate:lint": "atlas migrate lint --env dev --git-base main"
+}
+```
+
+## Files (in Dealbrain monorepo, not codegen-patterns)
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `atlas.hcl` | create | Atlas project config |
+| `packages/db/migrations/` | create dir | Migration SQL files |
+| `.github/workflows/atlas-lint.yml` | create | CI lint workflow |
+| `package.json` | modify | Add db:migrate:* scripts |
+
+## Acceptance Criteria
+
+- [ ] `atlas migrate diff` produces valid SQL from Drizzle schemas
+- [ ] `atlas migrate apply` applies migrations to local Postgres
+- [ ] `atlas migrate down` rolls back last migration
+- [ ] Atlas detects DROP COLUMN as destructive and blocks without annotation
+- [ ] CI workflow runs on PRs touching schema/migration files
+- [ ] `atlas.sum` integrity file committed and validated
+- [ ] drizzle-kit push removed from scripts

--- a/.claude/specs/a17-declarative-query-codegen.md
+++ b/.claude/specs/a17-declarative-query-codegen.md
@@ -1,0 +1,463 @@
+# SPEC-A17: Declarative Query Code Generation from YAML `queries:` Block
+
+**Status:** Approved  
+**Date:** 2026-04-12  
+**Depends on:** Schema/parser work (SPEC-002) — `QueryDeclarationSchema` in `schema/entity-definition.schema.ts` and `ParsedQuery` in `analyzer/types.ts` are already defined.
+
+---
+
+## Purpose
+
+The `queries:` block in entity YAML is parsed but not yet used by the template system. This spec covers the template-side implementation: generating Drizzle repository methods, service pass-throughs, and use case classes from `processedQueries[]` that is passed into Hygen templates via `prompt.js`.
+
+The goal is that `contact-v2.yaml`'s six query declarations all produce correct, compilable TypeScript with no hand-writing required.
+
+---
+
+## Files to Create or Modify
+
+| File | Action | Notes |
+|------|--------|-------|
+| `templates/entity/new/prompt.js` | modify | Derive `processedQueries` array from parsed `queries:` YAML block |
+| `templates/entity/new/backend/database/repository.ejs.t` | modify | Append declarative query methods after existing FK-based methods |
+| `templates/entity/new/backend/application/queries/declarative-queries.ejs.t` | create | New template: one use case class per declared query, all in one file |
+| `templates/entity/new/backend/modules/core/module.ejs.t` | modify | Register declarative query classes in providers + exports |
+| `test/fixtures/contact-v2.yaml` | read-only reference | Source of truth for the six queries to exercise |
+| `test/baseline/` | modify (re-baseline) | Run `bun test/run-test.ts baseline` after implementation |
+
+---
+
+## Background: The Six Queries in contact-v2.yaml
+
+```yaml
+queries:
+  - by: [user_id]
+  - by: [email]
+    unique: true
+  - by: [account_id]
+    order: created_at desc
+  - by: [user_id, account_id]
+  - by: [opportunity_id]
+    via: opportunity_contact_link
+  - by: [opportunity_id]
+    select: [email]
+    via: opportunity_contact_link
+```
+
+These map to the `ParsedQuery` type from `analyzer/types.ts`:
+
+```typescript
+interface ParsedQuery {
+  by: string[];
+  unique?: boolean;
+  select?: string[];
+  order?: string;
+  limit?: boolean;
+  via?: string;
+}
+```
+
+---
+
+## Implementation Steps
+
+### Step 1: Derive `processedQueries` in `prompt.js`
+
+In `prompt.js`, after the entity YAML is loaded and the fields map is built, add a function that transforms the raw `queries` array into a richer `processedQueries` array. Each element in `processedQueries` provides everything the templates need — method names, return types, Drizzle import hints — without requiring logic inside EJS.
+
+**Naming rules** (all fields converted snake_case → camelCase):
+
+| Declaration | Method name |
+|-------------|-------------|
+| `by: [user_id]` | `findByUserId` |
+| `by: [email], unique: true` | `findByEmail` |
+| `by: [account_id], order: created_at desc` | `findByAccountId` |
+| `by: [user_id, account_id]` | `findByUserIdAndAccountId` |
+| `by: [opportunity_id], via: opportunity_contact_link` | `findByOpportunityId` |
+| `by: [opportunity_id], select: [email], via: opportunity_contact_link` | `findEmailsByOpportunityId` |
+
+**Naming algorithm** (pseudocode):
+```
+function buildMethodName(query):
+  if query.select and query.select.length > 0:
+    selectedPart = toCamelCase(query.select.join('_and_'))  // "email" → "Emails"
+    byPart = toCamelCase(query.by.join('_and_'))            // "opportunity_id" → "OpportunityId"
+    return "find" + capitalize(selectedPart) + "sBy" + byPart
+  else:
+    byPart = toCamelCase(query.by.join('_and_'))
+    return "findBy" + byPart
+```
+
+Note: `findEmails...` uses plural because `select` implies a projection returning multiple values.
+
+**Return type rules**:
+
+| Condition | Repository return type | Service return type |
+|-----------|----------------------|---------------------|
+| Default (no `unique`, no `select`) | `ClassName[]` | `ClassName[]` |
+| `unique: true` | `ClassName \| null` | `ClassName \| null` |
+| `select: [field]` (single field) | `string[]` (or appropriate TS type) | `string[]` |
+| `limit: true` | adds paginated variant (see below) | adds paginated variant |
+
+**`processedQuery` object shape** (what `prompt.js` produces for each query):
+
+```typescript
+{
+  // Derived names
+  methodName: string,           // "findByUserId"
+  paginatedMethodName: string,  // "findByUserIdPaginated" (only if limit: true)
+  useCaseClassName: string,     // "FindContactsByUserIdQuery" (PascalCase)
+
+  // Parameters for the method signature
+  params: Array<{
+    name: string,               // "userId"
+    tsType: string,             // "string"
+    drizzleField: string,       // "user_id" (original snake_case for Drizzle column access)
+  }>,
+
+  // Return type
+  returnType: string,           // "Contact[]", "Contact | null", "string[]"
+  isUnique: boolean,
+  hasSelect: boolean,
+  selectFields: string[],       // camelCase field names, e.g. ["email"]
+  selectDrizzleFields: string[],// snake_case, e.g. ["email"] (same for simple fields)
+
+  // Ordering
+  orderBy: string | null,       // "created_at" (snake_case field)
+  orderDirection: 'asc' | 'desc' | null,
+
+  // Pagination
+  hasLimit: boolean,
+
+  // Junction table join
+  hasVia: boolean,
+  viaTable: string | null,      // "opportunity_contact_link"
+  viaTableCamel: string | null, // "opportunityContactLink"
+  viaJoinCondition: string | null, // hint for template: "contact_id = contacts.id"
+
+  // Drizzle imports needed by this query
+  drizzleImports: string[],     // e.g. ["eq", "and", "desc", "inArray"]
+}
+```
+
+For `via` queries, the template implementer must decide how to express the join condition. The simplest approach: document that `via` queries use `db.select().from(table).innerJoin(viaTable, eq(viaTable.contactId, table.id)).where(eq(viaTable.opportunityId, value))`. The `prompt.js` should provide `viaTable` and `viaTableCamel` strings; the EJS template handles the join expression.
+
+**Collect all Drizzle imports needed across all queries** and merge them with the existing `drizzleImports` array so the `_inject-schema-server-imports` template picks them up. Additions include: `and`, `desc`, `asc`, `inArray` (if needed), plus `sql` for raw junction queries if the template uses that approach.
+
+---
+
+### Step 2: Modify `repository.ejs.t` — Append Declarative Query Methods
+
+After the existing `belongsToRelations` and `entityRefFields` method blocks (and before the closing `}`), append a new loop block for `processedQueries`.
+
+**Pseudocode for each query type in EJS:**
+
+**Simple (single field, no via, no unique):**
+```typescript
+async findByUserId(userId: string): Promise<Contact[]> {
+  const records = await this.baseQuery()
+    .where(eq(contacts.userId, userId));
+  return records.map(Contact.fromRecord);
+}
+```
+
+**Multi-field:**
+```typescript
+async findByUserIdAndAccountId(userId: string, accountId: string): Promise<Contact[]> {
+  const records = await this.baseQuery()
+    .where(and(
+      eq(contacts.userId, userId),
+      eq(contacts.accountId, accountId),
+    ));
+  return records.map(Contact.fromRecord);
+}
+```
+
+**Unique (returns T | null):**
+```typescript
+async findByEmail(email: string): Promise<Contact | null> {
+  const result = await this.baseQuery()
+    .where(eq(contacts.email, email))
+    .limit(1);
+  const record = result[0];
+  return record ? Contact.fromRecord(record) : null;
+}
+```
+
+**With order:**
+```typescript
+async findByAccountId(accountId: string): Promise<Contact[]> {
+  const records = await this.baseQuery()
+    .where(eq(contacts.accountId, accountId))
+    .orderBy(desc(contacts.createdAt));
+  return records.map(Contact.fromRecord);
+}
+```
+
+**With limit (paginated variant — generated in addition to the base method):**
+```typescript
+async findByXPaginated(x: string, limit: number, offset: number): Promise<Contact[]> {
+  const records = await this.baseQuery()
+    .where(eq(contacts.x, x))
+    .limit(limit)
+    .offset(offset);
+  return records.map(Contact.fromRecord);
+}
+```
+
+**Via junction table (returns entity rows):**
+```typescript
+async findByOpportunityId(opportunityId: string): Promise<Contact[]> {
+  const records = await this.db
+    .select()
+    .from(contacts)
+    .innerJoin(
+      opportunityContactLink,
+      eq(opportunityContactLink.contactId, contacts.id),
+    )
+    .where(eq(opportunityContactLink.opportunityId, opportunityId));
+  return records.map((r) => Contact.fromRecord(r.contacts));
+}
+```
+
+Note: `r.contacts` is the shape Drizzle returns when using `.innerJoin` with named tables — the select result is namespaced by table. Verify this against the Drizzle version in use.
+
+**Via junction table with select projection (returns scalar array):**
+```typescript
+async findEmailsByOpportunityId(opportunityId: string): Promise<string[]> {
+  const rows = await this.db
+    .select({ email: contacts.email })
+    .from(contacts)
+    .innerJoin(
+      opportunityContactLink,
+      eq(opportunityContactLink.contactId, contacts.id),
+    )
+    .where(eq(opportunityContactLink.opportunityId, opportunityId));
+  return rows.map((r) => r.email);
+}
+```
+
+**EJS template structure (append inside repository class, both base_class and inline branches):**
+```ejs
+<% if (processedQueries && processedQueries.length > 0) { -%>
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Declarative queries (generated from YAML queries: block)
+  // ═══════════════════════════════════════════════════════════════════════
+<% processedQueries.forEach((q) => { -%>
+
+  async <%= q.methodName %>(<%= q.params.map(p => `${p.name}: ${p.tsType}`).join(', ') %>): Promise<<%= q.returnType %>> {
+<%   if (q.hasVia && q.hasSelect) { -%>
+    // junction + projection
+<%   } else if (q.hasVia) { -%>
+    // junction join
+<%   } else if (q.isUnique) { -%>
+    // unique — returns T | null
+<%   } else { -%>
+    // standard multi-where
+<%   } -%>
+    // ... (see method pseudocode above for each case)
+  }
+<% if (q.hasLimit) { -%>
+
+  async <%= q.paginatedMethodName %>(<%= q.params.map(p => `${p.name}: ${p.tsType}`).join(', ') %>, limit: number, offset: number): Promise<<%= q.returnType %>> {
+    // paginated variant
+  }
+<% } -%>
+<% }) -%>
+<% } -%>
+```
+
+The `via` table import (e.g., `opportunityContactLink`) must be derived in `prompt.js` and added to the imports list. The junction table is assumed to live in the same Drizzle schema file as the main entity. If it does not exist yet, the generated code will fail to compile — document this in a comment.
+
+---
+
+### Step 3: Create `declarative-queries.ejs.t` — Use Case Classes
+
+Generate a single file containing one `@Injectable()` class per declared query. This avoids proliferating files while keeping each class testable.
+
+**File location rule:**
+```
+to: <%= generate.queries && processedQueries.length > 0
+       ? `${basePaths.backendSrc}/${paths.queries}/${name}/declarative-queries.ts`
+       : '' %>
+```
+
+Use the same `outputPaths.listQuery` path conventions from `prompt.js` as a reference for the `paths.queries` segment.
+
+**Generated file shape:**
+
+```typescript
+/**
+ * Declarative Queries — <%= classNamePlural %>
+ * Generated from YAML queries: block. Do not edit directly.
+ */
+
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { <%= repositoryToken %> } from '<%= imports.constants %>';
+import type { I<%= className %>Repository } from '<%= imports.domain %>';
+import { <%= className %> } from '<%= imports.domain %>';
+
+// ─── FindContactsByUserIdQuery ─────────────────────────────────────────────
+
+@Injectable()
+export class FindContactsByUserIdQuery {
+  constructor(
+    @Inject(<%= repositoryToken %>)
+    private readonly <%= camelName %>Repository: I<%= className %>Repository,
+  ) {}
+
+  async execute(userId: string): Promise<Contact[]> {
+    return this.<%= camelName %>Repository.findByUserId(userId);
+  }
+}
+
+// ─── FindContactByEmailQuery ───────────────────────────────────────────────
+
+@Injectable()
+export class FindContactByEmailQuery {
+  constructor(
+    @Inject(<%= repositoryToken %>)
+    private readonly <%= camelName %>Repository: I<%= className %>Repository,
+  ) {}
+
+  async execute(email: string): Promise<Contact | null> {
+    return this.<%= camelName %>Repository.findByEmail(email);
+  }
+}
+
+// ... one class per processedQuery ...
+```
+
+**Use case class naming convention:**
+
+| `methodName` | `useCaseClassName` |
+|---|---|
+| `findByUserId` | `FindContactsByUserIdQuery` |
+| `findByEmail` (unique) | `FindContactByEmailQuery` (singular, no `s`) |
+| `findByAccountId` | `FindContactsByAccountIdQuery` |
+| `findByUserIdAndAccountId` | `FindContactsByUserIdAndAccountIdQuery` |
+| `findByOpportunityId` (via) | `FindContactsByOpportunityIdQuery` |
+| `findEmailsByOpportunityId` (select) | `FindContactEmailsByOpportunityIdQuery` |
+
+Rule: prefix `Find`, entity name pluralized (singular for unique), `By` + field(s) in PascalCase, suffix `Query`. For select projections, insert the selected field name(s) between entity name and `By`.
+
+**Export an index** at the bottom of the file so the module can import cleanly:
+```typescript
+export const declarativeQueryClasses = [
+  FindContactsByUserIdQuery,
+  FindContactByEmailQuery,
+  // ...
+] as const;
+```
+
+The module template uses `declarativeQueryClasses` spread into providers and exports.
+
+---
+
+### Step 4: Modify `module.ejs.t` — Register Declarative Query Classes
+
+Add a conditional import and spread of `declarativeQueryClasses` into the module:
+
+```ejs
+<% if (processedQueries && processedQueries.length > 0) { -%>
+import { declarativeQueryClasses } from '<%= imports.moduleToDeclarativeQueries %>';
+<% } -%>
+```
+
+In the `providers` and `exports` arrays:
+```ejs
+    // Declarative queries (from YAML queries: block)
+<% if (processedQueries && processedQueries.length > 0) { -%>
+    ...declarativeQueryClasses,
+<% } -%>
+```
+
+The import path `imports.moduleToDeclarativeQueries` must be derived in `prompt.js` following the same relative-path convention used for `imports.moduleToGetByIdQuery`.
+
+---
+
+## Drizzle Import Tracking
+
+The `processedQueries` derivation in `prompt.js` must merge any new Drizzle imports into the existing `drizzleImports` array used by the inject templates. Required additions per query type:
+
+| Query type | Additional imports |
+|---|---|
+| Any multi-field `by` | `and` |
+| `order: ... desc` | `desc` |
+| `order: ... asc` | `asc` |
+| `via` (junction) | `innerJoin` is a method call, not an import; but `eq` already imported |
+| Unique | no new imports (uses `limit(1)`) |
+
+Deduplicate before passing to the inject template. The `drizzleImports` array already contains `eq` and `isNull` (from soft delete); do not add duplicates.
+
+---
+
+## Repository Interface
+
+The generated repository methods must also appear in the `IContactRepository` interface. The `repository-interface.ejs.t` template (in `templates/entity/new/backend/domain/`) must be modified with the same `processedQueries` loop to emit method signatures.
+
+**Interface method signatures:**
+
+```typescript
+findByUserId(userId: string): Promise<Contact[]>;
+findByEmail(email: string): Promise<Contact | null>;
+findByAccountId(accountId: string): Promise<Contact[]>;
+findByUserIdAndAccountId(userId: string, accountId: string): Promise<Contact[]>;
+findByOpportunityId(opportunityId: string): Promise<Contact[]>;
+findEmailsByOpportunityId(opportunityId: string): Promise<string[]>;
+```
+
+This is required for the `I<%= className %>Repository` contract that use case classes depend on via `@Inject`.
+
+---
+
+## Testing Strategy
+
+### Baseline Test
+
+After implementing all templates, run:
+```bash
+bun codegen entity test/fixtures/contact-v2.yaml
+bun test/run-test.ts baseline
+```
+
+This captures the new generated output as the new baseline. Subsequent runs of `bun test/run-test.ts full` will catch regressions.
+
+### Compile Check
+
+The generated output must pass TypeScript compilation. A minimal compile check:
+```bash
+cd gen/contacts && tsc --noEmit
+```
+
+This requires a `tsconfig.json` in `gen/contacts/` or the repo root tsconfig covering that path.
+
+### Manual Verification of Each Query
+
+After running codegen on `contact-v2.yaml`, inspect the generated repository and confirm each of the following methods is present and uses the correct Drizzle pattern:
+
+| Method | Pattern to verify |
+|--------|------------------|
+| `findByUserId` | `baseQuery().where(eq(contacts.userId, userId))` |
+| `findByEmail` | `.limit(1)`, returns `Contact \| null` |
+| `findByAccountId` | `.orderBy(desc(contacts.createdAt))` |
+| `findByUserIdAndAccountId` | `and(eq(...), eq(...))` |
+| `findByOpportunityId` | `.innerJoin(opportunityContactLink, ...)` |
+| `findEmailsByOpportunityId` | `.select({ email: contacts.email })`, returns `string[]` |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `prompt.js` exports a `processedQueries` array when the YAML has a `queries:` block; exports an empty array or `undefined` when absent (backward compatible — no regressions on existing entity YAMLs)
+- [ ] Running `bun codegen entity test/fixtures/contact-v2.yaml` generates all six repository methods in `contact.repository.ts`
+- [ ] Junction table queries use `.innerJoin()`, not raw SQL
+- [ ] Unique queries return `T | null` (not `T[]`)
+- [ ] Paginated variant is generated when `limit: true` is present on a query declaration
+- [ ] Select-projection queries return `string[]` (or typed scalar array), not entity arrays
+- [ ] `declarative-queries.ts` is generated with one `@Injectable()` class per declared query
+- [ ] All six classes appear in the `ContactsModule` providers and exports
+- [ ] `IContactRepository` interface includes all six method signatures
+- [ ] Existing entity YAMLs without a `queries:` block generate identical output to pre-implementation baseline (no regressions)
+- [ ] `bun test/run-test.ts full` passes after re-baselining with `contact-v2.yaml` added to the fixture set

--- a/.claude/specs/a5-prompt-js-evolution.md
+++ b/.claude/specs/a5-prompt-js-evolution.md
@@ -1,0 +1,47 @@
+# A5: prompt.js Evolution
+
+## Overview
+Extend `templates/entity/new/prompt.js` to consume v2 YAML blocks (family, queries, sync, events) and route to the Clean-Lite-PS template set based on `pipelines.backend.architecture` config.
+
+## Files
+| File | Action | Purpose |
+|------|--------|---------|
+| `templates/entity/new/prompt.js` | modify | Read v2 fields, compute derived vars, expose architecture target |
+| `config/paths.mjs` | modify | Export `getPipelinesConfig()` helper |
+
+## New Variables Passed to Templates
+
+### Architecture routing
+- `architectureTarget`: `'clean'|'clean-lite'|'clean-lite-ps'|'vertical-slice'` (default: `'clean'`)
+
+### Family
+- `family`: string|null — raw from `entity.family`
+- `hasFamily`: boolean
+- `familyBaseRepository`: `'CrmEntityRepository'|'ActivityEntityRepository'|'KnowledgeEntityRepository'|'MetadataEntityRepository'|null`
+- `familyBaseService`: matching service base class name or null
+
+### Queries
+- `hasQueries`: boolean
+- `processedQueries[]`: each with:
+  - `by`, `unique`, `select`, `order`, `limit`, `via` (raw from YAML)
+  - `methodName`: derived (e.g., `findByUserId`, `findEmailsByOpportunityId`)
+  - `returnType`: `'single'|'array'`
+  - `hasVia`, `hasSelect`, `hasOrder`, `hasLimit` convenience flags
+
+**Method name derivation:**
+- `by:[user_id]` → `findByUserId`
+- `by:[user_id, account_id]` → `findByUserIdAndAccountId`
+- `by:[opportunity_id], select:[email]` → `findEmailsByOpportunityId`
+
+### Sync
+- `hasSyncBlock`, `syncElectric`, `hasSyncProviders`
+- `syncProviders[]`: name, remoteEntity, direction, cdc, fieldMapping (as `{local, remote}[]`), readOnlyFields
+
+### Events
+- `hasEvents`
+- `processedEvents[]`: name, queue, body (as `{field, type}[]`), generateHandler, `className` (PascalCase+Event), `handlerClassName`
+
+## Acceptance Criteria
+- [ ] v1 entities without v2 blocks: all new flags false/empty, no template output change
+- [ ] contact-v2.yaml: `family='crm-synced'`, `familyBaseRepository='CrmEntityRepository'`, 6 queries, 3 events, sync with salesforce provider
+- [ ] `bun test/run-test.ts compare` produces no diff against existing baseline

--- a/.claude/specs/a6-clean-lite-ps-templates.md
+++ b/.claude/specs/a6-clean-lite-ps-templates.md
@@ -1,0 +1,709 @@
+# Spec A6 — Clean-Lite-PS Template Set
+
+**Status:** Approved for implementation
+**Issue:** A6
+**Related ADRs:** ADR-002, ADR-003, ADR-005
+**Reference output:** `docs/architecture/sketches/contact-module-sketch.md`
+
+---
+
+## Overview
+
+Introduce a new Hygen EJS template set that generates domain-first NestJS modules following the Clean-Lite-PS (Pattern Stack) architecture. The template set lives at `templates/entity/new/clean-lite-ps/` and produces 11 files per entity, all colocated under a single `modules/<plural>/` directory.
+
+This replaces the dispersed output of the current `backend/` template tree (separate `domain/`, `application/`, `infrastructure/`, `presentation/` outputs) with a single-directory module that includes every layer.
+
+---
+
+## Files to Create
+
+| File | Action | Description |
+|------|--------|-------------|
+| `templates/entity/new/clean-lite-ps/entity.ejs.t` | create | Drizzle table + relations + inferred types |
+| `templates/entity/new/clean-lite-ps/repository.ejs.t` | create | Family base class extension, entity-specific skeleton |
+| `templates/entity/new/clean-lite-ps/service.ejs.t` | create | Family service extension with WithAnalytics mixin |
+| `templates/entity/new/clean-lite-ps/use-cases/find-by-id.ejs.t` | create | FindById use case delegating to service |
+| `templates/entity/new/clean-lite-ps/use-cases/list.ejs.t` | create | List use case delegating to service |
+| `templates/entity/new/clean-lite-ps/controller.ejs.t` | create | Thin REST adapter, all routes through use cases |
+| `templates/entity/new/clean-lite-ps/module.ejs.t` | create | NestJS module wiring imports/providers/exports |
+| `templates/entity/new/clean-lite-ps/dto/create.ejs.t` | create | Zod create schema |
+| `templates/entity/new/clean-lite-ps/dto/update.ejs.t` | create | Zod update schema (partial of create) |
+| `templates/entity/new/clean-lite-ps/dto/output.ejs.t` | create | Zod output schema including all fields |
+| `templates/entity/new/clean-lite-ps/prompt-extension.js` | create | Template locals extension for clean-lite-ps variables |
+
+No existing files are modified by this spec. The existing `backend/` template tree is untouched.
+
+---
+
+## Interface Definitions
+
+### Template Locals (available in all templates)
+
+All variables from the existing `prompt.js` are available. The clean-lite-ps templates additionally require:
+
+```typescript
+interface CleanLitePsLocals {
+  // Entity identity
+  entityName: string;           // "contact"
+  entityNamePascal: string;     // "Contact"
+  entityNamePlural: string;     // "contacts"
+  entityNamePluralPascal: string; // "Contacts"
+
+  // Family
+  family: 'crm-synced' | 'activity' | 'knowledge' | 'metadata' | 'base';
+
+  // Base class names (derived from family)
+  repositoryBaseClass: string;  // "CrmEntityRepository"
+  serviceBaseClass: string;     // "CrmEntityService"
+
+  // Import paths for base classes
+  repositoryBaseImport: string; // "@shared/base-classes/crm-entity-repository"
+  serviceBaseImport: string;    // "@shared/base-classes/crm-entity-service"
+
+  // Output paths (all relative to project root)
+  outputPaths: {
+    entity: string;             // "modules/contacts/contact.entity.ts"
+    repository: string;         // "modules/contacts/contact.repository.ts"
+    service: string;            // "modules/contacts/contact.service.ts"
+    controller: string;         // "modules/contacts/contact.controller.ts"
+    module: string;             // "modules/contacts/contacts.module.ts"
+    findByIdUseCase: string;    // "modules/contacts/use-cases/find-contact-by-id.use-case.ts"
+    listUseCase: string;        // "modules/contacts/use-cases/list-contacts.use-case.ts"
+    createDto: string;          // "modules/contacts/dto/create-contact.dto.ts"
+    updateDto: string;          // "modules/contacts/dto/update-contact.dto.ts"
+    outputDto: string;          // "modules/contacts/dto/contact-output.dto.ts"
+  };
+
+  // Class names
+  classNames: {
+    entity: string;             // "Contact"
+    entityTable: string;        // "contacts" (Drizzle table variable)
+    repository: string;         // "ContactRepository"
+    service: string;            // "ContactService"
+    controller: string;         // "ContactController"
+    module: string;             // "ContactsModule"
+    findByIdUseCase: string;    // "FindContactByIdUseCase"
+    listUseCase: string;        // "ListContactsUseCase"
+    createDto: string;          // "CreateContactDto"
+    updateDto: string;          // "UpdateContactDto"
+    outputDto: string;          // "ContactOutputDto"
+    createSchema: string;       // "CreateContactSchema"
+    updateSchema: string;       // "UpdateContactSchema"
+    outputSchema: string;       // "ContactOutputSchema"
+  };
+
+  // Fields (processed for template use)
+  processedFields: ProcessedField[];
+
+  // Relationships (for FK columns and relations block)
+  belongsTo: BelongsToRelation[];  // generates FK columns + relations()
+
+  // Behaviors (from existing behavior registry)
+  behaviorFields: BehaviorField[];
+  hasTimestamps: boolean;
+  hasSoftDelete: boolean;
+}
+
+interface ProcessedField {
+  name: string;           // "first_name" (snake_case)
+  camelName: string;      // "firstName"
+  drizzleType: string;    // "text"
+  zodType: string;        // "z.string().min(1)"
+  tsType: string;         // "string"
+  nullable: boolean;
+  required: boolean;      // !nullable && no default
+  hasDefault: boolean;
+  isPrimaryKey: boolean;
+  drizzleChain: string;   // full drizzle column definition e.g. text('first_name').notNull()
+}
+
+interface BelongsToRelation {
+  field: string;          // "account_id"
+  camelField: string;     // "accountId"
+  relatedEntity: string;  // "account"
+  relatedEntityPascal: string; // "Account"
+  relatedTable: string;   // "accounts"
+  relatedPlural: string;  // "accounts"
+  nullable: boolean;
+  importPath: string;     // "../accounts/account.entity"
+}
+```
+
+### Family → Base Class Mapping
+
+| Family YAML value | Repository base | Service base | Import path prefix |
+|-------------------|----------------|--------------|-------------------|
+| `crm-synced` | `CrmEntityRepository` | `CrmEntityService` | `@shared/base-classes/crm-entity-*` |
+| `activity` | `ActivityEntityRepository` | `ActivityEntityService` | `@shared/base-classes/activity-entity-*` |
+| `knowledge` | `KnowledgeEntityRepository` | `KnowledgeEntityService` | `@shared/base-classes/knowledge-entity-*` |
+| `metadata` | `MetadataEntityRepository` | `MetadataEntityService` | `@shared/base-classes/metadata-entity-*` |
+| `base` (default) | `BaseRepository` | `BaseService` | `@shared/base-classes/base-*` |
+
+When no `family` key is present in the entity YAML, default to `base`.
+
+---
+
+## Template Specifications
+
+### 1. `entity.ejs.t`
+
+**Output path:** `modules/<plural>/<entity>.entity.ts`
+
+**Hygen header:**
+```
+---
+to: modules/<%= entityNamePlural %>/<%= entityName %>.entity.ts
+force: true
+---
+```
+
+**Content structure:**
+
+```typescript
+import { pgTable, uuid, /* field-derived imports */ } from 'drizzle-orm/pg-core';
+import { relations, type InferSelectModel } from 'drizzle-orm';
+// One import per belongs_to relation:
+// import { <relatedTable> } from '../<relatedPlural>/<relatedEntity>.entity';
+
+export const <%= entityNamePlural %> = pgTable(
+  '<%= entityNamePlural %>',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // FK columns from belongs_to relationships:
+    // <camelField>: uuid('<field>')[.notNull()][.references(() => <relatedTable>.id)],
+    // Regular fields from processedFields:
+    // <camelName>: <drizzleChain>,
+    // Behavior fields appended last (created_at, updated_at, deleted_at, etc.)
+  },
+);
+
+// Only emitted when belongs_to relations exist:
+export const <%= entityNamePlural %>Relations = relations(<%= entityNamePlural %>, ({ one }) => ({
+  // one per belongs_to:
+  // <relatedEntity>: one(<relatedTable>, { fields: [<%= entityNamePlural %>.<camelField>], references: [<relatedTable>.id] }),
+}));
+
+export type <%= classNames.entity %> = InferSelectModel<typeof <%= entityNamePlural %>>;
+export type <%= classNames.entity %>Insert = typeof <%= entityNamePlural %>.$inferInsert;
+```
+
+**Field → Drizzle type mapping** (same mapping used in existing `schema.ejs.t`):
+
+| YAML type | Drizzle function | Chain modifiers |
+|-----------|-----------------|-----------------|
+| `string` | `text` | `.notNull()` if required |
+| `uuid` | `uuid` | `.notNull()` if required, `.references()` if FK |
+| `integer` | `integer` | `.notNull()` if required |
+| `decimal` | `numeric` | `.notNull()` if required |
+| `boolean` | `boolean` | `.notNull()` if required, `.default(val)` if has default |
+| `date` | `date` | `.notNull()` if required |
+| `datetime` | `timestamp` | `.notNull()` if required, `.defaultNow()` for timestamps |
+| `json` | `jsonb` | `.notNull()` if required |
+
+Drizzle imports are collected from all used types and listed at the top of the file.
+
+---
+
+### 2. `repository.ejs.t`
+
+**Output path:** `modules/<plural>/<entity>.repository.ts`
+
+**Content structure:**
+
+```typescript
+import { Injectable, Inject } from '@nestjs/common';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
+import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
+import { <%= entityNamePlural %>, type <%= classNames.entity %> } from './<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%= classNames.entity %>> {
+  readonly table = <%= entityNamePlural %>;
+
+  constructor(@Inject(DRIZZLE) db: DrizzleClient) {
+    super(db);
+  }
+
+  // TODO: Add entity-specific query methods here.
+  // Inherited from <%= repositoryBaseClass %>:
+  //   findById, findByIds, list, count, exists, create, update, delete, upsertMany
+  // [family-specific inherited methods listed as comments per family]
+}
+```
+
+**Family-specific inherited method comments:**
+
+- `crm-synced`: also lists `findByExternalId, findAllByUserId, findVisibleByUserId, syncUpsert`
+- `activity`: also lists `findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId`
+- `knowledge`: also lists `semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch`
+- `metadata`: also lists `findByEntityIdAndType, listByEntityId, listHistoryByEntityId`
+
+---
+
+### 3. `service.ejs.t`
+
+**Output path:** `modules/<plural>/<entity>.service.ts`
+
+**Content structure:**
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/base-analytics-service';
+import { <%= serviceBaseClass %> } from '<%= serviceBaseImport %>';
+import { <%= classNames.repository %> } from './<%= entityName %>.repository';
+import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.service %> extends WithAnalytics(
+  <%= serviceBaseClass %><<%= classNames.repository %>, <%= classNames.entity %>>,
+) {
+  constructor(protected readonly repository: <%= classNames.repository %>) {
+    super();
+  }
+
+  // TODO: Add entity-specific domain methods here.
+  // Services contain pure data operations only (ADR-003).
+  // Do NOT emit events, enqueue jobs, or call external systems from service methods.
+  //
+  // Inherited from <%= serviceBaseClass %>:
+  //   findById, findByIds, list, count, exists, create, update, delete
+  // [family-specific inherited methods listed as comments]
+}
+```
+
+No side effects are emitted in the skeleton. The comment block cites ADR-003 to guide hand-written additions.
+
+---
+
+### 4. `use-cases/find-by-id.ejs.t`
+
+**Output path:** `modules/<plural>/use-cases/find-<entity>-by-id.use-case.ts`
+
+**Content structure:**
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.findByIdUseCase %> {
+  constructor(private readonly service: <%= classNames.service %>) {}
+
+  async execute(id: string): Promise<<%= classNames.entity %> | null> {
+    return this.service.findById(id);
+  }
+}
+```
+
+This is an auto-generated read use case. It exists to satisfy the no-exceptions rule from ADR-003: controllers always call use cases, including for reads.
+
+---
+
+### 5. `use-cases/list.ejs.t`
+
+**Output path:** `modules/<plural>/use-cases/list-<plural>.use-case.ts`
+
+**Content structure:**
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.listUseCase %> {
+  constructor(private readonly service: <%= classNames.service %>) {}
+
+  async execute(): Promise<<%= classNames.entity %>[]> {
+    return this.service.list();
+  }
+}
+```
+
+---
+
+### 6. `controller.ejs.t`
+
+**Output path:** `modules/<plural>/<entity>.controller.ts`
+
+**Content structure:**
+
+```typescript
+import { Controller, Get, Post, Put, Delete, Param, Body } from '@nestjs/common';
+import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
+import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
+import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
+// Write use cases must be hand-written. Import them here when ready.
+
+@Controller('<%= entityNamePlural %>')
+export class <%= classNames.controller %> {
+  constructor(
+    // All routes go through use cases (ADR-003 — no controller → service shortcuts)
+    private readonly findById: <%= classNames.findByIdUseCase %>,
+    private readonly list: <%= classNames.listUseCase %>,
+    // TODO: inject hand-written write use cases here
+  ) {}
+
+  @Get()
+  async getAll(): Promise<<%= classNames.entity %>[]> {
+    return this.list.execute();
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string): Promise<<%= classNames.entity %> | null> {
+    return this.findById.execute(id);
+  }
+
+  // TODO: Add write routes. Each must call a hand-written use case, not the service.
+  // Example:
+  // @Post()
+  // async create(@Body() dto: Create<%= classNames.entity %>Dto): Promise<<%= classNames.entity %>> {
+  //   return this.createUseCase.execute(dto);
+  // }
+}
+```
+
+**Constraint:** The controller MUST NOT import any `*.repository.ts` file. Controllers import only `*.use-case.ts` files. This is enforced by the comment structure and will be verified by ESLint rules (file-pattern import restriction on `modules/` code).
+
+---
+
+### 7. `module.ejs.t`
+
+**Output path:** `modules/<plural>/<plural>.module.ts`
+
+**Content structure:**
+
+```typescript
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@shared/database/database.module';
+// Cross-domain module imports (one per belongs_to relationship):
+// import { <%= RelatedPluralModule %> } from '../<relatedPlural>/<relatedPlural>.module';
+
+import { <%= classNames.repository %> } from './<%= entityName %>.repository';
+import { <%= classNames.service %> } from './<%= entityName %>.service';
+import { <%= classNames.controller %> } from './<%= entityName %>.controller';
+import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
+import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
+
+@Module({
+  imports: [
+    DatabaseModule,
+    // TODO: Add subsystem modules as needed (EventsSubsystemModule, IntegrationsSubsystemModule, etc.)
+    // Cross-domain modules from relationships:
+    // <%= RelatedPluralModule %>,
+  ],
+  controllers: [<%= classNames.controller %>],
+  providers: [
+    <%= classNames.repository %>,
+    <%= classNames.service %>,
+    <%= classNames.findByIdUseCase %>,
+    <%= classNames.listUseCase %>,
+    // TODO: Register hand-written use cases here
+  ],
+  exports: [<%= classNames.service %>],  // Only service is exported (ADR-002)
+})
+export class <%= classNames.module %> {}
+```
+
+Per ADR-002, only the service is exported. Repositories and use cases are internal implementation details.
+
+---
+
+### 8. `dto/create.ejs.t`
+
+**Output path:** `modules/<plural>/dto/create-<entity>.dto.ts`
+
+**Content structure:**
+
+```typescript
+import { z } from 'zod';
+
+export const <%= classNames.createSchema %> = z.object({
+  // Fields from processedFields (excluding id, and behavior-managed fields):
+  // Required string field:   fieldName: z.string().min(1),
+  // Optional string field:   fieldName: z.string().optional(),
+  // Nullable string field:   fieldName: z.string().nullable(),
+  // Required UUID FK field:  fieldName: z.string().uuid(),
+  // Optional UUID FK field:  fieldName: z.string().uuid().optional(),
+  // Boolean with default:    fieldName: z.boolean().default(false),
+  // Integer:                 fieldName: z.number().int(),
+  // Decimal:                 fieldName: z.number(),
+  // Date:                    fieldName: z.coerce.date(),
+  // DateTime:                fieldName: z.coerce.date(),
+  // JSON:                    fieldName: z.record(z.unknown()).optional(),
+  // Enum (has choices):      fieldName: z.enum(['val1', 'val2']),
+});
+
+export type <%= classNames.createDto %> = z.infer<typeof <%= classNames.createSchema %>>;
+```
+
+**Field inclusion rules for create DTO:**
+- Exclude `id` (auto-generated)
+- Exclude behavior-managed fields: `created_at`, `updated_at`, `deleted_at`, `created_by`, `updated_by`, `valid_from`, `valid_to`, `is_active`
+- Include all FK fields from `belongs_to` relationships (as `z.string().uuid()`)
+- Include all explicit entity fields
+
+**Zod type derivation:**
+
+| YAML type | Zod chain | Nullable modifier | Optional modifier |
+|-----------|-----------|-------------------|-------------------|
+| `string` | `z.string()` | `.nullable()` | `.optional()` |
+| `uuid` | `z.string().uuid()` | `.nullable()` | `.optional()` |
+| `integer` | `z.number().int()` | `.nullable()` | `.optional()` |
+| `decimal` | `z.number()` | `.nullable()` | `.optional()` |
+| `boolean` | `z.boolean()` | — | `.optional()` |
+| `date` | `z.coerce.date()` | `.nullable()` | `.optional()` |
+| `datetime` | `z.coerce.date()` | `.nullable()` | `.optional()` |
+| `json` | `z.record(z.unknown())` | `.nullable()` | `.optional()` |
+
+When a field has `choices`, use `z.enum([...])` regardless of base type.
+
+---
+
+### 9. `dto/update.ejs.t`
+
+**Output path:** `modules/<plural>/dto/update-<entity>.dto.ts`
+
+**Content structure:**
+
+```typescript
+import { z } from 'zod';
+import { <%= classNames.createSchema %> } from './create-<%= entityName %>.dto';
+
+export const <%= classNames.updateSchema %> = <%= classNames.createSchema %>.partial();
+
+export type <%= classNames.updateDto %> = z.infer<typeof <%= classNames.updateSchema %>>;
+```
+
+This is a strict one-liner using Zod's `.partial()`. No field-by-field redeclaration.
+
+---
+
+### 10. `dto/output.ejs.t`
+
+**Output path:** `modules/<plural>/dto/<entity>-output.dto.ts`
+
+**Content structure:**
+
+```typescript
+import { z } from 'zod';
+
+export const <%= classNames.outputSchema %> = z.object({
+  id: z.string().uuid(),
+  // All entity fields including nullable ones:
+  // FK fields from belongs_to:  fieldName: z.string().uuid().nullable(),
+  // All processedFields using same Zod mapping as create, but nullable allowed
+  // Behavior timestamp fields:
+  // createdAt: z.coerce.date(),
+  // updatedAt: z.coerce.date(),
+  // deletedAt: z.coerce.date().nullable(),  (if soft_delete)
+});
+
+export type <%= classNames.outputDto %> = z.infer<typeof <%= classNames.outputSchema %>>;
+```
+
+**Field inclusion rules for output DTO:**
+- Include `id`
+- Include all entity fields (nullable where applicable)
+- Include all FK fields from `belongs_to`
+- Include behavior-managed fields present on the entity (`created_at` → `createdAt`, `updated_at` → `updatedAt`, `deleted_at` → `deletedAt`)
+
+---
+
+## Implementation Steps
+
+### Step 1 — Build the `prompt-extension.js` locals derivation
+
+Create `templates/entity/new/clean-lite-ps/prompt-extension.js` that exports a function `buildCleanLitePsLocals(definition, baseLocals)`. This function:
+
+1. Reads `entity.family` from the YAML definition (defaulting to `'base'` if absent)
+2. Maps family to base class names using the family mapping table above
+3. Derives all output paths using the pattern `modules/<plural>/<file>`
+4. Derives all class names using `pascalCase` of entity name
+5. Processes fields into `ProcessedField[]` shape
+6. Processes `relationships.belongs_to` entries into `BelongsToRelation[]` shape
+7. Returns a merged locals object
+
+The existing `prompt.js` invokes this function when `generate.cleanLitePs: true` is set in `codegen.config.yaml` and merges the result into the Hygen locals before returning.
+
+### Step 2 — Create the entity template
+
+Implement `entity.ejs.t`. Verify:
+- Drizzle imports are collected from field types and behavior types
+- FK columns appear before entity fields
+- `relations()` block is omitted when there are no `belongs_to` entries
+- `$inferInsert` type is always emitted
+
+### Step 3 — Create the repository template
+
+Implement `repository.ejs.t`. Verify:
+- Extends the correct family base class
+- `readonly table` is assigned
+- Constructor uses `@Inject(DRIZZLE)` token
+- Inherited method comment block lists family-specific methods
+
+### Step 4 — Create the service template
+
+Implement `service.ejs.t`. Verify:
+- Extends `WithAnalytics(FamilyEntityService<Repo, Entity>)` with correct generic parameters
+- Constructor uses `protected readonly`
+- ADR-003 comment is present
+
+### Step 5 — Create the two read use case templates
+
+Implement `use-cases/find-by-id.ejs.t` and `use-cases/list.ejs.t`. Both are thin pass-throughs.
+
+### Step 6 — Create the controller template
+
+Implement `controller.ejs.t`. Verify:
+- No repository imports present
+- Only use-case classes injected in constructor
+- Write route stubs are comments, not live code
+
+### Step 7 — Create the module template
+
+Implement `module.ejs.t`. Verify:
+- `exports` array contains only the service
+- Cross-domain module import stubs appear as comments
+- All providers (repo, service, two read use cases) are registered
+
+### Step 8 — Create the three DTO templates
+
+Implement `dto/create.ejs.t`, `dto/update.ejs.t`, `dto/output.ejs.t`. Verify:
+- Create excludes id and behavior-managed fields
+- Update uses `.partial()` delegation
+- Output includes id and timestamp behavior fields
+
+### Step 9 — Wire into `prompt.js`
+
+Add `cleanLitePs` guard to existing `prompt.js`:
+
+```javascript
+const cleanLitePs = projectConfig?.generate?.cleanLitePs ?? false;
+if (cleanLitePs) {
+  const { buildCleanLitePsLocals } = await import('./clean-lite-ps/prompt-extension.js');
+  Object.assign(locals, buildCleanLitePsLocals(definition, locals));
+}
+```
+
+When `cleanLitePs` is false, clean-lite-ps templates emit nothing (Hygen `to:` resolves to empty string or a no-op path).
+
+---
+
+## Testing Strategy
+
+### Unit Tests — `prompt-extension.js`
+
+File: `test/clean-lite-ps/prompt-extension.test.ts`
+
+```typescript
+describe('buildCleanLitePsLocals', () => {
+  it('derives correct class names from entity name', () => {});
+  it('maps crm-synced family to CrmEntityRepository and CrmEntityService', () => {});
+  it('maps activity family to ActivityEntityRepository and ActivityEntityService', () => {});
+  it('defaults to base family when family key is absent', () => {});
+  it('generates correct output paths for entity with plural name', () => {});
+  it('processes belongs_to relations into BelongsToRelation shape', () => {});
+  it('excludes id and behavior fields from create DTO field list', () => {});
+  it('includes all fields including id in output DTO field list', () => {});
+  it('derives nullable correctly for fields with nullable: true', () => {});
+});
+```
+
+### Baseline Test — Contact entity
+
+Add `test/fixtures/contact-v2.yaml` with the Contact entity definition matching the sketch:
+
+```yaml
+entity:
+  name: contact
+  family: crm-synced
+
+fields:
+  first_name:
+    type: string
+    required: true
+  last_name:
+    type: string
+    required: true
+  email:
+    type: string
+    required: true
+  title:
+    type: string
+    nullable: true
+  phone:
+    type: string
+    nullable: true
+  linkedin_url:
+    type: string
+    nullable: true
+
+relationships:
+  belongs_to:
+    - entity: account
+      field: account_id
+      nullable: true
+    - entity: user
+      field: user_id
+      nullable: false
+
+behaviors:
+  - timestamps
+```
+
+Run `bun codegen entity entities/contact-v2.yaml` with `generate.cleanLitePs: true` and capture as baseline:
+
+```bash
+bun test/run-test.ts baseline
+```
+
+Verify baseline output matches the structure from the contact-module-sketch:
+- `modules/contacts/contact.entity.ts` — table, relations, two type exports
+- `modules/contacts/contact.repository.ts` — extends CrmEntityRepository
+- `modules/contacts/contact.service.ts` — extends WithAnalytics(CrmEntityService)
+- `modules/contacts/contact.controller.ts` — no repository imports
+- `modules/contacts/contacts.module.ts` — exports ContactService only
+- `modules/contacts/use-cases/find-contact-by-id.use-case.ts`
+- `modules/contacts/use-cases/list-contacts.use-case.ts`
+- `modules/contacts/dto/create-contact.dto.ts`
+- `modules/contacts/dto/update-contact.dto.ts`
+- `modules/contacts/dto/contact-output.dto.ts`
+
+### TypeScript Compilation Check
+
+The generated Contact module must pass:
+
+```bash
+cd <target-project>
+bun tsc --noEmit
+```
+
+This validates that all imports resolve and types are correct. The check requires the `@shared/base-classes/*` paths to exist or be mocked with `paths` in `tsconfig.json`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 11 template files exist under `templates/entity/new/clean-lite-ps/`
+- [ ] Running `bun codegen entity entities/contact-v2.yaml` with `generate.cleanLitePs: true` produces exactly the 10 output files listed in the baseline test
+- [ ] Generated Contact module directory structure matches `docs/architecture/sketches/contact-module-sketch.md`
+- [ ] `contact.controller.ts` contains zero imports of `*.repository.ts` files
+- [ ] `contacts.module.ts` exports array contains only `ContactService`
+- [ ] `contact.service.ts` class declaration uses `WithAnalytics(CrmEntityService<...>)` pattern
+- [ ] `contact.entity.ts` exports both `Contact` (InferSelectModel) and `ContactInsert` ($inferInsert)
+- [ ] `update-contact.dto.ts` uses `createSchema.partial()` and does not redeclare fields
+- [ ] All unit tests in `test/clean-lite-ps/prompt-extension.test.ts` pass
+- [ ] Baseline comparison passes: `bun test/run-test.ts compare`
+- [ ] When `generate.cleanLitePs: false` (or absent), no clean-lite-ps files are emitted
+
+---
+
+## Constraints
+
+- Do not modify any existing template under `templates/entity/new/backend/` or `templates/entity/new/frontend/`
+- Do not modify `prompt.js` beyond the minimal guard block described in Step 9
+- Family base class import paths use the `@shared/base-classes/` alias convention; do not hardcode relative paths into the templates
+- Use the same `behaviorRegistry` field type mapping already present in `prompt.js` — do not duplicate the registry

--- a/.claude/specs/a7-wiring-templates.md
+++ b/.claude/specs/a7-wiring-templates.md
@@ -1,0 +1,365 @@
+# Spec A7 — Wiring Templates
+
+**Status:** Approved for implementation
+**Issue:** A7
+**Depends on:** A6 (clean-lite-ps template set)
+**Related ADRs:** ADR-002, ADR-003
+**Reference output:** `docs/architecture/sketches/contact-module-sketch.md`
+
+---
+
+## Overview
+
+Three additional templates that wire generated modules into the running NestJS application. These templates handle:
+
+1. Injecting the new module's import statement into `app.module.ts`
+2. Injecting the new module into AppModule's `imports` array
+3. Generating a barrel `index.ts` per module that exports only public symbols
+
+Like A6, all templates are guarded by `generate.cleanLitePs: true`. When the flag is absent or false, every template emits nothing.
+
+---
+
+## Files to Create
+
+| File | Action | Description |
+|------|--------|-------------|
+| `templates/entity/new/clean-lite-ps/_inject-app-module-import.ejs.t` | create | Injects import statement into app.module.ts |
+| `templates/entity/new/clean-lite-ps/_inject-app-module-array.ejs.t` | create | Injects module into AppModule imports array |
+| `templates/entity/new/clean-lite-ps/index.ejs.t` | create | Barrel exports for module public surface |
+
+No existing files are modified by this spec beyond the two injection targets in `app.module.ts` (which are modified at generation time, not at implementation time).
+
+---
+
+## Interface Definitions
+
+All locals from A6's `CleanLitePsLocals` are available. The following additional locals are needed:
+
+```typescript
+interface WiringLocals {
+  // Derived from entityNamePluralPascal
+  moduleName: string;         // "ContactsModule"
+  moduleImportPath: string;   // "./modules/contacts/contacts.module"
+
+  // Path to the target app module file (from config or convention)
+  appModulePath: string;      // "src/app.module.ts" (configurable)
+
+  // Cross-domain imports from belongs_to relationships
+  // (same BelongsToRelation[] from A6, used to derive cross-module imports in index)
+  belongsTo: BelongsToRelation[];
+
+  // Class names mirror A6 classNames
+  classNames: CleanLitePsLocals['classNames'];
+}
+```
+
+The `appModulePath` is read from `codegen.config.yaml` under `paths.app_module`, defaulting to `src/app.module.ts`.
+
+---
+
+## Template Specifications
+
+### 1. `_inject-app-module-import.ejs.t`
+
+**Purpose:** Injects the module import statement into `app.module.ts` after a marker comment.
+
+**Hygen header:**
+
+```
+---
+to: <%= appModulePath %>
+inject: true
+skip_if: "from './<%= moduleImportPath %>'"
+after: "// Codegen module imports"
+---
+import { <%= moduleName %> } from './<%= moduleImportPath %>';
+```
+
+**Marker convention:** `app.module.ts` must contain the line `// Codegen module imports` as the injection anchor. The `skip_if` guard prevents duplicate injection if the module is already imported.
+
+**Example `app.module.ts` setup required before first codegen run:**
+
+```typescript
+import { Module } from '@nestjs/common';
+// Codegen module imports
+
+@Module({
+  imports: [
+    // Codegen modules
+  ],
+})
+export class AppModule {}
+```
+
+**Resulting file after generating contacts:**
+
+```typescript
+import { Module } from '@nestjs/common';
+// Codegen module imports
+import { ContactsModule } from './modules/contacts/contacts.module';
+
+@Module({
+  imports: [
+    // Codegen modules
+    ContactsModule,
+  ],
+})
+export class AppModule {}
+```
+
+**Constraints:**
+- `skip_if` must match a substring present in the injected line — use the import path fragment, not the full line
+- The anchor comment `// Codegen module imports` must be on its own line in the target file
+- Hygen's `after:` places injection on the line immediately following the anchor
+
+---
+
+### 2. `_inject-app-module-array.ejs.t`
+
+**Purpose:** Injects the module class name into AppModule's `imports` array.
+
+**Hygen header:**
+
+```
+---
+to: <%= appModulePath %>
+inject: true
+skip_if: "<%= moduleName %>,"
+after: "// Codegen modules"
+---
+    <%= moduleName %>,
+```
+
+**Marker convention:** AppModule's `imports` array must contain `// Codegen modules` as a line within the array body. The four-space indent on the injected line matches standard NestJS formatting.
+
+**Constraints:**
+- `skip_if` checks for `<ModuleName>,` to prevent duplicate array entries
+- The anchor comment `// Codegen modules` must be inside the `imports: [...]` array body
+- Both this template and `_inject-app-module-import.ejs.t` target the same file; Hygen processes them sequentially
+
+---
+
+### 3. `index.ejs.t`
+
+**Output path:** `modules/<plural>/index.ts`
+
+**Hygen header:**
+
+```
+---
+to: modules/<%= entityNamePlural %>/index.ts
+force: true
+---
+```
+
+**Content structure:**
+
+```typescript
+// Public surface for the <%= entityNamePluralPascal %> module.
+// Internal details (repository, use cases) are not exported — consumers depend on the service only.
+
+export { <%= classNames.module %> } from './<%= entityNamePlural %>.module';
+export { <%= classNames.service %> } from './<%= entityName %>.service';
+export { <%= classNames.controller %> } from './<%= entityName %>.controller';
+
+// Type-only exports — no runtime dependency on entity or DTO implementations
+export type { <%= classNames.entity %>, <%= classNames.entity %>Insert } from './<%= entityName %>.entity';
+export type { <%= classNames.createDto %> } from './dto/create-<%= entityName %>.dto';
+export type { <%= classNames.updateDto %> } from './dto/update-<%= entityName %>.dto';
+export type { <%= classNames.outputDto %> } from './dto/<%= entityName %>-output.dto';
+```
+
+**Export rules (per ADR-002):**
+
+| Symbol | Exported | Export style |
+|--------|----------|-------------|
+| `<Entity>Module` | Yes | value export |
+| `<Entity>Service` | Yes | value export |
+| `<Entity>Controller` | Yes | value export |
+| `<Entity>` type | Yes | `export type` only |
+| `<Entity>Insert` type | Yes | `export type` only |
+| `Create<Entity>Dto` type | Yes | `export type` only |
+| `Update<Entity>Dto` type | Yes | `export type` only |
+| `<Entity>OutputDto` type | Yes | `export type` only |
+| `<Entity>Repository` | No | internal — not exported |
+| `Find<Entity>ByIdUseCase` | No | internal — not exported |
+| `List<Entities>UseCase` | No | internal — not exported |
+
+The repository is an internal implementation detail. Use cases are internal to the module and not part of the cross-domain public API. Other domain modules that need to trigger behavior compose through the service (reads) or via their own use case calling this module's service. They never import this module's use cases directly.
+
+---
+
+## Cross-Domain Import Logic
+
+For entities that have `belongs_to` relationships, the generated module needs to import the related entity's NestJS module. This is handled in A6's `module.ejs.t` (as commented stubs). In A7, the `index.ejs.t` does NOT re-export related module imports — those are the consuming module's concern.
+
+However, when generating a module that depends on related modules, the wiring templates must ensure the related module is importable. The path convention for cross-domain module imports is:
+
+```typescript
+// Relative path from current module's module.ts to the related module file:
+import { AccountsModule } from '../accounts/accounts.module';
+import { UsersModule } from '../users/users.module';
+```
+
+This pattern is generated in A6's `module.ejs.t`. A7's templates do not need to handle cross-domain imports — they only wire the current module into `app.module.ts`.
+
+---
+
+## Architecture Mode Guard
+
+All three templates in A7 check the `generate.cleanLitePs` flag before emitting output. The guard is implemented in the Hygen `to:` header using a conditional:
+
+```ejs
+---
+to: <%- cleanLitePs ? 'modules/' + entityNamePlural + '/index.ts' : '' %>
+force: true
+---
+```
+
+When `cleanLitePs` is false, Hygen receives an empty `to:` path. Hygen skips files with empty `to:` paths without error.
+
+The injection templates use the same guard on their `to:` path:
+
+```ejs
+---
+to: <%- cleanLitePs ? appModulePath : '' %>
+inject: true
+skip_if: ...
+after: ...
+---
+```
+
+---
+
+## `app.module.ts` Setup Requirements
+
+Before any module can be wired in, `app.module.ts` must contain both marker comments:
+
+```typescript
+import { Module } from '@nestjs/common';
+// Codegen module imports        ← injection anchor for import statements
+
+@Module({
+  imports: [
+    // Codegen modules           ← injection anchor for module array entries
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}
+```
+
+These comments are the sole coupling between the wiring templates and the host project's `AppModule`. The codegen does not parse or rewrite the module decorator — it only appends lines at the anchors.
+
+If either marker is missing, Hygen silently skips injection (the `after:` target is not found). This is acceptable behavior for projects that manage `AppModule` manually — they simply omit the markers and register modules by hand.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Create `_inject-app-module-import.ejs.t`
+
+Implement with the correct `skip_if`, `after`, `inject: true`, and guarded `to:` path. Test by running codegen against a minimal `app.module.ts` fixture that contains both markers.
+
+### Step 2 — Create `_inject-app-module-array.ejs.t`
+
+Implement in the same pattern. Verify the injected line uses consistent indentation (four spaces) matching standard NestJS formatting.
+
+### Step 3 — Create `index.ejs.t`
+
+Implement the barrel file. Pay attention to:
+- `export type` (not bare `export`) for entity and DTO types
+- Repository and use case classes must NOT appear in any export
+- Insert the module-scoping comment at the top
+
+### Step 4 — Extend `prompt-extension.js` with wiring locals
+
+Add `appModulePath`, `moduleName`, and `moduleImportPath` derivation to the `buildCleanLitePsLocals` function from A6. `moduleImportPath` must be a relative path from `appModulePath`'s directory to the module file, without `.ts` extension.
+
+### Step 5 — Verify injection idempotency
+
+Run codegen twice against the same `app.module.ts` fixture. The second run must produce identical file contents — no duplicate imports or array entries.
+
+---
+
+## Testing Strategy
+
+### Unit Tests — wiring locals derivation
+
+File: `test/clean-lite-ps/wiring-locals.test.ts`
+
+```typescript
+describe('wiring locals derivation', () => {
+  it('derives moduleImportPath as relative path from app module location', () => {});
+  it('defaults appModulePath to src/app.module.ts when not configured', () => {});
+  it('reads appModulePath from codegen.config.yaml paths.app_module', () => {});
+  it('derives moduleName as PluralPascal + Module suffix', () => {});
+});
+```
+
+### Integration Test — injection idempotency
+
+File: `test/clean-lite-ps/wiring-injection.test.ts`
+
+```typescript
+describe('app.module.ts injection', () => {
+  it('injects import statement after // Codegen module imports marker', () => {});
+  it('injects module name into imports array after // Codegen modules marker', () => {});
+  it('does not inject duplicate import when codegen runs twice', () => {});
+  it('does not inject duplicate array entry when codegen runs twice', () => {});
+  it('skips injection when // Codegen module imports marker is absent', () => {});
+});
+```
+
+Use a temporary `app.module.ts` fixture for each test. Assert file contents after each codegen run.
+
+### Baseline Test — barrel index
+
+File: `test/clean-lite-ps/index-barrel.test.ts`
+
+```typescript
+describe('index.ts barrel export', () => {
+  it('exports module, service, and controller as value exports', () => {});
+  it('exports entity and DTO types as type-only exports', () => {});
+  it('does not export repository', () => {});
+  it('does not export use cases', () => {});
+});
+```
+
+Parse the generated `modules/contacts/index.ts` from the contact-v2.yaml baseline run and assert on the export list.
+
+### Full Baseline Run
+
+After implementing all three templates, run the full baseline:
+
+```bash
+bun test/run-test.ts baseline
+```
+
+Verify the contact-v2.yaml baseline now includes `modules/contacts/index.ts` in the output.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `_inject-app-module-import.ejs.t` injects exactly one import line after `// Codegen module imports`
+- [ ] `_inject-app-module-array.ejs.t` injects exactly one array entry after `// Codegen modules`
+- [ ] Running codegen twice produces identical `app.module.ts` contents (idempotency)
+- [ ] `index.ts` barrel exports `ContactsModule`, `ContactService`, `ContactController` as value exports
+- [ ] `index.ts` barrel exports `Contact`, `ContactInsert`, `CreateContactDto`, `UpdateContactDto`, `ContactOutputDto` as `export type` (not value exports)
+- [ ] `index.ts` does NOT export `ContactRepository`, `FindContactByIdUseCase`, or `ListContactsUseCase`
+- [ ] When `generate.cleanLitePs: false`, all three templates emit no files and do not modify `app.module.ts`
+- [ ] When `app.module.ts` lacks the marker comments, injection silently skips without error
+- [ ] All unit and integration tests pass
+- [ ] Baseline comparison passes: `bun test/run-test.ts compare`
+
+---
+
+## Constraints
+
+- Do not modify any files in `templates/entity/new/backend/` or `templates/entity/new/frontend/`
+- Do not add logic to parse or rewrite the `@Module()` decorator — use marker-comment injection only
+- The `// Codegen module imports` and `// Codegen modules` marker strings are fixed — do not make them configurable (would add indirection with no benefit)
+- `moduleImportPath` in the injection templates must use forward slashes on all platforms (Hygen runs on darwin, linux, and Windows)
+- The barrel `index.ts` must use `export type` for entity and DTO types to avoid circular dependency issues at runtime and to signal intent: downstream modules must not take a runtime dependency on the DTO implementation modules

--- a/.claude/specs/a9-base-repository.md
+++ b/.claude/specs/a9-base-repository.md
@@ -1,0 +1,104 @@
+# A9: BaseRepository\<TEntity\>
+
+**Status:** Draft
+**Last Updated:** 2026-04-12
+**Depends on:** None (foundational)
+**References:** ADR-005, contact module sketch
+
+## Overview
+
+Hand-written abstract class at `shared/base-classes/base-repository.ts`. Provides standard CRUD via Drizzle ORM. Every generated repository extends this. Family-specific bases (CrmEntityRepository, etc.) extend it in v0.1 without any changes to BaseRepository.
+
+## Interface
+
+```typescript
+abstract class BaseRepository<TEntity> {
+  protected abstract readonly table: PgTableWithColumns<any>;
+  protected readonly behaviors: BehaviorConfig = {
+    timestamps: false,
+    softDelete: false,
+    userTracking: false,
+  };
+  protected readonly db: DrizzleClient;
+
+  constructor(db: DrizzleClient) { this.db = db; }
+
+  // Reads
+  findById(id: string): Promise<TEntity | null>;
+  findByIds(ids: string[]): Promise<TEntity[]>;
+  list(options?: ListOptions): Promise<TEntity[]>;
+  count(where?: SQL): Promise<number>;
+  exists(id: string): Promise<boolean>;
+
+  // Writes
+  create(input: Partial<TEntity>): Promise<TEntity>;
+  update(id: string, input: Partial<TEntity>): Promise<TEntity>;
+  delete(id: string): Promise<void>;  // soft or hard based on behaviors.softDelete
+  upsertMany(inputs: Array<Partial<TEntity>>): Promise<TEntity[]>;  // naive default, family overrides
+
+  // Protected helpers
+  protected baseQuery(): SelectBuilder;  // auto-filters soft-deleted rows
+  protected withTimestamps(input, mode: 'create'|'update'): Record<string, unknown>;
+}
+
+interface ListOptions {
+  where?: SQL;
+  limit?: number;
+  offset?: number;
+  orderBy?: Column | SQL;
+}
+
+interface BehaviorConfig {
+  timestamps: boolean;
+  softDelete: boolean;
+  userTracking: boolean;
+}
+```
+
+## Implementation Details
+
+**`baseQuery()`**: `db.select().from(table)` + `.where(isNull(table.deletedAt))` when softDelete=true.
+
+**`withTimestamps(input, mode)`**: On create: merge `{createdAt: now, updatedAt: now}`. On update: merge `{updatedAt: now}`.
+
+**`findById`**: `baseQuery().where(eq(table.id, id)).limit(1)` → first result or null.
+
+**`findByIds`**: Early return `[]` for empty array. `baseQuery().where(inArray(table.id, ids))`.
+
+**`list`**: `baseQuery()` + optional where/limit/offset/orderBy from ListOptions.
+
+**`delete`**: If softDelete: `update(table).set({deletedAt: new Date()})`. Else: `delete(table).where(eq(id))`.
+
+**`upsertMany`**: Naive default: `Promise.all(inputs.map(this.create))`. CrmEntityRepository overrides with proper conflict-target upsert in v0.1.
+
+## NestJS DI Pattern
+
+```typescript
+// BaseRepository is NOT @Injectable (abstract)
+// Concrete repos are @Injectable with DRIZZLE injection:
+@Injectable()
+export class ContactRepository extends BaseRepository<Contact> {
+  readonly table = contacts;
+  constructor(@Inject(DRIZZLE) db: DrizzleClient) { super(db); }
+}
+```
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `shared/base-classes/base-repository.ts` | create | Abstract base class |
+| `shared/base-classes/index.ts` | create | Barrel export |
+| `shared/types/drizzle.ts` | create | DrizzleClient type alias |
+| `shared/constants/tokens.ts` | create | DRIZZLE injection token |
+| `shared/base-classes/base-repository.spec.ts` | create | Tests with real Postgres |
+
+## Acceptance Criteria
+
+- [ ] `ContactRepository extends BaseRepository<Contact>` compiles
+- [ ] Inherits all 9 CRUD methods without overrides
+- [ ] `behaviors.softDelete=true`: delete sets deletedAt, list excludes soft-deleted
+- [ ] `behaviors.timestamps=true`: create sets both timestamps, update sets updatedAt
+- [ ] `CrmEntityRepository<T> extends BaseRepository<T>` can be added later without changes
+- [ ] `findByIds([])` returns `[]` without DB error
+- [ ] All tests pass against real Postgres (TestContainers)

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,13 @@ build/
 # Test output (regenerated)
 test/gen/
 
+# Codegen output (generated from entity YAML — never commit)
+gen/
+app/
+apps/
+modules/
+packages/
+
 # IDE
 .vscode/
 .idea/

--- a/analyzer/consistency-checker.ts
+++ b/analyzer/consistency-checker.ts
@@ -13,6 +13,7 @@
 
 import type { ParsedEntity, DomainGraph, AnalysisIssue } from './types';
 import { findOrphanEntities, findCircularDependencies } from './graph-builder';
+import { resolveBehaviorFields } from '../behaviors/index';
 
 /**
  * Run all consistency checks on the domain graph
@@ -27,6 +28,13 @@ export function checkConsistency(graph: DomainGraph): AnalysisIssue[] {
 		issues.push(...checkNamingConventions(entity));
 		issues.push(...checkMissingIndexes(entity));
 		issues.push(...checkUiMetadata(entity));
+		if (entity.queries !== undefined) {
+			issues.push(...checkQueryFieldReferences(entity));
+		}
+		if (entity.sync !== undefined) {
+			issues.push(...checkSyncFieldMappingReferences(entity));
+			issues.push(...checkExternalIdTrackingCollision(entity));
+		}
 	}
 
 	// Check graph-level issues
@@ -287,6 +295,117 @@ function checkMissingInverses(graph: DomainGraph): AnalysisIssue[] {
 				field: relationship.name,
 				message: `Relationship "${relationship.name}" to "${to}" has no inverse defined on target`,
 				suggestion: `Add inverse relationship on "${to}" pointing back to "${from}"`,
+			});
+		}
+	}
+
+	return issues;
+}
+
+/**
+ * Get the set of all valid field names for an entity, including behavior-added fields
+ */
+function getAvailableFieldNames(entity: ParsedEntity): string[] {
+	const entityFieldNames = Array.from(entity.fields.keys());
+	const behaviorFields = resolveBehaviorFields(entity.behaviors);
+	const behaviorFieldNames = behaviorFields.map((f) => f.name);
+	return [...new Set([...entityFieldNames, ...behaviorFieldNames])];
+}
+
+/**
+ * Check that query.by and query.select fields reference existing entity fields
+ */
+function checkQueryFieldReferences(entity: ParsedEntity): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+	const availableFields = getAvailableFieldNames(entity);
+	const availableSet = new Set(availableFields);
+
+	for (const query of entity.queries ?? []) {
+		// Skip by-field validation when via is specified — those fields come from the junction table
+		if (!query.via) {
+			for (const fieldName of query.by) {
+				if (!availableSet.has(fieldName)) {
+					issues.push({
+						severity: 'error',
+						type: 'unknown_query_field',
+						entity: entity.name,
+						field: fieldName,
+						message: `Query references unknown field "${fieldName}" in entity "${entity.name}". Available fields: ${availableFields.join(', ')}`,
+					});
+				}
+			}
+		}
+
+		for (const fieldName of query.select ?? []) {
+			if (!availableSet.has(fieldName)) {
+				issues.push({
+					severity: 'error',
+					type: 'unknown_query_field',
+					entity: entity.name,
+					field: fieldName,
+					message: `Query references unknown field "${fieldName}" in entity "${entity.name}". Available fields: ${availableFields.join(', ')}`,
+				});
+			}
+		}
+	}
+
+	return issues;
+}
+
+/**
+ * Check that sync field_mapping keys and read_only_fields reference existing entity fields
+ */
+function checkSyncFieldMappingReferences(entity: ParsedEntity): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+	const availableFields = getAvailableFieldNames(entity);
+	const availableSet = new Set(availableFields);
+
+	for (const [providerName, provider] of Object.entries(entity.sync?.providers ?? {})) {
+		for (const fieldName of Object.keys(provider.fieldMapping ?? {})) {
+			if (!availableSet.has(fieldName)) {
+				issues.push({
+					severity: 'warning',
+					type: 'unknown_sync_field_mapping',
+					entity: entity.name,
+					field: fieldName,
+					message: `Sync field mapping references unknown field "${fieldName}" for provider "${providerName}" in entity "${entity.name}"`,
+				});
+			}
+		}
+
+		for (const fieldName of provider.readOnlyFields ?? []) {
+			if (!availableSet.has(fieldName)) {
+				issues.push({
+					severity: 'warning',
+					type: 'unknown_sync_field_mapping',
+					entity: entity.name,
+					field: fieldName,
+					message: `Sync field mapping references unknown field "${fieldName}" for provider "${providerName}" in entity "${entity.name}"`,
+				});
+			}
+		}
+	}
+
+	return issues;
+}
+
+/**
+ * Check for potential collision between external_id_tracking behavior and sync field_mapping
+ */
+function checkExternalIdTrackingCollision(entity: ParsedEntity): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+
+	const hasExternalIdTracking = entity.behaviors.includes('external_id_tracking');
+	if (!hasExternalIdTracking) return issues;
+
+	for (const [providerName, provider] of Object.entries(entity.sync?.providers ?? {})) {
+		if (provider.fieldMapping && 'external_id' in provider.fieldMapping) {
+			issues.push({
+				severity: 'warning',
+				type: 'external_id_tracking_collision',
+				entity: entity.name,
+				field: 'external_id',
+				message: `Entity "${entity.name}" has external_id_tracking behavior and also maps "external_id" in sync field_mapping for provider "${providerName}". The behavior-added field may collide with the mapped field.`,
 			});
 		}
 	}

--- a/analyzer/types.ts
+++ b/analyzer/types.ts
@@ -52,14 +52,49 @@ export interface ParsedRelationship {
 	resolved: boolean;
 }
 
+export type EntityFamily = 'crm-synced' | 'activity' | 'knowledge' | 'metadata';
+
+export interface ParsedQuery {
+	by: string[];
+	unique?: boolean;
+	select?: string[];
+	order?: string;
+	limit?: boolean;
+	via?: string;
+}
+
+export interface ParsedProviderSync {
+	remoteEntity: string;
+	direction: 'inbound' | 'outbound' | 'bidirectional';
+	cdc: boolean;
+	fieldMapping?: Record<string, string>;
+	readOnlyFields?: string[];
+}
+
+export interface ParsedSync {
+	electric: boolean;
+	providers?: Record<string, ParsedProviderSync>;
+}
+
+export interface ParsedEvent {
+	name: string;
+	queue: string;
+	body: Record<string, string>;
+	generateHandler: boolean;
+}
+
 export interface ParsedEntity {
 	name: string;
 	plural: string;
 	table: string;
+	family?: EntityFamily;
 	folderStructure: 'nested' | 'flat';
 	fields: Map<string, ParsedField>;
 	relationships: Map<string, ParsedRelationship>;
 	behaviors: string[];
+	queries?: ParsedQuery[];
+	sync?: ParsedSync;
+	events?: ParsedEvent[];
 	sourcePath: string;
 }
 

--- a/behaviors/external-id-tracking.ts
+++ b/behaviors/external-id-tracking.ts
@@ -1,0 +1,71 @@
+/**
+ * External ID Tracking Behavior
+ *
+ * Adds external_id, provider, and provider_metadata fields to track
+ * records that are synced from external systems (e.g., Salesforce, HubSpot).
+ */
+
+import type { BehaviorDefinition } from './types';
+
+export const externalIdTrackingBehavior: BehaviorDefinition = {
+	name: 'external_id_tracking',
+	description: 'Adds external_id, provider, and provider_metadata fields for external system sync tracking',
+
+	fields: [
+		{
+			name: 'external_id',
+			camelName: 'externalId',
+			type: 'string',
+			tsType: 'string | null',
+			drizzleType: 'varchar',
+			drizzleImports: ['varchar', 'index'],
+			zodType: 'z.string().nullable()',
+			nullable: true,
+			ui: {
+				label: 'External ID',
+				type: 'text',
+				importance: 'tertiary',
+				group: 'metadata',
+				visible: false,
+			},
+		},
+		{
+			name: 'provider',
+			camelName: 'provider',
+			type: 'string',
+			tsType: 'string | null',
+			drizzleType: 'varchar',
+			drizzleImports: ['varchar'],
+			zodType: 'z.string().nullable()',
+			nullable: true,
+			ui: {
+				label: 'Provider',
+				type: 'text',
+				importance: 'tertiary',
+				group: 'metadata',
+				visible: false,
+			},
+		},
+		{
+			name: 'provider_metadata',
+			camelName: 'providerMetadata',
+			type: 'json',
+			tsType: 'unknown | null',
+			drizzleType: 'jsonb',
+			drizzleImports: ['jsonb'],
+			zodType: 'z.unknown().nullable()',
+			nullable: true,
+			ui: {
+				label: 'Provider Metadata',
+				type: 'json',
+				importance: 'tertiary',
+				group: 'metadata',
+				visible: false,
+			},
+		},
+	],
+
+	drizzleImports: ['varchar', 'jsonb', 'index'],
+
+	configKey: 'externalIdTracking',
+};

--- a/behaviors/index.ts
+++ b/behaviors/index.ts
@@ -7,6 +7,7 @@
  * - Resolve fields added by behaviors
  */
 
+import { externalIdTrackingBehavior } from './external-id-tracking';
 import { softDeleteBehavior } from './soft-delete';
 import { timestampsBehavior } from './timestamps';
 import type {
@@ -27,6 +28,7 @@ const behaviorRegistry = new Map<string, BehaviorDefinition>([
 	['timestamps', timestampsBehavior],
 	['soft_delete', softDeleteBehavior],
 	['user_tracking', userTrackingBehavior],
+	['external_id_tracking', externalIdTrackingBehavior],
 ]);
 
 /**
@@ -189,6 +191,7 @@ export function resolveBehaviors(configs: BehaviorConfig[]): ResolvedBehaviors {
 	const hasTimestamps = enabledNames.has('timestamps');
 	const hasSoftDelete = enabledNames.has('soft_delete');
 	const hasUserTracking = enabledNames.has('user_tracking');
+	const hasExternalIdTracking = enabledNames.has('external_id_tracking');
 
 	return {
 		configs: normalized,
@@ -204,6 +207,7 @@ export function resolveBehaviors(configs: BehaviorConfig[]): ResolvedBehaviors {
 		hasTimestamps,
 		hasSoftDelete,
 		hasUserTracking,
+		hasExternalIdTracking,
 	};
 }
 
@@ -223,3 +227,4 @@ export type {
 export { timestampsBehavior } from './timestamps';
 export { softDeleteBehavior } from './soft-delete';
 export { userTrackingBehavior } from './user-tracking';
+export { externalIdTrackingBehavior } from './external-id-tracking';

--- a/behaviors/types.ts
+++ b/behaviors/types.ts
@@ -157,4 +157,5 @@ export interface ResolvedBehaviors {
 	hasTimestamps: boolean;
 	hasSoftDelete: boolean;
 	hasUserTracking: boolean;
+	hasExternalIdTracking?: boolean;
 }

--- a/config/config-loader.ts
+++ b/config/config-loader.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared configuration loader for codegen
+ *
+ * Loads and caches codegen.config.yaml once, shared by all config modules.
+ * Validates the `pipelines` block with Zod if present; passes all other
+ * config through as-is for backward compatibility.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'yaml';
+import { PipelinesConfigSchema, type PipelinesConfig } from '../schema/pipelines-config.schema.ts';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Typed representation of the `pipelines` block.
+ * Only this block is Zod-validated; the rest of the config is untyped.
+ */
+export interface ProjectConfig {
+  pipelines?: PipelinesConfig;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Loader
+// ============================================================================
+
+/**
+ * Load project-specific codegen configuration from codegen.config.yaml.
+ * Returns null if the config file doesn't exist (falls back to defaults).
+ *
+ * If a `pipelines` block is present it is parsed and validated through
+ * PipelinesConfigSchema. A warning is printed on validation failure and
+ * the raw value is preserved so nothing else breaks.
+ */
+function loadProjectConfig(cwd = process.cwd()): ProjectConfig | null {
+  const configPath = path.resolve(cwd, 'codegen.config.yaml');
+
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    const raw = yaml.parse(content) as Record<string, unknown>;
+
+    // Validate the pipelines block if present
+    if (raw && typeof raw === 'object' && 'pipelines' in raw && raw.pipelines != null) {
+      const result = PipelinesConfigSchema.safeParse(raw.pipelines);
+      if (result.success) {
+        raw.pipelines = result.data;
+      } else {
+        console.warn(
+          `Warning: codegen.config.yaml has an invalid "pipelines" block:\n` +
+            result.error.issues
+              .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+              .join('\n')
+        );
+        // Leave raw.pipelines as-is so callers still get something
+      }
+    }
+
+    return raw as ProjectConfig;
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`Warning: Failed to load codegen.config.yaml: ${msg}`);
+    return null;
+  }
+}
+
+// Load project config once at module initialization
+export const projectConfig: ProjectConfig | null = loadProjectConfig();
+
+export default projectConfig;

--- a/config/naming-config.mjs
+++ b/config/naming-config.mjs
@@ -16,7 +16,7 @@ import {
   BackendNamingConfigSchema,
   DEFAULT_BACKEND_NAMING,
   resolveLayerNaming as resolveLayer,
-} from '../schema/naming-config.schema.ts';
+} from '../schema/naming-config.schema.mjs';
 
 // ============================================================================
 // Deep Merge Utility

--- a/config/paths.mjs
+++ b/config/paths.mjs
@@ -15,10 +15,10 @@
  */
 
 import path from 'node:path';
-import { projectConfig } from './config-loader.ts';
+import { projectConfig } from './config-loader.mjs';
 import { getNamingConfig } from './naming-config.mjs';
 import { applyCase, toPascalCase, getCaseSeparator } from './case-converters.mjs';
-import { FILE_TYPE_SUFFIXES } from '../schema/naming-config.schema.ts';
+import { FILE_TYPE_SUFFIXES } from '../schema/naming-config.schema.mjs';
 import { LOCATIONS } from './locations.mjs';
 
 // Re-export LOCATIONS for unified path + import configuration

--- a/config/paths.mjs
+++ b/config/paths.mjs
@@ -15,7 +15,7 @@
  */
 
 import path from 'node:path';
-import { projectConfig } from './config-loader.mjs';
+import { projectConfig } from './config-loader.ts';
 import { getNamingConfig } from './naming-config.mjs';
 import { applyCase, toPascalCase, getCaseSeparator } from './case-converters.mjs';
 import { FILE_TYPE_SUFFIXES } from '../schema/naming-config.schema.ts';
@@ -585,6 +585,18 @@ export function getProjectConfig() {
   return projectConfig;
 }
 
+/**
+ * Get pipelines configuration from project config.
+ * Returns the pipelines block (or an empty object if not configured).
+ *
+ * Usage:
+ *   const pipelines = getPipelinesConfig();
+ *   const arch = pipelines?.backend?.architecture ?? 'clean';
+ */
+export function getPipelinesConfig() {
+  return projectConfig?.pipelines ?? {};
+}
+
 // Default export for convenience
 export default {
   // Layout options
@@ -612,6 +624,7 @@ export default {
   getLayoutConfig,
   getDatabaseDialect,
   getProjectConfig,
+  getPipelinesConfig,
   // NEW: Config-driven naming functions
   computeFileName,
   computeFileNaming,

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,2 +1,7 @@
-- [Dealbrain v2 Initiative](project_v2_initiative.md) — Three-track rebuild: codegen evolution → backend rebuild → agent port
+- [Dealbrain v2 Initiative](project_v2_initiative.md) — Three-track rebuild: codegen evolution, backend rebuild, agent port
 - [Doug - Architect](user_doug_role.md) — Sole architect driving v2, DDD/NestJS/codegen expert, values mechanical enforcement
+- [ORM + Analytics Decisions](feedback_orm_analytics_decisions.md) — Drizzle stays, Atlas for migrations, port MetricFlow pattern to TS
+- [EOD Milestone Status](project_eod_milestone_status.md) — Issues #1-#6 complete, integration harness (31 tests), PR #21 open
+- [Active Branch/PR](project_branch_and_pr.md) — claude/eod-milestone-92a711, PR #21 closes #2-#6
+- [Codegen Testing](feedback_codegen_testing.md) — Must run actual hygen generation + `bun test:integration` against real Postgres
+- [Next Session Bootstrap](project_next_session.md) — Commit harness, merge PR #21, then v0.1 issues #7-#11

--- a/memory/feedback_codegen_testing.md
+++ b/memory/feedback_codegen_testing.md
@@ -1,0 +1,23 @@
+---
+name: Codegen testing requires actual generation
+description: Unit tests alone are insufficient — must run actual hygen codegen and integration tests against real Postgres
+type: feedback
+---
+
+Always test codegen changes by running actual generation, not just unit tests.
+
+**Why:** During EOD milestone, all 232 unit tests passed but actual `bun codegen entity` revealed three bugs:
+1. `.mjs` files importing `.ts` broke hygen (runs under Node.js, not Bun)
+2. EJS `<%= %>` HTML-encoded single quotes in generated TypeScript (`&#39;` instead of `'`)
+3. Duplicate FK fields — belongs_to loop and processedFields loop both emitted same columns
+
+None of these were caught by unit tests. They only surfaced when running hygen end-to-end.
+
+**How to apply:** After any template or prompt.js change:
+1. Run `bun codegen entity test/fixtures/opportunity.yaml` (v1 regression check)
+2. Run `bun codegen entity test/fixtures/contact-v2.yaml` (v2 generation check)
+3. Read the generated files and verify no HTML entities, no duplicates, correct imports
+4. Remember: `.mjs` files in `config/` are loaded by hygen under Node.js — they CANNOT import `.ts` files
+5. EJS code output must use `<%- %>` (unescaped), not `<%= %>` (HTML-escaped), for any variable containing quotes
+6. Run `bun test:integration` to validate generated code compiles, DI wires up, and CRUD works against real Postgres
+7. For quick iteration (DB already running): `bun test:integration:quick`

--- a/memory/feedback_orm_analytics_decisions.md
+++ b/memory/feedback_orm_analytics_decisions.md
@@ -1,0 +1,27 @@
+---
+name: ORM and Analytics Architecture Decisions
+description: Drizzle stays as ORM, Atlas for migrations, port MetricFlow pattern for analytics — decided 2026-04-12
+type: feedback
+---
+
+Stay with Drizzle ORM. Don't switch.
+
+**Why:** Drizzle's composable `sql` template literals + `groupBy` + `$with` CTEs are the right foundation for the analytics layer. Prisma's aggregation API is closed/non-composable. Kysely has no schema-as-code. TypeORM is viable but no clear win over Drizzle.
+
+**How to apply:** Generate Drizzle schemas from YAML. Use Drizzle for queries and type inference. Decouple migrations to Atlas.
+
+---
+
+Atlas replaces drizzle-kit for migrations. Fast-follow after EOD.
+
+**Why:** Atlas does Alembic-style declarative diffing, has an official Drizzle integration via `drizzle-kit export`, generates rollback SQL, and has 50+ analyzers for destructive change detection. drizzle-kit lacks rollback and destructive change detection.
+
+**How to apply:** Pipeline: YAML → codegen → Drizzle schema → `atlas migrate diff` → migration SQL. For now use drizzle-kit, swap to Atlas as first fast-follow.
+
+---
+
+Port MetricFlow definitions AND thin runtime to TypeScript, not a Python bridge.
+
+**Why:** Bridge approach has the same subprocess friction as the agent stdio bridge (Track C is killing that pattern). The four metric types Doug uses (Simple, Derived, Ratio, Cumulative) each map to a bounded Drizzle query builder pattern. ~300-400 lines of TS runtime, not a MetricFlow replacement.
+
+**How to apply:** Semantic definitions in `*.semantics.yaml` (SPEC-007). Runtime in `shared/base-classes/base-analytics-service.ts`. MetricQueryBuilder generates Drizzle queries from definitions. This is post-EOD work.

--- a/memory/project_branch_and_pr.md
+++ b/memory/project_branch_and_pr.md
@@ -1,0 +1,14 @@
+---
+name: Active branch and PR
+description: Current working branch and PR for the EOD milestone codegen pipeline work
+type: project
+---
+
+**Branch:** `claude/eod-milestone-92a711`
+**PR:** pattern-stack/codegen-patterns#21
+**Status:** Open, ready for review/merge as of 2026-04-12
+**Closes:** #2, #3, #4, #5, #6
+
+**Why:** This is the consolidated branch for the entire EOD milestone. All feature commits + bug fixes are here.
+
+**How to apply:** When resuming work on v0.1 issues (#7-#11), ensure PR #21 is merged first, or branch from `claude/eod-milestone-92a711`.

--- a/memory/project_eod_milestone_status.md
+++ b/memory/project_eod_milestone_status.md
@@ -1,0 +1,83 @@
+---
+name: EOD Milestone Status
+description: Status of the EOD milestone (issues #1-#6) and integration test harness, as of 2026-04-12
+type: project
+---
+
+## EOD Milestone — Completed 2026-04-12
+
+PR #21 (`claude/eod-milestone-92a711`) covers issues #1-#6. All validated and passing 232 tests.
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #1 | A1: YAML schema evolution | Done (v2 blocks: family, queries, sync, events, pipelines) |
+| #2 | A5: prompt.js evolution | Done — consumes v2 fields, routes architecture target |
+| #3 | A9: BaseRepository<T> | Done — 9 CRUD methods, soft-delete, timestamps |
+| #4 | A10: BaseService + read use cases | Done — pass-through service + BaseFindByIdUseCase/BaseListUseCase |
+| #5 | A6: Clean-Lite-PS core templates | Done — 11 Hygen EJS templates under templates/entity/new/clean-lite-ps/ |
+| #6 | A15: NestJS scaffold | Done — test/scaffold/ with Docker Postgres + validate.sh |
+
+## Integration Test Harness — Added 2026-04-12
+
+31 tests against real Docker Postgres. Validates BaseRepository (all 9 methods) and full NestJS HTTP stack.
+
+### How to run
+
+```bash
+bun test:integration              # Full: docker up → codegen → schema push → tests → teardown
+bun test:integration:quick        # Quick: skip codegen + push, reuse existing Postgres state
+```
+
+**Prerequisites:** Docker running. That's it — the orchestrator handles everything else.
+
+**Manual step-by-step** (if orchestrator breaks):
+```bash
+docker compose -f test/scaffold/docker-compose.yml up -d --wait
+cat > codegen.config.yaml << 'EOF'
+generate:
+  cleanLitePs: true
+EOF
+bun codegen entity test/scaffold/contact-scaffold.yaml
+cd test/scaffold && bun install && bun run drizzle-kit push --config drizzle.config.ts && cd ../..
+bun test test/scaffold/tests/
+docker compose -f test/scaffold/docker-compose.yml down -v
+rm codegen.config.yaml
+```
+
+**Verify Postgres directly:**
+```bash
+psql postgresql://postgres:postgres@localhost:5432/scaffold_test -c '\dt'
+```
+
+### Fixes made during harness build
+- Added `family: base` to schema enum (was missing the un-specialized base case)
+- Created root `tsconfig.json` extending scaffold's — enables `@shared/*` and `@gen/*` alias resolution for generated code at `modules/`
+- Added `@nestjs/common@10`, `@nestjs/core@10`, `reflect-metadata`, `rxjs` as root devDeps for generated file import resolution
+- NestJS boot requires running from repo root: `NODE_PATH=$PWD/test/scaffold/node_modules bun run $PWD/test/scaffold/src/main.ts`
+
+### Test files
+| File | Tests | Validates |
+|------|-------|-----------|
+| `tests/repository.test.ts` | 22 | BaseRepository: create, findById, findByIds, list, count, exists, update, delete (soft), upsertMany |
+| `tests/http.test.ts` | 9 | NestJS DI wiring, controller routing, full CRUD lifecycle via supertest |
+| `tests/setup.ts` | — | DB lifecycle: connect, truncate, close |
+| `tests/helpers.ts` | — | Contact factory, unique email generation |
+| `run-integration.ts` | — | Orchestrator: Docker → codegen → push → test → teardown |
+
+## Known gaps
+
+- **FK nullable** — `processBelongsTo` doesn't cross-reference field `required` for nullable inference.
+- **Baseline test infra** — `bun test/run-test.ts full` broken by stale bunx hygen cache (pre-existing).
+
+## Next up (v0.1 milestone)
+
+Unblocked by EOD completion:
+- #7 A9+: Family repositories (blocked by #3 done, #6 done)
+- #8 A10+: Family services + WithAnalytics (blocked by #4, #7)
+- #9 A16: Atlas migrations (blocked by #5)
+- #10 A17: Declarative query codegen (blocked by #2, #5)
+- #11 A7: Wiring templates (blocked by #5)
+
+**Why:** v0.1 adds entity family specialization and the remaining template types needed for a complete codegen run.
+
+**How to apply:** Issues #7-#11 can proceed once PR #21 is merged. #7 and #9/#10/#11 are independent and can be parallelized.

--- a/memory/project_next_session.md
+++ b/memory/project_next_session.md
@@ -1,0 +1,54 @@
+---
+name: Next session bootstrap
+description: Starting context for the next work session — what's done, what to do, key commands
+type: project
+---
+
+## Where we are (as of 2026-04-12)
+
+**Branch:** `claude/eod-milestone-92a711`
+**PR:** pattern-stack/codegen-patterns#21 (open, mergeable, closes #2-#6)
+**Uncommitted work:** Integration test harness (31 tests), `family: base` schema fix, root tsconfig, NestJS devDeps
+
+## Immediate actions
+
+1. **Commit the integration harness work** — new files in `test/scaffold/tests/`, `run-integration.ts`, root `tsconfig.json`, `package.json` changes, schema fix
+2. **Push to PR #21** and merge it — everything downstream is blocked on this
+3. **Pick v0.1 issues to start**
+
+## v0.1 issues (all unblocked once PR #21 merges)
+
+| Issue | Title | Parallelizable | Notes |
+|-------|-------|---------------|-------|
+| **#7** | A9+: Family repos (Crm, Activity, Knowledge, Metadata) | Yes | Highest value — extends BaseRepository with family-specific methods. Add integration tests per family. |
+| **#8** | A10+: Family services + WithAnalytics | After #7 | Depends on family repos existing |
+| **#9** | A16: Atlas migration integration | Yes | Independent — replaces drizzle-kit push with Atlas |
+| **#10** | A17: Declarative query codegen | Yes | `queries:` YAML block → generated `findByX` methods |
+| **#11** | A7: Wiring templates | Yes | Module inject, barrel exports — NestJS module auto-wiring |
+
+**Recommended order:** #7 first (family repos extend the integration test pattern we just built), then #8 follows naturally. #9/#10/#11 can be done anytime in parallel.
+
+## Key commands
+
+```bash
+# Smoke test
+bun codegen entity test/fixtures/contact-v2.yaml
+
+# Integration tests (31 tests, real Postgres)
+bun test:integration              # Full: docker → codegen → push → test → teardown
+bun test:integration:quick        # Skip codegen, reuse running Postgres
+
+# Unit tests
+bun test scanner/orm-detector.test.ts   # Individual scanner test
+
+# Verify DB manually
+psql postgresql://postgres:postgres@localhost:5432/scaffold_test -c '\dt'
+```
+
+## Architecture context
+
+- `test/scaffold/` — NestJS app skeleton with Docker Postgres, BaseRepository/BaseService, hand-written write use cases
+- Generated code lands at `modules/contacts/` via `@gen/*` path alias
+- Root `tsconfig.json` extends scaffold's for Bun module resolution
+- `contact-scaffold.yaml` uses `family: base` (simplest tier, no specialization)
+- `contact-v2.yaml` uses `family: crm-synced` (specialized, requires CrmEntityRepository — not yet implemented, that's #7)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "codegen": "bun cli.ts",
-    "test": "bun test/run-test.ts full"
+    "test": "bun test/run-test.ts full",
+    "test:integration": "bun test/scaffold/run-integration.ts",
+    "test:integration:quick": "bun test/scaffold/run-integration.ts --skip-codegen"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",
@@ -18,7 +20,11 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@nestjs/common": "10",
+    "@nestjs/core": "10",
+    "@types/bun": "latest",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
   },
   "peerDependencies": {
     "hygen": "^6.2.11"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",
-    "yaml": "^2.3.4",
+    "drizzle-orm": "^0.45.2",
+    "yaml": "^2.8.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/parser/load-entities.ts
+++ b/parser/load-entities.ts
@@ -12,7 +12,7 @@ import {
 	type LoadResult,
 	type LoadError,
 } from '../utils/yaml-loader';
-import type { ParsedEntity, ParsedField, ParsedRelationship, AnalysisIssue } from '../analyzer/types';
+import type { ParsedEntity, ParsedEvent, ParsedField, ParsedProviderSync, ParsedQuery, ParsedRelationship, ParsedSync, AnalysisIssue } from '../analyzer/types';
 
 export interface LoadEntitiesResult {
 	entities: ParsedEntity[];
@@ -25,14 +25,25 @@ export interface LoadEntitiesResult {
 function transformToEntity(result: LoadResult): ParsedEntity {
 	const { definition, filePath } = result;
 
+	const queries: ParsedQuery[] | undefined = definition.queries?.map((q) => ({
+		by: q.by,
+		unique: q.unique,
+		select: q.select,
+		order: q.order,
+		limit: q.limit,
+		via: q.via,
+	}));
+
 	const entity: ParsedEntity = {
 		name: definition.entity.name,
 		plural: definition.entity.plural,
 		table: definition.entity.table,
+		family: definition.entity.family,
 		folderStructure: definition.entity.folder_structure ?? 'nested',
 		fields: new Map(),
 		relationships: new Map(),
-		behaviors: [],
+		behaviors: definition.behaviors.map((b) => (typeof b === 'string' ? b : b.name)),
+		queries,
 		sourcePath: filePath,
 	};
 
@@ -80,6 +91,44 @@ function transformToEntity(result: LoadResult): ParsedEntity {
 			};
 			entity.relationships.set(name, relationship);
 		}
+	}
+
+	// Parse sync configuration
+	if (definition.sync) {
+		const syncDef = definition.sync;
+		const parsedSync: ParsedSync = {
+			electric: syncDef.electric ?? false,
+		};
+
+		if (syncDef.providers) {
+			parsedSync.providers = {};
+			for (const [providerName, providerDef] of Object.entries(syncDef.providers)) {
+				const parsedProvider: ParsedProviderSync = {
+					remoteEntity: providerDef.remote_entity,
+					direction: providerDef.direction,
+					cdc: providerDef.cdc ?? false,
+				};
+				if (providerDef.field_mapping) {
+					parsedProvider.fieldMapping = providerDef.field_mapping;
+				}
+				if (providerDef.read_only_fields) {
+					parsedProvider.readOnlyFields = providerDef.read_only_fields;
+				}
+				parsedSync.providers[providerName] = parsedProvider;
+			}
+		}
+
+		entity.sync = parsedSync;
+	}
+
+	// Parse events
+	if (definition.events) {
+		entity.events = definition.events.map((ev): ParsedEvent => ({
+			name: ev.name,
+			queue: ev.queue,
+			body: ev.body,
+			generateHandler: ev.generate_handler,
+		}));
 	}
 
 	return entity;

--- a/schema/entity-definition.schema.ts
+++ b/schema/entity-definition.schema.ts
@@ -373,10 +373,108 @@ const EntityConfigSchema = z
       .array(ExposeLayerSchema)
       .optional()
       .default(["repository", "rest", "trpc"]),
+
+    // v2: Entity family classification (ADR-005)
+    // Determines which base class hierarchy the entity inherits from
+    family: z
+      .enum(["crm-synced", "activity", "knowledge", "metadata"])
+      .optional(),
   })
   .strict();
 
 export type EntityConfig = z.infer<typeof EntityConfigSchema>;
+
+// ============================================================================
+// Query Declaration
+// ============================================================================
+
+/**
+ * Query Declaration Schema - Declarative query generation (ADR-005)
+ *
+ * Each declaration generates repository + service + use case methods.
+ *
+ * Examples:
+ *   { by: ["user_id"] }
+ *   { by: ["email"], unique: true }
+ *   { by: ["account_id"], order: "created_at desc", limit: true }
+ *   { by: ["opportunity_id"], select: ["email"], via: "opportunity_contact_link" }
+ */
+const QueryDeclarationSchema = z.object({
+  by: z.array(z.string()).min(1),
+  unique: z.boolean().optional(),
+  select: z.array(z.string()).optional(),
+  order: z.string().optional(),
+  limit: z.boolean().optional(),
+  via: z.string().optional(),
+});
+
+export type QueryDeclaration = z.infer<typeof QueryDeclarationSchema>;
+
+// ============================================================================
+// Sync Configuration
+// ============================================================================
+
+/**
+ * Direction of sync with an external provider
+ */
+export const SyncDirectionSchema = z.enum([
+  'inbound',
+  'outbound',
+  'bidirectional',
+]);
+
+export type SyncDirection = z.infer<typeof SyncDirectionSchema>;
+
+/**
+ * Per-provider sync configuration
+ */
+export const ProviderSyncSchema = z.object({
+  remote_entity: z.string(),
+  direction: SyncDirectionSchema,
+  cdc: z.boolean().optional().default(false),
+  field_mapping: z.record(z.string(), z.string()).optional(),
+  read_only_fields: z.array(z.string()).optional(),
+});
+
+export type ProviderSync = z.infer<typeof ProviderSyncSchema>;
+
+/**
+ * Top-level sync block: Electric SQL + named provider configs
+ */
+export const SyncConfigSchema = z.object({
+  electric: z.boolean().optional().default(false),
+  providers: z.record(z.string(), ProviderSyncSchema).optional(),
+});
+
+export type SyncConfig = z.infer<typeof SyncConfigSchema>;
+
+// ============================================================================
+// Event Declaration
+// ============================================================================
+
+/**
+ * Event Declaration Schema - Domain event declarations (CODEGEN-EVOLUTION-PLAN Phase 2)
+ *
+ * Each declaration generates typed event classes, handlers, and queue registration.
+ *
+ * Example:
+ *   name: opportunity_stage_changed
+ *   queue: domain-events
+ *   body:
+ *     opportunity_id: uuid
+ *     old_stage: string
+ *   generate_handler: true
+ */
+const EventDeclarationSchema = z.object({
+  name: z
+    .string()
+    .regex(/^[a-z][a-z0-9_]*$/, "Event name must be snake_case"),
+  queue: z.string(),
+  body: z.record(z.string(), z.string()),
+  generate_handler: z.boolean().optional().default(false),
+});
+
+export type EventDeclaration = z.infer<typeof EventDeclarationSchema>;
 
 // ============================================================================
 // Full Entity Definition
@@ -389,6 +487,18 @@ export const EntityDefinitionSchema = z
     relationships: z.record(z.string(), RelationshipSchema).optional(),
     // Behaviors add cross-cutting concerns (timestamps, soft_delete, user_tracking, etc.)
     behaviors: z.array(BehaviorConfigSchema).optional().default([]),
+
+    // v2: Declarative query generation (ADR-005)
+    // Generates repository + service + use case methods from declarations
+    queries: z.array(QueryDeclarationSchema).optional(),
+
+    // v2: Integration sync configuration (CODEGEN-EVOLUTION-PLAN Phase 2)
+    // Electric SQL + provider sync (Salesforce, HubSpot, etc.)
+    sync: SyncConfigSchema.optional(),
+
+    // v2: Domain event declarations (CODEGEN-EVOLUTION-PLAN Phase 2)
+    // Generates typed event classes, handlers, and queue registration
+    events: z.array(EventDeclarationSchema).optional(),
   })
   .strict();
 

--- a/schema/entity-definition.schema.ts
+++ b/schema/entity-definition.schema.ts
@@ -377,7 +377,7 @@ const EntityConfigSchema = z
     // v2: Entity family classification (ADR-005)
     // Determines which base class hierarchy the entity inherits from
     family: z
-      .enum(["crm-synced", "activity", "knowledge", "metadata"])
+      .enum(["base", "crm-synced", "activity", "knowledge", "metadata"])
       .optional(),
   })
   .strict();

--- a/schema/naming-config.schema.mjs
+++ b/schema/naming-config.schema.mjs
@@ -1,0 +1,119 @@
+/**
+ * naming-config.schema.mjs
+ *
+ * Pure-JS mirror of naming-config.schema.ts for use in hygen (Node.js) context.
+ * No Zod, no TypeScript — only plain-object constants and functions.
+ *
+ * Keep in sync with naming-config.schema.ts.
+ */
+
+// ============================================================================
+// Default Configuration
+// ============================================================================
+
+export const DEFAULT_BACKEND_NAMING = {
+  fileCase: 'kebab-case',
+  suffixStyle: 'dotted',
+  entityInclusion: 'flat-only',
+  terminology: {
+    command: 'command',
+    query: 'query',
+  },
+};
+
+// ============================================================================
+// Validation (plain JS — no Zod)
+// ============================================================================
+
+const VALID_FILE_CASES = ['kebab-case', 'camelCase', 'snake_case', 'PascalCase'];
+const VALID_SUFFIX_STYLES = ['dotted', 'suffixed', 'worded'];
+const VALID_ENTITY_INCLUSIONS = ['always', 'never', 'flat-only'];
+const VALID_COMMAND_TERMS = ['command', 'use-case'];
+const VALID_QUERY_TERMS = ['query', 'use-case'];
+
+/**
+ * Validate and parse a backend naming config object.
+ * Applies defaults for missing fields.
+ * Throws on invalid values.
+ */
+export const BackendNamingConfigSchema = {
+  parse(data) {
+    const fc = data?.fileCase ?? DEFAULT_BACKEND_NAMING.fileCase;
+    const ss = data?.suffixStyle ?? DEFAULT_BACKEND_NAMING.suffixStyle;
+    const ei = data?.entityInclusion ?? DEFAULT_BACKEND_NAMING.entityInclusion;
+    const tc = data?.terminology?.command ?? DEFAULT_BACKEND_NAMING.terminology.command;
+    const tq = data?.terminology?.query ?? DEFAULT_BACKEND_NAMING.terminology.query;
+
+    if (!VALID_FILE_CASES.includes(fc)) {
+      throw new Error(`Invalid fileCase: ${fc}. Must be one of: ${VALID_FILE_CASES.join(', ')}`);
+    }
+    if (!VALID_SUFFIX_STYLES.includes(ss)) {
+      throw new Error(`Invalid suffixStyle: ${ss}. Must be one of: ${VALID_SUFFIX_STYLES.join(', ')}`);
+    }
+    if (!VALID_ENTITY_INCLUSIONS.includes(ei)) {
+      throw new Error(`Invalid entityInclusion: ${ei}. Must be one of: ${VALID_ENTITY_INCLUSIONS.join(', ')}`);
+    }
+    if (!VALID_COMMAND_TERMS.includes(tc)) {
+      throw new Error(`Invalid terminology.command: ${tc}. Must be one of: ${VALID_COMMAND_TERMS.join(', ')}`);
+    }
+    if (!VALID_QUERY_TERMS.includes(tq)) {
+      throw new Error(`Invalid terminology.query: ${tq}. Must be one of: ${VALID_QUERY_TERMS.join(', ')}`);
+    }
+
+    return {
+      fileCase: fc,
+      suffixStyle: ss,
+      entityInclusion: ei,
+      terminology: { command: tc, query: tq },
+      layers: data?.layers ?? undefined,
+    };
+  },
+};
+
+// ============================================================================
+// Resolution Helper
+// ============================================================================
+
+/**
+ * Resolve effective naming config for a specific layer.
+ * Merges layer-specific overrides with global defaults.
+ */
+export function resolveLayerNaming(config, layer) {
+  const layerConfig = config.layers?.[layer];
+  return {
+    fileCase: layerConfig?.fileCase ?? config.fileCase,
+    suffixStyle: layerConfig?.suffixStyle ?? config.suffixStyle,
+    entityInclusion: layerConfig?.entityInclusion ?? config.entityInclusion,
+    terminology: {
+      command: layerConfig?.terminology?.command ?? config.terminology.command,
+      query: layerConfig?.terminology?.query ?? config.terminology.query,
+    },
+  };
+}
+
+// ============================================================================
+// File Type Suffixes
+// ============================================================================
+
+export const FILE_TYPE_SUFFIXES = {
+  entity: { dotted: '.entity', suffixed: 'Entity', word: 'entity' },
+  repositoryInterface: {
+    dotted: '.repository.interface',
+    suffixed: 'RepositoryInterface',
+    word: 'repository-interface',
+  },
+  repository: { dotted: '.repository', suffixed: 'Repository', word: 'repository' },
+  command: { dotted: '.command', suffixed: 'Command', word: 'command' },
+  query: { dotted: '.query', suffixed: 'Query', word: 'query' },
+  dto: { dotted: '.dto', suffixed: 'Dto', word: 'dto' },
+  controller: { dotted: '.controller', suffixed: 'Controller', word: 'controller' },
+  module: { dotted: '.module', suffixed: 'Module', word: 'module' },
+  schema: { dotted: '.schema', suffixed: 'Schema', word: 'schema' },
+};
+
+export default {
+  DEFAULT_BACKEND_NAMING,
+  BackendNamingConfigSchema,
+  resolveLayerNaming,
+  FILE_TYPE_SUFFIXES,
+};

--- a/schema/pipelines-config.schema.ts
+++ b/schema/pipelines-config.schema.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+
+/**
+ * Pipelines Configuration Schema
+ *
+ * Defines which generation pipelines are enabled and how they are configured.
+ * Each pipeline controls a distinct layer of generated output:
+ * - backend: NestJS/Clean Architecture scaffolding
+ * - frontend: Electric SQL collections, hooks, type metadata
+ * - shared: Zod entity schemas in shared packages (e.g., packages/db)
+ */
+
+// ============================================================================
+// Architecture Target
+// ============================================================================
+
+/**
+ * Backend architecture pattern to generate code for
+ *
+ * - clean: Full Clean Architecture (domain + application + infrastructure + presentation)
+ * - clean-lite: Clean Architecture without repository interfaces
+ * - clean-lite-ps: Clean Architecture lite with PostgREST-style controllers
+ * - vertical-slice: Feature-sliced architecture (all layers co-located per feature)
+ */
+export const ArchitectureTargetSchema = z.enum([
+  "clean",
+  "clean-lite",
+  "clean-lite-ps",
+  "vertical-slice",
+]);
+
+export type ArchitectureTarget = z.infer<typeof ArchitectureTargetSchema>;
+
+// ============================================================================
+// Backend Pipeline
+// ============================================================================
+
+/**
+ * Backend pipeline configuration
+ *
+ * Controls NestJS / Clean Architecture code generation.
+ */
+export const BackendPipelineSchema = z.object({
+  /** Whether the backend pipeline is active */
+  enabled: z.boolean().default(true),
+  /** Architecture pattern to generate. Defaults to 'clean'. */
+  architecture: ArchitectureTargetSchema.optional().default("clean"),
+});
+
+export type BackendPipeline = z.infer<typeof BackendPipelineSchema>;
+
+// ============================================================================
+// Frontend Pipeline
+// ============================================================================
+
+/**
+ * Frontend pipeline configuration
+ *
+ * Controls Electric SQL collection, hook, and metadata generation.
+ */
+export const FrontendPipelineSchema = z.object({
+  /** Whether the frontend pipeline is active */
+  enabled: z.boolean().default(true),
+  /**
+   * Named preset that collapses the ~12 individual frontend config knobs
+   * into a single opinionated bundle. Resolved elsewhere in the codegen.
+   * Examples: 'dealbrain', 'tanstack-electric'
+   */
+  preset: z.string().optional(),
+});
+
+export type FrontendPipeline = z.infer<typeof FrontendPipelineSchema>;
+
+// ============================================================================
+// Shared Pipeline
+// ============================================================================
+
+/**
+ * Shared pipeline configuration
+ *
+ * Controls generation of Zod entity schemas in shared packages (packages/db).
+ */
+export const SharedPipelineSchema = z.object({
+  /** Whether the shared pipeline is active */
+  enabled: z.boolean().default(true),
+});
+
+export type SharedPipeline = z.infer<typeof SharedPipelineSchema>;
+
+// ============================================================================
+// Top-Level Pipelines Config
+// ============================================================================
+
+/**
+ * Complete pipelines configuration block
+ *
+ * All pipelines are optional — omitting a pipeline keeps the existing behavior
+ * (no structured pipeline config, generation driven by individual toggles).
+ *
+ * Example in codegen.config.yaml:
+ *
+ * ```yaml
+ * pipelines:
+ *   backend:
+ *     enabled: true
+ *     architecture: clean-lite-ps
+ *   frontend:
+ *     enabled: true
+ *     preset: dealbrain
+ *   shared:
+ *     enabled: true
+ * ```
+ */
+export const PipelinesConfigSchema = z.object({
+  backend: BackendPipelineSchema.optional(),
+  frontend: FrontendPipelineSchema.optional(),
+  shared: SharedPipelineSchema.optional(),
+});
+
+export type PipelinesConfig = z.infer<typeof PipelinesConfigSchema>;
+
+// ============================================================================
+// Validation Helpers
+// ============================================================================
+
+/**
+ * Parse and validate a pipelines config block.
+ * @throws ZodError if validation fails
+ */
+export function validatePipelinesConfig(data: unknown): PipelinesConfig {
+  return PipelinesConfigSchema.parse(data);
+}
+
+/**
+ * Safely validate a pipelines config block.
+ * Returns { success: true, data } or { success: false, error }.
+ */
+export function safeValidatePipelinesConfig(data: unknown): {
+  success: boolean;
+  data?: PipelinesConfig;
+  error?: z.ZodError;
+} {
+  const result = PipelinesConfigSchema.safeParse(data);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  return { success: false, error: result.error };
+}

--- a/shared/base-classes/base-read-use-cases.spec.ts
+++ b/shared/base-classes/base-read-use-cases.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Base read use cases unit tests
+ *
+ * Verifies that BaseFindByIdUseCase and BaseListUseCase delegate correctly
+ * to the injected service. These are pure delegation classes — no additional
+ * logic is expected.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import { BaseFindByIdUseCase, BaseListUseCase } from './base-read-use-cases';
+import type { IFindByIdService, IListService } from './base-read-use-cases';
+
+// ============================================================================
+// Test entity
+// ============================================================================
+
+interface TestEntity {
+  id: string;
+  name: string;
+}
+
+// ============================================================================
+// Concrete use case implementations for tests
+// ============================================================================
+
+class TestFindByIdUseCase extends BaseFindByIdUseCase<IFindByIdService<TestEntity>, TestEntity> {}
+class TestListUseCase extends BaseListUseCase<IListService<TestEntity>, TestEntity> {}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('BaseFindByIdUseCase', () => {
+  it('execute(id) delegates to service.findById(id)', async () => {
+    const entity: TestEntity = { id: 'abc', name: 'Test' };
+    const service: IFindByIdService<TestEntity> = {
+      findById: mock(async () => entity),
+    };
+    const useCase = new TestFindByIdUseCase(service);
+
+    const result = await useCase.execute('abc');
+
+    expect(result).toBe(entity);
+    expect(service.findById).toHaveBeenCalledWith('abc');
+  });
+
+  it('returns null when service.findById returns null', async () => {
+    const service: IFindByIdService<TestEntity> = {
+      findById: mock(async () => null),
+    };
+    const useCase = new TestFindByIdUseCase(service);
+
+    const result = await useCase.execute('missing');
+
+    expect(result).toBeNull();
+    expect(service.findById).toHaveBeenCalledWith('missing');
+  });
+
+  it('forwards the id argument exactly as received', async () => {
+    const service: IFindByIdService<TestEntity> = {
+      findById: mock(async () => null),
+    };
+    const useCase = new TestFindByIdUseCase(service);
+    const id = 'some-uuid-1234';
+
+    await useCase.execute(id);
+
+    expect(service.findById).toHaveBeenCalledWith(id);
+  });
+});
+
+describe('BaseListUseCase', () => {
+  it('execute() delegates to service.list()', async () => {
+    const entities: TestEntity[] = [
+      { id: '1', name: 'A' },
+      { id: '2', name: 'B' },
+    ];
+    const service: IListService<TestEntity> = {
+      list: mock(async () => entities),
+    };
+    const useCase = new TestListUseCase(service);
+
+    const result = await useCase.execute();
+
+    expect(result).toBe(entities);
+    expect(service.list).toHaveBeenCalled();
+  });
+
+  it('returns empty array when service.list returns empty array', async () => {
+    const service: IListService<TestEntity> = {
+      list: mock(async () => []),
+    };
+    const useCase = new TestListUseCase(service);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([]);
+  });
+
+  it('service.list is called with no arguments', async () => {
+    const service: IListService<TestEntity> = {
+      list: mock(async () => []),
+    };
+    const useCase = new TestListUseCase(service);
+
+    await useCase.execute();
+
+    // execute() calls list() with no arguments — callers needing filters
+    // should use a dedicated use case
+    expect(service.list).toHaveBeenCalledWith();
+  });
+});

--- a/shared/base-classes/base-read-use-cases.ts
+++ b/shared/base-classes/base-read-use-cases.ts
@@ -1,0 +1,88 @@
+/**
+ * Base read use cases
+ *
+ * Abstract base classes for auto-generated per-entity read use cases.
+ * Controllers always import use case classes — never services directly (ADR-003).
+ *
+ * Each entity gets a single generated file with two named exports:
+ *   - ContactFindByIdUseCase extends BaseFindByIdUseCase<ContactService, Contact>
+ *   - ContactListUseCase extends BaseListUseCase<ContactService, Contact>
+ *
+ * Note: @Injectable() is applied on concrete use case classes (not here),
+ * matching the pattern established by BaseRepository and BaseService.
+ */
+
+// ============================================================================
+// BaseFindByIdUseCase
+// ============================================================================
+
+/**
+ * Structural interface for any service that supports findById.
+ * Keeps base use cases decoupled from concrete service implementations.
+ */
+export interface IFindByIdService<TEntity> {
+  findById(id: string): Promise<TEntity | null>;
+}
+
+/**
+ * Base class for generated FindById use cases.
+ *
+ * Generated usage:
+ * ```typescript
+ * @Injectable()
+ * export class ContactFindByIdUseCase extends BaseFindByIdUseCase<ContactService, Contact> {
+ *   constructor(service: ContactService) { super(service); }
+ * }
+ * ```
+ */
+export abstract class BaseFindByIdUseCase<
+  TService extends IFindByIdService<TEntity>,
+  TEntity,
+> {
+  constructor(protected readonly service: TService) {}
+
+  /**
+   * Find a single entity by its primary key.
+   * Returns null if not found.
+   */
+  execute(id: string): Promise<TEntity | null> {
+    return this.service.findById(id);
+  }
+}
+
+// ============================================================================
+// BaseListUseCase
+// ============================================================================
+
+/**
+ * Structural interface for any service that supports list.
+ */
+export interface IListService<TEntity> {
+  list(options?: unknown): Promise<TEntity[]>;
+}
+
+/**
+ * Base class for generated List use cases.
+ *
+ * Generated usage:
+ * ```typescript
+ * @Injectable()
+ * export class ContactListUseCase extends BaseListUseCase<ContactService, Contact> {
+ *   constructor(service: ContactService) { super(service); }
+ * }
+ * ```
+ */
+export abstract class BaseListUseCase<
+  TService extends IListService<TEntity>,
+  TEntity,
+> {
+  constructor(protected readonly service: TService) {}
+
+  /**
+   * List all entities (no filters).
+   * Controllers that need filtered lists should use a dedicated use case.
+   */
+  execute(): Promise<TEntity[]> {
+    return this.service.list();
+  }
+}

--- a/shared/base-classes/base-repository.spec.ts
+++ b/shared/base-classes/base-repository.spec.ts
@@ -1,0 +1,310 @@
+/**
+ * BaseRepository unit tests
+ *
+ * Uses in-memory mocks for the Drizzle client since TestContainers is not
+ * configured in this repository. Behavioral correctness is verified via mock
+ * call inspection and return value assertions.
+ */
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { BaseRepository, type BehaviorConfig, type ListOptions } from './base-repository';
+import type { DrizzleClient } from '../types/drizzle';
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+
+// ============================================================================
+// Test entity and table setup
+// ============================================================================
+
+interface TestEntity {
+  id: string;
+  name: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  deletedAt?: Date | null;
+}
+
+/** Minimal table mock that mirrors what Drizzle exposes */
+function makeTable(extraColumns: Record<string, unknown> = {}) {
+  return {
+    id: { name: 'id' },
+    name: { name: 'name' },
+    createdAt: { name: 'created_at' },
+    updatedAt: { name: 'updated_at' },
+    deletedAt: { name: 'deleted_at' },
+    ...extraColumns,
+  } as unknown as PgTableWithColumns<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+// ============================================================================
+// Concrete repository for tests
+// ============================================================================
+
+class TestRepository extends BaseRepository<TestEntity> {
+  readonly table: PgTableWithColumns<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  readonly behaviors: BehaviorConfig;
+
+  constructor(
+    db: DrizzleClient,
+    table: PgTableWithColumns<any>, // eslint-disable-line @typescript-eslint/no-explicit-any
+    behaviors?: Partial<BehaviorConfig>,
+  ) {
+    super(db);
+    this.table = table;
+    this.behaviors = {
+      timestamps: false,
+      softDelete: false,
+      userTracking: false,
+      ...behaviors,
+    };
+  }
+}
+
+// ============================================================================
+// Drizzle mock builder
+// ============================================================================
+
+/**
+ * Returns a mock DB that tracks method chains and resolves to `returnValue`
+ * for any terminal await.
+ */
+function makeMockDb(returnValue: unknown = []) {
+  // Chainable query proxy — each method returns itself or a final thenable
+  const query: Record<string, unknown> & PromiseLike<unknown> = {
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(returnValue).then(resolve),
+    catch: (reject: (e: unknown) => unknown) => Promise.resolve(returnValue).catch(reject),
+    finally: (cb: () => void) => Promise.resolve(returnValue).finally(cb),
+  };
+
+  const chainMethods = [
+    'select', 'from', 'where', 'limit', 'offset', 'orderBy',
+    'insert', 'values', 'returning',
+    'update', 'set',
+    'delete',
+  ];
+  for (const m of chainMethods) {
+    query[m] = mock(() => query);
+  }
+
+  return query as unknown as DrizzleClient & typeof query;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('BaseRepository', () => {
+  describe('constructor', () => {
+    it('stores the db instance', () => {
+      const db = makeMockDb();
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      // @ts-expect-error accessing protected for test
+      expect(repo.db).toBe(db);
+    });
+
+    it('has default behaviors all false', () => {
+      const db = makeMockDb();
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      expect(repo.behaviors).toEqual({
+        timestamps: false,
+        softDelete: false,
+        userTracking: false,
+      });
+    });
+  });
+
+  describe('findByIds', () => {
+    it('returns [] immediately for empty array without hitting DB', async () => {
+      const db = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.findByIds([]);
+      expect(result).toEqual([]);
+      // select should never have been called
+      expect((db as any).select).not.toHaveBeenCalled();
+    });
+
+    it('queries the DB when ids are provided', async () => {
+      const mockRow: TestEntity = { id: 'abc', name: 'Test' };
+      const db = makeMockDb([mockRow]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.findByIds(['abc']);
+      expect(result).toEqual([mockRow]);
+      expect((db as any).select).toHaveBeenCalled();
+    });
+  });
+
+  describe('findById', () => {
+    it('returns null when no rows found', async () => {
+      const db = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.findById('missing-id');
+      expect(result).toBeNull();
+    });
+
+    it('returns first row when found', async () => {
+      const mockRow: TestEntity = { id: 'abc', name: 'Test' };
+      const db = makeMockDb([mockRow]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.findById('abc');
+      expect(result).toEqual(mockRow);
+    });
+  });
+
+  describe('exists', () => {
+    it('returns false when entity not found', async () => {
+      const db = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      expect(await repo.exists('ghost')).toBe(false);
+    });
+
+    it('returns true when entity is found', async () => {
+      const mockRow: TestEntity = { id: 'real', name: 'Real' };
+      const db = makeMockDb([mockRow]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      expect(await repo.exists('real')).toBe(true);
+    });
+  });
+
+  describe('withTimestamps (protected helper)', () => {
+    it('is a no-op when timestamps=false', () => {
+      const db = makeMockDb();
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { timestamps: false });
+      const input = { name: 'Test' };
+      // @ts-expect-error accessing protected for test
+      expect(repo.withTimestamps(input, 'create')).toEqual(input);
+    });
+
+    it('adds createdAt and updatedAt on create when timestamps=true', () => {
+      const db = makeMockDb();
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { timestamps: true });
+      const input = { name: 'Test' };
+      // @ts-expect-error accessing protected for test
+      const result = repo.withTimestamps(input, 'create');
+      expect(result.name).toBe('Test');
+      expect(result.createdAt).toBeInstanceOf(Date);
+      expect(result.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('adds only updatedAt on update when timestamps=true', () => {
+      const db = makeMockDb();
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { timestamps: true });
+      const input = { name: 'Updated' };
+      // @ts-expect-error accessing protected for test
+      const result = repo.withTimestamps(input, 'update');
+      expect(result.name).toBe('Updated');
+      expect(result.updatedAt).toBeInstanceOf(Date);
+      expect(result.createdAt).toBeUndefined();
+    });
+  });
+
+  describe('create', () => {
+    it('inserts and returns the created row', async () => {
+      const mockRow: TestEntity = { id: 'new-id', name: 'Created' };
+      const db = makeMockDb([mockRow]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.create({ name: 'Created' });
+      expect(result).toEqual(mockRow);
+      expect((db as any).insert).toHaveBeenCalled();
+    });
+
+    it('merges timestamps when behavior is enabled', async () => {
+      const mockRow: TestEntity = { id: 'ts-id', name: 'TS', createdAt: new Date(), updatedAt: new Date() };
+      const db = makeMockDb([mockRow]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { timestamps: true });
+      const result = await repo.create({ name: 'TS' });
+      expect(result).toEqual(mockRow);
+      // values() should have been called with createdAt/updatedAt merged
+      const valuesCall = (db as any).values.mock.calls[0][0] as Record<string, unknown>;
+      expect(valuesCall.createdAt).toBeInstanceOf(Date);
+      expect(valuesCall.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('update', () => {
+    it('updates the row and returns it', async () => {
+      const mockRow: TestEntity = { id: 'upd-id', name: 'Updated' };
+      const db = makeMockDb([mockRow]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.update('upd-id', { name: 'Updated' });
+      expect(result).toEqual(mockRow);
+      expect((db as any).update).toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('hard-deletes when softDelete=false', async () => {
+      const db = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { softDelete: false });
+      await repo.delete('del-id');
+      expect((db as any).delete).toHaveBeenCalled();
+      expect((db as any).update).not.toHaveBeenCalled();
+    });
+
+    it('soft-deletes (sets deletedAt) when softDelete=true', async () => {
+      const db = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { softDelete: true });
+      await repo.delete('soft-del-id');
+      // update should be used, not delete
+      expect((db as any).update).toHaveBeenCalled();
+      expect((db as any).delete).not.toHaveBeenCalled();
+      // set() should have been called with an object containing deletedAt
+      const setArg = (db as any).set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.deletedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('upsertMany', () => {
+    it('creates all inputs and returns results', async () => {
+      const rows: TestEntity[] = [
+        { id: '1', name: 'A' },
+        { id: '2', name: 'B' },
+      ];
+      let callCount = 0;
+      const db = makeMockDb();
+      // Override returning for sequential calls
+      (db as any).returning = mock(() => {
+        const row = rows[callCount++];
+        return Promise.resolve([row]);
+      });
+
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.upsertMany([{ name: 'A' }, { name: 'B' }]);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('list', () => {
+    it('returns all rows with no options', async () => {
+      const rows: TestEntity[] = [{ id: '1', name: 'A' }, { id: '2', name: 'B' }];
+      const db = makeMockDb(rows);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      const result = await repo.list();
+      expect(result).toEqual(rows);
+    });
+
+    it('applies limit and offset options', async () => {
+      const db = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+      await repo.list({ limit: 10, offset: 5 });
+      expect((db as any).limit).toHaveBeenCalledWith(10);
+      expect((db as any).offset).toHaveBeenCalledWith(5);
+    });
+  });
+});

--- a/shared/base-classes/base-repository.ts
+++ b/shared/base-classes/base-repository.ts
@@ -1,0 +1,244 @@
+/**
+ * BaseRepository<TEntity>
+ *
+ * Abstract base class providing standard CRUD operations via Drizzle ORM.
+ * Every generated repository extends this class.
+ *
+ * Family-specific bases (CrmEntityRepository, etc.) extend this in v0.1
+ * without any changes to BaseRepository.
+ *
+ * NOT @Injectable — concrete repositories are @Injectable and inject DRIZZLE.
+ */
+import { eq, inArray, isNull, sql } from 'drizzle-orm';
+import type { PgTableWithColumns, Column } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { DrizzleClient } from '../types/drizzle';
+
+// ============================================================================
+// Interfaces
+// ============================================================================
+
+/**
+ * Behavior flags for the repository. Controls automatic timestamp injection
+ * and soft-delete filtering.
+ */
+export interface BehaviorConfig {
+  timestamps: boolean;
+  softDelete: boolean;
+  userTracking: boolean;
+}
+
+/**
+ * Options for the list() method.
+ */
+export interface ListOptions {
+  where?: SQL;
+  limit?: number;
+  offset?: number;
+  orderBy?: Column | SQL;
+}
+
+// ============================================================================
+// BaseRepository
+// ============================================================================
+
+export abstract class BaseRepository<TEntity> {
+  /**
+   * The Drizzle table schema for this entity.
+   * Concrete repositories declare this as a class property.
+   */
+  protected abstract readonly table: PgTableWithColumns<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  /**
+   * Behavior flags controlling automatic behavior injection.
+   * Override in concrete repositories to enable behaviors.
+   */
+  protected readonly behaviors: BehaviorConfig = {
+    timestamps: false,
+    softDelete: false,
+    userTracking: false,
+  };
+
+  protected readonly db: DrizzleClient;
+
+  constructor(db: DrizzleClient) {
+    this.db = db;
+  }
+
+  // ============================================================================
+  // Read Operations
+  // ============================================================================
+
+  /**
+   * Find a single entity by its primary key.
+   * Returns null if not found (or soft-deleted when softDelete=true).
+   */
+  async findById(id: string): Promise<TEntity | null> {
+    const rows = await this.baseQuery()
+      .where(eq(this.table['id'], id))
+      .limit(1);
+    return (rows[0] as TEntity) ?? null;
+  }
+
+  /**
+   * Find multiple entities by their primary keys.
+   * Returns empty array immediately for empty input (avoids DB errors).
+   */
+  async findByIds(ids: string[]): Promise<TEntity[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.baseQuery().where(inArray(this.table['id'], ids));
+    return rows as TEntity[];
+  }
+
+  /**
+   * List entities with optional filtering, pagination, and ordering.
+   */
+  async list(options?: ListOptions): Promise<TEntity[]> {
+    let query = this.baseQuery();
+
+    if (options?.where) {
+      query = query.where(options.where) as typeof query;
+    }
+    if (options?.orderBy) {
+      query = query.orderBy(options.orderBy as SQL) as typeof query;
+    }
+    if (options?.limit !== undefined) {
+      query = query.limit(options.limit) as typeof query;
+    }
+    if (options?.offset !== undefined) {
+      query = query.offset(options.offset) as typeof query;
+    }
+
+    const rows = await query;
+    return rows as TEntity[];
+  }
+
+  /**
+   * Count entities matching an optional WHERE clause.
+   * Soft-deleted rows are always excluded when softDelete=true.
+   */
+  async count(where?: SQL): Promise<number> {
+    let query = this.db
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(this.table);
+
+    const conditions: SQL[] = [];
+    if (this.behaviors.softDelete) {
+      conditions.push(isNull(this.table['deletedAt']));
+    }
+    if (where) {
+      conditions.push(where);
+    }
+
+    if (conditions.length === 1) {
+      query = query.where(conditions[0]) as typeof query;
+    } else if (conditions.length > 1) {
+      // Combine with AND by building the condition inline
+      const { and } = await import('drizzle-orm');
+      query = query.where(and(...conditions)) as typeof query;
+    }
+
+    const rows = await query;
+    return rows[0]?.count ?? 0;
+  }
+
+  /**
+   * Check whether an entity with the given id exists.
+   */
+  async exists(id: string): Promise<boolean> {
+    const result = await this.findById(id);
+    return result !== null;
+  }
+
+  // ============================================================================
+  // Write Operations
+  // ============================================================================
+
+  /**
+   * Insert a new entity. Timestamps are auto-injected when timestamps=true.
+   */
+  async create(input: Partial<TEntity>): Promise<TEntity> {
+    const data = this.withTimestamps(input as Record<string, unknown>, 'create');
+    const rows = await this.db
+      .insert(this.table)
+      .values(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+      .returning();
+    return rows[0] as TEntity;
+  }
+
+  /**
+   * Update an existing entity by id. updatedAt is auto-injected when timestamps=true.
+   * Returns the updated entity.
+   */
+  async update(id: string, input: Partial<TEntity>): Promise<TEntity> {
+    const data = this.withTimestamps(input as Record<string, unknown>, 'update');
+    const rows = await this.db
+      .update(this.table)
+      .set(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+      .where(eq(this.table['id'], id))
+      .returning();
+    return rows[0] as TEntity;
+  }
+
+  /**
+   * Delete an entity by id.
+   * - softDelete=true: sets deletedAt to current timestamp
+   * - softDelete=false: hard-deletes the row
+   */
+  async delete(id: string): Promise<void> {
+    if (this.behaviors.softDelete) {
+      await this.db
+        .update(this.table)
+        .set({ deletedAt: new Date() } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+        .where(eq(this.table['id'], id));
+    } else {
+      await this.db
+        .delete(this.table)
+        .where(eq(this.table['id'], id));
+    }
+  }
+
+  /**
+   * Insert or update multiple entities.
+   * Default naive implementation — family repositories override with
+   * proper conflict-target upsert (e.g., CrmEntityRepository).
+   */
+  async upsertMany(inputs: Array<Partial<TEntity>>): Promise<TEntity[]> {
+    return Promise.all(inputs.map((input) => this.create(input)));
+  }
+
+  // ============================================================================
+  // Protected Helpers
+  // ============================================================================
+
+  /**
+   * Base SELECT query that automatically excludes soft-deleted rows
+   * when softDelete behavior is enabled.
+   */
+  protected baseQuery() {
+    const query = this.db.select().from(this.table);
+    if (this.behaviors.softDelete) {
+      return query.where(isNull(this.table['deletedAt']));
+    }
+    return query;
+  }
+
+  /**
+   * Merge timestamp fields into an input object.
+   * - mode='create': adds createdAt and updatedAt
+   * - mode='update': adds updatedAt only
+   *
+   * No-op when timestamps behavior is disabled.
+   */
+  protected withTimestamps(
+    input: Record<string, unknown>,
+    mode: 'create' | 'update',
+  ): Record<string, unknown> {
+    if (!this.behaviors.timestamps) return input;
+    const now = new Date();
+    if (mode === 'create') {
+      return { ...input, createdAt: now, updatedAt: now };
+    }
+    return { ...input, updatedAt: now };
+  }
+}

--- a/shared/base-classes/base-service.spec.ts
+++ b/shared/base-classes/base-service.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * BaseService unit tests
+ *
+ * Verifies that every CRUD method delegates to the injected repository
+ * and returns its result unchanged. No side effects are expected.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import { BaseService } from './base-service';
+import type { IBaseRepository } from './base-service';
+
+// ============================================================================
+// Test entity and concrete service
+// ============================================================================
+
+interface TestEntity {
+  id: string;
+  name: string;
+}
+
+/** Minimal concrete service for tests — no additional logic */
+class TestService extends BaseService<IBaseRepository<TestEntity>, TestEntity> {}
+
+// ============================================================================
+// Mock repository builder
+// ============================================================================
+
+function makeMockRepo(overrides: Partial<IBaseRepository<TestEntity>> = {}): IBaseRepository<TestEntity> {
+  return {
+    findById: mock(async (_id: string) => null),
+    findByIds: mock(async (_ids: string[]) => []),
+    list: mock(async () => []),
+    count: mock(async () => 0),
+    exists: mock(async (_id: string) => false),
+    create: mock(async (input: Partial<TestEntity>) => ({ id: 'new', ...input } as TestEntity)),
+    update: mock(async (_id: string, input: Partial<TestEntity>) => ({ id: _id, ...input } as TestEntity)),
+    delete: mock(async (_id: string) => undefined),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('BaseService', () => {
+  describe('findById', () => {
+    it('delegates to repository.findById and returns its result', async () => {
+      const entity: TestEntity = { id: 'abc', name: 'Test' };
+      const repo = makeMockRepo({ findById: mock(async () => entity) });
+      const service = new TestService(repo);
+
+      const result = await service.findById('abc');
+
+      expect(result).toBe(entity);
+      expect(repo.findById).toHaveBeenCalledWith('abc');
+    });
+
+    it('returns null when repository returns null', async () => {
+      const repo = makeMockRepo({ findById: mock(async () => null) });
+      const service = new TestService(repo);
+
+      const result = await service.findById('missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByIds', () => {
+    it('delegates to repository.findByIds and returns its result', async () => {
+      const entities: TestEntity[] = [{ id: '1', name: 'A' }, { id: '2', name: 'B' }];
+      const repo = makeMockRepo({ findByIds: mock(async () => entities) });
+      const service = new TestService(repo);
+
+      const result = await service.findByIds(['1', '2']);
+
+      expect(result).toBe(entities);
+      expect(repo.findByIds).toHaveBeenCalledWith(['1', '2']);
+    });
+  });
+
+  describe('list', () => {
+    it('delegates to repository.list and returns its result', async () => {
+      const entities: TestEntity[] = [{ id: '1', name: 'A' }];
+      const repo = makeMockRepo({ list: mock(async () => entities) });
+      const service = new TestService(repo);
+
+      const result = await service.list();
+
+      expect(result).toBe(entities);
+      expect(repo.list).toHaveBeenCalledWith(undefined);
+    });
+
+    it('forwards options to repository.list', async () => {
+      const repo = makeMockRepo({ list: mock(async () => []) });
+      const service = new TestService(repo);
+      const options = { limit: 10, offset: 5 };
+
+      await service.list(options);
+
+      expect(repo.list).toHaveBeenCalledWith(options);
+    });
+  });
+
+  describe('count', () => {
+    it('delegates to repository.count and returns its result', async () => {
+      const repo = makeMockRepo({ count: mock(async () => 42) });
+      const service = new TestService(repo);
+
+      const result = await service.count();
+
+      expect(result).toBe(42);
+      expect(repo.count).toHaveBeenCalledWith(undefined);
+    });
+
+    it('forwards where clause to repository.count', async () => {
+      const repo = makeMockRepo({ count: mock(async () => 7) });
+      const service = new TestService(repo);
+      const where = { active: true };
+
+      await service.count(where);
+
+      expect(repo.count).toHaveBeenCalledWith(where);
+    });
+  });
+
+  describe('exists', () => {
+    it('delegates to repository.exists and returns true', async () => {
+      const repo = makeMockRepo({ exists: mock(async () => true) });
+      const service = new TestService(repo);
+
+      const result = await service.exists('abc');
+
+      expect(result).toBe(true);
+      expect(repo.exists).toHaveBeenCalledWith('abc');
+    });
+
+    it('returns false when repository.exists returns false', async () => {
+      const repo = makeMockRepo({ exists: mock(async () => false) });
+      const service = new TestService(repo);
+
+      const result = await service.exists('ghost');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to repository.create and returns the created entity', async () => {
+      const entity: TestEntity = { id: 'new', name: 'Created' };
+      const repo = makeMockRepo({ create: mock(async () => entity) });
+      const service = new TestService(repo);
+
+      const result = await service.create({ name: 'Created' });
+
+      expect(result).toBe(entity);
+      expect(repo.create).toHaveBeenCalledWith({ name: 'Created' });
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to repository.update and returns the updated entity', async () => {
+      const entity: TestEntity = { id: 'upd', name: 'Updated' };
+      const repo = makeMockRepo({ update: mock(async () => entity) });
+      const service = new TestService(repo);
+
+      const result = await service.update('upd', { name: 'Updated' });
+
+      expect(result).toBe(entity);
+      expect(repo.update).toHaveBeenCalledWith('upd', { name: 'Updated' });
+    });
+  });
+
+  describe('delete', () => {
+    it('delegates to repository.delete', async () => {
+      const repo = makeMockRepo({ delete: mock(async () => undefined) });
+      const service = new TestService(repo);
+
+      await service.delete('del-id');
+
+      expect(repo.delete).toHaveBeenCalledWith('del-id');
+    });
+  });
+});

--- a/shared/base-classes/base-service.ts
+++ b/shared/base-classes/base-service.ts
@@ -1,0 +1,98 @@
+/**
+ * BaseService<TRepo, TEntity>
+ *
+ * Abstract base class providing 8 CRUD pass-through methods delegating to
+ * an injected repository. Every generated service extends this class.
+ *
+ * No side effects — pure delegation per ADR-003. Enrichment logic lives in
+ * concrete service subclasses or dedicated use cases.
+ *
+ * Note: @Injectable() is applied on concrete services (not here) so that
+ * NestJS DI metadata is emitted at the concrete class level. This matches
+ * the pattern established by BaseRepository.
+ */
+
+// ============================================================================
+// IBaseRepository interface
+// ============================================================================
+
+/**
+ * Structural interface that BaseRepository satisfies.
+ * Use this as the TRepo constraint so BaseService is not coupled to the
+ * concrete Drizzle-backed BaseRepository.
+ */
+export interface IBaseRepository<TEntity> {
+  findById(id: string): Promise<TEntity | null>;
+  findByIds(ids: string[]): Promise<TEntity[]>;
+  list(options?: unknown): Promise<TEntity[]>;
+  count(where?: unknown): Promise<number>;
+  exists(id: string): Promise<boolean>;
+  create(input: Partial<TEntity>): Promise<TEntity>;
+  update(id: string, input: Partial<TEntity>): Promise<TEntity>;
+  delete(id: string): Promise<void>;
+}
+
+// ============================================================================
+// BaseService
+// ============================================================================
+
+export abstract class BaseService<TRepo extends IBaseRepository<TEntity>, TEntity> {
+  constructor(protected readonly repository: TRepo) {}
+
+  /**
+   * Find a single entity by its primary key.
+   * Returns null if not found.
+   */
+  findById(id: string): Promise<TEntity | null> {
+    return this.repository.findById(id);
+  }
+
+  /**
+   * Find multiple entities by their primary keys.
+   */
+  findByIds(ids: string[]): Promise<TEntity[]> {
+    return this.repository.findByIds(ids);
+  }
+
+  /**
+   * List entities with optional filtering/pagination options.
+   */
+  list(options?: unknown): Promise<TEntity[]> {
+    return this.repository.list(options);
+  }
+
+  /**
+   * Count entities matching an optional filter.
+   */
+  count(where?: unknown): Promise<number> {
+    return this.repository.count(where);
+  }
+
+  /**
+   * Check whether an entity with the given id exists.
+   */
+  exists(id: string): Promise<boolean> {
+    return this.repository.exists(id);
+  }
+
+  /**
+   * Insert a new entity.
+   */
+  create(input: Partial<TEntity>): Promise<TEntity> {
+    return this.repository.create(input);
+  }
+
+  /**
+   * Update an existing entity by id.
+   */
+  update(id: string, input: Partial<TEntity>): Promise<TEntity> {
+    return this.repository.update(id, input);
+  }
+
+  /**
+   * Delete an entity by id.
+   */
+  delete(id: string): Promise<void> {
+    return this.repository.delete(id);
+  }
+}

--- a/shared/base-classes/index.ts
+++ b/shared/base-classes/index.ts
@@ -3,3 +3,9 @@
  */
 export { BaseRepository } from './base-repository';
 export type { BehaviorConfig, ListOptions } from './base-repository';
+
+export { BaseService } from './base-service';
+export type { IBaseRepository } from './base-service';
+
+export { BaseFindByIdUseCase, BaseListUseCase } from './base-read-use-cases';
+export type { IFindByIdService, IListService } from './base-read-use-cases';

--- a/shared/base-classes/index.ts
+++ b/shared/base-classes/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Base classes barrel export
+ */
+export { BaseRepository } from './base-repository';
+export type { BehaviorConfig, ListOptions } from './base-repository';

--- a/shared/constants/tokens.ts
+++ b/shared/constants/tokens.ts
@@ -1,0 +1,15 @@
+/**
+ * NestJS injection tokens
+ *
+ * Used with @Inject() decorator in concrete repository constructors.
+ */
+
+/**
+ * Injection token for the Drizzle ORM database client.
+ *
+ * Usage in concrete repositories:
+ * ```typescript
+ * constructor(@Inject(DRIZZLE) db: DrizzleClient) { super(db); }
+ * ```
+ */
+export const DRIZZLE = 'DRIZZLE' as const;

--- a/shared/types/drizzle.ts
+++ b/shared/types/drizzle.ts
@@ -1,0 +1,15 @@
+/**
+ * DrizzleClient type alias
+ *
+ * Type alias for the Drizzle ORM database client. Using NodePgDatabase
+ * as the canonical Drizzle Postgres client type.
+ */
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+/**
+ * The Drizzle database client type used throughout the application.
+ * Typed with a permissive schema to allow use in the abstract base class
+ * without coupling to a specific schema module.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DrizzleClient = NodePgDatabase<any>;

--- a/templates/entity/new/clean-lite-ps/controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/controller.ejs.t
@@ -1,0 +1,36 @@
+---
+to: <%= clpOutputPaths.controller %>
+force: true
+---
+import { Controller, Get, Param } from '@nestjs/common';
+import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
+import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
+import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
+// Write use cases must be hand-written. Import them here when ready.
+
+@Controller('<%= entityNamePlural %>')
+export class <%= classNames.controller %> {
+  constructor(
+    // All routes go through use cases (ADR-003 — no controller → service shortcuts)
+    private readonly findByIdUseCase: <%= classNames.findByIdUseCase %>,
+    private readonly listUseCase: <%= classNames.listUseCase %>,
+    // TODO: inject hand-written write use cases here
+  ) {}
+
+  @Get()
+  async getAll(): Promise<<%= classNames.entity %>[]> {
+    return this.listUseCase.execute();
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string): Promise<<%= classNames.entity %> | null> {
+    return this.findByIdUseCase.execute(id);
+  }
+
+  // TODO: Add write routes. Each must call a hand-written use case, not the service.
+  // Example:
+  // @Post()
+  // async create(@Body() dto: Create<%= classNames.entity %>Dto): Promise<<%= classNames.entity %>> {
+  //   return this.createUseCase.execute(dto);
+  // }
+}

--- a/templates/entity/new/clean-lite-ps/controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/controller.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.controller %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.controller : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { Controller, Get, Param } from '@nestjs/common';

--- a/templates/entity/new/clean-lite-ps/dto/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/create.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.createDto %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.createDto : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { z } from 'zod';

--- a/templates/entity/new/clean-lite-ps/dto/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/create.ejs.t
@@ -1,0 +1,16 @@
+---
+to: <%= clpOutputPaths.createDto %>
+force: true
+---
+import { z } from 'zod';
+
+export const <%= classNames.createSchema %> = z.object({
+<%_ clpBelongsToFkFields.forEach(fk => { _%>
+  <%= fk.camelName %>: <%= fk.zodChainCreate %>,
+<%_ }) _%>
+<%_ clpCreateDtoFields.forEach(field => { _%>
+  <%= field.camelName %>: <%= field.zodChainCreate %>,
+<%_ }) _%>
+});
+
+export type <%= classNames.createDto %> = z.infer<typeof <%= classNames.createSchema %>>;

--- a/templates/entity/new/clean-lite-ps/dto/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/create.ejs.t
@@ -6,10 +6,10 @@ import { z } from 'zod';
 
 export const <%= classNames.createSchema %> = z.object({
 <%_ clpBelongsToFkFields.forEach(fk => { _%>
-  <%= fk.camelName %>: <%= fk.zodChainCreate %>,
+  <%= fk.camelName %>: <%- fk.zodChainCreate %>,
 <%_ }) _%>
 <%_ clpCreateDtoFields.forEach(field => { _%>
-  <%= field.camelName %>: <%= field.zodChainCreate %>,
+  <%= field.camelName %>: <%- field.zodChainCreate %>,
 <%_ }) _%>
 });
 

--- a/templates/entity/new/clean-lite-ps/dto/output.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/output.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.outputDto %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.outputDto : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { z } from 'zod';

--- a/templates/entity/new/clean-lite-ps/dto/output.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/output.ejs.t
@@ -1,0 +1,24 @@
+---
+to: <%= clpOutputPaths.outputDto %>
+force: true
+---
+import { z } from 'zod';
+
+export const <%= classNames.outputSchema %> = z.object({
+  id: z.string().uuid(),
+<%_ clpBelongsToFkFields.forEach(fk => { _%>
+  <%= fk.camelName %>: <%= fk.zodChainOutput %>,
+<%_ }) _%>
+<%_ clpOutputDtoFields.forEach(field => { _%>
+  <%= field.camelName %>: <%= field.zodChainOutput %>,
+<%_ }) _%>
+<%_ if (hasTimestamps) { _%>
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+<%_ } _%>
+<%_ if (hasSoftDelete) { _%>
+  deletedAt: z.coerce.date().nullable(),
+<%_ } _%>
+});
+
+export type <%= classNames.outputDto %> = z.infer<typeof <%= classNames.outputSchema %>>;

--- a/templates/entity/new/clean-lite-ps/dto/output.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/output.ejs.t
@@ -7,10 +7,10 @@ import { z } from 'zod';
 export const <%= classNames.outputSchema %> = z.object({
   id: z.string().uuid(),
 <%_ clpBelongsToFkFields.forEach(fk => { _%>
-  <%= fk.camelName %>: <%= fk.zodChainOutput %>,
+  <%= fk.camelName %>: <%- fk.zodChainOutput %>,
 <%_ }) _%>
 <%_ clpOutputDtoFields.forEach(field => { _%>
-  <%= field.camelName %>: <%= field.zodChainOutput %>,
+  <%= field.camelName %>: <%- field.zodChainOutput %>,
 <%_ }) _%>
 <%_ if (hasTimestamps) { _%>
   createdAt: z.coerce.date(),

--- a/templates/entity/new/clean-lite-ps/dto/update.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/update.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.updateDto %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.updateDto : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { z } from 'zod';

--- a/templates/entity/new/clean-lite-ps/dto/update.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/update.ejs.t
@@ -1,0 +1,10 @@
+---
+to: <%= clpOutputPaths.updateDto %>
+force: true
+---
+import { z } from 'zod';
+import { <%= classNames.createSchema %> } from './create-<%= entityName %>.dto';
+
+export const <%= classNames.updateSchema %> = <%= classNames.createSchema %>.partial();
+
+export type <%= classNames.updateDto %> = z.infer<typeof <%= classNames.updateSchema %>>;

--- a/templates/entity/new/clean-lite-ps/entity.ejs.t
+++ b/templates/entity/new/clean-lite-ps/entity.ejs.t
@@ -24,7 +24,7 @@ export const <%= entityNamePlural %> = pgTable(
     <%= rel.camelField %>: uuid('<%= rel.field %>')<%= rel.nullable ? '' : '.notNull()' %>,
 <%_ }) _%>
 <%_ clpProcessedFields.forEach(field => { _%>
-    <%= field.camelName %>: <%= field.drizzleChain %>,
+    <%= field.camelName %>: <%- field.drizzleChain %>,
 <%_ }) _%>
 <%_ if (hasTimestamps) { _%>
     createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/templates/entity/new/clean-lite-ps/entity.ejs.t
+++ b/templates/entity/new/clean-lite-ps/entity.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.entity %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.entity : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import {

--- a/templates/entity/new/clean-lite-ps/entity.ejs.t
+++ b/templates/entity/new/clean-lite-ps/entity.ejs.t
@@ -1,0 +1,51 @@
+---
+to: <%= clpOutputPaths.entity %>
+force: true
+---
+import {
+<%_ clpDrizzleImports.filter(i => i !== 'relations').forEach(i => { _%>
+  <%= i %>,
+<%_ }) _%>
+} from 'drizzle-orm/pg-core';
+<%_ if (clpHasRelationsBlock) { _%>
+import { relations, type InferSelectModel } from 'drizzle-orm';
+<%_ } else { _%>
+import { type InferSelectModel } from 'drizzle-orm';
+<%_ } _%>
+<%_ clpBelongsTo.forEach(rel => { _%>
+import { <%= rel.relatedTable %> } from '<%= rel.importPath %>';
+<%_ }) _%>
+
+export const <%= entityNamePlural %> = pgTable(
+  '<%= entityNamePlural %>',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+<%_ clpBelongsTo.forEach(rel => { _%>
+    <%= rel.camelField %>: uuid('<%= rel.field %>')<%= rel.nullable ? '' : '.notNull()' %>,
+<%_ }) _%>
+<%_ clpProcessedFields.forEach(field => { _%>
+    <%= field.camelName %>: <%= field.drizzleChain %>,
+<%_ }) _%>
+<%_ if (hasTimestamps) { _%>
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+<%_ } _%>
+<%_ if (hasSoftDelete) { _%>
+    deletedAt: timestamp('deleted_at'),
+<%_ } _%>
+  },
+);
+<%_ if (clpHasRelationsBlock) { _%>
+
+export const <%= entityNamePlural %>Relations = relations(<%= entityNamePlural %>, ({ one }) => ({
+<%_ clpBelongsTo.forEach(rel => { _%>
+  <%= rel.relatedEntity %>: one(<%= rel.relatedTable %>, {
+    fields: [<%= entityNamePlural %>.<%= rel.camelField %>],
+    references: [<%= rel.relatedTable %>.id],
+  }),
+<%_ }) _%>
+}));
+<%_ } _%>
+
+export type <%= classNames.entity %> = InferSelectModel<typeof <%= entityNamePlural %>>;
+export type <%= classNames.entity %>Insert = typeof <%= entityNamePlural %>.$inferInsert;

--- a/templates/entity/new/clean-lite-ps/module.ejs.t
+++ b/templates/entity/new/clean-lite-ps/module.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.module %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.module : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { Module } from '@nestjs/common';

--- a/templates/entity/new/clean-lite-ps/module.ejs.t
+++ b/templates/entity/new/clean-lite-ps/module.ejs.t
@@ -1,0 +1,36 @@
+---
+to: <%= clpOutputPaths.module %>
+force: true
+---
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@shared/database/database.module';
+<%_ clpBelongsTo.forEach(rel => { _%>
+// import { <%= rel.relatedEntityPascal %>sModule } from '../<%= rel.relatedPlural %>/<%= rel.relatedPlural %>.module';
+<%_ }) _%>
+
+import { <%= classNames.repository %> } from './<%= entityName %>.repository';
+import { <%= classNames.service %> } from './<%= entityName %>.service';
+import { <%= classNames.controller %> } from './<%= entityName %>.controller';
+import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
+import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
+
+@Module({
+  imports: [
+    DatabaseModule,
+    // TODO: Add subsystem modules as needed (EventsSubsystemModule, IntegrationsSubsystemModule, etc.)
+    // Cross-domain modules from relationships:
+<%_ clpBelongsTo.forEach(rel => { _%>
+    // <%= rel.relatedEntityPascal %>sModule,
+<%_ }) _%>
+  ],
+  controllers: [<%= classNames.controller %>],
+  providers: [
+    <%= classNames.repository %>,
+    <%= classNames.service %>,
+    <%= classNames.findByIdUseCase %>,
+    <%= classNames.listUseCase %>,
+    // TODO: Register hand-written use cases here
+  ],
+  exports: [<%= classNames.service %>],  // Only service is exported (ADR-002)
+})
+export class <%= classNames.module %> {}

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -1,0 +1,479 @@
+/**
+ * Clean-Lite-PS template locals extension
+ *
+ * Exports buildCleanLitePsLocals(definition, baseLocals) which derives
+ * all variables required by the clean-lite-ps template set.
+ */
+
+// ============================================================================
+// Family → Base Class Mapping
+// ============================================================================
+
+const FAMILY_MAP = {
+  'crm-synced': {
+    repositoryBaseClass: 'CrmEntityRepository',
+    serviceBaseClass: 'CrmEntityService',
+    repositoryBaseImport: '@shared/base-classes/crm-entity-repository',
+    serviceBaseImport: '@shared/base-classes/crm-entity-service',
+    repositoryInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+      'findByExternalId, findAllByUserId, findVisibleByUserId, syncUpsert',
+    ],
+    serviceInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete',
+      'findByExternalId, findAllByUserId, findVisibleByUserId',
+    ],
+  },
+  activity: {
+    repositoryBaseClass: 'ActivityEntityRepository',
+    serviceBaseClass: 'ActivityEntityService',
+    repositoryBaseImport: '@shared/base-classes/activity-entity-repository',
+    serviceBaseImport: '@shared/base-classes/activity-entity-service',
+    repositoryInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+      'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
+    ],
+    serviceInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete',
+      'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
+    ],
+  },
+  knowledge: {
+    repositoryBaseClass: 'KnowledgeEntityRepository',
+    serviceBaseClass: 'KnowledgeEntityService',
+    repositoryBaseImport: '@shared/base-classes/knowledge-entity-repository',
+    serviceBaseImport: '@shared/base-classes/knowledge-entity-service',
+    repositoryInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+      'semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch',
+    ],
+    serviceInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete',
+      'semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch',
+    ],
+  },
+  metadata: {
+    repositoryBaseClass: 'MetadataEntityRepository',
+    serviceBaseClass: 'MetadataEntityService',
+    repositoryBaseImport: '@shared/base-classes/metadata-entity-repository',
+    serviceBaseImport: '@shared/base-classes/metadata-entity-service',
+    repositoryInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+      'findByEntityIdAndType, listByEntityId, listHistoryByEntityId',
+    ],
+    serviceInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete',
+      'findByEntityIdAndType, listByEntityId, listHistoryByEntityId',
+    ],
+  },
+  base: {
+    repositoryBaseClass: 'BaseRepository',
+    serviceBaseClass: 'BaseService',
+    repositoryBaseImport: '@shared/base-classes/base-repository',
+    serviceBaseImport: '@shared/base-classes/base-service',
+    repositoryInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+    ],
+    serviceInheritedMethods: [
+      'findById, findByIds, list, count, exists, create, update, delete',
+    ],
+  },
+};
+
+// ============================================================================
+// Helper utilities
+// ============================================================================
+
+const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
+const camelCase = (s) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+const pascalCase = (s) => capitalize(camelCase(s));
+const pluralize = (s) => {
+  if (s.endsWith('y')) return s.slice(0, -1) + 'ies';
+  if (s.endsWith('s') || s.endsWith('x') || s.endsWith('ch') || s.endsWith('sh'))
+    return s + 'es';
+  return s + 's';
+};
+
+// ============================================================================
+// Drizzle type mapping
+// ============================================================================
+
+const DRIZZLE_TYPE_MAP = {
+  string: 'text',
+  integer: 'integer',
+  decimal: 'numeric',
+  boolean: 'boolean',
+  uuid: 'uuid',
+  date: 'date',
+  datetime: 'timestamp',
+  json: 'jsonb',
+};
+
+// Drizzle import name for each drizzle type
+const DRIZZLE_IMPORT_MAP = {
+  text: 'text',
+  integer: 'integer',
+  numeric: 'numeric',
+  boolean: 'boolean',
+  uuid: 'uuid',
+  date: 'date',
+  timestamp: 'timestamp',
+  jsonb: 'jsonb',
+};
+
+// ============================================================================
+// Zod type mapping
+// ============================================================================
+
+const ZOD_TYPE_MAP = {
+  string: 'z.string()',
+  integer: 'z.number().int()',
+  decimal: 'z.number()',
+  boolean: 'z.boolean()',
+  uuid: 'z.string().uuid()',
+  date: 'z.coerce.date()',
+  datetime: 'z.coerce.date()',
+  json: 'z.record(z.unknown())',
+};
+
+// TypeScript type mapping
+const TS_TYPE_MAP = {
+  string: 'string',
+  integer: 'number',
+  decimal: 'number',
+  boolean: 'boolean',
+  uuid: 'string',
+  date: 'Date',
+  datetime: 'Date',
+  json: 'unknown',
+};
+
+// Fields managed by behaviors — excluded from create DTO
+const BEHAVIOR_MANAGED_FIELDS = new Set([
+  'created_at',
+  'updated_at',
+  'deleted_at',
+  'created_by',
+  'updated_by',
+  'valid_from',
+  'valid_to',
+  'is_active',
+]);
+
+// ============================================================================
+// Field processors
+// ============================================================================
+
+/**
+ * Build a Drizzle column chain for a field
+ */
+function buildDrizzleChain(fieldName, field, drizzleType) {
+  const nullable = field.nullable ?? false;
+  const required = field.required ?? false;
+  const hasDefault = field.default !== undefined && field.default !== null;
+
+  let chain = `${drizzleType}('${fieldName}')`;
+
+  // Add .notNull() for non-nullable required fields
+  if (required && !nullable) {
+    chain += '.notNull()';
+  }
+
+  // Boolean defaults
+  if (drizzleType === 'boolean' && hasDefault) {
+    chain += `.default(${field.default})`;
+  }
+
+  // Timestamp defaults for datetime fields in behavior context handled separately
+  return chain;
+}
+
+/**
+ * Process entity fields into ProcessedField[]
+ */
+function processFields(fields) {
+  const processed = [];
+
+  for (const [fieldName, field] of Object.entries(fields)) {
+    if (fieldName === 'id') continue;
+
+    const type = field.type || 'string';
+    const nullable = field.nullable ?? false;
+    const required = field.required ?? false;
+    const hasDefault = field.default !== undefined && field.default !== null;
+    const choices = field.choices;
+    const hasChoices = Array.isArray(choices) && choices.length > 0;
+
+    const drizzleType = DRIZZLE_TYPE_MAP[type] || 'text';
+    const tsType = hasChoices
+      ? choices.map((c) => `'${c}'`).join(' | ')
+      : (TS_TYPE_MAP[type] || 'unknown');
+    const zodType = hasChoices
+      ? `z.enum([${choices.map((c) => `'${c}'`).join(', ')}])`
+      : (ZOD_TYPE_MAP[type] || 'z.unknown()');
+
+    const drizzleChain = buildDrizzleChain(fieldName, field, drizzleType);
+
+    processed.push({
+      name: fieldName,
+      camelName: camelCase(fieldName),
+      type,
+      drizzleType,
+      zodType,
+      tsType,
+      nullable,
+      required,
+      hasDefault,
+      isPrimaryKey: false,
+      drizzleChain,
+      choices,
+      hasChoices,
+    });
+  }
+
+  return processed;
+}
+
+/**
+ * Process belongs_to relationships into BelongsToRelation[]
+ */
+function processBelongsTo(relationships) {
+  if (!relationships) return [];
+
+  const result = [];
+
+  for (const [relName, rel] of Object.entries(relationships)) {
+    if (rel.type !== 'belongs_to') continue;
+
+    const target = rel.target;
+    const field = rel.foreign_key;
+    const nullable = rel.nullable ?? true;
+    const relatedPlural = pluralize(target);
+
+    result.push({
+      field,
+      camelField: camelCase(field),
+      relatedEntity: target,
+      relatedEntityPascal: pascalCase(target),
+      relatedTable: relatedPlural,
+      relatedPlural,
+      nullable,
+      importPath: `../${relatedPlural}/${target}.entity`,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Collect drizzle imports needed for entity fields
+ */
+function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete) {
+  const imports = new Set(['pgTable', 'uuid']);
+
+  for (const field of processedFields) {
+    const importName = DRIZZLE_IMPORT_MAP[field.drizzleType];
+    if (importName) imports.add(importName);
+  }
+
+  // FK uuid columns from belongs_to
+  if (belongsTo.length > 0) {
+    imports.add('uuid');
+  }
+
+  // Behavior imports
+  if (hasTimestamps || hasSoftDelete) {
+    imports.add('timestamp');
+  }
+
+  if (belongsTo.length > 0) {
+    imports.add('relations');
+  }
+
+  return Array.from(imports).sort();
+}
+
+/**
+ * Derive Zod chain for a field in create DTO context
+ */
+function zodChainForCreate(field) {
+  const { type, nullable, required, hasDefault, hasChoices, choices } = field;
+
+  if (hasChoices) {
+    const base = `z.enum([${choices.map((c) => `'${c}'`).join(', ')}])`;
+    if (!required && !nullable) return base + '.optional()';
+    if (nullable) return base + '.nullable()';
+    return base;
+  }
+
+  let base = ZOD_TYPE_MAP[type] || 'z.unknown()';
+
+  if (type === 'boolean' && hasDefault) {
+    base += `.default(${field.default ?? false})`;
+    return base;
+  }
+
+  if (nullable) {
+    return base + '.nullable()';
+  }
+
+  if (!required) {
+    return base + '.optional()';
+  }
+
+  return base;
+}
+
+/**
+ * Derive Zod chain for a field in output DTO context
+ */
+function zodChainForOutput(field) {
+  const { type, nullable, hasChoices, choices } = field;
+
+  if (hasChoices) {
+    const base = `z.enum([${choices.map((c) => `'${c}'`).join(', ')}])`;
+    if (nullable) return base + '.nullable()';
+    return base;
+  }
+
+  let base = ZOD_TYPE_MAP[type] || 'z.unknown()';
+
+  if (nullable) {
+    return base + '.nullable()';
+  }
+
+  return base;
+}
+
+// ============================================================================
+// Main export
+// ============================================================================
+
+/**
+ * Build Clean-Lite-PS template locals from entity definition and base locals
+ *
+ * @param {object} definition - Parsed entity YAML
+ * @param {object} baseLocals - Locals from main prompt.js
+ * @returns {object} Merged locals with all clean-lite-ps variables
+ */
+export function buildCleanLitePsLocals(definition, baseLocals) {
+  const entity = definition.entity;
+  const fields = definition.fields || {};
+  const relationships = definition.relationships || {};
+  const behaviors = definition.behaviors || [];
+
+  const entityName = entity.name;
+  const entityNamePascal = pascalCase(entityName);
+  const entityNamePlural = entity.plural || pluralize(entityName);
+  const entityNamePluralPascal = pascalCase(entityNamePlural);
+
+  // Family resolution
+  const family = entity.family || 'base';
+  const familyConfig = FAMILY_MAP[family] || FAMILY_MAP['base'];
+
+  // Process entity fields
+  const processedFields = processFields(fields);
+
+  // Behavior flags (re-read from behaviors array for clean-lite-ps use)
+  const behaviorNames = behaviors.map((b) => (typeof b === 'string' ? b : b.name));
+  const hasTimestamps = behaviorNames.includes('timestamps');
+  const hasSoftDelete = behaviorNames.includes('soft_delete');
+
+  // Process belongs_to relationships
+  const belongsTo = processBelongsTo(relationships);
+
+  // Drizzle imports needed
+  const drizzleEntityImports = collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete);
+  // Whether relations() import is needed
+  const hasRelationsBlock = belongsTo.length > 0;
+
+  // Output paths
+  const outputPaths = {
+    entity: `modules/${entityNamePlural}/${entityName}.entity.ts`,
+    repository: `modules/${entityNamePlural}/${entityName}.repository.ts`,
+    service: `modules/${entityNamePlural}/${entityName}.service.ts`,
+    controller: `modules/${entityNamePlural}/${entityName}.controller.ts`,
+    module: `modules/${entityNamePlural}/${entityNamePlural}.module.ts`,
+    findByIdUseCase: `modules/${entityNamePlural}/use-cases/find-${entityName}-by-id.use-case.ts`,
+    listUseCase: `modules/${entityNamePlural}/use-cases/list-${entityNamePlural}.use-case.ts`,
+    createDto: `modules/${entityNamePlural}/dto/create-${entityName}.dto.ts`,
+    updateDto: `modules/${entityNamePlural}/dto/update-${entityName}.dto.ts`,
+    outputDto: `modules/${entityNamePlural}/dto/${entityName}-output.dto.ts`,
+  };
+
+  // Class names
+  const classNames = {
+    entity: entityNamePascal,
+    entityTable: entityNamePlural,
+    repository: `${entityNamePascal}Repository`,
+    service: `${entityNamePascal}Service`,
+    controller: `${entityNamePascal}Controller`,
+    module: `${entityNamePluralPascal}Module`,
+    findByIdUseCase: `Find${entityNamePascal}ByIdUseCase`,
+    listUseCase: `List${entityNamePluralPascal}UseCase`,
+    createDto: `Create${entityNamePascal}Dto`,
+    updateDto: `Update${entityNamePascal}Dto`,
+    outputDto: `${entityNamePascal}OutputDto`,
+    createSchema: `Create${entityNamePascal}Schema`,
+    updateSchema: `Update${entityNamePascal}Schema`,
+    outputSchema: `${entityNamePascal}OutputSchema`,
+  };
+
+  // Fields for create DTO: exclude id and behavior-managed fields
+  const createDtoFields = processedFields.filter(
+    (f) => !BEHAVIOR_MANAGED_FIELDS.has(f.name),
+  );
+
+  // FK fields from belongs_to for create/output DTOs
+  const belongsToFkFields = belongsTo.map((rel) => ({
+    camelName: rel.camelField,
+    zodChainCreate: rel.nullable ? 'z.string().uuid().nullable()' : 'z.string().uuid()',
+    zodChainOutput: rel.nullable ? 'z.string().uuid().nullable()' : 'z.string().uuid()',
+    nullable: rel.nullable,
+  }));
+
+  // Build zodChain for each create DTO field
+  const createDtoFieldsWithZod = createDtoFields.map((f) => ({
+    ...f,
+    zodChainCreate: zodChainForCreate(f),
+  }));
+
+  // Build zodChain for each output DTO field (all fields including id)
+  const outputDtoFields = processedFields.map((f) => ({
+    ...f,
+    zodChainOutput: zodChainForOutput(f),
+  }));
+
+  return {
+    // Clean-Lite-PS identity
+    entityName,
+    entityNamePascal,
+    entityNamePlural,
+    entityNamePluralPascal,
+
+    // Family
+    family,
+    ...familyConfig,
+
+    // Behavior flags (also exposed at top level for template use)
+    hasTimestamps,
+    hasSoftDelete,
+
+    // Output paths
+    clpOutputPaths: outputPaths,
+
+    // Class names
+    classNames,
+
+    // Field data
+    clpProcessedFields: processedFields,
+    clpCreateDtoFields: createDtoFieldsWithZod,
+    clpOutputDtoFields: outputDtoFields,
+    clpBelongsTo: belongsTo,
+    clpBelongsToFkFields: belongsToFkFields,
+
+    // Drizzle
+    clpDrizzleImports: drizzleEntityImports,
+    clpHasRelationsBlock: hasRelationsBlock,
+  };
+}

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -382,6 +382,10 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // Process belongs_to relationships
   const belongsTo = processBelongsTo(relationships);
 
+  // Filter FK fields that are already emitted by the clpBelongsTo loop
+  const fkFieldNames = new Set(belongsTo.map((r) => r.field));
+  const nonFkFields = processedFields.filter((f) => !fkFieldNames.has(f.name));
+
   // Drizzle imports needed
   const drizzleEntityImports = collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete);
   // Whether relations() import is needed
@@ -419,8 +423,8 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     outputSchema: `${entityNamePascal}OutputSchema`,
   };
 
-  // Fields for create DTO: exclude id and behavior-managed fields
-  const createDtoFields = processedFields.filter(
+  // Fields for create DTO: exclude id, behavior-managed fields, and FK fields
+  const createDtoFields = nonFkFields.filter(
     (f) => !BEHAVIOR_MANAGED_FIELDS.has(f.name),
   );
 
@@ -438,8 +442,8 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     zodChainCreate: zodChainForCreate(f),
   }));
 
-  // Build zodChain for each output DTO field (all fields including id)
-  const outputDtoFields = processedFields.map((f) => ({
+  // Build zodChain for each output DTO field (all non-FK fields)
+  const outputDtoFields = nonFkFields.map((f) => ({
     ...f,
     zodChainOutput: zodChainForOutput(f),
   }));
@@ -466,7 +470,7 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     classNames,
 
     // Field data
-    clpProcessedFields: processedFields,
+    clpProcessedFields: nonFkFields,
     clpCreateDtoFields: createDtoFieldsWithZod,
     clpOutputDtoFields: outputDtoFields,
     clpBelongsTo: belongsTo,

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.repository %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.repository : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { Injectable, Inject } from '@nestjs/common';

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -1,0 +1,24 @@
+---
+to: <%= clpOutputPaths.repository %>
+force: true
+---
+import { Injectable, Inject } from '@nestjs/common';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
+import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
+import { <%= entityNamePlural %>, type <%= classNames.entity %> } from './<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%= classNames.entity %>> {
+  readonly table = <%= entityNamePlural %>;
+
+  constructor(@Inject(DRIZZLE) db: DrizzleClient) {
+    super(db);
+  }
+
+  // TODO: Add entity-specific query methods here.
+  // Inherited from <%= repositoryBaseClass %>:
+<%_ repositoryInheritedMethods.forEach(line => { _%>
+  //   <%= line %>
+<%_ }) _%>
+}

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: <%= clpOutputPaths.service %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.service : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { Injectable } from '@nestjs/common';

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -1,0 +1,27 @@
+---
+to: <%= clpOutputPaths.service %>
+force: true
+---
+import { Injectable } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/base-analytics-service';
+import { <%= serviceBaseClass %> } from '<%= serviceBaseImport %>';
+import { <%= classNames.repository %> } from './<%= entityName %>.repository';
+import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.service %> extends WithAnalytics(
+  <%= serviceBaseClass %><<%= classNames.repository %>, <%= classNames.entity %>>,
+) {
+  constructor(protected readonly repository: <%= classNames.repository %>) {
+    super();
+  }
+
+  // TODO: Add entity-specific domain methods here.
+  // Services contain pure data operations only (ADR-003).
+  // Do NOT emit events, enqueue jobs, or call external systems from service methods.
+  //
+  // Inherited from <%= serviceBaseClass %>:
+<%_ serviceInheritedMethods.forEach(line => { _%>
+  //   <%= line %>
+<%_ }) _%>
+}

--- a/templates/entity/new/clean-lite-ps/use-cases/find-by-id.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/find-by-id.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= clpOutputPaths.findByIdUseCase %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.findByIdUseCase : null %>"
 force: true
 ---
 import { Injectable } from '@nestjs/common';

--- a/templates/entity/new/clean-lite-ps/use-cases/find-by-id.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/find-by-id.ejs.t
@@ -1,0 +1,16 @@
+---
+to: <%= clpOutputPaths.findByIdUseCase %>
+force: true
+---
+import { Injectable } from '@nestjs/common';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.findByIdUseCase %> {
+  constructor(private readonly service: <%= classNames.service %>) {}
+
+  async execute(id: string): Promise<<%= classNames.entity %> | null> {
+    return this.service.findById(id);
+  }
+}

--- a/templates/entity/new/clean-lite-ps/use-cases/list.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/list.ejs.t
@@ -1,0 +1,16 @@
+---
+to: <%= clpOutputPaths.listUseCase %>
+force: true
+---
+import { Injectable } from '@nestjs/common';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.listUseCase %> {
+  constructor(private readonly service: <%= classNames.service %>) {}
+
+  async execute(): Promise<<%= classNames.entity %>[]> {
+    return this.service.list();
+  }
+}

--- a/templates/entity/new/clean-lite-ps/use-cases/list.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/list.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= clpOutputPaths.listUseCase %>
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.listUseCase : null %>"
 force: true
 ---
 import { Injectable } from '@nestjs/common';

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -1296,6 +1296,32 @@ export default {
     if (cleanLitePs) {
       const { buildCleanLitePsLocals } = await import('./clean-lite-ps/prompt-extension.js');
       Object.assign(locals, buildCleanLitePsLocals(definition, locals));
+    } else {
+      // Inject safe stub locals so CLP template bodies can render without crashing.
+      // The to: guard resolves to "null" which causes Hygen to skip file writing.
+      const _n = definition.entity?.name || '';
+      const _p = definition.entity?.plural || _n + 's';
+      Object.assign(locals, {
+        clpOutputPaths: undefined,
+        entityName: _n,
+        entityNamePlural: _p,
+        entityNamePascal: _n,
+        entityNamePluralPascal: _p,
+        classNames: {},
+        clpDrizzleImports: [],
+        clpProcessedFields: [],
+        clpCreateDtoFields: [],
+        clpOutputDtoFields: [],
+        clpBelongsTo: [],
+        clpBelongsToFkFields: [],
+        clpHasRelationsBlock: false,
+        repositoryBaseClass: '',
+        serviceBaseClass: '',
+        repositoryBaseImport: '',
+        serviceBaseImport: '',
+        repositoryInheritedMethods: [],
+        serviceInheritedMethods: [],
+      });
     }
 
     return locals;

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -937,7 +937,7 @@ export default {
       }
     }
 
-    return {
+    const locals = {
       // Database configuration
       databaseDialect,
       schemaDir: BASE_PATHS.schemaDir,
@@ -1122,5 +1122,15 @@ export default {
       electricWhereColumn,
       electricWhereValue,
     };
+
+    // Clean-Lite-PS template locals (only when generate.cleanLitePs: true)
+    const projectConfig = getProjectConfig();
+    const cleanLitePs = projectConfig?.generate?.cleanLitePs ?? false;
+    if (cleanLitePs) {
+      const { buildCleanLitePsLocals } = await import('./clean-lite-ps/prompt-extension.js');
+      Object.assign(locals, buildCleanLitePsLocals(definition, locals));
+    }
+
+    return locals;
   },
 };

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -19,6 +19,7 @@ import {
   getLayoutConfig,
   getDatabaseDialect,
   getProjectConfig,
+  getPipelinesConfig,
 } from "../../../config/paths.mjs";
 import { getNamingConfig } from "../../../config/naming-config.mjs";
 
@@ -248,6 +249,11 @@ export default {
     const fields = definition.fields || {};
     const relationships = definition.relationships || {};
     const behaviors = definition.behaviors || [];
+
+    // v2 blocks (optional — absent in v1 entities)
+    const queriesBlock = definition.queries || null;
+    const syncBlock = definition.sync || null;
+    const eventsBlock = definition.events || null;
 
     // Helper functions
     const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
@@ -937,6 +943,140 @@ export default {
       }
     }
 
+    // ============================================================================
+    // Architecture Target (from pipelines config)
+    // ============================================================================
+
+    const pipelinesConfig = getPipelinesConfig();
+    const architectureTarget = pipelinesConfig?.backend?.architecture ?? 'clean';
+
+    // ============================================================================
+    // v2: Family
+    // ============================================================================
+
+    const FAMILY_REPOSITORY_MAP = {
+      'crm-synced': 'CrmEntityRepository',
+      'activity': 'ActivityEntityRepository',
+      'knowledge': 'KnowledgeEntityRepository',
+      'metadata': 'MetadataEntityRepository',
+    };
+
+    const FAMILY_SERVICE_MAP = {
+      'crm-synced': 'CrmEntityService',
+      'activity': 'ActivityEntityService',
+      'knowledge': 'KnowledgeEntityService',
+      'metadata': 'MetadataEntityService',
+    };
+
+    const family = entity.family ?? null;
+    const hasFamily = family != null;
+    const familyBaseRepository = family ? (FAMILY_REPOSITORY_MAP[family] ?? null) : null;
+    const familyBaseService = family ? (FAMILY_SERVICE_MAP[family] ?? null) : null;
+
+    // ============================================================================
+    // v2: Queries
+    // ============================================================================
+
+    /**
+     * Derive a camelCase method name from a query spec.
+     *
+     * Rules:
+     *   select present → findXsByY  (e.g., select:[email], by:[opportunity_id] → findEmailsByOpportunityId)
+     *   otherwise      → findByX    (e.g., by:[user_id] → findByUserId)
+     *                                (e.g., by:[user_id, account_id] → findByUserIdAndAccountId)
+     */
+    function deriveQueryMethodName(query) {
+      const byFields = Array.isArray(query.by) ? query.by : [];
+      const selectFields = Array.isArray(query.select) ? query.select : [];
+
+      // Convert snake_case field list to PascalCase joined by "And"
+      const byPart = byFields.map((f) => pascalCase(f)).join('And');
+
+      if (selectFields.length > 0) {
+        // findEmailsByOpportunityId — select fields come first (plural implied)
+        const selectPart = selectFields.map((f) => pascalCase(f)).join('And') + 's';
+        return `find${selectPart}By${byPart}`;
+      }
+
+      return `findBy${byPart}`;
+    }
+
+    const hasQueries = queriesBlock != null && queriesBlock.length > 0;
+    const processedQueries = hasQueries
+      ? queriesBlock.map((q) => ({
+          // Raw YAML fields
+          by: q.by ?? [],
+          unique: q.unique ?? false,
+          select: q.select ?? null,
+          order: q.order ?? null,
+          limit: q.limit ?? null,
+          via: q.via ?? null,
+          // Derived
+          methodName: deriveQueryMethodName(q),
+          returnType: q.unique ? 'single' : 'array',
+          // Convenience flags
+          hasVia: q.via != null,
+          hasSelect: Array.isArray(q.select) && q.select.length > 0,
+          hasOrder: q.order != null,
+          hasLimit: q.limit != null,
+        }))
+      : [];
+
+    // ============================================================================
+    // v2: Sync
+    // ============================================================================
+
+    const hasSyncBlock = syncBlock != null;
+    const syncElectric = hasSyncBlock ? (syncBlock.electric ?? false) : false;
+    const rawSyncProviders = hasSyncBlock ? (syncBlock.providers ?? {}) : {};
+    const hasSyncProviders = Object.keys(rawSyncProviders).length > 0;
+
+    const syncProviders = hasSyncProviders
+      ? Object.entries(rawSyncProviders).map(([providerName, cfg]) => {
+          // Normalize field_mapping: { local: key, remote: value }[]
+          const rawMapping = cfg.field_mapping ?? {};
+          const fieldMapping = Object.entries(rawMapping).map(([local, remote]) => ({
+            local,
+            remote,
+          }));
+
+          return {
+            name: providerName,
+            remoteEntity: cfg.remote_entity ?? null,
+            direction: cfg.direction ?? 'bidirectional',
+            cdc: cfg.cdc ?? false,
+            fieldMapping,
+            readOnlyFields: cfg.read_only_fields ?? [],
+          };
+        })
+      : [];
+
+    // ============================================================================
+    // v2: Events
+    // ============================================================================
+
+    const hasEvents = eventsBlock != null && eventsBlock.length > 0;
+    const processedEvents = hasEvents
+      ? eventsBlock.map((ev) => {
+          // Convert body: { field: type } to array of { field, type }
+          const rawBody = ev.body ?? {};
+          const body = Object.entries(rawBody).map(([field, type]) => ({ field, type }));
+
+          // Derive class names from event name (snake_case → PascalCase + Event)
+          const className = pascalCase(ev.name) + 'Event';
+          const handlerClassName = pascalCase(ev.name) + 'Handler';
+
+          return {
+            name: ev.name,
+            queue: ev.queue ?? null,
+            body,
+            generateHandler: ev.generate_handler ?? false,
+            className,
+            handlerClassName,
+          };
+        })
+      : [];
+
     return {
       // Database configuration
       databaseDialect,
@@ -1121,6 +1261,33 @@ export default {
       // Electric SQL where clause (derived from entity FK fields)
       electricWhereColumn,
       electricWhereValue,
+
+      // ======================================================================
+      // v2 variables
+      // ======================================================================
+
+      // Architecture target (from pipelines.backend.architecture config)
+      architectureTarget,
+
+      // Family
+      family,
+      hasFamily,
+      familyBaseRepository,
+      familyBaseService,
+
+      // Queries
+      hasQueries,
+      processedQueries,
+
+      // Sync
+      hasSyncBlock,
+      syncElectric,
+      hasSyncProviders,
+      syncProviders,
+
+      // Events
+      hasEvents,
+      processedEvents,
     };
   },
 };

--- a/test/clean-lite-ps/prompt-extension.test.ts
+++ b/test/clean-lite-ps/prompt-extension.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for clean-lite-ps/prompt-extension.js
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { buildCleanLitePsLocals } from '../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+// Minimal base locals (the real version has many more fields, but we only need
+// the shape to test the extension itself)
+const EMPTY_BASE_LOCALS = {};
+
+// ============================================================================
+// Contact entity definition matching test/fixtures/contact-v2.yaml
+// ============================================================================
+
+const contactDefinition = {
+  entity: {
+    name: 'contact',
+    plural: 'contacts',
+    table: 'contacts',
+    family: 'crm-synced',
+  },
+  fields: {
+    user_id: { type: 'uuid', required: true },
+    account_id: { type: 'uuid', nullable: true },
+    first_name: { type: 'string', required: true },
+    last_name: { type: 'string', required: true },
+    email: { type: 'string', required: true },
+    title: { type: 'string', nullable: true },
+    phone: { type: 'string', nullable: true },
+    linkedin_url: { type: 'string', nullable: true },
+  },
+  relationships: {
+    account: { type: 'belongs_to', target: 'account', foreign_key: 'account_id', nullable: true },
+    user: { type: 'belongs_to', target: 'user', foreign_key: 'user_id', nullable: false },
+  },
+  behaviors: ['timestamps', 'soft_delete'],
+};
+
+// Entity without family key
+const noFamilyDefinition = {
+  entity: { name: 'task', plural: 'tasks', table: 'tasks' },
+  fields: { title: { type: 'string', required: true } },
+  relationships: {},
+  behaviors: [],
+};
+
+// Activity family entity
+const activityDefinition = {
+  entity: { name: 'note', plural: 'notes', table: 'notes', family: 'activity' },
+  fields: { body: { type: 'string', required: true } },
+  relationships: {},
+  behaviors: ['timestamps'],
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('buildCleanLitePsLocals', () => {
+  it('derives correct class names from entity name', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.entityName).toBe('contact');
+    expect(locals.entityNamePascal).toBe('Contact');
+    expect(locals.entityNamePlural).toBe('contacts');
+    expect(locals.entityNamePluralPascal).toBe('Contacts');
+
+    expect(locals.classNames.entity).toBe('Contact');
+    expect(locals.classNames.repository).toBe('ContactRepository');
+    expect(locals.classNames.service).toBe('ContactService');
+    expect(locals.classNames.controller).toBe('ContactController');
+    expect(locals.classNames.module).toBe('ContactsModule');
+    expect(locals.classNames.findByIdUseCase).toBe('FindContactByIdUseCase');
+    expect(locals.classNames.listUseCase).toBe('ListContactsUseCase');
+    expect(locals.classNames.createDto).toBe('CreateContactDto');
+    expect(locals.classNames.updateDto).toBe('UpdateContactDto');
+    expect(locals.classNames.outputDto).toBe('ContactOutputDto');
+    expect(locals.classNames.createSchema).toBe('CreateContactSchema');
+    expect(locals.classNames.updateSchema).toBe('UpdateContactSchema');
+    expect(locals.classNames.outputSchema).toBe('ContactOutputSchema');
+  });
+
+  it('maps crm-synced family to CrmEntityRepository and CrmEntityService', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.family).toBe('crm-synced');
+    expect(locals.repositoryBaseClass).toBe('CrmEntityRepository');
+    expect(locals.serviceBaseClass).toBe('CrmEntityService');
+    expect(locals.repositoryBaseImport).toBe('@shared/base-classes/crm-entity-repository');
+    expect(locals.serviceBaseImport).toBe('@shared/base-classes/crm-entity-service');
+  });
+
+  it('maps activity family to ActivityEntityRepository and ActivityEntityService', () => {
+    const locals = buildCleanLitePsLocals(activityDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.family).toBe('activity');
+    expect(locals.repositoryBaseClass).toBe('ActivityEntityRepository');
+    expect(locals.serviceBaseClass).toBe('ActivityEntityService');
+    expect(locals.repositoryBaseImport).toBe('@shared/base-classes/activity-entity-repository');
+    expect(locals.serviceBaseImport).toBe('@shared/base-classes/activity-entity-service');
+  });
+
+  it('defaults to base family when family key is absent', () => {
+    const locals = buildCleanLitePsLocals(noFamilyDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.family).toBe('base');
+    expect(locals.repositoryBaseClass).toBe('BaseRepository');
+    expect(locals.serviceBaseClass).toBe('BaseService');
+    expect(locals.repositoryBaseImport).toBe('@shared/base-classes/base-repository');
+    expect(locals.serviceBaseImport).toBe('@shared/base-classes/base-service');
+  });
+
+  it('generates correct output paths for entity with plural name', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.clpOutputPaths.entity).toBe('modules/contacts/contact.entity.ts');
+    expect(locals.clpOutputPaths.repository).toBe('modules/contacts/contact.repository.ts');
+    expect(locals.clpOutputPaths.service).toBe('modules/contacts/contact.service.ts');
+    expect(locals.clpOutputPaths.controller).toBe('modules/contacts/contact.controller.ts');
+    expect(locals.clpOutputPaths.module).toBe('modules/contacts/contacts.module.ts');
+    expect(locals.clpOutputPaths.findByIdUseCase).toBe('modules/contacts/use-cases/find-contact-by-id.use-case.ts');
+    expect(locals.clpOutputPaths.listUseCase).toBe('modules/contacts/use-cases/list-contacts.use-case.ts');
+    expect(locals.clpOutputPaths.createDto).toBe('modules/contacts/dto/create-contact.dto.ts');
+    expect(locals.clpOutputPaths.updateDto).toBe('modules/contacts/dto/update-contact.dto.ts');
+    expect(locals.clpOutputPaths.outputDto).toBe('modules/contacts/dto/contact-output.dto.ts');
+  });
+
+  it('processes belongs_to relations into BelongsToRelation shape', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.clpBelongsTo).toHaveLength(2);
+
+    const accountRel = locals.clpBelongsTo.find((r: any) => r.relatedEntity === 'account');
+    expect(accountRel).toBeDefined();
+    expect(accountRel!.field).toBe('account_id');
+    expect(accountRel!.camelField).toBe('accountId');
+    expect(accountRel!.relatedEntityPascal).toBe('Account');
+    expect(accountRel!.relatedTable).toBe('accounts');
+    expect(accountRel!.nullable).toBe(true);
+    expect(accountRel!.importPath).toBe('../accounts/account.entity');
+
+    const userRel = locals.clpBelongsTo.find((r: any) => r.relatedEntity === 'user');
+    expect(userRel).toBeDefined();
+    expect(userRel!.nullable).toBe(false);
+  });
+
+  it('excludes id and behavior fields from create DTO field list', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    const fieldNames = locals.clpCreateDtoFields.map((f: any) => f.name);
+
+    // Must not include these
+    expect(fieldNames).not.toContain('id');
+    expect(fieldNames).not.toContain('created_at');
+    expect(fieldNames).not.toContain('updated_at');
+    expect(fieldNames).not.toContain('deleted_at');
+
+    // Must include entity fields (FK fields handled separately in clpBelongsToFkFields)
+    expect(fieldNames).toContain('first_name');
+    expect(fieldNames).toContain('last_name');
+    expect(fieldNames).toContain('email');
+    expect(fieldNames).toContain('title');
+  });
+
+  it('includes all fields including id in output DTO field list', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    const fieldNames = locals.clpOutputDtoFields.map((f: any) => f.name);
+
+    // All entity fields appear (id is added via template literal, not in processedFields)
+    expect(fieldNames).toContain('first_name');
+    expect(fieldNames).toContain('last_name');
+    expect(fieldNames).toContain('email');
+    expect(fieldNames).toContain('title');
+    // Behavior fields NOT in clpOutputDtoFields (they come from hasTimestamps/hasSoftDelete)
+    // FK fields come from clpBelongsToFkFields
+  });
+
+  it('derives nullable correctly for fields with nullable: true', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    const titleField = locals.clpCreateDtoFields.find((f: any) => f.name === 'title');
+    expect(titleField).toBeDefined();
+    expect(titleField!.nullable).toBe(true);
+    expect(titleField!.zodChainCreate).toContain('.nullable()');
+
+    const firstNameField = locals.clpCreateDtoFields.find((f: any) => f.name === 'first_name');
+    expect(firstNameField).toBeDefined();
+    expect(firstNameField!.nullable).toBe(false);
+    expect(firstNameField!.zodChainCreate).not.toContain('.nullable()');
+  });
+
+  it('sets hasTimestamps and hasSoftDelete flags from behaviors', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.hasTimestamps).toBe(true);
+    expect(locals.hasSoftDelete).toBe(true);
+  });
+
+  it('sets hasTimestamps false when timestamps behavior absent', () => {
+    const locals = buildCleanLitePsLocals(noFamilyDefinition, EMPTY_BASE_LOCALS);
+
+    expect(locals.hasTimestamps).toBe(false);
+    expect(locals.hasSoftDelete).toBe(false);
+  });
+});

--- a/test/fixtures/codegen.config.yaml
+++ b/test/fixtures/codegen.config.yaml
@@ -42,3 +42,16 @@ locations:
   backendConstants:
     path: packages/api/src/constants
     import: "@api/constants"
+
+pipelines:
+  backend:
+    enabled: true
+    architecture: clean-lite-ps
+  frontend:
+    enabled: true
+    preset: dealbrain
+  shared:
+    enabled: true
+
+generate:
+  cleanLitePs: true

--- a/test/fixtures/contact-v2.yaml
+++ b/test/fixtures/contact-v2.yaml
@@ -1,0 +1,121 @@
+# Contact Entity Definition — v2 Architecture
+# Exercises all v2 schema blocks: family, queries, sync, events
+# Reference: docs/architecture/sketches/contact-module-sketch.md
+
+entity:
+  name: contact
+  plural: contacts
+  table: contacts
+  family: crm-synced
+  folder_structure: nested
+
+fields:
+  user_id:
+    type: uuid
+    required: true
+    index: true
+    foreign_key: users.id
+
+  account_id:
+    type: uuid
+    nullable: true
+    index: true
+    foreign_key: accounts.id
+
+  first_name:
+    type: string
+    required: true
+    max_length: 100
+
+  last_name:
+    type: string
+    required: true
+    max_length: 100
+
+  email:
+    type: string
+    required: true
+    max_length: 255
+
+  title:
+    type: string
+    nullable: true
+    max_length: 200
+
+  phone:
+    type: string
+    nullable: true
+    max_length: 50
+
+  linkedin_url:
+    type: string
+    nullable: true
+    max_length: 500
+
+behaviors:
+  - timestamps
+  - soft_delete
+  - external_id_tracking
+
+relationships:
+  account:
+    type: belongs_to
+    target: account
+    foreign_key: account_id
+
+  user:
+    type: belongs_to
+    target: user
+    foreign_key: user_id
+
+queries:
+  - by: [user_id]
+  - by: [email]
+    unique: true
+  - by: [account_id]
+    order: created_at desc
+  - by: [user_id, account_id]
+  - by: [opportunity_id]
+    via: opportunity_contact_link
+  - by: [opportunity_id]
+    select: [email]
+    via: opportunity_contact_link
+
+sync:
+  electric: true
+  providers:
+    salesforce:
+      remote_entity: Contact
+      direction: bidirectional
+      cdc: true
+      field_mapping:
+        first_name: FirstName
+        last_name: LastName
+        email: Email
+        title: Title
+        phone: Phone
+      read_only_fields:
+        - linkedin_url
+
+events:
+  - name: contact_created
+    queue: domain-events
+    body:
+      contact_id: uuid
+      account_id: uuid
+      created_by: uuid
+    generate_handler: true
+
+  - name: contact_merged
+    queue: domain-events
+    body:
+      source_id: uuid
+      target_id: uuid
+      merged_by: uuid
+    generate_handler: true
+
+  - name: contact_marked_champion
+    queue: domain-events
+    body:
+      contact_id: uuid
+      opportunity_id: uuid

--- a/test/scaffold/contact-scaffold.yaml
+++ b/test/scaffold/contact-scaffold.yaml
@@ -1,0 +1,47 @@
+# Simplified Contact Entity — Scaffold Test Harness
+#
+# Stripped-down version of contact-v2.yaml for use by test/scaffold/validate.sh.
+# Differences from contact-v2.yaml:
+#   - family: base (instead of crm-synced) — CrmEntityRepository does not exist yet
+#   - No external_id_tracking behavior — not yet supported in templates
+#   - No FK relationships to other entities — avoids circular import issues in scaffold
+#   - No queries/sync/events blocks — those are v2-only schema additions
+#
+# This is intentionally minimal. The scaffold exists only to prove the codegen
+# pipeline compiles and serves HTTP traffic, not to exercise every feature.
+
+entity:
+  name: contact
+  plural: contacts
+  table: contacts
+  family: base
+
+fields:
+  first_name:
+    type: string
+    required: true
+    max_length: 100
+
+  last_name:
+    type: string
+    required: true
+    max_length: 100
+
+  email:
+    type: string
+    required: true
+    max_length: 255
+
+  title:
+    type: string
+    nullable: true
+    max_length: 200
+
+  phone:
+    type: string
+    nullable: true
+    max_length: 50
+
+behaviors:
+  - timestamps
+  - soft_delete

--- a/test/scaffold/docker-compose.yml
+++ b/test/scaffold/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: scaffold_test
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10

--- a/test/scaffold/drizzle.config.ts
+++ b/test/scaffold/drizzle.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url:
+      process.env.DATABASE_URL ??
+      'postgresql://postgres:postgres@localhost:5432/scaffold_test',
+  },
+});

--- a/test/scaffold/package.json
+++ b/test/scaffold/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "scaffold",
+  "private": true,
+  "scripts": {
+    "start": "bun src/main.ts",
+    "drizzle-kit": "drizzle-kit"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "drizzle-orm": "^0.30.0",
+    "pg": "^8.11.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.0",
+    "drizzle-kit": "^0.21.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/test/scaffold/package.json
+++ b/test/scaffold/package.json
@@ -15,8 +15,11 @@
     "rxjs": "^7.8.0"
   },
   "devDependencies": {
+    "@nestjs/testing": "10",
     "@types/pg": "^8.11.0",
+    "@types/supertest": "^7.2.0",
     "drizzle-kit": "^0.21.0",
+    "supertest": "^7.2.2",
     "typescript": "^5.3.0"
   }
 }

--- a/test/scaffold/run-integration.ts
+++ b/test/scaffold/run-integration.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+/**
+ * Integration test orchestrator.
+ *
+ * Single command that: starts Docker Postgres, runs codegen,
+ * pushes schema, runs tests, and tears down.
+ *
+ * Usage:
+ *   bun test/scaffold/run-integration.ts          # full run
+ *   bun test/scaffold/run-integration.ts --skip-codegen  # skip codegen + push (already done)
+ *   bun test/scaffold/run-integration.ts --no-teardown   # keep Postgres running after tests
+ */
+import { $ } from 'bun';
+
+const REPO_ROOT = new URL('../..', import.meta.url).pathname.replace(/\/$/, '');
+const SCAFFOLD_DIR = new URL('.', import.meta.url).pathname.replace(/\/$/, '');
+
+const args = new Set(process.argv.slice(2));
+const skipCodegen = args.has('--skip-codegen');
+const noTeardown = args.has('--no-teardown');
+
+async function run() {
+  let exitCode = 0;
+
+  try {
+    // 1. Check Docker
+    console.log('==> Checking Docker...');
+    const dockerCheck = Bun.spawnSync(['docker', 'info', '--format', '{{.ServerVersion}}']);
+    if (dockerCheck.exitCode !== 0) {
+      console.error('ERROR: Docker is not running. Start Docker and try again.');
+      process.exit(1);
+    }
+    console.log(`    Docker ${new TextDecoder().decode(dockerCheck.stdout).trim()}`);
+
+    // 2. Start Postgres
+    console.log('==> Starting Postgres...');
+    await $`docker compose -f ${SCAFFOLD_DIR}/docker-compose.yml up -d --wait`.quiet();
+    console.log('    Postgres ready');
+
+    // 3. Install scaffold deps
+    console.log('==> Installing scaffold dependencies...');
+    await $`cd ${SCAFFOLD_DIR} && bun install`.quiet();
+
+    if (!skipCodegen) {
+      // 4. Setup codegen config
+      console.log('==> Running codegen...');
+      const configPath = `${REPO_ROOT}/codegen.config.yaml`;
+      const configBackup = `${configPath}.integration-bak`;
+      const existingConfig = Bun.file(configPath);
+      const hadConfig = await existingConfig.exists();
+      if (hadConfig) {
+        await Bun.write(configBackup, existingConfig);
+      }
+
+      await Bun.write(
+        configPath,
+        'generate:\n  cleanLitePs: true\n',
+      );
+
+      try {
+        await $`cd ${REPO_ROOT} && bun codegen entity test/scaffold/contact-scaffold.yaml`.quiet();
+        console.log('    Codegen complete');
+
+        // 5. Push schema
+        console.log('==> Pushing schema...');
+        await $`cd ${SCAFFOLD_DIR} && bun run drizzle-kit push --config drizzle.config.ts`.quiet();
+        console.log('    Schema pushed');
+      } finally {
+        // Restore config
+        if (hadConfig) {
+          const backup = Bun.file(configBackup);
+          await Bun.write(configPath, backup);
+          await $`rm -f ${configBackup}`.quiet();
+        } else {
+          await $`rm -f ${configPath}`.quiet();
+        }
+      }
+    } else {
+      console.log('==> Skipping codegen (--skip-codegen)');
+    }
+
+    // 6. Run tests
+    console.log('==> Running integration tests...');
+    const testResult = Bun.spawnSync(
+      ['bun', 'test', 'test/scaffold/tests/'],
+      { cwd: REPO_ROOT, stdio: ['inherit', 'inherit', 'inherit'] },
+    );
+    exitCode = testResult.exitCode;
+
+    if (exitCode === 0) {
+      console.log('\n==> All integration tests passed');
+    } else {
+      console.error('\n==> Some tests failed');
+    }
+  } finally {
+    // 7. Teardown
+    if (noTeardown) {
+      console.log('==> Skipping teardown (--no-teardown)');
+    } else {
+      console.log('==> Tearing down Postgres...');
+      await $`docker compose -f ${SCAFFOLD_DIR}/docker-compose.yml down -v`.quiet();
+    }
+  }
+
+  process.exit(exitCode);
+}
+
+run();

--- a/test/scaffold/schema.ts
+++ b/test/scaffold/schema.ts
@@ -1,0 +1,12 @@
+/**
+ * Drizzle schema for the scaffold test harness.
+ *
+ * Re-exports the contacts table from codegen output so that:
+ *   1. drizzle-kit push can create the contacts table in Docker Postgres
+ *   2. DatabaseModule can pass the schema to drizzle() for typed queries
+ *
+ * The import path uses the @gen alias (maps to repo root via tsconfig.json).
+ * After running codegen, the entity file lives at:
+ *   <repo-root>/modules/contacts/contact.entity.ts
+ */
+export { contacts } from '@gen/modules/contacts/contact.entity';

--- a/test/scaffold/shared/base-classes/base-analytics-service.ts
+++ b/test/scaffold/shared/base-classes/base-analytics-service.ts
@@ -1,0 +1,17 @@
+/**
+ * WithAnalytics — mixin stub for scaffold validation.
+ *
+ * The generated service uses WithAnalytics(BaseService<...>) mixin pattern.
+ * This stub is a no-op pass-through that satisfies the import.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+/**
+ * No-op analytics mixin. In production this would add analytics tracking.
+ * For the scaffold it just passes the base class through unchanged.
+ */
+export function WithAnalytics<TBase extends Constructor>(Base: TBase): TBase {
+  return Base;
+}

--- a/test/scaffold/shared/base-classes/base-repository.ts
+++ b/test/scaffold/shared/base-classes/base-repository.ts
@@ -1,0 +1,104 @@
+/**
+ * BaseRepository — minimal implementation for scaffold validation.
+ *
+ * Provides the CRUD interface that generated repositories inherit.
+ * Generated repositories call: findById, list, create, update, delete.
+ * This scaffold stub uses Drizzle directly with a generic table reference.
+ */
+import { eq, isNull } from 'drizzle-orm';
+import type { DrizzleClient } from '../types/drizzle';
+
+export abstract class BaseRepository<TEntity extends { id: string }> {
+  protected abstract readonly table: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  protected readonly db: DrizzleClient;
+
+  constructor(db: DrizzleClient) {
+    this.db = db;
+  }
+
+  async findById(id: string): Promise<TEntity | null> {
+    const rows = await this.db
+      .select()
+      .from(this.table)
+      .where(eq(this.table.id, id));
+    return (rows[0] as TEntity) ?? null;
+  }
+
+  async findByIds(ids: string[]): Promise<TEntity[]> {
+    if (ids.length === 0) return [];
+    const results: TEntity[] = [];
+    for (const id of ids) {
+      const row = await this.findById(id);
+      if (row) results.push(row);
+    }
+    return results;
+  }
+
+  async list(): Promise<TEntity[]> {
+    const rows = await this.db.select().from(this.table);
+    // Filter soft-deleted rows if deletedAt column exists
+    return (rows as TEntity[]).filter((r: any) => r.deletedAt == null); // eslint-disable-line @typescript-eslint/no-explicit-any
+  }
+
+  async count(): Promise<number> {
+    const rows = await this.list();
+    return rows.length;
+  }
+
+  async exists(id: string): Promise<boolean> {
+    const row = await this.findById(id);
+    return row != null;
+  }
+
+  async create(data: Omit<TEntity, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>): Promise<TEntity> {
+    const rows = await this.db
+      .insert(this.table)
+      .values(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+      .returning();
+    return rows[0] as TEntity;
+  }
+
+  async update(id: string, data: Partial<TEntity>): Promise<TEntity | null> {
+    const rows = await this.db
+      .update(this.table)
+      .set({ ...data, updatedAt: new Date() } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+      .where(eq(this.table.id, id))
+      .returning();
+    return (rows[0] as TEntity) ?? null;
+  }
+
+  async delete(id: string): Promise<TEntity | null> {
+    // Soft-delete: set deletedAt if the column exists, otherwise hard-delete
+    const row = await this.findById(id);
+    if (!row) return null;
+
+    if ('deletedAt' in this.table) {
+      const rows = await this.db
+        .update(this.table)
+        .set({ deletedAt: new Date() } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+        .where(eq(this.table.id, id))
+        .returning();
+      return (rows[0] as TEntity) ?? null;
+    }
+
+    const rows = await this.db
+      .delete(this.table)
+      .where(eq(this.table.id, id))
+      .returning();
+    return (rows[0] as TEntity) ?? null;
+  }
+
+  async upsertMany(items: Partial<TEntity>[]): Promise<TEntity[]> {
+    const results: TEntity[] = [];
+    for (const item of items) {
+      if ((item as any).id) { // eslint-disable-line @typescript-eslint/no-explicit-any
+        const updated = await this.update((item as any).id, item); // eslint-disable-line @typescript-eslint/no-explicit-any
+        if (updated) results.push(updated);
+      } else {
+        const created = await this.create(item as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+        results.push(created);
+      }
+    }
+    return results;
+  }
+}

--- a/test/scaffold/shared/base-classes/base-service.ts
+++ b/test/scaffold/shared/base-classes/base-service.ts
@@ -1,0 +1,46 @@
+/**
+ * BaseService — minimal implementation for scaffold validation.
+ *
+ * Provides the service layer that generated services inherit.
+ * Delegates all operations to the repository.
+ */
+import type { BaseRepository } from './base-repository';
+
+export abstract class BaseService<
+  TRepository extends BaseRepository<TEntity>,
+  TEntity extends { id: string },
+> {
+  protected abstract readonly repository: TRepository;
+
+  async findById(id: string): Promise<TEntity | null> {
+    return this.repository.findById(id);
+  }
+
+  async findByIds(ids: string[]): Promise<TEntity[]> {
+    return this.repository.findByIds(ids);
+  }
+
+  async list(): Promise<TEntity[]> {
+    return this.repository.list();
+  }
+
+  async count(): Promise<number> {
+    return this.repository.count();
+  }
+
+  async exists(id: string): Promise<boolean> {
+    return this.repository.exists(id);
+  }
+
+  async create(data: Omit<TEntity, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>): Promise<TEntity> {
+    return this.repository.create(data);
+  }
+
+  async update(id: string, data: Partial<TEntity>): Promise<TEntity | null> {
+    return this.repository.update(id, data);
+  }
+
+  async delete(id: string): Promise<TEntity | null> {
+    return this.repository.delete(id);
+  }
+}

--- a/test/scaffold/shared/constants/tokens.ts
+++ b/test/scaffold/shared/constants/tokens.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared injection tokens.
+ * DRIZZLE must match exactly what generated repositories use in @Inject(DRIZZLE).
+ * The generated repository imports this constant from '@shared/constants/tokens'.
+ */
+export const DRIZZLE = 'DRIZZLE' as const;
+export type DrizzleToken = typeof DRIZZLE;

--- a/test/scaffold/shared/database/database.module.ts
+++ b/test/scaffold/shared/database/database.module.ts
@@ -1,0 +1,40 @@
+/**
+ * DatabaseModule — provides the DRIZZLE injection token globally.
+ *
+ * DESIGN DECISION (A15):
+ * The generated repository imports DRIZZLE from '@shared/constants/tokens'.
+ * This module uses that same constant (re-exported from shared/constants/tokens.ts)
+ * so the token string matches exactly. The path alias @shared/* resolves to
+ * test/scaffold/shared/ via tsconfig.json paths, making the token value identical
+ * at runtime.
+ *
+ * Option A was chosen: a single source of truth at @shared/constants/tokens
+ * rather than duplicating the token string in multiple places.
+ */
+import { Module, Global } from '@nestjs/common';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as schema from '../../schema';
+import { DRIZZLE } from '../constants/tokens';
+
+export { DRIZZLE };
+export type DrizzleDB = ReturnType<typeof drizzle<typeof schema>>;
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: DRIZZLE,
+      useFactory: () => {
+        const pool = new Pool({
+          connectionString:
+            process.env.DATABASE_URL ??
+            'postgresql://postgres:postgres@localhost:5432/scaffold_test',
+        });
+        return drizzle(pool, { schema });
+      },
+    },
+  ],
+  exports: [DRIZZLE],
+})
+export class DatabaseModule {}

--- a/test/scaffold/shared/types/drizzle.ts
+++ b/test/scaffold/shared/types/drizzle.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared Drizzle type definitions.
+ * DrizzleClient is used by generated repositories as the db parameter type.
+ */
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DrizzleClient = NodePgDatabase<any>;

--- a/test/scaffold/src/app.module.ts
+++ b/test/scaffold/src/app.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../shared/database/database.module';
+import { ScaffoldContactsModule } from './contacts/scaffold-contacts.module';
+
+/**
+ * AppModule — root module for the scaffold test harness.
+ *
+ * DatabaseModule must come first — it is @Global() and provides the DRIZZLE
+ * injection token that ContactRepository (and thus all generated providers) depend on.
+ *
+ * ScaffoldContactsModule assembles generated providers (ContactRepository,
+ * ContactService, use cases) with hand-written write use cases and a full-CRUD
+ * controller, proving the codegen output compiles and wires up correctly.
+ */
+@Module({
+  imports: [DatabaseModule, ScaffoldContactsModule],
+})
+export class AppModule {}

--- a/test/scaffold/src/contacts/contacts-full.controller.ts
+++ b/test/scaffold/src/contacts/contacts-full.controller.ts
@@ -1,0 +1,67 @@
+/**
+ * ContactsFullController — scaffold controller with full CRUD routes.
+ *
+ * The generated ContactsController only has GET routes (read-only by design).
+ * This scaffold controller adds POST/PUT/DELETE to exercise the full stack.
+ * It overrides the route prefix 'contacts' and is registered in ScaffoldContactsModule
+ * in place of the generated controller.
+ */
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { FindContactByIdUseCase } from '@gen/modules/contacts/use-cases/find-contact-by-id.use-case';
+import { ListContactsUseCase } from '@gen/modules/contacts/use-cases/list-contacts.use-case';
+import type { Contact, ContactInsert } from '@gen/modules/contacts/contact.entity';
+import { CreateContactUseCase } from './create-contact.use-case';
+import { UpdateContactUseCase } from './update-contact.use-case';
+import { DeleteContactUseCase } from './delete-contact.use-case';
+
+@Controller('contacts')
+export class ContactsFullController {
+  constructor(
+    private readonly findByIdUseCase: FindContactByIdUseCase,
+    private readonly listUseCase: ListContactsUseCase,
+    private readonly createUseCase: CreateContactUseCase,
+    private readonly updateUseCase: UpdateContactUseCase,
+    private readonly deleteUseCase: DeleteContactUseCase,
+  ) {}
+
+  @Get()
+  async getAll(): Promise<Contact[]> {
+    return this.listUseCase.execute();
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string): Promise<Contact | null> {
+    return this.findByIdUseCase.execute(id);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() body: Omit<ContactInsert, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>,
+  ): Promise<Contact> {
+    return this.createUseCase.execute(body);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() body: Partial<Contact>,
+  ): Promise<Contact | null> {
+    return this.updateUseCase.execute(id, body);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: string): Promise<Contact | null> {
+    return this.deleteUseCase.execute(id);
+  }
+}

--- a/test/scaffold/src/contacts/create-contact.use-case.ts
+++ b/test/scaffold/src/contacts/create-contact.use-case.ts
@@ -1,0 +1,18 @@
+/**
+ * CreateContactUseCase — hand-written write use case for scaffold validation.
+ *
+ * In production, write use cases are hand-written per ADR-003.
+ * This scaffold implementation demonstrates the pattern.
+ */
+import { Injectable } from '@nestjs/common';
+import { ContactService } from '@gen/modules/contacts/contact.service';
+import type { Contact, ContactInsert } from '@gen/modules/contacts/contact.entity';
+
+@Injectable()
+export class CreateContactUseCase {
+  constructor(private readonly service: ContactService) {}
+
+  async execute(data: Omit<ContactInsert, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>): Promise<Contact> {
+    return this.service.create(data);
+  }
+}

--- a/test/scaffold/src/contacts/delete-contact.use-case.ts
+++ b/test/scaffold/src/contacts/delete-contact.use-case.ts
@@ -1,0 +1,16 @@
+/**
+ * DeleteContactUseCase — hand-written write use case for scaffold validation.
+ * Soft-deletes the contact (sets deletedAt) via BaseService.delete.
+ */
+import { Injectable } from '@nestjs/common';
+import { ContactService } from '@gen/modules/contacts/contact.service';
+import type { Contact } from '@gen/modules/contacts/contact.entity';
+
+@Injectable()
+export class DeleteContactUseCase {
+  constructor(private readonly service: ContactService) {}
+
+  async execute(id: string): Promise<Contact | null> {
+    return this.service.delete(id);
+  }
+}

--- a/test/scaffold/src/contacts/scaffold-contacts.module.ts
+++ b/test/scaffold/src/contacts/scaffold-contacts.module.ts
@@ -1,0 +1,42 @@
+/**
+ * ScaffoldContactsModule — assembles generated providers with a full-CRUD controller.
+ *
+ * WHY NOT import ContactsModule directly:
+ *   The generated ContactsModule registers ContactsController (read-only GET routes).
+ *   Adding a second controller for the same /contacts prefix would cause route conflicts.
+ *   Instead, this module imports the generated providers individually, which validates
+ *   that they compile and inject correctly without duplicating the route prefix.
+ *
+ * This module exercises:
+ *   - ContactRepository (generated) — injects DRIZZLE, extends BaseRepository
+ *   - ContactService (generated) — injects repository, extends BaseService
+ *   - FindContactByIdUseCase (generated) — injects service
+ *   - ListContactsUseCase (generated) — injects service
+ *   - Write use cases (hand-written) — injects service
+ *   - ContactsFullController (hand-written) — injects all use cases
+ */
+import { Module } from '@nestjs/common';
+import { ContactRepository } from '@gen/modules/contacts/contact.repository';
+import { ContactService } from '@gen/modules/contacts/contact.service';
+import { FindContactByIdUseCase } from '@gen/modules/contacts/use-cases/find-contact-by-id.use-case';
+import { ListContactsUseCase } from '@gen/modules/contacts/use-cases/list-contacts.use-case';
+import { ContactsFullController } from './contacts-full.controller';
+import { CreateContactUseCase } from './create-contact.use-case';
+import { UpdateContactUseCase } from './update-contact.use-case';
+import { DeleteContactUseCase } from './delete-contact.use-case';
+
+@Module({
+  controllers: [ContactsFullController],
+  providers: [
+    // Generated providers (validated by compilation)
+    ContactRepository,
+    ContactService,
+    FindContactByIdUseCase,
+    ListContactsUseCase,
+    // Hand-written write use cases
+    CreateContactUseCase,
+    UpdateContactUseCase,
+    DeleteContactUseCase,
+  ],
+})
+export class ScaffoldContactsModule {}

--- a/test/scaffold/src/contacts/update-contact.use-case.ts
+++ b/test/scaffold/src/contacts/update-contact.use-case.ts
@@ -1,0 +1,15 @@
+/**
+ * UpdateContactUseCase — hand-written write use case for scaffold validation.
+ */
+import { Injectable } from '@nestjs/common';
+import { ContactService } from '@gen/modules/contacts/contact.service';
+import type { Contact } from '@gen/modules/contacts/contact.entity';
+
+@Injectable()
+export class UpdateContactUseCase {
+  constructor(private readonly service: ContactService) {}
+
+  async execute(id: string, data: Partial<Contact>): Promise<Contact | null> {
+    return this.service.update(id, data);
+  }
+}

--- a/test/scaffold/src/main.ts
+++ b/test/scaffold/src/main.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableShutdownHooks();
+  await app.listen(3000);
+  console.log('NestJS scaffold listening on http://localhost:3000');
+}
+
+bootstrap().catch((err) => {
+  console.error('Failed to start scaffold app:', err);
+  process.exit(1);
+});

--- a/test/scaffold/tests/helpers.ts
+++ b/test/scaffold/tests/helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Test helpers — factories and utilities.
+ */
+import type { ContactInsert } from '@gen/modules/contacts/contact.entity';
+
+let counter = 0;
+
+/** Generate a unique email for test isolation. */
+export function uniqueEmail(): string {
+  return `test-${++counter}-${Date.now()}@example.com`;
+}
+
+/** Factory for valid contact creation data. */
+export function contactFactory(
+  overrides?: Partial<Omit<ContactInsert, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>>,
+) {
+  return {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: uniqueEmail(),
+    ...overrides,
+  };
+}

--- a/test/scaffold/tests/http.test.ts
+++ b/test/scaffold/tests/http.test.ts
@@ -1,0 +1,190 @@
+/**
+ * HTTP integration tests — full NestJS stack via supertest.
+ *
+ * Validates DI wiring, controller routing, use case integration,
+ * and the full request/response lifecycle against real Postgres.
+ */
+import 'reflect-metadata';
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import supertest from 'supertest';
+import { AppModule } from '../src/app.module';
+import { truncateAll, closeDb } from './setup';
+
+let app: INestApplication;
+let request: ReturnType<typeof supertest>;
+
+beforeAll(async () => {
+  const moduleRef = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  app = moduleRef.createNestApplication();
+  await app.init();
+  request = supertest(app.getHttpServer());
+});
+
+beforeEach(async () => {
+  await truncateAll();
+});
+
+afterAll(async () => {
+  await app?.close();
+  await closeDb();
+});
+
+// ---------------------------------------------------------------------------
+// POST /contacts
+// ---------------------------------------------------------------------------
+describe('POST /contacts', () => {
+  test('creates a contact and returns 201', async () => {
+    const res = await request
+      .post('/contacts')
+      .send({ firstName: 'Ada', lastName: 'Lovelace', email: 'ada@example.com' })
+      .expect(201);
+
+    expect(res.body.id).toBeDefined();
+    expect(res.body.firstName).toBe('Ada');
+    expect(res.body.lastName).toBe('Lovelace');
+    expect(res.body.email).toBe('ada@example.com');
+    expect(res.body.createdAt).toBeDefined();
+    expect(res.body.deletedAt).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /contacts
+// ---------------------------------------------------------------------------
+describe('GET /contacts', () => {
+  test('returns empty array when no contacts', async () => {
+    const res = await request.get('/contacts').expect(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('returns all non-deleted contacts', async () => {
+    await request
+      .post('/contacts')
+      .send({ firstName: 'Alice', lastName: 'A', email: 'alice@example.com' });
+    await request
+      .post('/contacts')
+      .send({ firstName: 'Bob', lastName: 'B', email: 'bob@example.com' });
+
+    const res = await request.get('/contacts').expect(200);
+    expect(res.body).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /contacts/:id
+// ---------------------------------------------------------------------------
+describe('GET /contacts/:id', () => {
+  test('returns the correct contact', async () => {
+    const created = await request
+      .post('/contacts')
+      .send({ firstName: 'Ada', lastName: 'L', email: 'ada@example.com' });
+
+    const res = await request.get(`/contacts/${created.body.id}`).expect(200);
+    expect(res.body.id).toBe(created.body.id);
+    expect(res.body.firstName).toBe('Ada');
+  });
+
+  test('returns empty body for nonexistent ID', async () => {
+    const res = await request
+      .get('/contacts/00000000-0000-0000-0000-000000000000')
+      .expect(200);
+    // Controller returns null, NestJS serializes as empty object
+    expect(res.body.id).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /contacts/:id
+// ---------------------------------------------------------------------------
+describe('PUT /contacts/:id', () => {
+  test('updates fields and returns updated contact', async () => {
+    const created = await request
+      .post('/contacts')
+      .send({ firstName: 'Ada', lastName: 'L', email: 'ada@example.com' });
+
+    const res = await request
+      .put(`/contacts/${created.body.id}`)
+      .send({ title: 'Mathematician' })
+      .expect(200);
+
+    expect(res.body.title).toBe('Mathematician');
+    expect(res.body.firstName).toBe('Ada'); // unchanged
+    // updatedAt should be bumped
+    expect(new Date(res.body.updatedAt).getTime()).toBeGreaterThan(
+      new Date(created.body.updatedAt).getTime(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /contacts/:id (soft-delete)
+// ---------------------------------------------------------------------------
+describe('DELETE /contacts/:id', () => {
+  test('soft-deletes and returns the entity with deletedAt set', async () => {
+    const created = await request
+      .post('/contacts')
+      .send({ firstName: 'Ada', lastName: 'L', email: 'ada@example.com' });
+
+    const res = await request
+      .delete(`/contacts/${created.body.id}`)
+      .expect(200);
+
+    expect(res.body.id).toBe(created.body.id);
+    expect(res.body.deletedAt).toBeDefined();
+    expect(res.body.deletedAt).not.toBeNull();
+  });
+
+  test('soft-deleted contacts excluded from GET /contacts', async () => {
+    const created = await request
+      .post('/contacts')
+      .send({ firstName: 'Ada', lastName: 'L', email: 'ada@example.com' });
+
+    await request.delete(`/contacts/${created.body.id}`);
+
+    const res = await request.get('/contacts').expect(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full lifecycle
+// ---------------------------------------------------------------------------
+describe('full CRUD lifecycle', () => {
+  test('create → read → update → delete → verify gone from list', async () => {
+    // Create
+    const createRes = await request
+      .post('/contacts')
+      .send({ firstName: 'Ada', lastName: 'Lovelace', email: 'ada@test.com' })
+      .expect(201);
+    const id = createRes.body.id;
+
+    // Read
+    const getRes = await request.get(`/contacts/${id}`).expect(200);
+    expect(getRes.body.firstName).toBe('Ada');
+
+    // Update
+    const putRes = await request
+      .put(`/contacts/${id}`)
+      .send({ title: 'Pioneer' })
+      .expect(200);
+    expect(putRes.body.title).toBe('Pioneer');
+
+    // List includes updated entity
+    const listRes = await request.get('/contacts').expect(200);
+    expect(listRes.body).toHaveLength(1);
+    expect(listRes.body[0].title).toBe('Pioneer');
+
+    // Delete
+    const delRes = await request.delete(`/contacts/${id}`).expect(200);
+    expect(delRes.body.deletedAt).not.toBeNull();
+
+    // List excludes deleted
+    const listAfter = await request.get('/contacts').expect(200);
+    expect(listAfter.body).toEqual([]);
+  });
+});

--- a/test/scaffold/tests/repository.test.ts
+++ b/test/scaffold/tests/repository.test.ts
@@ -1,0 +1,264 @@
+/**
+ * BaseRepository integration tests against real Postgres.
+ *
+ * No NestJS, no HTTP — just Drizzle → Postgres.
+ * Tests every inherited method from BaseRepository using ContactRepository.
+ */
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { ContactRepository } from '@gen/modules/contacts/contact.repository';
+import type { Contact } from '@gen/modules/contacts/contact.entity';
+import { getTestDb, truncateAll, closeDb } from './setup';
+import { contactFactory } from './helpers';
+
+let repo: ContactRepository;
+
+beforeAll(() => {
+  const db = getTestDb();
+  // Direct instantiation — @Inject is just metadata, constructor takes DrizzleClient
+  repo = new ContactRepository(db as any);
+});
+
+beforeEach(async () => {
+  await truncateAll();
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+describe('create', () => {
+  test('returns entity with generated UUID and timestamps', async () => {
+    const data = contactFactory();
+    const result = await repo.create(data);
+
+    expect(result.id).toBeDefined();
+    expect(result.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(result.firstName).toBe(data.firstName);
+    expect(result.lastName).toBe(data.lastName);
+    expect(result.email).toBe(data.email);
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.updatedAt).toBeInstanceOf(Date);
+    expect(result.deletedAt).toBeNull();
+  });
+
+  test('creates multiple distinct entities', async () => {
+    const a = await repo.create(contactFactory({ firstName: 'Alice' }));
+    const b = await repo.create(contactFactory({ firstName: 'Bob' }));
+
+    expect(a.id).not.toBe(b.id);
+    expect(a.firstName).toBe('Alice');
+    expect(b.firstName).toBe('Bob');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findById
+// ---------------------------------------------------------------------------
+describe('findById', () => {
+  test('returns the correct entity', async () => {
+    const created = await repo.create(contactFactory());
+    const found = await repo.findById(created.id);
+
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(created.id);
+    expect(found!.email).toBe(created.email);
+  });
+
+  test('returns null for nonexistent ID', async () => {
+    const found = await repo.findById('00000000-0000-0000-0000-000000000000');
+    expect(found).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findByIds
+// ---------------------------------------------------------------------------
+describe('findByIds', () => {
+  test('returns correct subset', async () => {
+    const a = await repo.create(contactFactory({ firstName: 'Alice' }));
+    const b = await repo.create(contactFactory({ firstName: 'Bob' }));
+    await repo.create(contactFactory({ firstName: 'Charlie' }));
+
+    const found = await repo.findByIds([a.id, b.id]);
+
+    expect(found).toHaveLength(2);
+    const names = found.map((c) => c.firstName).sort();
+    expect(names).toEqual(['Alice', 'Bob']);
+  });
+
+  test('returns empty array for empty input', async () => {
+    const found = await repo.findByIds([]);
+    expect(found).toEqual([]);
+  });
+
+  test('skips nonexistent IDs', async () => {
+    const a = await repo.create(contactFactory());
+    const found = await repo.findByIds([a.id, '00000000-0000-0000-0000-000000000000']);
+    expect(found).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+describe('list', () => {
+  test('returns all non-deleted entities', async () => {
+    await repo.create(contactFactory({ firstName: 'Alice' }));
+    await repo.create(contactFactory({ firstName: 'Bob' }));
+
+    const all = await repo.list();
+    expect(all).toHaveLength(2);
+  });
+
+  test('returns empty array when no entities exist', async () => {
+    const all = await repo.list();
+    expect(all).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// count
+// ---------------------------------------------------------------------------
+describe('count', () => {
+  test('returns correct count', async () => {
+    expect(await repo.count()).toBe(0);
+
+    await repo.create(contactFactory());
+    expect(await repo.count()).toBe(1);
+
+    await repo.create(contactFactory());
+    expect(await repo.count()).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exists
+// ---------------------------------------------------------------------------
+describe('exists', () => {
+  test('returns true for existing entity', async () => {
+    const created = await repo.create(contactFactory());
+    expect(await repo.exists(created.id)).toBe(true);
+  });
+
+  test('returns false for nonexistent ID', async () => {
+    expect(await repo.exists('00000000-0000-0000-0000-000000000000')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+describe('update', () => {
+  test('changes fields and bumps updatedAt', async () => {
+    const created = await repo.create(contactFactory());
+
+    // Small delay to ensure updatedAt changes
+    await new Promise((r) => setTimeout(r, 10));
+
+    const updated = await repo.update(created.id, { title: 'Mathematician' });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.title).toBe('Mathematician');
+    expect(updated!.firstName).toBe(created.firstName); // unchanged
+    expect(updated!.updatedAt.getTime()).toBeGreaterThan(created.updatedAt.getTime());
+  });
+
+  test('returns null for nonexistent ID', async () => {
+    const result = await repo.update('00000000-0000-0000-0000-000000000000', {
+      title: 'Ghost',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete (soft)
+// ---------------------------------------------------------------------------
+describe('delete (soft)', () => {
+  test('sets deletedAt timestamp', async () => {
+    const created = await repo.create(contactFactory());
+    const deleted = await repo.delete(created.id);
+
+    expect(deleted).not.toBeNull();
+    expect(deleted!.id).toBe(created.id);
+    expect(deleted!.deletedAt).toBeInstanceOf(Date);
+  });
+
+  test('soft-deleted entities excluded from list()', async () => {
+    const a = await repo.create(contactFactory({ firstName: 'Alice' }));
+    await repo.create(contactFactory({ firstName: 'Bob' }));
+
+    await repo.delete(a.id);
+
+    const all = await repo.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].firstName).toBe('Bob');
+  });
+
+  test('soft-deleted entities excluded from count()', async () => {
+    const a = await repo.create(contactFactory());
+    await repo.create(contactFactory());
+
+    await repo.delete(a.id);
+    expect(await repo.count()).toBe(1);
+  });
+
+  test('findById still returns soft-deleted entity', async () => {
+    const created = await repo.create(contactFactory());
+    await repo.delete(created.id);
+
+    // findById does NOT filter soft-deleted — intentional for lookups
+    const found = await repo.findById(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.deletedAt).not.toBeNull();
+  });
+
+  test('returns null for nonexistent ID', async () => {
+    const result = await repo.delete('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertMany
+// ---------------------------------------------------------------------------
+describe('upsertMany', () => {
+  test('creates new entities when no id provided', async () => {
+    const results = await repo.upsertMany([
+      contactFactory({ firstName: 'Alice' }) as Partial<Contact>,
+      contactFactory({ firstName: 'Bob' }) as Partial<Contact>,
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].id).toBeDefined();
+    expect(results[1].id).toBeDefined();
+  });
+
+  test('updates existing entities when id provided', async () => {
+    const created = await repo.create(contactFactory({ firstName: 'Old' }));
+
+    const results = await repo.upsertMany([
+      { id: created.id, firstName: 'New' } as Partial<Contact>,
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].firstName).toBe('New');
+    expect(results[0].id).toBe(created.id);
+  });
+
+  test('handles mix of creates and updates', async () => {
+    const existing = await repo.create(contactFactory({ firstName: 'Existing' }));
+
+    const results = await repo.upsertMany([
+      { id: existing.id, title: 'Updated' } as Partial<Contact>,
+      contactFactory({ firstName: 'Brand New' }) as Partial<Contact>,
+    ]);
+
+    expect(results).toHaveLength(2);
+  });
+});

--- a/test/scaffold/tests/setup.ts
+++ b/test/scaffold/tests/setup.ts
@@ -1,0 +1,41 @@
+/**
+ * Test infrastructure — DB lifecycle management.
+ *
+ * Provides a Drizzle client connected to the Docker Postgres instance
+ * from docker-compose.yml. Used by both repository and HTTP tests.
+ */
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { sql } from 'drizzle-orm';
+import * as schema from '../schema';
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ??
+  'postgresql://postgres:postgres@localhost:5432/scaffold_test';
+
+let pool: Pool | null = null;
+let db: ReturnType<typeof drizzle<typeof schema>> | null = null;
+
+/** Get or create the shared Drizzle client. */
+export function getTestDb() {
+  if (!db) {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    db = drizzle(pool, { schema });
+  }
+  return db;
+}
+
+/** Truncate all known tables. Call between tests for isolation. */
+export async function truncateAll() {
+  const client = getTestDb();
+  await client.execute(sql`TRUNCATE contacts CASCADE`);
+}
+
+/** Close the connection pool. Call in afterAll. */
+export async function closeDb() {
+  if (pool) {
+    await pool.end();
+    pool = null;
+    db = null;
+  }
+}

--- a/test/scaffold/tsconfig.json
+++ b/test/scaffold/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "@gen/*": ["../../*"],
+      "@shared/*": ["./shared/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "shared/**/*",
+    "schema.ts",
+    "drizzle.config.ts"
+  ]
+}

--- a/test/scaffold/tsconfig.json
+++ b/test/scaffold/tsconfig.json
@@ -18,6 +18,7 @@
     "src/**/*",
     "shared/**/*",
     "schema.ts",
-    "drizzle.config.ts"
+    "drizzle.config.ts",
+    "../../modules/**/*"
   ]
 }

--- a/test/scaffold/validate.sh
+++ b/test/scaffold/validate.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test/scaffold/validate.sh
+#
+# Full integration loop: generates contact entity, migrates schema, starts
+# NestJS app, exercises CRUD endpoints, then tears down.
+#
+# IMPORTANT — Simplified entity:
+#   This script uses test/scaffold/contact-scaffold.yaml (not contact-v2.yaml).
+#   contact-v2.yaml uses family: crm-synced and external_id_tracking behavior
+#   which depend on CrmEntityRepository/CrmEntityService that are not yet
+#   implemented. contact-scaffold.yaml uses family: base which only requires
+#   BaseRepository and BaseService (provided by test/scaffold/shared/).
+#
+# Usage:
+#   bash test/scaffold/validate.sh
+#   or: chmod +x test/scaffold/validate.sh && ./test/scaffold/validate.sh
+#
+# Requirements:
+#   - Docker (for Postgres 16)
+#   - bun (runtime)
+#   - hygen (peer dep: bun add -d hygen from repo root)
+#
+set -euo pipefail
+
+SCAFFOLD_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCAFFOLD_DIR/../.." && pwd)"
+CODEGEN_CONFIG="$REPO_ROOT/codegen.config.yaml"
+CODEGEN_CONFIG_BACKUP="$REPO_ROOT/codegen.config.yaml.scaffold-bak"
+
+# ---------------------------------------------------------------------------
+# Cleanup function — always runs on exit (success or failure)
+# ---------------------------------------------------------------------------
+cleanup() {
+  local exit_code=$?
+  echo "==> Cleanup (exit_code=$exit_code)"
+
+  # Kill the app if still running
+  if [ -n "${APP_PID:-}" ]; then
+    kill "$APP_PID" 2>/dev/null || true
+  fi
+
+  # Tear down Docker
+  docker compose -f "$SCAFFOLD_DIR/docker-compose.yml" down -v 2>/dev/null || true
+
+  # Restore or remove the temporary codegen config
+  if [ -f "$CODEGEN_CONFIG_BACKUP" ]; then
+    mv "$CODEGEN_CONFIG_BACKUP" "$CODEGEN_CONFIG"
+  elif [ "${SCAFFOLD_CONFIG_CREATED:-false}" = "true" ]; then
+    rm -f "$CODEGEN_CONFIG"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Install scaffold dependencies
+# ---------------------------------------------------------------------------
+echo "==> Installing scaffold dependencies"
+cd "$SCAFFOLD_DIR"
+bun install
+
+# ---------------------------------------------------------------------------
+# 2. Create a temporary codegen.config.yaml with cleanLitePs enabled
+#    The test runner (run-test.ts) also manages this file, so we back it up
+#    if it already exists and restore it in the cleanup function.
+# ---------------------------------------------------------------------------
+echo "==> Setting up codegen config for scaffold"
+cd "$REPO_ROOT"
+if [ -f "$CODEGEN_CONFIG" ]; then
+  cp "$CODEGEN_CONFIG" "$CODEGEN_CONFIG_BACKUP"
+fi
+SCAFFOLD_CONFIG_CREATED=true
+
+cat > "$CODEGEN_CONFIG" << 'YAML_EOF'
+# Temporary config created by test/scaffold/validate.sh
+# Cleaned up automatically on exit.
+generate:
+  cleanLitePs: true
+YAML_EOF
+
+# ---------------------------------------------------------------------------
+# 3. Start Postgres
+# ---------------------------------------------------------------------------
+echo "==> Starting Postgres"
+docker compose -f "$SCAFFOLD_DIR/docker-compose.yml" up -d --wait
+
+# ---------------------------------------------------------------------------
+# 4. Run codegen
+#    Uses contact-scaffold.yaml (base family, no CRM dependencies).
+#    Output lands at <repo-root>/modules/contacts/ (Hygen output path).
+# ---------------------------------------------------------------------------
+echo "==> Running codegen for contact-scaffold"
+cd "$REPO_ROOT"
+bun codegen entity test/scaffold/contact-scaffold.yaml
+
+# ---------------------------------------------------------------------------
+# 5. Push schema with drizzle-kit
+# ---------------------------------------------------------------------------
+echo "==> Running drizzle-kit push"
+cd "$SCAFFOLD_DIR"
+bun run drizzle-kit push --config drizzle.config.ts
+
+# ---------------------------------------------------------------------------
+# 6. Start NestJS app in background
+# ---------------------------------------------------------------------------
+echo "==> Starting NestJS app"
+cd "$SCAFFOLD_DIR"
+APP_PID=""
+bun run start &
+APP_PID=$!
+
+# Wait until port 3000 accepts connections (max 20s)
+echo "==> Waiting for app to be ready..."
+for i in $(seq 1 20); do
+  if curl -sf http://localhost:3000/contacts > /dev/null 2>&1; then
+    echo "    App ready after ${i}s"
+    break
+  fi
+  if [ "$i" -eq 20 ]; then
+    echo "ERROR: App did not start within 20 seconds"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# 7. CRUD assertions
+# ---------------------------------------------------------------------------
+echo "==> POST /contacts (create)"
+CREATE_RESPONSE=$(curl -sf -X POST http://localhost:3000/contacts \
+  -H 'Content-Type: application/json' \
+  -d '{"firstName":"Ada","lastName":"Lovelace","email":"ada@example.com"}')
+echo "$CREATE_RESPONSE"
+
+# Extract contact ID — prefer jq, fall back to python3
+if command -v jq > /dev/null 2>&1; then
+  CONTACT_ID=$(echo "$CREATE_RESPONSE" | jq -r '.id')
+else
+  CONTACT_ID=$(echo "$CREATE_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+fi
+
+if [ -z "$CONTACT_ID" ] || [ "$CONTACT_ID" = "null" ]; then
+  echo "ERROR: POST did not return an id"
+  exit 1
+fi
+echo "    Created contact id=$CONTACT_ID"
+
+echo "==> GET /contacts (list)"
+LIST_RESPONSE=$(curl -sf http://localhost:3000/contacts)
+echo "$LIST_RESPONSE"
+if command -v jq > /dev/null 2>&1; then
+  LIST_LEN=$(echo "$LIST_RESPONSE" | jq 'length')
+else
+  LIST_LEN=$(echo "$LIST_RESPONSE" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+fi
+if [ "$LIST_LEN" -lt 1 ]; then
+  echo "ERROR: GET /contacts returned empty array"
+  exit 1
+fi
+echo "    list ok, count=$LIST_LEN"
+
+echo "==> GET /contacts/:id"
+GET_RESPONSE=$(curl -sf "http://localhost:3000/contacts/$CONTACT_ID")
+echo "$GET_RESPONSE"
+if command -v jq > /dev/null 2>&1; then
+  FETCHED_ID=$(echo "$GET_RESPONSE" | jq -r '.id')
+else
+  FETCHED_ID=$(echo "$GET_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+fi
+if [ "$FETCHED_ID" != "$CONTACT_ID" ]; then
+  echo "ERROR: GET /contacts/:id returned wrong id (got $FETCHED_ID, expected $CONTACT_ID)"
+  exit 1
+fi
+echo "    get-by-id ok"
+
+echo "==> PUT /contacts/:id (update)"
+UPDATE_RESPONSE=$(curl -sf -X PUT "http://localhost:3000/contacts/$CONTACT_ID" \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Mathematician"}')
+echo "$UPDATE_RESPONSE"
+if command -v jq > /dev/null 2>&1; then
+  UPDATED_TITLE=$(echo "$UPDATE_RESPONSE" | jq -r '.title')
+else
+  UPDATED_TITLE=$(echo "$UPDATE_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])")
+fi
+if [ "$UPDATED_TITLE" != "Mathematician" ]; then
+  echo "ERROR: PUT did not update title (got $UPDATED_TITLE)"
+  exit 1
+fi
+echo "    update ok"
+
+echo "==> DELETE /contacts/:id (soft-delete)"
+DELETE_RESPONSE=$(curl -sf -X DELETE "http://localhost:3000/contacts/$CONTACT_ID")
+echo "$DELETE_RESPONSE"
+if command -v jq > /dev/null 2>&1; then
+  DELETED_ID=$(echo "$DELETE_RESPONSE" | jq -r '.id')
+else
+  DELETED_ID=$(echo "$DELETE_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+fi
+if [ "$DELETED_ID" != "$CONTACT_ID" ]; then
+  echo "ERROR: DELETE response missing correct id (got $DELETED_ID)"
+  exit 1
+fi
+echo "    delete (soft) ok"
+
+# ---------------------------------------------------------------------------
+# 8. Done (cleanup runs via trap)
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> All checks passed"
+exit 0

--- a/test/schema-v2.test.ts
+++ b/test/schema-v2.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Schema v2 validation tests
+ *
+ * Tests for SPEC-002: family, queries, sync, events blocks
+ * and pipelines config schema.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { EntityDefinitionSchema } from '../schema/entity-definition.schema';
+import { PipelinesConfigSchema } from '../schema/pipelines-config.schema';
+import { loadEntityFromYaml } from '../utils/yaml-loader';
+import { loadEntities } from '../parser/load-entities';
+import { buildDomainGraph } from '../analyzer/graph-builder';
+import { checkConsistency } from '../analyzer/consistency-checker';
+import { resolveBehaviors } from '../behaviors/index';
+import { resolve } from 'path';
+
+// ============================================================================
+// Entity Family
+// ============================================================================
+
+describe('family enum', () => {
+	const base = {
+		entity: { name: 'test', plural: 'tests', table: 'tests' },
+		fields: { id: { type: 'uuid', required: true } },
+	};
+
+	it('accepts all four family values', () => {
+		for (const family of ['crm-synced', 'activity', 'knowledge', 'metadata']) {
+			const result = EntityDefinitionSchema.safeParse({
+				...base,
+				entity: { ...base.entity, family },
+			});
+			expect(result.success).toBe(true);
+		}
+	});
+
+	it('rejects invalid family', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, family: 'invalid' },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('family is optional', () => {
+		const result = EntityDefinitionSchema.safeParse(base);
+		expect(result.success).toBe(true);
+		expect(result.data!.entity.family).toBeUndefined();
+	});
+});
+
+// ============================================================================
+// Queries Block
+// ============================================================================
+
+describe('queries block', () => {
+	const base = {
+		entity: { name: 'contact', plural: 'contacts', table: 'contacts' },
+		fields: { email: { type: 'string', required: true } },
+	};
+
+	it('accepts a simple query', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			queries: [{ by: ['email'] }],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts all query options', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			queries: [
+				{ by: ['user_id'] },
+				{ by: ['email'], unique: true },
+				{ by: ['user_id', 'account_id'] },
+				{ by: ['opportunity_id'], select: ['email'], via: 'opportunity_contact_link' },
+				{ by: ['account_id'], order: 'created_at desc', limit: true },
+			],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects empty by array', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			queries: [{ by: [] }],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('queries block is optional', () => {
+		const result = EntityDefinitionSchema.safeParse(base);
+		expect(result.success).toBe(true);
+	});
+});
+
+// ============================================================================
+// Sync Block
+// ============================================================================
+
+describe('sync block', () => {
+	const base = {
+		entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities' },
+		fields: { name: { type: 'string', required: true } },
+	};
+
+	it('accepts electric-only sync', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			sync: { electric: true },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts full provider config', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			sync: {
+				electric: true,
+				providers: {
+					salesforce: {
+						remote_entity: 'Opportunity',
+						direction: 'bidirectional',
+						cdc: true,
+						field_mapping: { name: 'Name' },
+						read_only_fields: ['is_closed'],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects invalid direction', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			sync: {
+				providers: {
+					salesforce: { remote_entity: 'X', direction: 'invalid' },
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts all three direction values', () => {
+		for (const direction of ['inbound', 'outbound', 'bidirectional']) {
+			const result = EntityDefinitionSchema.safeParse({
+				...base,
+				sync: {
+					providers: {
+						test: { remote_entity: 'X', direction },
+					},
+				},
+			});
+			expect(result.success).toBe(true);
+		}
+	});
+});
+
+// ============================================================================
+// Events Block
+// ============================================================================
+
+describe('events block', () => {
+	const base = {
+		entity: { name: 'contact', plural: 'contacts', table: 'contacts' },
+		fields: { email: { type: 'string', required: true } },
+	};
+
+	it('accepts valid events', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			events: [
+				{
+					name: 'contact_created',
+					queue: 'domain-events',
+					body: { contact_id: 'uuid', created_by: 'uuid' },
+					generate_handler: true,
+				},
+			],
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects non-snake_case event name', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			events: [{ name: 'BadName', queue: 'q', body: {} }],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('generate_handler defaults to false', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			events: [{ name: 'test_event', queue: 'q', body: { id: 'uuid' } }],
+		});
+		expect(result.success).toBe(true);
+		expect(result.data!.events![0].generate_handler).toBe(false);
+	});
+});
+
+// ============================================================================
+// External ID Tracking Behavior
+// ============================================================================
+
+describe('external_id_tracking behavior', () => {
+	it('is recognized by the behavior registry', () => {
+		const resolved = resolveBehaviors(['external_id_tracking']);
+		expect(resolved.hasExternalIdTracking).toBe(true);
+	});
+
+	it('adds external_id, provider, provider_metadata fields', () => {
+		const resolved = resolveBehaviors(['external_id_tracking']);
+		const fieldNames = resolved.fields.map((f) => f.name);
+		expect(fieldNames).toContain('external_id');
+		expect(fieldNames).toContain('provider');
+		expect(fieldNames).toContain('provider_metadata');
+	});
+});
+
+// ============================================================================
+// Pipelines Config
+// ============================================================================
+
+describe('pipelines config', () => {
+	it('accepts full config', () => {
+		const result = PipelinesConfigSchema.safeParse({
+			backend: { enabled: true, architecture: 'clean-lite-ps' },
+			frontend: { enabled: true, preset: 'dealbrain' },
+			shared: { enabled: false },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts empty config (all defaults)', () => {
+		const result = PipelinesConfigSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects invalid architecture', () => {
+		const result = PipelinesConfigSchema.safeParse({
+			backend: { architecture: 'nonexistent' },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts all architecture targets', () => {
+		for (const arch of ['clean', 'clean-lite', 'clean-lite-ps', 'vertical-slice']) {
+			const result = PipelinesConfigSchema.safeParse({
+				backend: { architecture: arch },
+			});
+			expect(result.success).toBe(true);
+		}
+	});
+});
+
+// ============================================================================
+// Strict mode — unknown keys still rejected
+// ============================================================================
+
+describe('strict mode preserved', () => {
+	it('rejects unknown top-level key on entity definition', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			entity: { name: 'x', plural: 'xs', table: 'xs' },
+			fields: { a: { type: 'string' } },
+			bogus: true,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects unknown key in entity config', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			entity: { name: 'x', plural: 'xs', table: 'xs', random_key: 'foo' },
+			fields: { a: { type: 'string' } },
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+// ============================================================================
+// Integration: contact-v2.yaml fixture
+// ============================================================================
+
+describe('contact-v2.yaml integration', () => {
+	it('parses through YAML loader', () => {
+		const result = loadEntityFromYaml(resolve('test/fixtures/contact-v2.yaml'));
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.definition.entity.family).toBe('crm-synced');
+			expect(result.definition.queries).toHaveLength(6);
+			expect(result.definition.sync?.electric).toBe(true);
+			expect(result.definition.events).toHaveLength(3);
+		}
+	});
+
+	it('maps through parser with correct types', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const contact = result.entities[0];
+
+		expect(contact.family).toBe('crm-synced');
+		expect(contact.behaviors).toContain('external_id_tracking');
+		expect(contact.queries).toHaveLength(6);
+		expect(contact.sync?.electric).toBe(true);
+		expect(contact.sync?.providers?.salesforce?.remoteEntity).toBe('Contact');
+		expect(contact.events).toHaveLength(3);
+		expect(contact.events![0].generateHandler).toBe(true);
+	});
+
+	it('passes consistency checks', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const graph = buildDomainGraph(result.entities);
+		const issues = checkConsistency(graph);
+
+		const v2Issues = issues.filter((i) =>
+			['unknown_query_field', 'unknown_sync_field_mapping', 'external_id_tracking_collision'].includes(i.type),
+		);
+		expect(v2Issues).toHaveLength(0);
+	});
+});
+
+// ============================================================================
+// Consistency checker: invalid references
+// ============================================================================
+
+describe('cross-block validation', () => {
+	it('catches query referencing unknown field', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const contact = result.entities[0];
+
+		// Inject a bad query
+		contact.queries = [...(contact.queries ?? []), { by: ['nonexistent_field'] }];
+
+		const graph = buildDomainGraph([contact]);
+		const issues = checkConsistency(graph);
+		const queryIssues = issues.filter((i) => i.type === 'unknown_query_field');
+		expect(queryIssues.length).toBeGreaterThan(0);
+		expect(queryIssues[0].message).toContain('nonexistent_field');
+	});
+
+	it('skips by-field validation for via queries', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const contact = result.entities[0];
+
+		// Via query with cross-entity field should not error
+		contact.queries = [{ by: ['opportunity_id'], via: 'opportunity_contact_link' }];
+
+		const graph = buildDomainGraph([contact]);
+		const issues = checkConsistency(graph);
+		const queryIssues = issues.filter((i) => i.type === 'unknown_query_field');
+		expect(queryIssues).toHaveLength(0);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./test/scaffold/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@gen/*": ["./*"],
+      "@shared/*": ["./test/scaffold/shared/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **A1**: YAML schema evolution — v2 blocks (family, queries, sync, events, pipelines) + external-id-tracking behavior
- **A5**: prompt.js consumes v2 fields, routes architecture target, derives query method names
- **A9**: `BaseRepository<T>` abstract CRUD base class (9 methods, soft-delete, timestamps)
- **A10**: `BaseService<T>` pass-through + `BaseFindByIdUseCase` / `BaseListUseCase`
- **A6**: 11 Hygen EJS templates for Clean-Lite-PS architecture (entity, repo, service, controller, module, use cases, DTOs)
- **A15**: NestJS test scaffold at `test/scaffold/` with Docker Postgres + validate.sh integration script
- **.gitignore**: Ignore codegen output dirs (`app/`, `apps/`, `modules/`, `packages/`, `gen/`)
- **Bug fixes**: .mjs import compat for hygen/Node.js, EJS HTML-encoding, duplicate FK fields, v1 skip guards

## Generated output verified

Running `bun codegen entity test/fixtures/contact-v2.yaml` produces 10 correct Clean-Lite-PS files under `modules/contacts/`. V1 codegen (`opportunity.yaml`) still works without regression. 232 unit tests pass.

## Known limitations

- Base class tests use mocks, not real Postgres (TestContainers deferred)
- `test/scaffold/validate.sh` requires Docker — not run in CI yet
- FK nullable inference doesn't cross-reference field-level `required`

## Test plan

- [x] `bun test` — 232 pass, 0 fail
- [x] `bun codegen entity test/fixtures/opportunity.yaml` — v1 works, no CLP crash
- [x] `bun codegen entity test/fixtures/contact-v2.yaml` — 10 CLP files generated
- [x] Generated entity.ts has no HTML entities or duplicate fields
- [ ] `bash test/scaffold/validate.sh` — requires Docker (manual)

Closes #2, closes #3, closes #4, closes #5, closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)