### PR TITLE
fix: path hygiene — templates dir + WithAnalytics import (dogfood #6 + #8)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,7 +130,7 @@ function generateEntity(filePath: string, quiet = false): boolean {
 	console.log(`[GEN] Generating entity: ${result.definition.entity.name}`);
 
 	// Resolve templates directory dynamically
-	const templatesDir = process.env.CODEGEN_TEMPLATES_DIR || join(import.meta.dirname, 'templates');
+	const templatesDir = process.env.CODEGEN_TEMPLATES_DIR || join(import.meta.dirname, '..', 'templates');
 
 	// Run Hygen
 	const fullPath = resolve(process.cwd(), filePath);
@@ -197,7 +197,7 @@ function generateBroadcast(yamlPath?: string): boolean {
 
 	const cwd = process.cwd();
 	// Use env var or script location to find templates (works when running from any directory)
-	const templatesDir = process.env.CODEGEN_TEMPLATES_DIR || join(import.meta.dirname, 'templates');
+	const templatesDir = process.env.CODEGEN_TEMPLATES_DIR || join(import.meta.dirname, '..', 'templates');
 
 	// Build Hygen command
 	let hygenCmd = 'bunx hygen broadcast new';

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -4,7 +4,7 @@ skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { Injectable } from '@nestjs/common';
-import { WithAnalytics } from '@shared/base-classes/base-analytics-service';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
 import { <%= serviceBaseClass %> } from '<%= serviceBaseImport %>';
 import { <%= classNames.repository %> } from './<%= entityName %>.repository';
 import type { <%= classNames.entity %> } from './<%= entityName %>.entity';


### PR DESCRIPTION
## Summary
Fix two path resolution bugs surfaced during dogfooding: a wrong `templates/` directory path in the legacy CLI (broken when invoked outside the repo), and a mismatched import path for the `WithAnalytics` mixin in the clean-lite-ps service template.

## Changes
- Correct `templates/` resolution in `src/cli.ts` by adding `..` to escape `src/` after the v0.2 reorg — fixes "cannot find templates" when running the CLI from outside the repo
- Fix `WithAnalytics` import in clean-lite-ps service template to point at `with-analytics` (the actual runtime filename) instead of the nonexistent `base-analytics-service`

---
**Stack:** `cli-noun-verb-architecture` (PR 4 of 4)
*Managed by [stack CLI](https://github.com/dugshub/stack)*