### PR TITLE
feat: architecture enum + frontend flag (dogfood #1 + #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ YAML Entity Definition → Parser → Analyzer → Hygen Templates → Generated
 ### Two Template Pipelines
 
 - **`templates/entity/new/backend/`** + **`frontend/`** — Full Clean Architecture: separate command/query classes, repository interfaces, NestJS modules.
-- **`templates/entity/new/clean-lite-ps/`** — Clean-Lite-PS: lighter layout with entity, service, repository, controller, module, DTOs, use-cases. Enabled via `generate.cleanLitePs: true`. Has its own `prompt-extension.js`.
+- **`templates/entity/new/clean-lite-ps/`** — Clean-Lite-PS: lighter layout with entity, service, repository, controller, module, DTOs, use-cases. Selected via `generate.architecture: clean-lite-ps`. Has its own `prompt-extension.js`. The two backend template pipelines are mutually exclusive — `generate.architecture` picks exactly one.
 
 ### Project Layout
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ just gen entities/contact.yaml
 └── modules/                   # NestJS module wiring
 ```
 
-**Clean-Lite-PS** (`generate.cleanLitePs: true`):
+**Clean-Lite-PS** (`generate.architecture: clean-lite-ps`):
 ```
 modules/{plural}/
 ├── {entity}.entity.ts         # Drizzle table + types
@@ -176,7 +176,8 @@ paths:
   frontend_src: apps/frontend/src
 
 generate:
-  cleanLitePs: true               # Use Clean-Lite-PS architecture
+  architecture: clean-lite-ps      # Backend layout: clean | clean-lite-ps
+  frontend: false                  # Emit Electric-SQL frontend pipeline (default: false)
   commands: true                   # Generate write commands
   queries: true                    # Generate read queries
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -159,7 +159,8 @@ paths:
   frontend_src: apps/frontend/src
 
 generate:
-  cleanLitePs: true          # Use Clean-Lite-PS architecture (simpler)
+  architecture: clean-lite-ps  # clean | clean-lite-ps (mutually exclusive)
+  frontend: false              # Emit frontend pipeline? (default: false)
   commands: true
   queries: true
 

--- a/src/__tests__/scanner/config-generator.test.ts
+++ b/src/__tests__/scanner/config-generator.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { generateConfig, type ProposedConfig } from '../../scanner/config-generator.js';
 import type { ProjectProfile } from '../../scanner/types.js';
 
@@ -471,6 +475,42 @@ describe('generateConfig', () => {
 			expect(config.confidence.orm).toBe(100);
 			expect(config.confidence.architecture).toBe(100);
 			expect(config.confidence.naming).toBe(100);
+		});
+	});
+
+	describe('generate block', () => {
+		it('defaults architecture to "clean"', () => {
+			const profile = createMockProfile();
+			const config = generateConfig(profile);
+			expect(config.generate.architecture).toBe('clean');
+		});
+
+		it('defaults frontend to false when no frontend_src and no apps/frontend/', () => {
+			// Use a tmp root guaranteed not to contain apps/frontend
+			const tmpRoot = mkdtempSync(join(tmpdir(), 'codegen-scanner-'));
+			try {
+				const profile = createMockProfile({
+					paths: { root: tmpRoot, src: `${tmpRoot}/src` },
+				});
+				const config = generateConfig(profile);
+				expect(config.generate.frontend).toBe(false);
+			} finally {
+				rmSync(tmpRoot, { recursive: true, force: true });
+			}
+		});
+
+		it('emits frontend: true when apps/frontend/ exists under project root', () => {
+			const tmpRoot = mkdtempSync(join(tmpdir(), 'codegen-scanner-'));
+			try {
+				mkdirSync(join(tmpRoot, 'apps', 'frontend'), { recursive: true });
+				const profile = createMockProfile({
+					paths: { root: tmpRoot, src: `${tmpRoot}/src` },
+				});
+				const config = generateConfig(profile);
+				expect(config.generate.frontend).toBe(true);
+			} finally {
+				rmSync(tmpRoot, { recursive: true, force: true });
+			}
 		});
 	});
 

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -7,7 +7,10 @@
 
 import { describe, it, expect } from 'bun:test';
 import { EntityDefinitionSchema } from '../../schema/entity-definition.schema';
-import { PipelinesConfigSchema } from '../../schema/pipelines-config.schema';
+import {
+	GenerateConfigSchema,
+	PipelinesConfigSchema,
+} from '../../schema/pipelines-config.schema';
 import { loadEntityFromYaml } from '../../utils/yaml-loader';
 import { loadEntities } from '../../parser/load-entities';
 import { buildDomainGraph } from '../../analyzer/graph-builder';
@@ -254,6 +257,56 @@ describe('pipelines config', () => {
 				backend: { architecture: arch },
 			});
 			expect(result.success).toBe(true);
+		}
+	});
+});
+
+// ============================================================================
+// Generate Config
+// ============================================================================
+
+describe('generate config', () => {
+	it('applies defaults when block is empty', () => {
+		const result = GenerateConfigSchema.safeParse({});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.architecture).toBe('clean');
+			expect(result.data.frontend).toBe(false);
+		}
+	});
+
+	it('accepts architecture: clean', () => {
+		const result = GenerateConfigSchema.safeParse({ architecture: 'clean' });
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts architecture: clean-lite-ps', () => {
+		const result = GenerateConfigSchema.safeParse({ architecture: 'clean-lite-ps' });
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects unknown architecture values', () => {
+		const result = GenerateConfigSchema.safeParse({ architecture: 'vertical-slice' });
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts frontend: true', () => {
+		const result = GenerateConfigSchema.safeParse({ frontend: true });
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.frontend).toBe(true);
+	});
+
+	it('passes through unknown keys (legacy toggles)', () => {
+		const result = GenerateConfigSchema.safeParse({
+			architecture: 'clean',
+			frontend: false,
+			drizzleSchema: false,
+			hooks: true,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect((result.data as Record<string, unknown>).drizzleSchema).toBe(false);
+			expect((result.data as Record<string, unknown>).hooks).toBe(true);
 		}
 	});
 });

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -9,7 +9,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'yaml';
-import { PipelinesConfigSchema, type PipelinesConfig } from '../schema/pipelines-config.schema.ts';
+import {
+  GenerateConfigSchema,
+  PipelinesConfigSchema,
+  type GenerateConfig,
+  type PipelinesConfig,
+} from '../schema/pipelines-config.schema.ts';
 
 // ============================================================================
 // Types
@@ -21,6 +26,7 @@ import { PipelinesConfigSchema, type PipelinesConfig } from '../schema/pipelines
  */
 export interface ProjectConfig {
   pipelines?: PipelinesConfig;
+  generate?: GenerateConfig;
   [key: string]: unknown;
 }
 
@@ -61,6 +67,20 @@ function loadProjectConfig(cwd = process.cwd()): ProjectConfig | null {
         );
         // Leave raw.pipelines as-is so callers still get something
       }
+    }
+
+    // Validate the generate block (always — we want defaults applied even when absent)
+    const rawGenerate = raw && typeof raw === 'object' && 'generate' in raw ? raw.generate : undefined;
+    const generateResult = GenerateConfigSchema.safeParse(rawGenerate ?? {});
+    if (generateResult.success) {
+      raw.generate = generateResult.data;
+    } else {
+      console.warn(
+        `Warning: codegen.config.yaml has an invalid "generate" block:\n` +
+          generateResult.error.issues
+            .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+            .join('\n')
+      );
     }
 
     return raw as ProjectConfig;

--- a/src/config/paths.mjs
+++ b/src/config/paths.mjs
@@ -597,6 +597,22 @@ export function getPipelinesConfig() {
   return projectConfig?.pipelines ?? {};
 }
 
+/**
+ * Get the `generate` block with defaults applied for the two top-level
+ * pipeline switches validated by GenerateConfigSchema.
+ *
+ * Returns an object that always includes `architecture` and `frontend`
+ * alongside any other user-supplied toggles.
+ */
+export function getGenerateConfig() {
+  const raw = projectConfig?.generate ?? {};
+  return {
+    ...raw,
+    architecture: raw.architecture ?? 'clean',
+    frontend: raw.frontend ?? false,
+  };
+}
+
 // Default export for convenience
 export default {
   // Layout options
@@ -625,6 +641,7 @@ export default {
   getDatabaseDialect,
   getProjectConfig,
   getPipelinesConfig,
+  getGenerateConfig,
   // NEW: Config-driven naming functions
   computeFileName,
   computeFileNaming,

--- a/src/scanner/config-generator.ts
+++ b/src/scanner/config-generator.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
 import type { ProjectProfile } from './types.js';
 
 export interface ProposedConfig {
@@ -29,6 +32,18 @@ export interface ProposedConfig {
 		application: string;
 		infrastructure: string;
 		presentation: string;
+		frontend_src?: string;
+	};
+
+	// Generation toggles emitted into the `generate` block of codegen.config.yaml.
+	// Matches GenerateConfigSchema.
+	generate: {
+		/** Which backend architecture to emit. Defaults to 'clean'. */
+		architecture: 'clean' | 'clean-lite-ps';
+		/** Whether to emit the frontend pipeline at all. Default is false unless
+		 *  detection found an `apps/frontend/` directory or the profile set an
+		 *  explicit `paths.frontend_src`. */
+		frontend: boolean;
 	};
 
 	// Confidence summary
@@ -67,7 +82,13 @@ export function generateConfig(profile: ProjectProfile): ProposedConfig {
 	// 5. Naming conventions (with derived fields)
 	const naming = buildNamingConfig(profile);
 
-	// 6. Confidence: Calculate overall confidence
+	// 6. Generate toggles — architecture is always 'clean' by default (the
+	//    auto-detected path for new projects); frontend is true iff either the
+	//    profile exposed an explicit frontend_src or an `apps/frontend/`
+	//    directory exists under the project root.
+	const generate = buildGenerateConfig(profile, paths);
+
+	// 7. Confidence: Calculate overall confidence
 	const confidence = calculateConfidence(profile);
 
 	return {
@@ -77,7 +98,30 @@ export function generateConfig(profile: ProjectProfile): ProposedConfig {
 		file_grouping,
 		naming,
 		paths,
+		generate,
 		confidence,
+	};
+}
+
+/**
+ * Build the `generate` block for the proposed config.
+ *
+ * Detection rules for `frontend`:
+ * - true if `profile.paths` or `paths.frontend_src` is explicitly set (non-empty string)
+ * - true if `apps/frontend/` exists under the project root
+ * - false otherwise (backend-only default)
+ */
+function buildGenerateConfig(
+	profile: ProjectProfile,
+	paths: ProposedConfig['paths']
+): ProposedConfig['generate'] {
+	const explicitFrontendSrc =
+		typeof paths.frontend_src === 'string' && paths.frontend_src.length > 0;
+	const appsFrontendExists = existsSync(join(profile.paths.root, 'apps', 'frontend'));
+
+	return {
+		architecture: 'clean',
+		frontend: explicitFrontendSrc || appsFrontendExists,
 	};
 }
 

--- a/src/schema/pipelines-config.schema.ts
+++ b/src/schema/pipelines-config.schema.ts
@@ -88,6 +88,49 @@ export const SharedPipelineSchema = z.object({
 export type SharedPipeline = z.infer<typeof SharedPipelineSchema>;
 
 // ============================================================================
+// Generate Config
+// ============================================================================
+
+/**
+ * Top-level entity generation toggle schema.
+ *
+ * The `generate` block in `codegen.config.yaml` controls which pipelines the
+ * entity generator walks and which coarse-grained outputs it produces. It is
+ * intentionally narrower than the `pipelines` block — these are user-facing
+ * switches, not pipeline-internal wiring.
+ *
+ * Keys validated here:
+ * - `architecture`: which backend architecture flavor to emit. Selects one of
+ *   the two backend template sets and is mutually exclusive (emitting both
+ *   was the v0.2 dogfood bug).
+ * - `frontend`: whether to emit the frontend pipeline at all. Defaults to
+ *   `false` so backend-only projects don't get a half-built frontend tree.
+ *
+ * Additional untyped keys are permitted (passthrough) so the many template
+ * toggles already read directly off `generate.*` in `prompt.js` keep working
+ * without each needing a schema entry here.
+ */
+export const GenerateConfigSchema = z
+  .object({
+    /**
+     * Backend architecture to generate. One of:
+     * - 'clean'          — Full Clean Architecture (domain + application + infrastructure + presentation)
+     * - 'clean-lite-ps'  — Clean-Lite-PS modules/{plural}/ layout
+     *
+     * Default: 'clean'.
+     */
+    architecture: z.enum(["clean", "clean-lite-ps"]).default("clean"),
+    /**
+     * Whether to emit the frontend pipeline (collections, hooks, entity metadata).
+     * Default: false — backend-only projects opt out by default.
+     */
+    frontend: z.boolean().default(false),
+  })
+  .passthrough();
+
+export type GenerateConfig = z.infer<typeof GenerateConfigSchema>;
+
+// ============================================================================
 // Top-Level Pipelines Config
 // ============================================================================
 

--- a/templates/entity/new/backend/_inject-schema-client-imports.ejs.t
+++ b/templates/entity/new/backend/_inject-schema-client-imports.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.schemaClient ? locations.dbSchemaClient.path : '' %>"
+to: "<%= isCleanArchitecture ? (generate.schemaClient ? locations.dbSchemaClient.path : '') : '' %>"
 inject: true
 after: "import {"
 skip_if: "// Codegen imports managed"

--- a/templates/entity/new/backend/_inject-schema-client-table.ejs.t
+++ b/templates/entity/new/backend/_inject-schema-client-table.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.schemaClient ? locations.dbSchemaClient.path : '' %>"
+to: "<%= isCleanArchitecture ? (generate.schemaClient ? locations.dbSchemaClient.path : '') : '' %>"
 inject: true
 after: "// Codegen tables"
 skip_if: "export const <%= plural %> ="

--- a/templates/entity/new/backend/_inject-schema-client.ejs.t
+++ b/templates/entity/new/backend/_inject-schema-client.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.schemaClient ? locations.dbSchemaClient.path : '' %>"
+to: "<%= isCleanArchitecture ? (generate.schemaClient ? locations.dbSchemaClient.path : '') : '' %>"
 inject: true
 after: "// Codegen exports"
 skip_if: <%= camelName %>Schema

--- a/templates/entity/new/backend/_inject-schema-server-imports.ejs.t
+++ b/templates/entity/new/backend/_inject-schema-server-imports.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.schemaServer ? locations.dbSchemaServer.path : '' %>"
+to: "<%= isCleanArchitecture ? (generate.schemaServer ? locations.dbSchemaServer.path : '') : '' %>"
 inject: true
 after: "import {"
 skip_if: "// Codegen imports managed"

--- a/templates/entity/new/backend/_inject-schema-server-table.ejs.t
+++ b/templates/entity/new/backend/_inject-schema-server-table.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.schemaServer ? locations.dbSchemaServer.path : '' %>"
+to: "<%= isCleanArchitecture ? (generate.schemaServer ? locations.dbSchemaServer.path : '') : '' %>"
 inject: true
 after: "// Codegen tables"
 skip_if: "export const <%= plural %> ="

--- a/templates/entity/new/backend/application/commands/create.ejs.t
+++ b/templates/entity/new/backend/application/commands/create.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.commands ? outputPaths.createCommand : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.createCommand) { -%>

--- a/templates/entity/new/backend/application/commands/delete.ejs.t
+++ b/templates/entity/new/backend/application/commands/delete.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.commands ? outputPaths.deleteCommand : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.deleteCommand) { -%>

--- a/templates/entity/new/backend/application/commands/grouped-index.ejs.t
+++ b/templates/entity/new/backend/application/commands/grouped-index.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.commands ? outputPaths.commandsGroupedIndex : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.commandsGroupedIndex) { -%>

--- a/templates/entity/new/backend/application/commands/index.ejs.t
+++ b/templates/entity/new/backend/application/commands/index.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.commands ? outputPaths.commandsIndex : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.commandsIndex) { -%>

--- a/templates/entity/new/backend/application/commands/update.ejs.t
+++ b/templates/entity/new/backend/application/commands/update.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.commands ? outputPaths.updateCommand : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.updateCommand) { -%>

--- a/templates/entity/new/backend/application/queries/declarative-queries.ejs.t
+++ b/templates/entity/new/backend/application/queries/declarative-queries.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= hasDeclarativeQueries ? `${basePaths.backendSrc}/${paths.queries}/declarative-queries.ts` : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (hasDeclarativeQueries) { -%>

--- a/templates/entity/new/backend/application/queries/get-by-id.ejs.t
+++ b/templates/entity/new/backend/application/queries/get-by-id.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.queries ? outputPaths.getByIdQuery : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.getByIdQuery) { -%>

--- a/templates/entity/new/backend/application/queries/grouped-index.ejs.t
+++ b/templates/entity/new/backend/application/queries/grouped-index.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.queries ? outputPaths.queriesGroupedIndex : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.queriesGroupedIndex) { -%>

--- a/templates/entity/new/backend/application/queries/index.ejs.t
+++ b/templates/entity/new/backend/application/queries/index.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.queries ? outputPaths.queriesIndex : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.queriesIndex) { -%>

--- a/templates/entity/new/backend/application/queries/list.ejs.t
+++ b/templates/entity/new/backend/application/queries/list.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.queries ? outputPaths.listQuery : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.listQuery) { -%>

--- a/templates/entity/new/backend/application/schemas/_inject-index.ejs.t
+++ b/templates/entity/new/backend/application/schemas/_inject-index.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.dtos ? `${basePaths.backendSrc}/${backendLayers.schemas}/index.ts` : '' %>"
+to: "<%= isCleanArchitecture ? (generate.dtos ? `${basePaths.backendSrc}/${backendLayers.schemas}/index.ts` : '') : '' %>"
 inject: true
 append: true
 skip_if: <%= name %>.dto

--- a/templates/entity/new/backend/application/schemas/dto.ejs.t
+++ b/templates/entity/new/backend/application/schemas/dto.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.dtos ? outputPaths.dto : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 /**

--- a/templates/entity/new/backend/database/_inject-index.ejs.t
+++ b/templates/entity/new/backend/database/_inject-index.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.drizzleSchema ? `${basePaths.backendSrc}/${backendLayers.drizzle}/index.ts` : '' %>"
+to: "<%= isCleanArchitecture ? (generate.drizzleSchema ? `${basePaths.backendSrc}/${backendLayers.drizzle}/index.ts` : '') : '' %>"
 inject: true
 append: true
 skip_if: <%= plural %>.schema

--- a/templates/entity/new/backend/database/electric-migration.ejs.t
+++ b/templates/entity/new/backend/database/electric-migration.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= exposeElectric && databaseDialect === 'postgres' ? `${locations.dbMigrations.path}/${new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14)}_Add${classNamePlural}ToElectric.sql` : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 -- Electric SQL setup for <%= table %>

--- a/templates/entity/new/backend/database/repository.ejs.t
+++ b/templates/entity/new/backend/database/repository.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= basePaths.backendSrc %>/<%= paths.repositories %>/<%= name %>.repository.ts
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 /**

--- a/templates/entity/new/backend/database/schema.ejs.t
+++ b/templates/entity/new/backend/database/schema.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= generate.drizzleSchema ? outputPaths.drizzleSchema : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 /**

--- a/templates/entity/new/backend/domain/_inject-index.ejs.t
+++ b/templates/entity/new/backend/domain/_inject-index.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= basePaths.backendSrc %>/<%= backendLayers.domain %>/index.ts
+to: "<%= isCleanArchitecture ? `${basePaths.backendSrc}/${backendLayers.domain}/index.ts` : '' %>"
 inject: true
 append: true
 skip_if: <%= name %>

--- a/templates/entity/new/backend/domain/entity.ejs.t
+++ b/templates/entity/new/backend/domain/entity.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= outputPaths.entity %>
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.entity) { -%>

--- a/templates/entity/new/backend/domain/grouped-index.ejs.t
+++ b/templates/entity/new/backend/domain/grouped-index.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= outputPaths.domainGroupedIndex %>
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.domainGroupedIndex) { -%>

--- a/templates/entity/new/backend/domain/index.ejs.t
+++ b/templates/entity/new/backend/domain/index.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: <%= basePaths.backendSrc %>/<%= paths.domain %>/index.ts
-skip_if: <%= !isNested || isGrouped %>
+skip_if: <%= !isCleanArchitecture || (!isNested || isGrouped) %>
 force: true
 ---
 /**

--- a/templates/entity/new/backend/domain/repository-interface.ejs.t
+++ b/templates/entity/new/backend/domain/repository-interface.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= outputPaths.repositoryInterface %>
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (outputPaths.repositoryInterface) { -%>

--- a/templates/entity/new/backend/modules/core/_ensure-anchor-tokens.ejs.t
+++ b/templates/entity/new/backend/modules/core/_ensure-anchor-tokens.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= exposeRepository ? `${locations.backendConstants.path}/tokens.ts` : '' %>"
+to: "<%= isCleanArchitecture ? (exposeRepository ? `${locations.backendConstants.path}/tokens.ts` : '') : '' %>"
 inject: true
 append: true
 skip_if: "// Generated entity repository tokens"

--- a/templates/entity/new/backend/modules/core/_inject-app-array.ejs.t
+++ b/templates/entity/new/backend/modules/core/_inject-app-array.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= basePaths.backendSrc %>/app.module.ts
+to: "<%= isCleanArchitecture ? `${basePaths.backendSrc}/app.module.ts` : '' %>"
 inject: true
 skip_if: <%= classNamePlural %>Module
 after: "// Codegen module imports"

--- a/templates/entity/new/backend/modules/core/_inject-app-import.ejs.t
+++ b/templates/entity/new/backend/modules/core/_inject-app-import.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= basePaths.backendSrc %>/app.module.ts
+to: "<%= isCleanArchitecture ? `${basePaths.backendSrc}/app.module.ts` : '' %>"
 inject: true
 skip_if: <%= classNamePlural %>Module
 after: "// Codegen modules"

--- a/templates/entity/new/backend/modules/core/_inject-token.ejs.t
+++ b/templates/entity/new/backend/modules/core/_inject-token.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= locations.backendConstants.path %>/tokens.ts
+to: "<%= isCleanArchitecture ? `${locations.backendConstants.path}/tokens.ts` : '' %>"
 inject: true
 append: true
 skip_if: <%= repositoryToken %>

--- a/templates/entity/new/backend/modules/core/module.ejs.t
+++ b/templates/entity/new/backend/modules/core/module.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= outputPaths.module %>
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 /**

--- a/templates/entity/new/backend/modules/trpc/_inject-app-array.ejs.t
+++ b/templates/entity/new/backend/modules/trpc/_inject-app-array.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: ""
+skip_if: <%= !isCleanArchitecture %>
 ---
 <%# tRPC Router is added to TrpcModule providers manually, not as a separate module -%>
 <%# This template is intentionally disabled -%>

--- a/templates/entity/new/backend/modules/trpc/_inject-app-import.ejs.t
+++ b/templates/entity/new/backend/modules/trpc/_inject-app-import.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: ""
+skip_if: <%= !isCleanArchitecture %>
 ---
 <%# tRPC Router is added to TrpcModule providers manually, not as a separate module -%>
 <%# This template is intentionally disabled -%>

--- a/templates/entity/new/backend/modules/trpc/module.ejs.t
+++ b/templates/entity/new/backend/modules/trpc/module.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= exposeTrpc ? `${basePaths.backendSrc}/presentation/trpc/${plural}.router.ts` : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (exposeTrpc) { -%>

--- a/templates/entity/new/backend/presentation/controller.ejs.t
+++ b/templates/entity/new/backend/presentation/controller.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: "<%= (exposeRest || exposeElectric) ? `${basePaths.backendSrc}/${paths.controllers}/${plural}.controller.ts` : '' %>"
+skip_if: <%= !isCleanArchitecture %>
 force: true
 ---
 <% if (exposeRest) { -%>

--- a/templates/entity/new/frontend/_inject-entities-entry.ejs.t
+++ b/templates/entity/new/frontend/_inject-entities-entry.ejs.t
@@ -1,6 +1,6 @@
 ---
 inject: true
-to: <%= locations.frontendEntities.path %>/index.ts
+to: "<%= frontendEnabled ? `${locations.frontendEntities.path}/index.ts` : '' %>"
 after: "// \\[CODEGEN:ENTITY_ENTRIES\\]"
 skip_if: "<%= plural %>,"
 ---

--- a/templates/entity/new/frontend/_inject-entities-import.ejs.t
+++ b/templates/entity/new/frontend/_inject-entities-import.ejs.t
@@ -1,6 +1,6 @@
 ---
 inject: true
-to: <%= locations.frontendEntities.path %>/index.ts
+to: "<%= frontendEnabled ? `${locations.frontendEntities.path}/index.ts` : '' %>"
 after: "// \\[CODEGEN:ENTITY_IMPORTS\\]"
 skip_if: "from './<%= name %>'"
 ---

--- a/templates/entity/new/frontend/collections/_ensure-anchor-collections.ejs.t
+++ b/templates/entity/new/frontend/collections/_ensure-anchor-collections.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.collections ? `${locations.frontendCollections.path}/collections.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.collections ? `${locations.frontendCollections.path}/collections.ts` : '') : '' %>"
 inject: true
 append: true
 skip_if: "// Codegen collections"

--- a/templates/entity/new/frontend/collections/_inject-index.ejs.t
+++ b/templates/entity/new/frontend/collections/_inject-index.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.collectionsIndex ? `${locations.frontendCollections.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.collectionsIndex ? `${locations.frontendCollections.path}/index.ts` : '') : '' %>"
 inject: true
 after: "// Generated entity collections"
 skip_if: "from './collections'"

--- a/templates/entity/new/frontend/collections/_inject-schema-import.ejs.t
+++ b/templates/entity/new/frontend/collections/_inject-schema-import.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.collections && !frontend.collections?.schemaPrefix ? `${locations.frontendCollections.path}/collections.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.collections && !frontend.collections?.schemaPrefix ? `${locations.frontendCollections.path}/collections.ts` : '') : '' %>"
 inject: true
 after: "// Codegen schema imports"
 skip_if: <%= camelName %>Schema

--- a/templates/entity/new/frontend/collections/collection.ejs.t
+++ b/templates/entity/new/frontend/collections/collection.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.collections ? `${locations.frontendCollections.path}/collections.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.collections ? `${locations.frontendCollections.path}/collections.ts` : '') : '' %>"
 inject: true
 after: "// Codegen collections"
 skip_if: <%= camelName %>Collection

--- a/templates/entity/new/frontend/collections/collections-base.ejs.t
+++ b/templates/entity/new/frontend/collections/collections-base.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= locations.frontendCollections.path %>/collections.ts
+skip_if: <%= !frontendEnabled %>
 force: false
 ---
 /**

--- a/templates/entity/new/frontend/entity/collection.ejs.t
+++ b/templates/entity/new/frontend/entity/collection.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${generate.fileNaming === 'plural' ? plural : name}/collection.ts` : generate.structure === 'concern-first' ? `${locations.frontendGenerated.path}/collections/${generate.fileNaming === 'plural' ? plural : name}.ts` : '' %>"
-skip_if: <%= generate.structure === 'monolithic' %>
+skip_if: <%= !frontendEnabled || (generate.structure === 'monolithic') %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/combined.ejs.t
+++ b/templates/entity/new/frontend/entity/combined.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'monolithic' ? `${locations.frontendGenerated.path}/${generate.fileNaming === 'plural' ? plural : name}.ts` : '' %>"
-skip_if: <%= generate.structure !== 'monolithic' %>
+skip_if: <%= !frontendEnabled || (generate.structure !== 'monolithic') %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/fields.ejs.t
+++ b/templates/entity/new/frontend/entity/fields.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${name}/fields.ts` : generate.structure === 'concern-first' ? `${locations.frontendGenerated.path}/fields/${name}.ts` : '' %>"
-skip_if: <%= generate.structure === 'monolithic' || !generate.fieldMetadata %>
+skip_if: <%= !frontendEnabled || (generate.structure === 'monolithic' || !generate.fieldMetadata) %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/hooks.ejs.t
+++ b/templates/entity/new/frontend/entity/hooks.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${generate.fileNaming === 'plural' ? plural : name}/hooks.ts` : generate.structure === 'concern-first' ? `${locations.frontendGenerated.path}/hooks/${generate.fileNaming === 'plural' ? plural : name}.ts` : '' %>"
-skip_if: <%= generate.structure === 'monolithic' %>
+skip_if: <%= !frontendEnabled || (generate.structure === 'monolithic') %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/index.ejs.t
+++ b/templates/entity/new/frontend/entity/index.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${name}/index.ts` : '' %>"
-skip_if: <%= generate.structure !== 'entity-first' %>
+skip_if: <%= !frontendEnabled || (generate.structure !== 'entity-first') %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/mutation-hooks.ejs.t
+++ b/templates/entity/new/frontend/entity/mutation-hooks.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${generate.fileNaming === 'plural' ? plural : name}/mutation-hooks.ts` : generate.structure === 'concern-first' ? `${locations.frontendGenerated.path}/mutation-hooks/${generate.fileNaming === 'plural' ? plural : name}.ts` : '' %>"
-skip_if: <%= generate.structure === 'monolithic' || !generate.mutations || !(exposeTrpc || exposeRepository) %>
+skip_if: <%= !frontendEnabled || (generate.structure === 'monolithic' || !generate.mutations || !(exposeTrpc || exposeRepository)) %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/mutations.ejs.t
+++ b/templates/entity/new/frontend/entity/mutations.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${name}/mutations.ts` : generate.structure === 'concern-first' ? `${locations.frontendGenerated.path}/mutations/${name}.ts` : '' %>"
-skip_if: <%= generate.structure === 'monolithic' || !generate.mutations || !(exposeTrpc || exposeRepository) %>
+skip_if: <%= !frontendEnabled || (generate.structure === 'monolithic' || !generate.mutations || !(exposeTrpc || exposeRepository)) %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/entity/types.ejs.t
+++ b/templates/entity/new/frontend/entity/types.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= generate.structure === 'entity-first' ? `${locations.frontendGenerated.path}/${generate.fileNaming === 'plural' ? plural : name}/types.ts` : generate.structure === 'concern-first' ? `${locations.frontendGenerated.path}/types/${generate.fileNaming === 'plural' ? plural : name}.ts` : '' %>"
-skip_if: <%= generate.structure === 'monolithic' %>
+skip_if: <%= !frontendEnabled || (generate.structure === 'monolithic') %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/generated/_inject-index-export.ejs.t
+++ b/templates/entity/new/frontend/generated/_inject-index-export.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= locations.frontendGenerated.path %>/index.ts
+to: "<%= frontendEnabled ? `${locations.frontendGenerated.path}/index.ts` : '' %>"
 inject: true
 skip_if: "from './<%= name %>'"
 after: "// Entity exports"

--- a/templates/entity/new/frontend/generated/_inject-index-import.ejs.t
+++ b/templates/entity/new/frontend/generated/_inject-index-import.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= locations.frontendGenerated.path %>/index.ts
+to: "<%= frontendEnabled ? `${locations.frontendGenerated.path}/index.ts` : '' %>"
 inject: true
 skip_if: "import { <%= camelName %> }"
 after: "// Entity registry"

--- a/templates/entity/new/frontend/generated/_inject-index-registry.ejs.t
+++ b/templates/entity/new/frontend/generated/_inject-index-registry.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= locations.frontendGenerated.path %>/index.ts
+to: "<%= frontendEnabled ? `${locations.frontendGenerated.path}/index.ts` : '' %>"
 inject: true
 skip_if: "<%= camelName %>,"
 after: "// registry-entries"

--- a/templates/entity/new/frontend/store/_inject-collection-import.ejs.t
+++ b/templates/entity/new/frontend/store/_inject-collection-import.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.hooks ? `${locations.frontendStore.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.hooks ? `${locations.frontendStore.path}/index.ts` : '') : '' %>"
 inject: true
 after: "// Collection imports"
 skip_if: "from '<%= locations.frontendCollections.import %>/collections'"

--- a/templates/entity/new/frontend/store/_inject-collections.ejs.t
+++ b/templates/entity/new/frontend/store/_inject-collections.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.hooks ? `${locations.frontendStore.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.hooks ? `${locations.frontendStore.path}/index.ts` : '') : '' %>"
 inject: true
 after: "collections: \\{"
 skip_if: "<%= plural %>: <%= collectionVarName %>[^\\.]"

--- a/templates/entity/new/frontend/store/_inject-entity.ejs.t
+++ b/templates/entity/new/frontend/store/_inject-entity.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.hooks ? `${locations.frontendStore.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.hooks ? `${locations.frontendStore.path}/index.ts` : '') : '' %>"
 inject: true
 after: "entities: \\{"
 skip_if: "<%= plural %>: <%= camelName %>Hooks"

--- a/templates/entity/new/frontend/store/_inject-import.ejs.t
+++ b/templates/entity/new/frontend/store/_inject-import.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.hooks ? `${locations.frontendStore.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.hooks ? `${locations.frontendStore.path}/index.ts` : '') : '' %>"
 inject: true
 after: "// Entity hooks"
 skip_if: "from './entities/<%= name %>'"

--- a/templates/entity/new/frontend/store/_inject-lookups.ejs.t
+++ b/templates/entity/new/frontend/store/_inject-lookups.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.hooks ? `${locations.frontendStore.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.hooks ? `${locations.frontendStore.path}/index.ts` : '') : '' %>"
 inject: true
 after: "// Lookup entries"
 skip_if: "<%= plural %>: <%= collectionVarName %>\\.state"

--- a/templates/entity/new/frontend/store/_inject-resolve.ejs.t
+++ b/templates/entity/new/frontend/store/_inject-resolve.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= generate.hooks ? `${locations.frontendStore.path}/index.ts` : '' %>"
+to: "<%= frontendEnabled ? (generate.hooks ? `${locations.frontendStore.path}/index.ts` : '') : '' %>"
 inject: true
 after: "resolve: \\{"
 skip_if: "<%= singularCamelName %>:"

--- a/templates/entity/new/frontend/store/hooks.ejs.t
+++ b/templates/entity/new/frontend/store/hooks.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: <%= locations.frontendStoreEntities.path %>/<%= name %>.ts
-skip_if: <%= !generate.hooks %>
+skip_if: <%= !frontendEnabled || (!generate.hooks) %>
 force: true
 ---
 /**

--- a/templates/entity/new/frontend/unified-entity.ejs.t
+++ b/templates/entity/new/frontend/unified-entity.ejs.t
@@ -1,5 +1,6 @@
 ---
 to: <%= locations.frontendEntities.path %>/<%= name %>.ts
+skip_if: <%= !frontendEnabled %>
 force: true
 ---
 /**

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -20,6 +20,7 @@ import {
   getDatabaseDialect,
   getProjectConfig,
   getPipelinesConfig,
+  getGenerateConfig,
 } from "../../../src/config/paths.mjs";
 import { getNamingConfig } from "../../../src/config/naming-config.mjs";
 
@@ -945,11 +946,21 @@ export default {
     }
 
     // ============================================================================
-    // Architecture Target (from pipelines config)
+    // Architecture Target + pipeline gates (from generate config)
+    //
+    // `generate.architecture` is the single source of truth for which backend
+    // template set runs. Values:
+    //   - 'clean'         → templates/entity/new/backend/ (Clean Architecture)
+    //   - 'clean-lite-ps' → templates/entity/new/clean-lite-ps/ (modules/ layout)
+    //
+    // `generate.frontend` gates the frontend pipeline entirely.
     // ============================================================================
 
-    const pipelinesConfig = getPipelinesConfig();
-    const architectureTarget = pipelinesConfig?.backend?.architecture ?? 'clean';
+    const generateConfig = getGenerateConfig();
+    const architectureTarget = generateConfig.architecture;
+    const isCleanArchitecture = architectureTarget === 'clean';
+    const isCleanLitePs = architectureTarget === 'clean-lite-ps';
+    const frontendEnabled = generateConfig.frontend === true;
 
     // ============================================================================
     // v2: Family
@@ -1335,8 +1346,11 @@ export default {
       // v2 variables
       // ======================================================================
 
-      // Architecture target (from pipelines.backend.architecture config)
+      // Architecture target (from generate.architecture config)
       architectureTarget,
+      isCleanArchitecture,
+      isCleanLitePs,
+      frontendEnabled,
 
       // Family
       family,
@@ -1363,10 +1377,15 @@ export default {
       processedEvents,
     };
 
-    // Clean-Lite-PS template locals (only when generate.cleanLitePs: true)
-    const projectConfig = getProjectConfig();
-    const cleanLitePs = projectConfig?.generate?.cleanLitePs ?? false;
-    if (cleanLitePs) {
+    // ========================================================================
+    // Clean-Lite-PS template locals
+    //
+    // Populated only when `generate.architecture === 'clean-lite-ps'`.
+    // When the architecture is 'clean', stub locals are injected so CLP
+    // template bodies can render without crashing; their `to:` guards resolve
+    // to null which causes Hygen to skip file writing.
+    // ========================================================================
+    if (isCleanLitePs) {
       const { buildCleanLitePsLocals } = await import('./clean-lite-ps/prompt-extension.js');
       Object.assign(locals, buildCleanLitePsLocals(definition, locals));
     } else {

--- a/test/fixtures/codegen.config.yaml
+++ b/test/fixtures/codegen.config.yaml
@@ -46,7 +46,7 @@ locations:
 pipelines:
   backend:
     enabled: true
-    architecture: clean-lite-ps
+    architecture: clean
   frontend:
     enabled: true
     preset: dealbrain
@@ -54,4 +54,5 @@ pipelines:
     enabled: true
 
 generate:
-  cleanLitePs: true
+  architecture: clean
+  frontend: false

--- a/test/scaffold/run-integration.ts
+++ b/test/scaffold/run-integration.ts
@@ -54,7 +54,7 @@ async function run() {
 
       await Bun.write(
         configPath,
-        'generate:\n  cleanLitePs: true\n',
+        'generate:\n  architecture: clean-lite-ps\n  frontend: false\n',
       );
 
       try {

--- a/test/scaffold/validate.sh
+++ b/test/scaffold/validate.sh
@@ -61,7 +61,7 @@ cd "$SCAFFOLD_DIR"
 bun install
 
 # ---------------------------------------------------------------------------
-# 2. Create a temporary codegen.config.yaml with cleanLitePs enabled
+# 2. Create a temporary codegen.config.yaml with clean-lite-ps architecture
 #    The test runner (run-test.ts) also manages this file, so we back it up
 #    if it already exists and restore it in the cleanup function.
 # ---------------------------------------------------------------------------
@@ -76,7 +76,8 @@ cat > "$CODEGEN_CONFIG" << 'YAML_EOF'
 # Temporary config created by test/scaffold/validate.sh
 # Cleaned up automatically on exit.
 generate:
-  cleanLitePs: true
+  architecture: clean-lite-ps
+  frontend: false
 YAML_EOF
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Replaces the additive `cleanLitePs: true` boolean with a typed `generate.architecture` enum and explicit `generate.frontend` flag, making the two backend template pipelines mutually exclusive and fixing a bug where setting `cleanLitePs: true` would emit both Clean Architecture and Clean-Lite-PS output simultaneously.

## Changes
- Add `GenerateConfigSchema` (`architecture: 'clean' | 'clean-lite-ps'`, `frontend: boolean`) and wire it through `config-loader` so defaults are applied even when the `generate` block is absent
- Gate every backend template on `isCleanArchitecture`/`isCleanLitePs` and every frontend template on `frontendEnabled` in `prompt.js`, eliminating the dual-emit bug
- Expose `getGenerateConfig()` from `paths.mjs` for use in Hygen templates; fix the stale import path introduced by the `src/`+`runtime/` split
- Extend the scanner's `config-generator` to auto-detect and propose the `generate` block (defaults `architecture: 'clean'`; sets `frontend: true` only when `apps/frontend/` exists or `paths.frontend_src` is set)
- Add schema and scanner unit tests; update baseline fixture, scaffold scripts, and docs to reflect the new keys

---
**Stack:** `cli-noun-verb-architecture` (PR 2 of 2)
*Managed by [stack CLI](https://github.com/dugshub/stack)*