### PR TITLE
fix: prefix declarative query use case names with entity (dogfood #5)

### DIFF
--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -252,17 +252,76 @@ describe('buildCleanLitePsLocals', () => {
     expect(locals.processedQueries[1].methodName).toBe('findEmailsByOpportunityId');
   });
 
-  it('generates use case class names from queries', () => {
+  it('generates entity-prefixed use case class names from queries', () => {
     const withQueries = {
       ...contactDefinition,
       queries: [{ by: ['user_id'] }, { by: ['email'], unique: true }],
     };
     const locals = buildCleanLitePsLocals(withQueries, EMPTY_BASE_LOCALS);
 
+    // Names are prefixed with the entity to avoid collisions across modules
+    // and read as English: "Find contact by user id".
     expect(locals.declarativeQueryClasses).toEqual([
-      'FindByUserIdUseCase',
-      'FindByEmailUseCase',
+      'FindContactByUserIdUseCase',
+      'FindContactByEmailUseCase',
     ]);
+  });
+
+  it('generates entity-prefixed class names for composite queries', () => {
+    const withQueries = {
+      ...contactDefinition,
+      queries: [{ by: ['user_id', 'account_id'] }],
+    };
+    const locals = buildCleanLitePsLocals(withQueries, EMPTY_BASE_LOCALS);
+
+    expect(locals.declarativeQueryClasses).toEqual([
+      'FindContactByUserIdAndAccountIdUseCase',
+    ]);
+    expect(locals.processedQueries[0].useCaseClassName).toBe(
+      'FindContactByUserIdAndAccountIdUseCase',
+    );
+  });
+
+  it('generates entity-prefixed class names for select + via queries', () => {
+    const withQueries = {
+      ...contactDefinition,
+      queries: [
+        { by: ['opportunity_id'], select: ['email'], via: 'opportunity_contact_link' },
+      ],
+    };
+    const locals = buildCleanLitePsLocals(withQueries, EMPTY_BASE_LOCALS);
+
+    // methodName 'findEmailsByOpportunityId' → 'FindContactEmailsByOpportunityIdUseCase'
+    expect(locals.declarativeQueryClasses).toEqual([
+      'FindContactEmailsByOpportunityIdUseCase',
+    ]);
+  });
+
+  it('produces collision-free class names for different entities sharing a query', () => {
+    const accountDef = {
+      entity: { name: 'account', plural: 'accounts', table: 'accounts', family: 'synced' },
+      fields: { domain: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+      queries: [{ by: ['domain'], unique: true }],
+    };
+    const opportunityDef = {
+      entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', family: 'synced' },
+      fields: { domain: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+      queries: [{ by: ['domain'], unique: true }],
+    };
+
+    const accountLocals = buildCleanLitePsLocals(accountDef, EMPTY_BASE_LOCALS);
+    const opportunityLocals = buildCleanLitePsLocals(opportunityDef, EMPTY_BASE_LOCALS);
+
+    expect(accountLocals.declarativeQueryClasses).toEqual(['FindAccountByDomainUseCase']);
+    expect(opportunityLocals.declarativeQueryClasses).toEqual(['FindOpportunityByDomainUseCase']);
+    // Different entities must not produce colliding class names
+    expect(accountLocals.declarativeQueryClasses[0]).not.toBe(
+      opportunityLocals.declarativeQueryClasses[0],
+    );
   });
 
   it('sets hasDeclarativeQueries false when no queries block', () => {

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -419,7 +419,11 @@ function processQueries(queriesBlock, processedFields, entityNamePascal) {
       returnType = `${entityNamePascal}[]`;
     }
 
-    const useCaseClassName = `${pascalCase(methodName)}UseCase`;
+    // Prefix class name with entity to guarantee uniqueness across modules.
+    // e.g. methodName 'findByDomain' on Account → 'FindAccountByDomainUseCase'
+    //      methodName 'findEmailsByOpportunityId' on Contact → 'FindContactEmailsByOpportunityIdUseCase'
+    const methodPascal = pascalCase(methodName);
+    const useCaseClassName = methodPascal.replace(/^Find/, `Find${entityNamePascal}`) + 'UseCase';
 
     return {
       by: byFields,


### PR DESCRIPTION
## Summary
Fix declarative query use case class name collisions by prefixing each class with its entity name (e.g. `FindByDomainUseCase` → `FindAccountByDomainUseCase`), ensuring uniqueness when two entities share the same query shape.

## Changes
- Update `processQueries` to replace the leading `Find` in the method's PascalCase name with `Find<Entity>`, producing readable names like `FindContactByUserIdAndAccountIdUseCase`
- Add tests covering composite keys, `select`+`via` queries, and an explicit cross-entity collision scenario asserting `FindAccountByDomainUseCase ≠ FindOpportunityByDomainUseCase`

---
**Stack:** `cli-noun-verb-architecture` (PR 5 of 5)
*Managed by [stack CLI](https://github.com/dugshub/stack)*