### PR TITLE
feat(cli): noun-verb CLI architecture — foundation + entity + subsystem nouns

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,9 +22,9 @@ gen-all:
 scan path=".":
     bun codegen scan {{path}}
 
-# Scaffold a subsystem (events, jobs, cache, storage)
+# Scaffold a subsystem (events, jobs, cache, storage) via the new CLI
 gen-subsystem name:
-    bun codegen subsystem {{name}}
+    bun src/cli/index.ts subsystem install {{name}}
 
 # ─── Test ─────────────────────────────────────────────────────────────────────
 

--- a/justfile
+++ b/justfile
@@ -10,13 +10,13 @@ install:
     bun install
     cd test/scaffold && bun install
 
-# Generate a single entity from YAML
+# Generate a single entity from YAML (new noun-verb CLI)
 gen entity:
-    bun codegen entity {{entity}}
+    bun src/cli/index.ts entity new {{entity}}
 
-# Generate all entities
+# Generate all entities (new noun-verb CLI)
 gen-all:
-    bun codegen all
+    bun src/cli/index.ts entity new --all
 
 # Scan a project and generate config
 scan path=".":

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",
+    "chalk": "^5.6.2",
+    "clipanion": "^4.0.0-rc.4",
     "drizzle-orm": "^0.45.2",
+    "ora": "^9.3.0",
     "yaml": "^2.8.3",
     "zod": "^3.22.4"
   },

--- a/src/__tests__/cli/context.test.ts
+++ b/src/__tests__/cli/context.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for loadContext() — walks upward for codegen.config.yaml, detects
+ * entity count, and reports whether the project is initialized.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadContext } from '../../cli/shared/context.js';
+
+function mkTempDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), `ctx-${prefix}-`));
+}
+
+let tempRoots: string[] = [];
+
+function makeProject(layout: Record<string, string>): string {
+	const root = mkTempDir('proj');
+	tempRoots.push(root);
+	for (const [rel, content] of Object.entries(layout)) {
+		const full = path.join(root, rel);
+		fs.mkdirSync(path.dirname(full), { recursive: true });
+		fs.writeFileSync(full, content);
+	}
+	return root;
+}
+
+afterEach(() => {
+	for (const r of tempRoots) {
+		try {
+			fs.rmSync(r, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	}
+	tempRoots = [];
+});
+
+describe('loadContext', () => {
+	test('returns uninitialized context when no config and no entities', async () => {
+		const root = makeProject({});
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+		expect(ctx.cwd).toBe(path.resolve(root));
+		expect(ctx.configPath).toBeNull();
+		expect(ctx.isInitialized).toBe(false);
+		expect(ctx.entityCount).toBe(0);
+	});
+
+	test('detects config at cwd root', async () => {
+		const root = makeProject({
+			'codegen.config.yaml': 'paths:\n  entities: entities\n',
+			'entities/one.yaml': 'entity:\n  name: one\n',
+			'entities/two.yaml': 'entity:\n  name: two\n',
+		});
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+		expect(ctx.configPath).toBe(path.join(path.resolve(root), 'codegen.config.yaml'));
+		expect(ctx.isInitialized).toBe(true);
+		expect(ctx.entityCount).toBe(2);
+		expect(ctx.entitiesDir).toContain('entities');
+	});
+
+	test('walks upward to find config', async () => {
+		const root = makeProject({
+			'codegen.config.yaml': 'paths:\n  entities: entities\n',
+			'apps/web/placeholder.txt': '-',
+		});
+		const nested = path.join(root, 'apps', 'web');
+		const ctx = await loadContext({ cwd: nested, skipDetection: true });
+		expect(ctx.configPath).toBe(path.join(path.resolve(root), 'codegen.config.yaml'));
+		expect(ctx.isInitialized).toBe(true);
+	});
+
+	test('counts only .yaml/.yml files in entities dir', async () => {
+		const root = makeProject({
+			'codegen.config.yaml': 'paths:\n  entities: entities\n',
+			'entities/a.yaml': 'x: 1\n',
+			'entities/b.yml': 'x: 1\n',
+			'entities/notes.md': '# notes',
+		});
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+		expect(ctx.entityCount).toBe(2);
+	});
+
+	test('respects explicit --config override when file exists', async () => {
+		const root = makeProject({
+			'alt.yaml': 'paths:\n  entities: entities\n',
+			'entities/a.yaml': 'x: 1\n',
+		});
+		const ctx = await loadContext({
+			cwd: root,
+			configPath: path.join(root, 'alt.yaml'),
+			skipDetection: true,
+		});
+		expect(ctx.configPath).toBe(path.join(path.resolve(root), 'alt.yaml'));
+	});
+});

--- a/src/__tests__/cli/entity.test.ts
+++ b/src/__tests__/cli/entity.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the entity noun — summary, list, validate, dry-run new.
+ *
+ * Integration-level: these drive the Clipanion Cli with a temp project
+ * rooted at test/fixtures so we don't touch the user's cwd.
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { Cli } from 'clipanion';
+
+import entityNoun, {
+	EntityNewCommand,
+	EntityListCommand,
+	EntityValidateCommand,
+} from '../../cli/commands/entity.js';
+import { buildNounSummaryCommand } from '../../cli/noun-module.js';
+import { setJsonMode } from '../../cli/ui/json.js';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
+const CONTACT_FIXTURE = path.join(REPO_ROOT, 'test', 'fixtures', 'contact-v2.yaml');
+
+function mkTempProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'entity-cli-'));
+	fs.mkdirSync(path.join(dir, 'entities'), { recursive: true });
+	fs.copyFileSync(CONTACT_FIXTURE, path.join(dir, 'entities', 'contact.yaml'));
+	fs.writeFileSync(path.join(dir, 'codegen.config.yaml'), 'paths:\n  entities: entities\n');
+	return dir;
+}
+
+/** Project with a self-contained entity (no unresolved cross-refs). */
+function mkSelfContainedProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'entity-self-'));
+	fs.mkdirSync(path.join(dir, 'entities'), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, 'entities', 'note.yaml'),
+		[
+			'entity:',
+			'  name: note',
+			'  plural: notes',
+			'  table: notes',
+			'fields:',
+			'  id:',
+			'    type: uuid',
+			'    required: true',
+			'  title:',
+			'    type: string',
+			'    required: true',
+			'    max_length: 200',
+			'',
+		].join('\n')
+	);
+	fs.writeFileSync(path.join(dir, 'codegen.config.yaml'), 'paths:\n  entities: entities\n');
+	return dir;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	setJsonMode(false);
+	for (const d of tempDirs) {
+		try {
+			fs.rmSync(d, { recursive: true, force: true });
+		} catch {}
+	}
+	tempDirs.length = 0;
+});
+
+function buildCli() {
+	const cli = new Cli({ binaryName: 'codegen', binaryVersion: '0.0.0' });
+	for (const Cls of entityNoun.commandClasses) cli.register(Cls);
+	cli.register(buildNounSummaryCommand(entityNoun));
+	return cli;
+}
+
+function captureStdoutWrite<T>(fn: () => Promise<T>): Promise<{ result: T; out: string }> {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	process.stdout.write = ((data: string | Uint8Array) => {
+		chunks.push(typeof data === 'string' ? data : new TextDecoder().decode(data));
+		return true;
+	}) as typeof process.stdout.write;
+
+	const origLog = console.log;
+	console.log = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' ') + '\n');
+	};
+
+	return (async () => {
+		try {
+			const result = await fn();
+			return { result, out: chunks.join('') };
+		} finally {
+			process.stdout.write = original;
+			console.log = origLog;
+		}
+	})();
+}
+
+describe('entity noun — summary', () => {
+	test('renders pane listing fixture contact entity', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result, out } = await captureStdoutWrite(() => cli.run(['entity', '--cwd', root]));
+		expect(result).toBe(0);
+		expect(out).toContain('entities');
+		expect(out).toContain('contact');
+	});
+
+	test('JSON output includes noun + summary + hints', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { out } = await captureStdoutWrite(() =>
+			cli.run(['entity', '--cwd', root, '--json'])
+		);
+		const parsed = JSON.parse(out);
+		expect(parsed.noun).toBe('entity');
+		expect(parsed.summary.title).toBe('entities');
+		expect(Array.isArray(parsed.hints)).toBe(true);
+	});
+
+	test('summary is directly callable and reports counts', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const { loadContext } = await import('../../cli/shared/context.js');
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+		const pane = await entityNoun.summary(ctx);
+		expect(pane.footer).toContain('1 entities');
+	});
+});
+
+describe('entity noun — validate', () => {
+	test('passes for a self-contained entity set', async () => {
+		const root = mkSelfContainedProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await captureStdoutWrite(() =>
+			cli.run(['entity', 'validate', '--cwd', root])
+		);
+		expect(result).toBe(0);
+	});
+
+	test('fails when cross-refs are missing', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await captureStdoutWrite(() =>
+			cli.run(['entity', 'validate', '--cwd', root])
+		);
+		expect(result).toBe(1);
+	});
+
+	test('fails when directory does not exist', async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'entity-invalid-'));
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await captureStdoutWrite(() =>
+			cli.run(['entity', 'validate', 'missing-dir', '--cwd', root])
+		);
+		expect(result).toBe(1);
+	});
+});
+
+describe('entity noun — list', () => {
+	test('prints table with the fixture entity', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result, out } = await captureStdoutWrite(() =>
+			cli.run(['entity', 'list', '--cwd', root])
+		);
+		expect(result).toBe(0);
+		expect(out).toContain('NAME');
+		expect(out).toContain('contact');
+	});
+
+	test('json format emits structured payload', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { out } = await captureStdoutWrite(() =>
+			cli.run(['entity', 'list', '--format', 'json', '--cwd', root])
+		);
+		const parsed = JSON.parse(out);
+		expect(parsed.command).toBe('entity list');
+		expect(parsed.entities[0].name).toBe('contact');
+	});
+});
+
+describe('entity noun — new --dry-run', () => {
+	test('reports plan without invoking hygen', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result, out } = await captureStdoutWrite(() =>
+			cli.run([
+				'entity',
+				'new',
+				path.join(root, 'entities', 'contact.yaml'),
+				'--dry-run',
+				'--force',
+				'--cwd',
+				root,
+			])
+		);
+		expect(result).toBe(0);
+		expect(out).toContain('Dry run');
+		expect(out).toContain('contact');
+	});
+
+	test('rejects both --all and positional yaml', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await captureStdoutWrite(() =>
+			cli.run([
+				'entity',
+				'new',
+				path.join(root, 'entities', 'contact.yaml'),
+				'--all',
+				'--cwd',
+				root,
+			])
+		);
+		expect(result).toBe(2);
+	});
+
+	test('fails when no yaml and no --all', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await captureStdoutWrite(() =>
+			cli.run(['entity', 'new', '--cwd', root])
+		);
+		expect(result).toBe(2);
+	});
+});
+
+describe('entity noun — module shape', () => {
+	test('exports canonical command classes', () => {
+		expect(entityNoun.name).toBe('entity');
+		expect(entityNoun.commandClasses).toContain(EntityNewCommand);
+		expect(entityNoun.commandClasses).toContain(EntityListCommand);
+		expect(entityNoun.commandClasses).toContain(EntityValidateCommand);
+	});
+});

--- a/src/__tests__/cli/json.test.ts
+++ b/src/__tests__/cli/json.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for JSON mode flag + printJson helper.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { isJsonMode, setJsonMode, printJson } from '../../cli/ui/json.js';
+
+describe('json mode', () => {
+	afterEach(() => setJsonMode(false));
+
+	test('isJsonMode toggles with setJsonMode', () => {
+		expect(isJsonMode()).toBe(false);
+		setJsonMode(true);
+		expect(isJsonMode()).toBe(true);
+		setJsonMode(false);
+		expect(isJsonMode()).toBe(false);
+	});
+
+	test('printJson writes structured payload to stdout', () => {
+		const chunks: string[] = [];
+		const original = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((data: string | Uint8Array) => {
+			chunks.push(typeof data === 'string' ? data : new TextDecoder().decode(data));
+			return true;
+		}) as typeof process.stdout.write;
+
+		try {
+			printJson({ noun: 'entity', count: 2 });
+		} finally {
+			process.stdout.write = original;
+		}
+
+		const parsed = JSON.parse(chunks.join(''));
+		expect(parsed.noun).toBe('entity');
+		expect(parsed.count).toBe(2);
+	});
+});

--- a/src/__tests__/cli/noun-module.test.ts
+++ b/src/__tests__/cli/noun-module.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for buildNounSummaryCommand() — verifies the generated Command class
+ * loads context, calls the noun's summary/hints, and renders output.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { Cli } from 'clipanion';
+import { buildNounSummaryCommand, type NounModule } from '../../cli/noun-module.js';
+import { setJsonMode } from '../../cli/ui/json.js';
+
+function mkTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'nounmod-'));
+}
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+	setJsonMode(false);
+	for (const d of cleanup) {
+		try {
+			fs.rmSync(d, { recursive: true, force: true });
+		} catch {}
+	}
+	cleanup.length = 0;
+});
+
+function buildFakeNoun(): NounModule {
+	return {
+		name: 'fake',
+		commandClasses: [],
+		async summary() {
+			return {
+				title: 'fake-title',
+				body: ['line-one', 'line-two'],
+				footer: 'fake-footer',
+			};
+		},
+		async hints() {
+			return [
+				{ command: 'codegen fake new', description: 'create new' },
+			];
+		},
+	};
+}
+
+describe('buildNounSummaryCommand', () => {
+	test('generates a Command class with paths=[[nounName]]', () => {
+		const Cls = buildNounSummaryCommand(buildFakeNoun()) as unknown as {
+			paths: string[][];
+			usage: { description: string };
+		};
+		expect(Cls.paths).toEqual([['fake']]);
+		expect(Cls.usage.description).toContain('fake');
+	});
+
+	test('executes summary + hints and renders pane in text mode', async () => {
+		const root = mkTempDir();
+		cleanup.push(root);
+		// Uninitialized project — skipDetection path isn't strictly required,
+		// but the fake noun ignores ctx anyway.
+
+		const noun = buildFakeNoun();
+		const Cls = buildNounSummaryCommand(noun);
+
+		const cli = new Cli({ binaryName: 'codegen', binaryVersion: '0.0.0' });
+		cli.register(Cls);
+
+		// Capture stdout to confirm rendering
+		const chunks: string[] = [];
+		const orig = console.log;
+		console.log = (...a: unknown[]) => {
+			chunks.push(a.map((x) => String(x)).join(' '));
+		};
+		try {
+			const code = await cli.run(['fake', '--cwd', root]);
+			expect(code).toBe(0);
+		} finally {
+			console.log = orig;
+		}
+
+		const output = chunks.join('\n');
+		expect(output).toContain('fake-title');
+		expect(output).toContain('line-one');
+		expect(output).toContain('line-two');
+		expect(output).toContain('fake-footer');
+		expect(output).toContain('codegen fake new');
+	});
+
+	test('emits JSON when --json is set', async () => {
+		const root = mkTempDir();
+		cleanup.push(root);
+
+		const noun = buildFakeNoun();
+		const Cls = buildNounSummaryCommand(noun);
+
+		const cli = new Cli({ binaryName: 'codegen', binaryVersion: '0.0.0' });
+		cli.register(Cls);
+
+		const chunks: string[] = [];
+		const original = process.stdout.write.bind(process.stdout);
+		process.stdout.write = ((data: string | Uint8Array) => {
+			chunks.push(typeof data === 'string' ? data : new TextDecoder().decode(data));
+			return true;
+		}) as typeof process.stdout.write;
+
+		try {
+			const code = await cli.run(['fake', '--json', '--cwd', root]);
+			expect(code).toBe(0);
+		} finally {
+			process.stdout.write = original;
+		}
+
+		const parsed = JSON.parse(chunks.join(''));
+		expect(parsed.noun).toBe('fake');
+		expect(parsed.summary.title).toBe('fake-title');
+		expect(parsed.hints).toHaveLength(1);
+	});
+});

--- a/src/__tests__/cli/output.test.ts
+++ b/src/__tests__/cli/output.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the semantic output helpers (ADR-016 / SPEC-CLI-01).
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import { printSuccess, printError, printWarning, printInfo, printMuted } from '../../cli/ui/output.js';
+import { setJsonMode } from '../../cli/ui/json.js';
+
+function captureStdout(): { restore: () => string } {
+	const original = console.log;
+	const chunks: string[] = [];
+	console.log = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' '));
+	};
+	return {
+		restore: () => {
+			console.log = original;
+			return chunks.join('\n');
+		},
+	};
+}
+
+function captureStderr(): { restore: () => string } {
+	const original = console.error;
+	const chunks: string[] = [];
+	console.error = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' '));
+	};
+	return {
+		restore: () => {
+			console.error = original;
+			return chunks.join('\n');
+		},
+	};
+}
+
+function captureWarn(): { restore: () => string } {
+	const original = console.warn;
+	const chunks: string[] = [];
+	console.warn = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' '));
+	};
+	return {
+		restore: () => {
+			console.warn = original;
+			return chunks.join('\n');
+		},
+	};
+}
+
+describe('output helpers', () => {
+	beforeEach(() => setJsonMode(false));
+	afterEach(() => setJsonMode(false));
+
+	test('printSuccess writes to stdout', () => {
+		const cap = captureStdout();
+		printSuccess('done');
+		const output = cap.restore();
+		expect(output).toContain('done');
+	});
+
+	test('printError writes to stderr and truncates long messages', () => {
+		const cap = captureStderr();
+		const long = 'x'.repeat(600);
+		printError(long);
+		const output = cap.restore();
+		expect(output.length).toBeLessThan(600 + 20); // truncated + icon + space
+		expect(output).toContain('…');
+	});
+
+	test('printWarning writes to stderr via console.warn', () => {
+		const cap = captureWarn();
+		printWarning('careful');
+		const output = cap.restore();
+		expect(output).toContain('careful');
+	});
+
+	test('printInfo and printMuted write to stdout', () => {
+		const cap = captureStdout();
+		printInfo('i');
+		printMuted('m');
+		const output = cap.restore();
+		expect(output).toContain('i');
+		expect(output).toContain('m');
+	});
+
+	test('all helpers no-op in json mode', () => {
+		setJsonMode(true);
+		const outCap = captureStdout();
+		const errCap = captureStderr();
+		const warnCap = captureWarn();
+		printSuccess('a');
+		printError('b');
+		printWarning('c');
+		printInfo('d');
+		printMuted('e');
+		expect(outCap.restore()).toBe('');
+		expect(errCap.restore()).toBe('');
+		expect(warnCap.restore()).toBe('');
+	});
+});

--- a/src/__tests__/cli/subsystem.test.ts
+++ b/src/__tests__/cli/subsystem.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for the subsystem noun — summary, install (dry-run + real), list,
+ * remove stub. Uses a temp fixture project as the install target so we
+ * never touch the user's actual cwd.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { Cli } from 'clipanion';
+
+import subsystemNoun from '../../cli/commands/subsystem.js';
+import { buildNounSummaryCommand } from '../../cli/noun-module.js';
+import { setJsonMode } from '../../cli/ui/json.js';
+import {
+	detectInstalledSubsystems,
+	SUBSYSTEMS,
+} from '../../cli/shared/subsystem-detect.js';
+import { copyRuntime } from '../../cli/shared/runtime-copier.js';
+import { loadContext } from '../../cli/shared/context.js';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
+const RUNTIME_ROOT = path.join(REPO_ROOT, 'runtime');
+
+function mkTempProject(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'subsystem-cli-'));
+	fs.writeFileSync(
+		path.join(dir, 'codegen.config.yaml'),
+		'paths:\n  subsystems: src/shared/subsystems\n'
+	);
+	return dir;
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	setJsonMode(false);
+	for (const d of tempDirs) {
+		try {
+			fs.rmSync(d, { recursive: true, force: true });
+		} catch {}
+	}
+	tempDirs.length = 0;
+});
+
+function buildCli() {
+	const cli = new Cli({ binaryName: 'codegen', binaryVersion: '0.0.0' });
+	for (const Cls of subsystemNoun.commandClasses) cli.register(Cls);
+	cli.register(buildNounSummaryCommand(subsystemNoun));
+	return cli;
+}
+
+function capture<T>(fn: () => Promise<T>): Promise<{ result: T; out: string }> {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	process.stdout.write = ((data: string | Uint8Array) => {
+		chunks.push(typeof data === 'string' ? data : new TextDecoder().decode(data));
+		return true;
+	}) as typeof process.stdout.write;
+
+	const origLog = console.log;
+	const origWarn = console.warn;
+	const origErr = console.error;
+	console.log = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' ') + '\n');
+	};
+	console.warn = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' ') + '\n');
+	};
+	console.error = (...args: unknown[]) => {
+		chunks.push(args.map((a) => String(a)).join(' ') + '\n');
+	};
+
+	return (async () => {
+		try {
+			const result = await fn();
+			return { result, out: chunks.join('') };
+		} finally {
+			process.stdout.write = original;
+			console.log = origLog;
+			console.warn = origWarn;
+			console.error = origErr;
+		}
+	})();
+}
+
+// ---------------------------------------------------------------------------
+
+describe('subsystem — descriptor', () => {
+	test('knows all four subsystems', () => {
+		expect(SUBSYSTEMS.map((s) => s.name).sort()).toEqual(
+			['cache', 'events', 'jobs', 'storage'].sort()
+		);
+	});
+});
+
+describe('subsystem — summary + list', () => {
+	test('summary on a fresh project reports 0 installed', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result, out } = await capture(() => cli.run(['subsystem', '--cwd', root]));
+		expect(result).toBe(0);
+		expect(out).toContain('subsystems');
+		expect(out).toContain('No subsystems installed yet.');
+	});
+
+	test('list --format json emits structured rows', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { out } = await capture(() =>
+			cli.run(['subsystem', 'list', '--format', 'json', '--cwd', root])
+		);
+		const parsed = JSON.parse(out);
+		expect(parsed.command).toBe('subsystem list');
+		expect(parsed.subsystems).toHaveLength(4);
+		for (const row of parsed.subsystems) {
+			expect(row.status).toBe('available');
+		}
+	});
+});
+
+describe('subsystem — install (dry-run)', () => {
+	test('reports planned files without touching disk', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result, out } = await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'events',
+				'--dry-run',
+				'--force',
+				'--json',
+				'--cwd',
+				root,
+			])
+		);
+		expect(result).toBe(0);
+		const parsed = JSON.parse(out);
+		expect(parsed.subsystem).toBe('events');
+		expect(parsed.dryRun).toBe(true);
+		expect(parsed.files.planned.length).toBeGreaterThan(0);
+		// nothing should have been written
+		expect(fs.existsSync(path.join(root, 'src/shared/subsystems/events'))).toBe(false);
+	});
+
+	test('rejects unknown subsystem name', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run(['subsystem', 'install', 'unknown-thing', '--cwd', root])
+		);
+		expect(result).toBe(2);
+	});
+
+	test('rejects invalid --backend for subsystem', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run(['subsystem', 'install', 'events', '--backend', 'local', '--cwd', root])
+		);
+		expect(result).toBe(2);
+	});
+});
+
+describe('subsystem — install (real)', () => {
+	test('copies runtime/subsystems/events into target + follows deps', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'events',
+				'--force',
+				'--json',
+				'--cwd',
+				root,
+			])
+		);
+		expect(result).toBe(0);
+		const installDir = path.join(root, 'src/shared/subsystems/events');
+		expect(fs.existsSync(installDir)).toBe(true);
+		// Core files present
+		expect(fs.existsSync(path.join(installDir, 'events.module.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'event-bus.protocol.ts'))).toBe(true);
+		// Dependencies (runtime/types/drizzle.ts) copied to parallel tree
+		expect(fs.existsSync(path.join(root, 'src/shared/types/drizzle.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(root, 'src/shared/constants/tokens.ts'))).toBe(true);
+	});
+
+	test('memory backend skips .drizzle-backend.ts and .schema.ts', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'events',
+				'--backend',
+				'memory',
+				'--force',
+				'--json',
+				'--cwd',
+				root,
+			])
+		);
+		expect(result).toBe(0);
+		const installDir = path.join(root, 'src/shared/subsystems/events');
+		expect(fs.existsSync(path.join(installDir, 'event-bus.memory-backend.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'event-bus.drizzle-backend.ts'))).toBe(false);
+		expect(fs.existsSync(path.join(installDir, 'domain-events.schema.ts'))).toBe(false);
+	});
+
+	test('second install is idempotent without --force', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run(['subsystem', 'install', 'events', '--force', '--cwd', root])
+		);
+		// Second run
+		const { result, out } = await capture(() =>
+			cli.run(['subsystem', 'install', 'events', '--json', '--cwd', root])
+		);
+		expect(result).toBe(0);
+		const parsed = JSON.parse(out);
+		expect(parsed.status).toBe('already-installed');
+	});
+});
+
+describe('subsystem — detection', () => {
+	test('detectInstalledSubsystems finds events after install', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run(['subsystem', 'install', 'events', '--force', '--cwd', root])
+		);
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+		const installed = await detectInstalledSubsystems(ctx);
+		expect(installed.map((i) => i.name)).toContain('events');
+	});
+});
+
+describe('subsystem — remove stub', () => {
+	test('exits 1 with a not-implemented message', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result, out } = await capture(() =>
+			cli.run(['subsystem', 'remove', 'events', '--cwd', root])
+		);
+		expect(result).toBe(1);
+		expect(out.toLowerCase()).toContain('not yet implemented');
+	});
+});
+
+describe('runtime-copier unit', () => {
+	test('dry-run populates planned[] without writing', async () => {
+		const target = fs.mkdtempSync(path.join(os.tmpdir(), 'copier-'));
+		tempDirs.push(target);
+		const result = await copyRuntime({
+			sourceDir: path.join(RUNTIME_ROOT, 'subsystems', 'events'),
+			targetDir: path.join(target, 'events'),
+			resolveDeps: false,
+			dryRun: true,
+		});
+		expect(result.planned.length).toBeGreaterThan(0);
+		expect(result.written).toHaveLength(0);
+		expect(fs.existsSync(path.join(target, 'events'))).toBe(false);
+	});
+
+	test('non-dry-run writes files and reports unchanged on second run', async () => {
+		const target = fs.mkdtempSync(path.join(os.tmpdir(), 'copier2-'));
+		tempDirs.push(target);
+		const r1 = await copyRuntime({
+			sourceDir: path.join(RUNTIME_ROOT, 'subsystems', 'cache'),
+			targetDir: path.join(target, 'cache'),
+			resolveDeps: false,
+		});
+		expect(r1.written.length).toBeGreaterThan(0);
+		const r2 = await copyRuntime({
+			sourceDir: path.join(RUNTIME_ROOT, 'subsystems', 'cache'),
+			targetDir: path.join(target, 'cache'),
+			resolveDeps: false,
+		});
+		expect(r2.unchanged.length).toBe(r1.written.length);
+		expect(r2.written.length).toBe(0);
+	});
+});

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -1,0 +1,453 @@
+/**
+ * Entity noun — codegen entity / entity new / entity list / entity validate
+ *
+ * Implements SPEC-CLI-02. Delegates actual generation to the shared Hygen
+ * helper so behavior matches the legacy src/cli.ts.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command, Option } from 'clipanion';
+import type { CommandClass } from 'clipanion';
+
+import { loadEntityFromYaml } from '../../utils/yaml-loader.js';
+import { analyzeDomain, validateEntities } from '../../index.js';
+
+import { loadContext, type Context } from '../shared/context.js';
+import { invokeEntityNew } from '../shared/hygen.js';
+import { checkGitSafety } from '../shared/git-safety.js';
+
+import { theme } from '../ui/theme.js';
+import { icons } from '../ui/icons.js';
+import { printError, printInfo, printSuccess, printWarning } from '../ui/output.js';
+import { isJsonMode, printJson, setJsonMode } from '../ui/json.js';
+import type { PaneOutput } from '../ui/pane.js';
+import type { Hint } from '../ui/hints.js';
+import type { NounModule } from '../noun-module.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function listEntityYamls(dir: string): string[] {
+	if (!fs.existsSync(dir)) return [];
+	return fs
+		.readdirSync(dir)
+		.filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+		.map((f) => path.join(dir, f));
+}
+
+interface EntitySummaryRow {
+	name: string;
+	family: string;
+	fields: number;
+	queries: number;
+	file: string;
+}
+
+function summarizeEntityFile(filePath: string): EntitySummaryRow | null {
+	const result = loadEntityFromYaml(filePath);
+	if (!result.success) return null;
+	const def = result.definition;
+	return {
+		name: def.entity.name,
+		family: (def.entity as { family?: string }).family ?? 'base',
+		fields: Object.keys(def.fields ?? {}).length,
+		queries: Array.isArray(
+			(def as unknown as { queries?: unknown[] }).queries
+		)
+			? ((def as unknown as { queries: unknown[] }).queries).length
+			: 0,
+		file: filePath,
+	};
+}
+
+function padRight(s: string, n: number): string {
+	return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+// ---------------------------------------------------------------------------
+// summary + hints
+// ---------------------------------------------------------------------------
+
+async function summary(ctx: Context): Promise<PaneOutput> {
+	if (!ctx.entitiesDir || ctx.entityCount === 0) {
+		return {
+			title: 'entities',
+			body: [
+				'No entities defined yet.',
+				'',
+				`Create one at ${theme.system('entities/<name>.yaml')} to get started.`,
+			],
+		};
+	}
+
+	const files = listEntityYamls(ctx.entitiesDir);
+	const rows = files.map(summarizeEntityFile).filter((r): r is EntitySummaryRow => r !== null);
+
+	const families = new Set(rows.map((r) => r.family));
+	const queryCount = rows.reduce((sum, r) => sum + r.queries, 0);
+
+	const nameCol = Math.max(4, ...rows.map((r) => r.name.length));
+	const famCol = Math.max(6, ...rows.map((r) => r.family.length));
+
+	const body = rows.map((r) => {
+		const fields = `${r.fields} fields`.padEnd(10);
+		const queries = `${r.queries} queries`.padEnd(10);
+		return `${theme.system(icons.bullet)} ${padRight(r.name, nameCol)}  ${theme.muted(
+			padRight(r.family, famCol)
+		)}  ${theme.muted(fields)} ${theme.muted(queries)}`;
+	});
+
+	return {
+		title: 'entities',
+		body,
+		footer: `${rows.length} entities · ${families.size} families · ${queryCount} queries`,
+	};
+}
+
+async function hints(ctx: Context): Promise<Hint[]> {
+	if (!ctx.isInitialized) {
+		return [{ command: 'codegen init', description: 'Initialize project' }];
+	}
+	if (!ctx.entitiesDir || ctx.entityCount === 0) {
+		return [
+			{
+				command: 'codegen entity new entities/example.yaml',
+				description: 'Generate first entity',
+			},
+		];
+	}
+	return [
+		{ command: 'codegen entity new <file>', description: 'Generate one entity' },
+		{ command: 'codegen entity new --all', description: 'Regenerate all entities' },
+		{ command: 'codegen entity validate', description: 'Validate YAML definitions' },
+		{ command: 'codegen entity list', description: 'List entities as a table' },
+	];
+}
+
+// ---------------------------------------------------------------------------
+// EntityNewCommand
+// ---------------------------------------------------------------------------
+
+export class EntityNewCommand extends Command {
+	static paths = [['entity', 'new']];
+	static usage = Command.Usage({
+		description: 'Generate code for one or more entities from YAML',
+		examples: [
+			['Generate a single entity', 'codegen entity new entities/contact.yaml'],
+			['Regenerate all entities', 'codegen entity new --all'],
+			['Preview without writing', 'codegen entity new entities/contact.yaml --dry-run'],
+		],
+	});
+
+	yaml = Option.String({ required: false });
+	all = Option.Boolean('--all', false);
+	dryRun = Option.Boolean('--dry-run', false);
+	force = Option.Boolean('--force', false);
+	only = Option.String('--only', { required: false });
+	continueOnError = Option.Boolean('--continue-on-error', false);
+	json = Option.Boolean('--json', false);
+	cwd = Option.String('--cwd', { required: false });
+	configPath = Option.String('--config', { required: false });
+
+	async execute(): Promise<number> {
+		if (this.json) setJsonMode(true);
+		const ctx = await loadContext({
+			cwd: this.cwd,
+			configPath: this.configPath,
+			json: this.json,
+			skipDetection: true,
+		});
+
+		if (this.all && this.yaml) {
+			printError('Pass either a YAML path or --all, not both.');
+			return 2;
+		}
+
+		let targets: string[] = [];
+		if (this.all) {
+			const dir = ctx.entitiesDir ?? path.resolve(ctx.cwd, 'entities');
+			targets = listEntityYamls(dir);
+			if (targets.length === 0) {
+				printError(`No entity YAML files found in ${dir}`);
+				return 1;
+			}
+		} else if (this.yaml) {
+			targets = [path.resolve(ctx.cwd, this.yaml)];
+		} else {
+			printError('Missing YAML path. Pass a file or --all.');
+			return 2;
+		}
+
+		// Pre-flight: validate each YAML.
+		const validated: Array<{ file: string; name: string }> = [];
+		const invalid: Array<{ file: string; message: string }> = [];
+		for (const file of targets) {
+			const result = loadEntityFromYaml(file);
+			if (result.success) {
+				validated.push({ file, name: result.definition.entity.name });
+			} else {
+				invalid.push({ file, message: result.error });
+			}
+		}
+
+		if (invalid.length > 0 && !this.continueOnError) {
+			for (const i of invalid) {
+				printError(`${path.basename(i.file)} — ${i.message}`);
+			}
+			if (!isJsonMode()) {
+				return 1;
+			}
+		}
+
+		// Git safety — we don't know specific output paths without running Hygen,
+		// so scope the check to the cwd's generated source roots if we can.
+		if (!this.force) {
+			const gitCheck = checkGitSafety(['src'], ctx.cwd);
+			if (gitCheck.inRepo && !gitCheck.clean) {
+				printWarning(
+					`Uncommitted changes in ${gitCheck.dirty.length} files under src/. Pass --force to overwrite.`
+				);
+				if (!isJsonMode()) return 1;
+			}
+		}
+
+		if (this.dryRun) {
+			if (isJsonMode()) {
+				printJson({
+					command: 'entity new',
+					dryRun: true,
+					entities: validated.map((v) => ({ name: v.name, file: v.file })),
+					totals: { planned: validated.length, invalid: invalid.length },
+				});
+			} else {
+				printInfo(`Dry run — ${validated.length} entities would be generated:`);
+				for (const v of validated) {
+					console.log(`  ${theme.muted(icons.arrow)} ${v.name}  ${theme.muted(v.file)}`);
+				}
+				if (invalid.length > 0) {
+					for (const i of invalid) {
+						printWarning(`${path.basename(i.file)} — ${i.message}`);
+					}
+				}
+			}
+			return invalid.length > 0 && !this.continueOnError ? 1 : 0;
+		}
+
+		// Invoke Hygen for each validated target.
+		const succeeded: string[] = [];
+		const failed: Array<{ name: string; file: string; message: string }> = [
+			...invalid.map((i) => ({ name: path.basename(i.file), file: i.file, message: i.message })),
+		];
+		for (const v of validated) {
+			if (!isJsonMode()) {
+				printInfo(`generating ${v.name}`);
+			}
+			const res = invokeEntityNew(v.file, ctx.cwd);
+			if (res.ok) {
+				succeeded.push(v.name);
+				if (!isJsonMode()) printSuccess(`${v.name}`);
+			} else {
+				failed.push({
+					name: v.name,
+					file: v.file,
+					message: res.stderr ?? 'Hygen invocation failed',
+				});
+				if (!isJsonMode()) printError(`${v.name} — ${res.stderr ?? 'failed'}`);
+				if (!this.continueOnError) break;
+			}
+		}
+
+		if (isJsonMode()) {
+			printJson({
+				command: 'entity new',
+				totals: {
+					succeeded: succeeded.length,
+					failed: failed.length,
+				},
+				succeeded,
+				failed,
+			});
+		} else {
+			const total = validated.length + invalid.length;
+			console.log('');
+			if (failed.length === 0) {
+				printSuccess(`${total} entities · ${succeeded.length} succeeded`);
+			} else {
+				printWarning(
+					`${total} entities · ${succeeded.length} succeeded · ${failed.length} failed`
+				);
+			}
+		}
+
+		return failed.length === 0 ? 0 : 1;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EntityListCommand
+// ---------------------------------------------------------------------------
+
+export class EntityListCommand extends Command {
+	static paths = [['entity', 'list']];
+	static usage = Command.Usage({
+		description: 'List defined entities as a table',
+	});
+
+	family = Option.String('--family', { required: false });
+	format = Option.String('--format', 'plain');
+	json = Option.Boolean('--json', false);
+	cwd = Option.String('--cwd', { required: false });
+	configPath = Option.String('--config', { required: false });
+
+	async execute(): Promise<number> {
+		if (this.json || this.format === 'json') setJsonMode(true);
+		const ctx = await loadContext({
+			cwd: this.cwd,
+			configPath: this.configPath,
+			json: this.json,
+			skipDetection: true,
+		});
+
+		if (!ctx.entitiesDir) {
+			printError('No entities directory found.');
+			return 1;
+		}
+
+		const files = listEntityYamls(ctx.entitiesDir);
+		const rows = files
+			.map(summarizeEntityFile)
+			.filter((r): r is EntitySummaryRow => r !== null)
+			.filter((r) => (this.family ? r.family === this.family : true));
+
+		if (isJsonMode()) {
+			printJson({
+				command: 'entity list',
+				entities: rows,
+			});
+			return 0;
+		}
+
+		if (this.format === 'tree') {
+			const byFamily = new Map<string, EntitySummaryRow[]>();
+			for (const r of rows) {
+				const list = byFamily.get(r.family) ?? [];
+				list.push(r);
+				byFamily.set(r.family, list);
+			}
+			for (const [fam, list] of byFamily) {
+				console.log(theme.system(fam));
+				for (const r of list) {
+					console.log(`  ${theme.muted(icons.bullet)} ${r.name}  ${theme.muted(`${r.fields} fields`)}`);
+				}
+			}
+			return 0;
+		}
+
+		// plain
+		const nameW = Math.max(4, ...rows.map((r) => r.name.length));
+		const famW = Math.max(6, ...rows.map((r) => r.family.length));
+		console.log(
+			theme.muted(
+				`${padRight('NAME', nameW)}  ${padRight('FAMILY', famW)}  ${padRight('FIELDS', 8)} ${padRight('QUERIES', 8)}`
+			)
+		);
+		for (const r of rows) {
+			console.log(
+				`${padRight(r.name, nameW)}  ${padRight(r.family, famW)}  ${padRight(String(r.fields), 8)} ${padRight(String(r.queries), 8)}`
+			);
+		}
+		return 0;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EntityValidateCommand
+// ---------------------------------------------------------------------------
+
+export class EntityValidateCommand extends Command {
+	static paths = [['entity', 'validate']];
+	static usage = Command.Usage({
+		description: 'Validate entity YAML definitions against the schema',
+	});
+
+	dir = Option.String({ required: false });
+	strict = Option.Boolean('--strict', false);
+	json = Option.Boolean('--json', false);
+	cwd = Option.String('--cwd', { required: false });
+	configPath = Option.String('--config', { required: false });
+
+	async execute(): Promise<number> {
+		if (this.json) setJsonMode(true);
+		const ctx = await loadContext({
+			cwd: this.cwd,
+			configPath: this.configPath,
+			json: this.json,
+			skipDetection: true,
+		});
+
+		const targetDir = this.dir
+			? path.resolve(ctx.cwd, this.dir)
+			: ctx.entitiesDir ?? path.resolve(ctx.cwd, 'entities');
+
+		if (!fs.existsSync(targetDir)) {
+			printError(`Directory not found: ${targetDir}`);
+			return 1;
+		}
+
+		const quick = validateEntities(targetDir);
+		const full = await analyzeDomain(targetDir);
+
+		const errors = full.issues.filter((i) => i.severity === 'error');
+		const warnings = full.issues.filter((i) => i.severity === 'warning');
+
+		if (isJsonMode()) {
+			printJson({
+				command: 'entity validate',
+				directory: targetDir,
+				valid: quick.valid && errors.length === 0,
+				errors: errors.map((e) => ({ entity: e.entity, path: e.path, message: e.message })),
+				warnings: warnings.map((w) => ({
+					entity: w.entity,
+					path: w.path,
+					message: w.message,
+				})),
+			});
+			if (errors.length > 0) return 1;
+			if (this.strict && warnings.length > 0) return 1;
+			return 0;
+		}
+
+		if (errors.length === 0) {
+			printSuccess(`All entities validated — ${full.entities.length} checked`);
+		} else {
+			printError(`${errors.length} validation errors`);
+			for (const e of errors) {
+				console.log(`  ${theme.error(icons.error)} ${e.entity ?? e.path ?? ''}: ${e.message}`);
+			}
+		}
+		if (warnings.length > 0) {
+			for (const w of warnings) {
+				printWarning(`${w.entity ?? w.path ?? ''}: ${w.message}`);
+			}
+		}
+
+		if (errors.length > 0) return 1;
+		if (this.strict && warnings.length > 0) return 1;
+		return 0;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NounModule default export
+// ---------------------------------------------------------------------------
+
+const entityNoun: NounModule = {
+	name: 'entity',
+	commandClasses: [EntityNewCommand, EntityListCommand, EntityValidateCommand] as CommandClass[],
+	summary,
+	hints,
+};
+
+export default entityNoun;

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -1,0 +1,418 @@
+/**
+ * Subsystem noun — install / list / remove (stub).
+ *
+ * Implements SPEC-CLI-03. Installs runtime subsystems (events/jobs/cache/
+ * storage) into a user's project by copying `runtime/subsystems/<name>/`
+ * plus any referenced runtime dependencies (types, constants).
+ *
+ * The `runtime/` directory is shipped-read-only; this command only reads it.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command, Option } from 'clipanion';
+import type { CommandClass } from 'clipanion';
+
+import { loadContext, type Context } from '../shared/context.js';
+import { checkGitSafety } from '../shared/git-safety.js';
+import { copyRuntime } from '../shared/runtime-copier.js';
+import {
+	SUBSYSTEMS,
+	detectInstalledSubsystems,
+	type SubsystemDescriptor,
+	type SubsystemName,
+	type SubsystemBackend,
+	type InstalledSubsystem,
+} from '../shared/subsystem-detect.js';
+
+import { theme } from '../ui/theme.js';
+import { icons } from '../ui/icons.js';
+import { printError, printInfo, printSuccess, printWarning } from '../ui/output.js';
+import { isJsonMode, printJson, setJsonMode } from '../ui/json.js';
+import type { PaneOutput } from '../ui/pane.js';
+import type { Hint } from '../ui/hints.js';
+import type { NounModule } from '../noun-module.js';
+
+// ---------------------------------------------------------------------------
+// paths
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SUBSYSTEMS_REL = 'src/shared/subsystems';
+
+function runtimeRoot(): string {
+	// src/cli/commands/subsystem.ts → ../../../runtime
+	return path.resolve(import.meta.dirname, '..', '..', '..', 'runtime');
+}
+
+function subsystemSource(name: SubsystemName): string {
+	return path.join(runtimeRoot(), 'subsystems', name);
+}
+
+function resolveTargetRoot(ctx: Context, overrideTarget?: string): string {
+	if (overrideTarget) return path.resolve(ctx.cwd, overrideTarget);
+	const configured = ctx.config?.paths?.subsystems as string | undefined;
+	if (configured) return path.resolve(ctx.cwd, configured);
+	return path.resolve(ctx.cwd, DEFAULT_SUBSYSTEMS_REL);
+}
+
+function describeSubsystem(name: string): SubsystemDescriptor | null {
+	return SUBSYSTEMS.find((s) => s.name === name) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// summary + hints
+// ---------------------------------------------------------------------------
+
+async function summary(ctx: Context): Promise<PaneOutput> {
+	const installed = await detectInstalledSubsystems(ctx);
+	const installedNames = new Set(installed.map((i) => i.name));
+	const missing = SUBSYSTEMS.filter((s) => !installedNames.has(s.name));
+
+	const body: string[] = [];
+
+	if (installed.length === 0) {
+		body.push(theme.muted('Available:'));
+		for (const s of SUBSYSTEMS) {
+			body.push(
+				`  ${theme.muted(icons.dash)} ${s.name.padEnd(10)} ${theme.muted(s.description)}`
+			);
+		}
+		body.push('');
+		body.push(theme.muted('No subsystems installed yet.'));
+		return {
+			title: 'subsystems',
+			body,
+			footer: `0 of ${SUBSYSTEMS.length} subsystems installed`,
+		};
+	}
+
+	body.push(theme.muted('Installed:'));
+	for (const i of installed) {
+		const rel = path.relative(ctx.cwd, i.path) || i.path;
+		body.push(
+			`  ${theme.success(icons.check)} ${i.name.padEnd(10)} ${theme.muted(
+				`${i.backend} backend`
+			)}   ${theme.muted(rel)}`
+		);
+	}
+
+	if (missing.length > 0) {
+		body.push('');
+		body.push(theme.muted('Available:'));
+		for (const s of missing) {
+			body.push(
+				`  ${theme.muted(icons.dash)} ${s.name.padEnd(10)} ${theme.muted('not installed')}`
+			);
+		}
+	}
+
+	return {
+		title: 'subsystems',
+		body,
+		footer: `${installed.length} of ${SUBSYSTEMS.length} subsystems installed`,
+	};
+}
+
+async function hints(ctx: Context): Promise<Hint[]> {
+	if (!ctx.isInitialized) {
+		return [{ command: 'codegen init', description: 'Initialize project' }];
+	}
+	const installed = await detectInstalledSubsystems(ctx);
+	const installedNames = new Set(installed.map((i) => i.name));
+	const missing = SUBSYSTEMS.filter((s) => !installedNames.has(s.name));
+
+	if (missing.length === 0) {
+		return [{ command: 'codegen subsystem list', description: 'List installed subsystems' }];
+	}
+
+	const out: Hint[] = [];
+	for (const s of missing.slice(0, 3)) {
+		out.push({
+			command: `codegen subsystem install ${s.name}`,
+			description: `Install the ${s.name} subsystem`,
+		});
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// SubsystemInstallCommand
+// ---------------------------------------------------------------------------
+
+function isValidBackend(
+	name: SubsystemName,
+	backend: string
+): backend is SubsystemBackend {
+	const desc = describeSubsystem(name);
+	if (!desc) return false;
+	return (desc.backends as string[]).includes(backend);
+}
+
+function backendFileFilter(backend: SubsystemBackend): (file: string) => boolean {
+	return (file: string) => {
+		if (backend === 'memory') {
+			if (file.endsWith('.drizzle-backend.ts')) return false;
+			if (file.endsWith('.schema.ts')) return false;
+			return true;
+		}
+		if (backend === 'drizzle') {
+			if (file.endsWith('.memory-backend.ts')) return false;
+			return true;
+		}
+		// local / unknown — copy everything
+		return true;
+	};
+}
+
+export class SubsystemInstallCommand extends Command {
+	static paths = [['subsystem', 'install']];
+	static usage = Command.Usage({
+		description: 'Install a runtime subsystem into the project',
+		examples: [
+			['Install the events subsystem', 'codegen subsystem install events'],
+			['Install jobs with memory backend', 'codegen subsystem install jobs --backend memory'],
+			['Preview without writing', 'codegen subsystem install cache --dry-run'],
+		],
+	});
+
+	name = Option.String({ required: true });
+	backend = Option.String('--backend', { required: false });
+	target = Option.String('--target', { required: false });
+	force = Option.Boolean('--force', false);
+	yes = Option.Boolean('--yes,-y', false);
+	dryRun = Option.Boolean('--dry-run', false);
+	json = Option.Boolean('--json', false);
+	cwd = Option.String('--cwd', { required: false });
+	configPath = Option.String('--config', { required: false });
+
+	async execute(): Promise<number> {
+		if (this.json) setJsonMode(true);
+		const ctx = await loadContext({
+			cwd: this.cwd,
+			configPath: this.configPath,
+			json: this.json,
+			skipDetection: true,
+		});
+
+		const desc = describeSubsystem(this.name);
+		if (!desc) {
+			printError(
+				`Unknown subsystem '${this.name}'. Known: ${SUBSYSTEMS.map((s) => s.name).join(', ')}`
+			);
+			return 2;
+		}
+
+		const backend = (this.backend ?? desc.defaultBackend) as SubsystemBackend;
+		if (this.backend && !isValidBackend(desc.name, this.backend)) {
+			printError(
+				`Backend '${this.backend}' not supported for '${desc.name}'. Valid: ${desc.backends.join(
+					', '
+				)}`
+			);
+			return 2;
+		}
+
+		const installed = await detectInstalledSubsystems(ctx);
+		const already = installed.find((i) => i.name === desc.name);
+		if (already && !this.force) {
+			if (isJsonMode()) {
+				printJson({
+					command: 'subsystem install',
+					subsystem: desc.name,
+					status: 'already-installed',
+					path: already.path,
+					backend: already.backend,
+				});
+			} else {
+				printInfo(`${desc.name} is already installed at ${already.path} (pass --force to reinstall)`);
+			}
+			return 0;
+		}
+
+		const targetRoot = resolveTargetRoot(ctx, this.target);
+		const subsystemTarget = path.join(targetRoot, desc.name);
+		const source = subsystemSource(desc.name);
+
+		if (!fs.existsSync(source)) {
+			printError(`Runtime subsystem source missing: ${source}`);
+			return 1;
+		}
+
+		if (!this.force) {
+			const gitCheck = checkGitSafety([path.relative(ctx.cwd, subsystemTarget) || subsystemTarget], ctx.cwd);
+			if (gitCheck.inRepo && !gitCheck.clean) {
+				printWarning(
+					`Uncommitted changes under ${subsystemTarget}. Pass --force to overwrite.`
+				);
+				if (!isJsonMode()) return 1;
+			}
+		}
+
+		if (!isJsonMode()) {
+			printInfo(`target = ${path.relative(ctx.cwd, subsystemTarget) || subsystemTarget}`);
+			printInfo(`backend = ${backend}`);
+		}
+
+		const result = await copyRuntime({
+			sourceDir: source,
+			targetDir: subsystemTarget,
+			filter: backendFileFilter(backend),
+			resolveDeps: true,
+			runtimeRoot: runtimeRoot(),
+			depsTargetRoot: path.resolve(targetRoot, '..'),
+			dryRun: this.dryRun,
+		});
+
+		if (isJsonMode()) {
+			printJson({
+				command: 'subsystem install',
+				subsystem: desc.name,
+				backend,
+				target: subsystemTarget,
+				dryRun: this.dryRun,
+				files: {
+					written: result.written,
+					updated: result.updated,
+					unchanged: result.unchanged,
+					planned: result.planned,
+					dependencies: result.dependenciesCopied,
+				},
+			});
+			return 0;
+		}
+
+		if (this.dryRun) {
+			printInfo(`Dry run — ${result.planned.length} files would be written`);
+			for (const p of result.planned) {
+				console.log(`  ${theme.muted(icons.arrow)} ${path.relative(ctx.cwd, p) || p}`);
+			}
+			return 0;
+		}
+
+		const total = result.written.length + result.updated.length + result.unchanged.length;
+		printSuccess(
+			`copied ${total} files (${result.written.length} new, ${result.updated.length} updated, ${result.unchanged.length} unchanged)`
+		);
+		if (result.dependenciesCopied.length > 0) {
+			printInfo(`${result.dependenciesCopied.length} runtime dependencies copied`);
+		}
+		printSuccess(`${desc.name} subsystem installed with ${backend} backend.`);
+		printInfo(
+			`Register ${capitalize(desc.name)}Module.forRoot({ backend: '${backend}' }) in your app.module.ts`
+		);
+		return 0;
+	}
+}
+
+function capitalize(s: string): string {
+	return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// SubsystemListCommand
+// ---------------------------------------------------------------------------
+
+export class SubsystemListCommand extends Command {
+	static paths = [['subsystem', 'list']];
+	static usage = Command.Usage({
+		description: 'List installed and available subsystems',
+	});
+
+	format = Option.String('--format', 'plain');
+	json = Option.Boolean('--json', false);
+	cwd = Option.String('--cwd', { required: false });
+	configPath = Option.String('--config', { required: false });
+
+	async execute(): Promise<number> {
+		if (this.json || this.format === 'json') setJsonMode(true);
+		const ctx = await loadContext({
+			cwd: this.cwd,
+			configPath: this.configPath,
+			json: this.json,
+			skipDetection: true,
+		});
+
+		const installed = await detectInstalledSubsystems(ctx);
+		const byName = new Map<string, InstalledSubsystem>();
+		for (const i of installed) byName.set(i.name, i);
+
+		const rows = SUBSYSTEMS.map((s) => {
+			const inst = byName.get(s.name);
+			return {
+				name: s.name,
+				status: inst ? 'installed' : 'available',
+				backend: inst ? inst.backend : null,
+				path: inst ? path.relative(ctx.cwd, inst.path) || inst.path : null,
+			};
+		});
+
+		if (isJsonMode()) {
+			printJson({ command: 'subsystem list', subsystems: rows });
+			return 0;
+		}
+
+		const pad = (s: string, n: number) => (s.length >= n ? s : s + ' '.repeat(n - s.length));
+		console.log(
+			theme.muted(`${pad('NAME', 10)}${pad('STATUS', 12)}${pad('BACKEND', 12)}PATH`)
+		);
+		for (const r of rows) {
+			console.log(
+				`${pad(r.name, 10)}${pad(r.status, 12)}${pad(r.backend ?? '—', 12)}${r.path ?? '—'}`
+			);
+		}
+		return 0;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SubsystemRemoveCommand (stub)
+// ---------------------------------------------------------------------------
+
+export class SubsystemRemoveCommand extends Command {
+	static paths = [['subsystem', 'remove']];
+	static usage = Command.Usage({
+		description: 'Remove a subsystem (not yet implemented)',
+	});
+
+	name = Option.String({ required: true });
+	json = Option.Boolean('--json', false);
+	cwd = Option.String('--cwd', { required: false });
+	configPath = Option.String('--config', { required: false });
+
+	async execute(): Promise<number> {
+		if (this.json) setJsonMode(true);
+		if (isJsonMode()) {
+			printJson({
+				command: 'subsystem remove',
+				status: 'not-implemented',
+				message:
+					'Manually delete the subsystem directory and remove the module registration from your app.module.ts.',
+			});
+			return 1;
+		}
+		printError('subsystem remove is not yet implemented.');
+		console.log(
+			theme.muted(
+				'  Manually delete the subsystem directory and remove the module\n  registration from your app.module.ts.'
+			)
+		);
+		return 1;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NounModule default export
+// ---------------------------------------------------------------------------
+
+const subsystemNoun: NounModule = {
+	name: 'subsystem',
+	commandClasses: [
+		SubsystemInstallCommand,
+		SubsystemListCommand,
+		SubsystemRemoveCommand,
+	] as CommandClass[],
+	summary,
+	hints,
+};
+
+export default subsystemNoun;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+/**
+ * codegen — root CLI entry point.
+ *
+ * Registers every noun module with a single Clipanion Cli instance. Each
+ * noun contributes its Command classes plus an auto-generated zero-verb
+ * summary command (see {@link noun-module.ts}).
+ *
+ * The transition plan: this binary runs alongside the legacy `src/cli.ts`
+ * until all nouns are migrated. `package.json` `bin.codegen` only flips to
+ * this file once enough nouns are in place.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Builtins, Cli, Command } from 'clipanion';
+import { buildNounSummaryCommand, type NounModule } from './noun-module.js';
+import { setJsonMode } from './ui/json.js';
+import { loadContext } from './shared/context.js';
+import { renderPane } from './ui/pane.js';
+import { renderHints } from './ui/hints.js';
+import { theme } from './ui/theme.js';
+import { icons } from './ui/icons.js';
+
+// ---------------------------------------------------------------------------
+// Package metadata
+// ---------------------------------------------------------------------------
+
+function readVersion(): string {
+	try {
+		const pkgPath = join(import.meta.dirname, '..', '..', 'package.json');
+		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+		return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
+	} catch {
+		return '0.0.0';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Root summary command: `codegen` with no args
+// ---------------------------------------------------------------------------
+
+class RootSummaryCommand extends Command {
+	static paths = [Command.Default];
+	static usage = Command.Usage({
+		description: 'Show project status and available noun commands',
+	});
+
+	async execute(): Promise<number> {
+		const ctx = await loadContext();
+
+		if (!ctx.isInitialized) {
+			renderPane({
+				title: 'codegen',
+				body: [
+					'No codegen.config.yaml and no entities/ directory detected.',
+					'',
+					`  ${theme.muted('Run')} ${theme.system('codegen init')} ${theme.muted(
+						'to scaffold a project'
+					)}`,
+					`  ${theme.muted('Or')} ${theme.system('codegen entity')} ${theme.muted(
+						'to see entity-level hints'
+					)}`,
+				],
+			});
+			return 0;
+		}
+
+		renderPane({
+			title: 'codegen',
+			body: [
+				`${theme.success(icons.check)} project initialized`,
+				`  config:      ${ctx.configPath ?? '(none)'}`,
+				`  entities:    ${ctx.entityCount}`,
+				`  subsystems:  ${ctx.installedSubsystems.length}/4 installed`,
+			],
+		});
+		renderHints([
+			{ command: 'codegen entity', description: 'Entity summary + hints' },
+			{ command: 'codegen subsystem', description: 'Subsystem summary + hints' },
+		]);
+		return 0;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registry — populated by each phase as nouns are implemented.
+// ---------------------------------------------------------------------------
+
+const nouns: NounModule[] = [];
+
+// Phase 2 will push entityNoun here; Phase 3 will push subsystemNoun.
+// Dynamic imports avoid pulling in noun code until it exists.
+async function loadNouns(): Promise<void> {
+	try {
+		const mod = await import('./commands/entity.js');
+		if (mod?.default) nouns.push(mod.default as NounModule);
+	} catch {
+		// entity noun not implemented yet
+	}
+	try {
+		const mod = await import('./commands/subsystem.js');
+		if (mod?.default) nouns.push(mod.default as NounModule);
+	} catch {
+		// subsystem noun not implemented yet
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+	// Detect --json early so UI helpers short-circuit from the first call.
+	const argv = process.argv.slice(2);
+	if (argv.includes('--json')) setJsonMode(true);
+
+	await loadNouns();
+
+	const cli = new Cli({
+		binaryLabel: 'codegen',
+		binaryName: 'codegen',
+		binaryVersion: readVersion(),
+	});
+
+	cli.register(Builtins.HelpCommand);
+	cli.register(Builtins.VersionCommand);
+	cli.register(RootSummaryCommand);
+
+	for (const noun of nouns) {
+		for (const CommandClass of noun.commandClasses) {
+			cli.register(CommandClass);
+		}
+		cli.register(buildNounSummaryCommand(noun));
+	}
+
+	await cli.runExit(argv);
+}
+
+main().catch((err: unknown) => {
+	const msg = err instanceof Error ? err.message : String(err);
+	console.error(`${theme.error(icons.error)} ${msg}`);
+	process.exit(1);
+});

--- a/src/cli/noun-module.ts
+++ b/src/cli/noun-module.ts
@@ -1,0 +1,68 @@
+/**
+ * NounModule abstraction — see ADR-015 and SPEC-CLI-01.
+ *
+ * Each CLI noun (entity, subsystem, project, manifest) exports a NounModule.
+ * The root CLI registers each noun's command classes and builds a zero-verb
+ * summary command on the fly via {@link buildNounSummaryCommand}.
+ */
+
+import { Command, Option } from 'clipanion';
+import type { CommandClass } from 'clipanion';
+import type { Context } from './shared/context.js';
+import { loadContext } from './shared/context.js';
+import { renderPane, type PaneOutput } from './ui/pane.js';
+import { renderHints, type Hint } from './ui/hints.js';
+import { isJsonMode, printJson, setJsonMode } from './ui/json.js';
+
+export type { PaneOutput } from './ui/pane.js';
+export type { Hint } from './ui/hints.js';
+
+export interface NounModule {
+	name: string;
+	commandClasses: Array<CommandClass>;
+	summary(ctx: Context): Promise<PaneOutput>;
+	hints(ctx: Context): Promise<Hint[]>;
+}
+
+/**
+ * Build a Clipanion Command class whose path is `[[noun.name]]`. Loads the
+ * shared Context, renders the noun's summary + hints (or emits JSON).
+ */
+export function buildNounSummaryCommand(noun: NounModule): CommandClass {
+	class NounSummaryCommand extends Command {
+		static paths = [[noun.name]];
+		static usage = Command.Usage({
+			description: `Show ${noun.name} summary and suggested next commands`,
+		});
+
+		json = Option.Boolean('--json', false);
+		cwd = Option.String('--cwd', { required: false });
+		configPath = Option.String('--config', { required: false });
+		verbose = Option.Boolean('--verbose,-v', false);
+
+		async execute(): Promise<number> {
+			if (this.json) setJsonMode(true);
+			const ctx = await loadContext({
+				cwd: this.cwd,
+				configPath: this.configPath,
+				json: this.json,
+				verbose: this.verbose,
+			});
+			const [pane, hints] = await Promise.all([noun.summary(ctx), noun.hints(ctx)]);
+
+			if (isJsonMode()) {
+				printJson({ noun: noun.name, summary: pane, hints });
+				return 0;
+			}
+			renderPane(pane);
+			renderHints(hints);
+			return 0;
+		}
+	}
+
+	// Preserve a descriptive class name for debugging + Clipanion introspection.
+	Object.defineProperty(NounSummaryCommand, 'name', {
+		value: `${noun.name[0].toUpperCase()}${noun.name.slice(1)}SummaryCommand`,
+	});
+	return NounSummaryCommand as CommandClass;
+}

--- a/src/cli/shared/context.ts
+++ b/src/cli/shared/context.ts
@@ -127,8 +127,12 @@ function detectInstalledSubsystemNames(
 	for (const root of roots) {
 		if (!fs.existsSync(root)) continue;
 		for (const name of KNOWN_SUBSYSTEMS) {
-			const proto = path.join(root, name, `${name}.protocol.ts`);
-			if (fs.existsSync(proto)) found.add(name);
+			const dir = path.join(root, name);
+			if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) continue;
+			const hasProtocol = fs
+				.readdirSync(dir)
+				.some((f) => f.endsWith('.protocol.ts'));
+			if (hasProtocol) found.add(name);
 		}
 	}
 	return Array.from(found);

--- a/src/cli/shared/context.ts
+++ b/src/cli/shared/context.ts
@@ -1,0 +1,173 @@
+/**
+ * Context — shared CLI execution state.
+ *
+ * Loaded once per invocation and passed to every noun's summary/hints/commands.
+ * Commands should not re-read config or re-run detection; use the Context.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'yaml';
+import { scanProject } from '../../scanner/index.js';
+import type { ProjectProfile } from '../../scanner/types.js';
+
+export interface CodegenConfig {
+	paths?: {
+		entities?: string;
+		entities_dir?: string;
+		subsystems?: string;
+		backend_src?: string;
+		frontend_src?: string;
+	};
+	generate?: Record<string, unknown>;
+	framework?: string;
+	orm?: string;
+	[key: string]: unknown;
+}
+
+export interface Context {
+	cwd: string;
+	configPath: string | null;
+	config: CodegenConfig | null;
+	isInitialized: boolean;
+	framework: ProjectProfile | null;
+	installedSubsystems: string[];
+	entityCount: number;
+	entitiesDir: string | null;
+	json: boolean;
+	verbose: boolean;
+}
+
+export interface LoadContextOptions {
+	cwd?: string;
+	configPath?: string;
+	json?: boolean;
+	verbose?: boolean;
+	/**
+	 * Skip scanner / subsystem detection. Useful for fast command paths
+	 * and tests that don't need full project analysis.
+	 */
+	skipDetection?: boolean;
+}
+
+/**
+ * Walk upward from `start` looking for a `codegen.config.yaml`. Returns the
+ * absolute path or null if none is found before reaching the filesystem root.
+ */
+function findConfigUpward(start: string): string | null {
+	let dir = path.resolve(start);
+	const root = path.parse(dir).root;
+	while (true) {
+		const candidate = path.join(dir, 'codegen.config.yaml');
+		if (fs.existsSync(candidate)) return candidate;
+		if (dir === root) return null;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function loadConfigFromPath(configPath: string): CodegenConfig | null {
+	try {
+		const content = fs.readFileSync(configPath, 'utf-8');
+		const parsed = yaml.parse(content);
+		if (parsed && typeof parsed === 'object') {
+			return parsed as CodegenConfig;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function resolveEntitiesDir(cwd: string, config: CodegenConfig | null): string | null {
+	const fromConfig =
+		(config?.paths?.entities as string | undefined) ??
+		(config?.paths?.entities_dir as string | undefined);
+	const candidates: string[] = [];
+	if (fromConfig) candidates.push(path.resolve(cwd, fromConfig));
+	candidates.push(path.resolve(cwd, 'entities'));
+
+	for (const c of candidates) {
+		if (fs.existsSync(c) && fs.statSync(c).isDirectory()) return c;
+	}
+	return null;
+}
+
+function countEntityYamls(entitiesDir: string | null): number {
+	if (!entitiesDir || !fs.existsSync(entitiesDir)) return 0;
+	try {
+		return fs.readdirSync(entitiesDir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+			.length;
+	} catch {
+		return 0;
+	}
+}
+
+const KNOWN_SUBSYSTEMS = ['events', 'jobs', 'cache', 'storage'] as const;
+
+/**
+ * Cheap subsystem detection — scans common install paths for a protocol file.
+ * The richer {@link ../shared/subsystem-detect.ts} implementation returns
+ * full metadata; loadContext() only needs names for the summary.
+ */
+function detectInstalledSubsystemNames(
+	cwd: string,
+	config: CodegenConfig | null
+): string[] {
+	const configured = config?.paths?.subsystems as string | undefined;
+	const roots = [
+		...(configured ? [path.resolve(cwd, configured)] : []),
+		path.resolve(cwd, 'src/shared/subsystems'),
+		path.resolve(cwd, 'src/subsystems'),
+		path.resolve(cwd, 'shared/subsystems'),
+	];
+
+	const found = new Set<string>();
+	for (const root of roots) {
+		if (!fs.existsSync(root)) continue;
+		for (const name of KNOWN_SUBSYSTEMS) {
+			const proto = path.join(root, name, `${name}.protocol.ts`);
+			if (fs.existsSync(proto)) found.add(name);
+		}
+	}
+	return Array.from(found);
+}
+
+export async function loadContext(overrides: LoadContextOptions = {}): Promise<Context> {
+	const cwd = overrides.cwd ? path.resolve(overrides.cwd) : process.cwd();
+
+	const explicit = overrides.configPath ? path.resolve(cwd, overrides.configPath) : null;
+	const configPath = explicit && fs.existsSync(explicit) ? explicit : findConfigUpward(cwd);
+	const config = configPath ? loadConfigFromPath(configPath) : null;
+
+	const entitiesDir = resolveEntitiesDir(cwd, config);
+	const entityCount = countEntityYamls(entitiesDir);
+
+	const isInitialized = Boolean(configPath) || entityCount > 0;
+
+	let framework: ProjectProfile | null = null;
+	let installedSubsystems: string[] = [];
+
+	if (!overrides.skipDetection && isInitialized) {
+		try {
+			framework = await scanProject({ directory: cwd });
+		} catch {
+			framework = null;
+		}
+		installedSubsystems = detectInstalledSubsystemNames(cwd, config);
+	}
+
+	return {
+		cwd,
+		configPath,
+		config,
+		isInitialized,
+		framework,
+		installedSubsystems,
+		entityCount,
+		entitiesDir,
+		json: Boolean(overrides.json),
+		verbose: Boolean(overrides.verbose),
+	};
+}

--- a/src/cli/shared/git-safety.ts
+++ b/src/cli/shared/git-safety.ts
@@ -1,0 +1,68 @@
+/**
+ * Git safety check — warn before overwriting files with uncommitted changes.
+ *
+ * Used by `entity new` and `subsystem install` to prevent silent clobbering.
+ * Non-git projects return { clean: true, dirty: [] }.
+ */
+
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+export interface GitSafetyResult {
+	clean: boolean;
+	dirty: string[];
+	inRepo: boolean;
+}
+
+function isInsideGitRepo(cwd: string): boolean {
+	try {
+		execSync('git rev-parse --is-inside-work-tree', {
+			cwd,
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Run `git status --porcelain` against the given paths. Returns the subset
+ * of paths that have modifications. An empty `paths` array returns a clean
+ * result.
+ */
+export function checkGitSafety(paths: string[], cwd: string = process.cwd()): GitSafetyResult {
+	if (paths.length === 0) return { clean: true, dirty: [], inRepo: isInsideGitRepo(cwd) };
+
+	if (!isInsideGitRepo(cwd)) {
+		return { clean: true, dirty: [], inRepo: false };
+	}
+
+	// Normalize paths to relative POSIX paths — git status prefers them.
+	const rels = paths.map((p) => {
+		const abs = path.isAbsolute(p) ? p : path.resolve(cwd, p);
+		return path.relative(cwd, abs).replace(/\\/g, '/');
+	});
+
+	// Build safe argument list; execFile-style via execSync with `--` separator.
+	const argStr = rels.map((r) => `"${r.replace(/"/g, '\\"')}"`).join(' ');
+	let output = '';
+	try {
+		output = execSync(`git status --porcelain -- ${argStr}`, {
+			cwd,
+			stdio: ['ignore', 'pipe', 'ignore'],
+		}).toString();
+	} catch {
+		return { clean: true, dirty: [], inRepo: true };
+	}
+
+	const dirty: string[] = [];
+	for (const line of output.split('\n')) {
+		if (!line.trim()) continue;
+		// porcelain lines: "XY path" (X+Y = 2 status chars, then space, then path)
+		const match = line.match(/^..\s(.+)$/);
+		if (match) dirty.push(match[1].trim());
+	}
+
+	return { clean: dirty.length === 0, dirty, inRepo: true };
+}

--- a/src/cli/shared/hygen.ts
+++ b/src/cli/shared/hygen.ts
@@ -1,0 +1,96 @@
+/**
+ * Hygen invocation helper — shared between `entity` and `subsystem` nouns.
+ *
+ * Extracted verbatim from the legacy src/cli.ts so behavior is identical
+ * during the transition. We shell out to `bunx hygen <generator> <action>`
+ * with HYGEN_TMPLS pointing at our templates directory.
+ */
+
+import { execSync, type ExecSyncOptions } from 'node:child_process';
+import { join } from 'node:path';
+
+export interface HygenInvocation {
+	/** e.g. 'entity' */
+	generator: string;
+	/** e.g. 'new' */
+	action: string;
+	/** Absolute path to the templates/ directory. Defaults to bundled templates. */
+	templateRoot?: string;
+	/** Extra positional args passed after `<generator> <action>` */
+	args?: string[];
+	/** Extra env vars merged onto process.env */
+	env?: NodeJS.ProcessEnv;
+	/** Working directory Hygen executes in. Defaults to process.cwd(). */
+	cwd?: string;
+	/** If false, suppresses child stdio inheritance. Defaults to true. */
+	inherit?: boolean;
+}
+
+export interface HygenResult {
+	ok: boolean;
+	command: string;
+	stdout?: string;
+	stderr?: string;
+}
+
+function defaultTemplateRoot(): string {
+	// src/cli/shared/hygen.ts → ../../../templates
+	return join(import.meta.dirname, '..', '..', '..', 'templates');
+}
+
+function quoteArg(a: string): string {
+	if (a === '' || /[\s"'$`\\]/.test(a)) {
+		return `"${a.replace(/(["$`\\])/g, '\\$1')}"`;
+	}
+	return a;
+}
+
+/**
+ * Invoke Hygen synchronously, inheriting stdio by default (so users see the
+ * generator's own output). Returns {ok:false} on non-zero exit.
+ */
+export function invokeHygen(opts: HygenInvocation): HygenResult {
+	const templateRoot = opts.templateRoot ?? defaultTemplateRoot();
+	const extra = (opts.args ?? []).map(quoteArg).join(' ');
+	const command = `bunx hygen ${opts.generator} ${opts.action}${extra ? ' ' + extra : ''}`;
+
+	const execOpts: ExecSyncOptions = {
+		cwd: opts.cwd ?? process.cwd(),
+		env: { ...process.env, HYGEN_TMPLS: templateRoot, ...(opts.env ?? {}) },
+		stdio: opts.inherit === false ? 'pipe' : 'inherit',
+	};
+
+	try {
+		const out = execSync(command, execOpts);
+		return {
+			ok: true,
+			command,
+			stdout: out ? out.toString() : undefined,
+		};
+	} catch (err: unknown) {
+		const e = err as {
+			stdout?: Buffer | string;
+			stderr?: Buffer | string;
+			message?: string;
+		};
+		return {
+			ok: false,
+			command,
+			stdout: e.stdout ? e.stdout.toString() : undefined,
+			stderr: e.stderr ? e.stderr.toString() : e.message,
+		};
+	}
+}
+
+/**
+ * Convenience wrapper for the most common pattern — generating one entity
+ * from a YAML path.
+ */
+export function invokeEntityNew(absoluteYamlPath: string, cwd?: string): HygenResult {
+	return invokeHygen({
+		generator: 'entity',
+		action: 'new',
+		args: ['--yaml', absoluteYamlPath],
+		cwd,
+	});
+}

--- a/src/cli/shared/runtime-copier.ts
+++ b/src/cli/shared/runtime-copier.ts
@@ -1,0 +1,158 @@
+/**
+ * runtime-copier — copy a runtime/ subdirectory into a user's project.
+ *
+ * Used by the subsystem noun to install {events, jobs, cache, storage} from
+ * the shipped `runtime/subsystems/<name>/` into the user's project. Honors
+ * file filters (for backend selection) and optionally walks the import graph
+ * to also copy referenced runtime/types/ and runtime/constants/ files.
+ *
+ * The runtime tree is treated as read-only source of truth; this module only
+ * reads from it and writes into the user's target.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface RuntimeCopyOptions {
+	sourceDir: string;
+	targetDir: string;
+	filter?: (file: string) => boolean;
+	resolveDeps?: boolean;
+	/** runtime/ root (parent of subsystems/, types/, constants/). */
+	runtimeRoot?: string;
+	/** Where dependency files like runtime/types/foo.ts should land in the user project.
+	 * Defaults to the parent directory of targetDir. */
+	depsTargetRoot?: string;
+	dryRun?: boolean;
+}
+
+export interface RuntimeCopyResult {
+	written: string[];
+	updated: string[];
+	unchanged: string[];
+	dependenciesCopied: string[];
+	planned: string[];
+}
+
+function readIfExists(p: string): string | null {
+	try {
+		return fs.readFileSync(p, 'utf-8');
+	} catch {
+		return null;
+	}
+}
+
+function writeFile(target: string, content: string): 'written' | 'updated' | 'unchanged' {
+	const existing = readIfExists(target);
+	if (existing === content) return 'unchanged';
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.writeFileSync(target, content);
+	return existing === null ? 'written' : 'updated';
+}
+
+/**
+ * Extract relative import paths from a TypeScript source file. Returns the
+ * raw specifiers (e.g. '../../types/drizzle').
+ */
+function extractRelativeImports(source: string): string[] {
+	const out: string[] = [];
+	const re =
+		/(?:import|export)\s+(?:[^'"`;]*?\s+from\s+)?['"`](\.{1,2}\/[^'"`]+)['"`]/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(source)) !== null) {
+		out.push(m[1]);
+	}
+	return out;
+}
+
+function resolveSourceImport(
+	sourceFile: string,
+	specifier: string
+): string | null {
+	const base = path.resolve(path.dirname(sourceFile), specifier);
+	const candidates = [base + '.ts', base + '.tsx', path.join(base, 'index.ts')];
+	for (const c of candidates) {
+		if (fs.existsSync(c)) return c;
+	}
+	return null;
+}
+
+/**
+ * Copy `sourceDir` into `targetDir`. Optionally follows relative imports and
+ * copies referenced runtime/types/* and runtime/constants/* into a sibling
+ * directory structure of targetDir.
+ */
+export async function copyRuntime(opts: RuntimeCopyOptions): Promise<RuntimeCopyResult> {
+	const { sourceDir, targetDir, filter, resolveDeps, dryRun } = opts;
+
+	if (!fs.existsSync(sourceDir) || !fs.statSync(sourceDir).isDirectory()) {
+		throw new Error(`runtime source directory not found: ${sourceDir}`);
+	}
+
+	const runtimeRoot = opts.runtimeRoot
+		? path.resolve(opts.runtimeRoot)
+		: path.resolve(sourceDir, '..', '..'); // runtime/subsystems/<x> → runtime/
+	const depsTargetRoot = opts.depsTargetRoot ?? path.resolve(targetDir, '..');
+
+	const result: RuntimeCopyResult = {
+		written: [],
+		updated: [],
+		unchanged: [],
+		dependenciesCopied: [],
+		planned: [],
+	};
+
+	// Queue of source paths to copy; value is the destination path.
+	const queue: Array<{ src: string; dest: string; isDep: boolean }> = [];
+
+	// Enumerate files in sourceDir
+	const entries = fs.readdirSync(sourceDir);
+	for (const entry of entries) {
+		const src = path.join(sourceDir, entry);
+		const stat = fs.statSync(src);
+		if (!stat.isFile()) continue;
+		if (!entry.endsWith('.ts') && !entry.endsWith('.tsx')) continue;
+		if (filter && !filter(entry)) continue;
+		queue.push({ src, dest: path.join(targetDir, entry), isDep: false });
+	}
+
+	const visited = new Set<string>();
+
+	while (queue.length > 0) {
+		const next = queue.shift()!;
+		if (visited.has(next.src)) continue;
+		visited.add(next.src);
+
+		const content = fs.readFileSync(next.src, 'utf-8');
+		result.planned.push(next.dest);
+
+		if (!dryRun) {
+			const status = writeFile(next.dest, content);
+			if (status === 'written') result.written.push(next.dest);
+			else if (status === 'updated') result.updated.push(next.dest);
+			else result.unchanged.push(next.dest);
+			if (next.isDep) result.dependenciesCopied.push(next.dest);
+		}
+
+		if (resolveDeps) {
+			for (const spec of extractRelativeImports(content)) {
+				const resolvedSrc = resolveSourceImport(next.src, spec);
+				if (!resolvedSrc) continue;
+				// Only follow imports that land inside runtimeRoot.
+				const relToRuntime = path.relative(runtimeRoot, resolvedSrc);
+				if (relToRuntime.startsWith('..') || path.isAbsolute(relToRuntime)) continue;
+				// If already under sourceDir, it's local — copied by the main loop already.
+				const relToSource = path.relative(sourceDir, resolvedSrc);
+				if (!relToSource.startsWith('..') && !path.isAbsolute(relToSource)) continue;
+
+				// Place it under depsTargetRoot at the same relative path from runtimeRoot
+				// minus the leading 'subsystems/<name>' if the file lives elsewhere.
+				// Simpler: preserve runtime's own relative structure under depsTargetRoot.
+				const depDest = path.join(depsTargetRoot, relToRuntime);
+				queue.push({ src: resolvedSrc, dest: depDest, isDep: true });
+			}
+		}
+	}
+
+	return result;
+}

--- a/src/cli/shared/subsystem-detect.ts
+++ b/src/cli/shared/subsystem-detect.ts
@@ -1,0 +1,106 @@
+/**
+ * Detect which subsystems (events/jobs/cache/storage) are already installed
+ * in the user's project. A subsystem is "installed" when a `<name>.protocol.ts`
+ * exists under a known install root.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Context } from './context.js';
+
+export type SubsystemName = 'events' | 'jobs' | 'cache' | 'storage';
+export type SubsystemBackend = 'drizzle' | 'memory' | 'local' | 'unknown';
+
+export interface InstalledSubsystem {
+	name: SubsystemName;
+	path: string;
+	backend: SubsystemBackend;
+}
+
+export interface SubsystemDescriptor {
+	name: SubsystemName;
+	description: string;
+	backends: SubsystemBackend[];
+	defaultBackend: SubsystemBackend;
+}
+
+export const SUBSYSTEMS: SubsystemDescriptor[] = [
+	{
+		name: 'events',
+		description: 'Domain event bus (transactional outbox)',
+		backends: ['drizzle', 'memory'],
+		defaultBackend: 'drizzle',
+	},
+	{
+		name: 'jobs',
+		description: 'Background job queue',
+		backends: ['drizzle', 'memory'],
+		defaultBackend: 'drizzle',
+	},
+	{
+		name: 'cache',
+		description: 'Key-value cache with TTL',
+		backends: ['drizzle', 'memory'],
+		defaultBackend: 'drizzle',
+	},
+	{
+		name: 'storage',
+		description: 'File/object storage',
+		backends: ['local', 'memory'],
+		defaultBackend: 'local',
+	},
+];
+
+const KNOWN_NAMES = SUBSYSTEMS.map((s) => s.name);
+
+function candidateRoots(cwd: string, configured?: string): string[] {
+	const roots = [
+		...(configured ? [path.resolve(cwd, configured)] : []),
+		path.resolve(cwd, 'src/shared/subsystems'),
+		path.resolve(cwd, 'src/subsystems'),
+		path.resolve(cwd, 'shared/subsystems'),
+	];
+	// Deduplicate while preserving order
+	return Array.from(new Set(roots));
+}
+
+function inferBackend(dir: string, name: SubsystemName): SubsystemBackend {
+	const hasDrizzle = fs.existsSync(path.join(dir, `${name.replace(/s$/, '')}-bus.drizzle-backend.ts`))
+		|| fs.readdirSync(dir).some((f) => f.endsWith('.drizzle-backend.ts'));
+	const hasMemory = fs.readdirSync(dir).some((f) => f.endsWith('.memory-backend.ts'));
+	const hasLocal = fs.readdirSync(dir).some((f) => f.includes('local'));
+	if (hasDrizzle && hasMemory) return 'drizzle'; // both present → drizzle is the active one
+	if (hasDrizzle) return 'drizzle';
+	if (hasLocal) return 'local';
+	if (hasMemory) return 'memory';
+	return 'unknown';
+}
+
+export async function detectInstalledSubsystems(ctx: Context): Promise<InstalledSubsystem[]> {
+	const configured = ctx.config?.paths?.subsystems as string | undefined;
+	const roots = candidateRoots(ctx.cwd, configured);
+
+	const found: InstalledSubsystem[] = [];
+	const seen = new Set<SubsystemName>();
+
+	for (const root of roots) {
+		if (!fs.existsSync(root)) continue;
+		for (const name of KNOWN_NAMES) {
+			if (seen.has(name)) continue;
+			const dir = path.join(root, name);
+			if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) continue;
+			// A subsystem is installed when the directory contains any *.protocol.ts
+			const files = fs.readdirSync(dir);
+			const hasProtocol = files.some((f) => f.endsWith('.protocol.ts'));
+			if (!hasProtocol) continue;
+			seen.add(name);
+			found.push({
+				name,
+				path: dir,
+				backend: inferBackend(dir, name),
+			});
+		}
+	}
+
+	return found;
+}

--- a/src/cli/ui/hints.ts
+++ b/src/cli/ui/hints.ts
@@ -1,0 +1,26 @@
+/**
+ * Hint row — suggested next commands rendered under a summary pane.
+ *
+ * No-op in JSON mode (nouns emit hints in the JSON payload instead).
+ */
+
+import { theme } from './theme.js';
+import { isJsonMode } from './json.js';
+
+export interface Hint {
+	command: string;
+	description: string;
+}
+
+export function renderHints(hints: Hint[]): void {
+	if (isJsonMode()) return;
+	if (hints.length === 0) return;
+
+	console.log('');
+	console.log(theme.muted('  Next:'));
+	const maxCmd = Math.max(...hints.map((h) => h.command.length));
+	for (const h of hints) {
+		const pad = ' '.repeat(maxCmd - h.command.length + 2);
+		console.log(`    ${theme.system(h.command)}${pad}${theme.muted(h.description)}`);
+	}
+}

--- a/src/cli/ui/icons.ts
+++ b/src/cli/ui/icons.ts
@@ -1,0 +1,21 @@
+/**
+ * Icon glyphs with ASCII fallback for non-Unicode / non-TTY environments.
+ *
+ * Detection mirrors ADR-016: TTY present, TERM != 'dumb', not in CI.
+ */
+
+const unicode =
+	Boolean(process.stdout.isTTY) && process.env.TERM !== 'dumb' && !process.env.CI;
+
+export const icons = {
+	success: unicode ? '✓' : '[OK]',
+	error: unicode ? '✗' : '[FAIL]',
+	warning: unicode ? '⚠' : '[WARN]',
+	info: unicode ? '◆' : '[INFO]',
+	arrow: unicode ? '→' : '->',
+	bullet: unicode ? '▸' : '>',
+	check: unicode ? '✓' : '[x]',
+	dash: unicode ? '◌' : '[ ]',
+} as const;
+
+export type Icons = typeof icons;

--- a/src/cli/ui/json.ts
+++ b/src/cli/ui/json.ts
@@ -1,0 +1,20 @@
+/**
+ * JSON mode state + structured output helper.
+ *
+ * When enabled, the UI helpers (printSuccess, withStatus, renderPane, renderHints)
+ * short-circuit so commands can emit pure JSON without visual noise.
+ */
+
+let jsonMode = false;
+
+export function setJsonMode(enabled: boolean): void {
+	jsonMode = enabled;
+}
+
+export function isJsonMode(): boolean {
+	return jsonMode;
+}
+
+export function printJson(data: unknown): void {
+	process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+}

--- a/src/cli/ui/output.ts
+++ b/src/cli/ui/output.ts
@@ -1,0 +1,38 @@
+/**
+ * Semantic output helpers. Commands call these rather than reaching into theme/icons.
+ *
+ * Errors are truncated at 500 chars in interactive output (matching pts behavior).
+ * All helpers no-op in JSON mode.
+ */
+
+import { theme } from './theme.js';
+import { icons } from './icons.js';
+import { isJsonMode } from './json.js';
+
+const MAX_ERROR_LEN = 500;
+
+export function printSuccess(msg: string): void {
+	if (isJsonMode()) return;
+	console.log(`${theme.success(icons.success)} ${msg}`);
+}
+
+export function printError(msg: string): void {
+	if (isJsonMode()) return;
+	const truncated = msg.length > MAX_ERROR_LEN ? msg.slice(0, MAX_ERROR_LEN) + '…' : msg;
+	console.error(`${theme.error(icons.error)} ${truncated}`);
+}
+
+export function printWarning(msg: string): void {
+	if (isJsonMode()) return;
+	console.warn(`${theme.warning(icons.warning)} ${msg}`);
+}
+
+export function printInfo(msg: string): void {
+	if (isJsonMode()) return;
+	console.log(`${theme.system(icons.info)} ${msg}`);
+}
+
+export function printMuted(msg: string): void {
+	if (isJsonMode()) return;
+	console.log(theme.muted(msg));
+}

--- a/src/cli/ui/pane.ts
+++ b/src/cli/ui/pane.ts
@@ -1,0 +1,42 @@
+/**
+ * Pane primitives — border + content + optional footer.
+ *
+ * Nouns own the content layout; the pane module owns border, padding, and footer.
+ * No-op in JSON mode.
+ */
+
+import { theme } from './theme.js';
+import { isJsonMode } from './json.js';
+
+export interface PaneOutput {
+	title: string;
+	body: string | string[];
+	footer?: string;
+}
+
+function stripAnsi(s: string): string {
+	// strip ANSI escape sequences for width calculations
+	return s.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+export function renderPane(pane: PaneOutput): void {
+	if (isJsonMode()) return;
+
+	const cols = process.stdout.columns ?? 80;
+	const width = Math.min(Math.max(40, cols), 80);
+	const titleLen = stripAnsi(pane.title).length;
+	const dashes = Math.max(0, width - titleLen - 5);
+	const top = '┌─ ' + pane.title + ' ' + '─'.repeat(dashes) + '┐';
+	const bot = '└' + '─'.repeat(Math.max(2, width - 2)) + '┘';
+
+	console.log(theme.muted(top));
+	const lines = Array.isArray(pane.body) ? pane.body : pane.body.split('\n');
+	for (const line of lines) {
+		console.log('  ' + line);
+	}
+	if (pane.footer) {
+		console.log('');
+		console.log(theme.muted('  ' + pane.footer));
+	}
+	console.log(theme.muted(bot));
+}

--- a/src/cli/ui/spinner.ts
+++ b/src/cli/ui/spinner.ts
@@ -1,0 +1,26 @@
+/**
+ * withStatus — Ora wrapper mirroring pts with_status().
+ *
+ * No-ops in JSON mode or when stdout is not a TTY; commands always call it
+ * without branching on environment.
+ */
+
+import ora from 'ora';
+import { isJsonMode } from './json.js';
+
+export async function withStatus<T>(label: string, fn: () => Promise<T>): Promise<T> {
+	const isTty = Boolean(process.stdout.isTTY);
+	if (isJsonMode() || !isTty) {
+		return fn();
+	}
+
+	const spinner = ora({ text: label, color: 'magenta' }).start();
+	try {
+		const result = await fn();
+		spinner.succeed();
+		return result;
+	} catch (err) {
+		spinner.fail();
+		throw err;
+	}
+}

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -1,0 +1,23 @@
+/**
+ * Semantic color tokens for the CLI.
+ *
+ * Commands reference tokens by role (`theme.success`, `theme.muted`), not literal
+ * hex codes. A future dark/light toggle becomes a one-file change.
+ *
+ * See ADR-016 for rationale and palette choices.
+ */
+
+import chalk from 'chalk';
+
+export const theme = {
+	success: chalk.hex('#A8D8A8'),
+	error: chalk.hex('#FF8A80'),
+	warning: chalk.hex('#FFD580'),
+	system: chalk.hex('#A0D8EF'),
+	agent: chalk.hex('#C4A7FF'),
+	user: chalk.hex('#D4A5C9'),
+	muted: chalk.hex('#888888'),
+	dim: chalk.dim,
+} as const;
+
+export type Theme = typeof theme;

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -20,8 +20,8 @@ import {
   getDatabaseDialect,
   getProjectConfig,
   getPipelinesConfig,
-} from "../../../config/paths.mjs";
-import { getNamingConfig } from "../../../config/naming-config.mjs";
+} from "../../../src/config/paths.mjs";
+import { getNamingConfig } from "../../../src/config/naming-config.mjs";
 
 // ============================================================================
 // Behavior Registry (inline to avoid import issues with Hygen)


### PR DESCRIPTION
## Summary
Introduces a noun-verb CLI architecture (ADR-015) as a parallel implementation alongside the legacy `src/cli.ts`, replacing ad-hoc `bun codegen` verbs with a structured `clipanion`-based `entity <verb>` / `subsystem <verb>` interface. This sets the foundation for eventual distribution as an `npx`-installable binary.

## Changes
- **CLI foundation**: Add `NounModule` abstraction, Clipanion/chalk/ora deps, and UI primitives (theme, spinner, pane, hints, JSON output) with a `buildNounSummaryCommand()` helper that auto-wires each noun's summary + hints
- **Entity noun** (`src/cli/commands/entity.ts`): Implement `entity new` (with `--all`, `--dry-run`, `--force`), `entity list`, and `entity validate`; backed by a reusable `invokeHygen()` wrapper and a `git status` pre-flight guard
- **Subsystem noun** (`src/cli/commands/subsystem.ts`): Implement `subsystem install` (with `--backend`, `--target`, `--dry-run`, `--force`), `subsystem list`, and a stub `subsystem remove`; includes `runtime-copier.ts` that walks subsystem imports and drags along referenced `runtime/types/` and `runtime/constants/` files
- **justfile wired to new CLI**: `just gen`, `just gen-all`, and `just gen-subsystem` now shell out to `bun src/cli/index.ts`; `package.json bin` still points at legacy `src/cli.ts` until remaining verbs migrate
- **25 new tests** (entity, subsystem, context, UI) bringing total to 376; fix missed `src/config/` import paths in `templates/entity/new/prompt.js` after the v0.2 reorg

---
**Stack:** `cli-noun-verb-architecture` (PR 1 of 1)
*Managed by [stack CLI](https://github.com/dugshub/stack)*