### PR TITLE
fix: include belongs_to FK fields in query validation (dogfood #9)

### DIFF
--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -406,4 +406,50 @@ describe('cross-block validation', () => {
 		const queryIssues = issues.filter((i) => i.type === 'unknown_query_field');
 		expect(queryIssues).toHaveLength(0);
 	});
+
+	// dogfood #9: belongs_to FK fields (not separately declared under `fields:`)
+	// must still count as available fields for query validation.
+	it('accepts query on belongs_to FK field even when not declared in fields', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const contact = result.entities[0];
+
+		// Simulate the buggy scenario: author relies on the belongs_to relationship
+		// to imply the `account_id` column, without also declaring it under `fields:`.
+		contact.fields.delete('account_id');
+		contact.queries = [{ by: ['account_id'] }];
+
+		const graph = buildDomainGraph([contact]);
+		const issues = checkConsistency(graph);
+		const queryIssues = issues.filter((i) => i.type === 'unknown_query_field');
+		expect(queryIssues).toHaveLength(0);
+	});
+
+	it('still rejects query on truly nonexistent field when belongs_to is present', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const contact = result.entities[0];
+
+		contact.fields.delete('account_id');
+		contact.queries = [{ by: ['nonexistent'] }];
+
+		const graph = buildDomainGraph([contact]);
+		const issues = checkConsistency(graph);
+		const queryIssues = issues.filter((i) => i.type === 'unknown_query_field');
+		expect(queryIssues.length).toBeGreaterThan(0);
+		expect(queryIssues[0].message).toContain('nonexistent');
+	});
+
+	it('accepts composite query mixing declared field and belongs_to FK', () => {
+		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const contact = result.entities[0];
+
+		// Drop the declared account_id so only the belongs_to relationship provides it.
+		contact.fields.delete('account_id');
+		// user_id remains declared; account_id comes from the `account` belongs_to.
+		contact.queries = [{ by: ['user_id', 'account_id'] }];
+
+		const graph = buildDomainGraph([contact]);
+		const issues = checkConsistency(graph);
+		const queryIssues = issues.filter((i) => i.type === 'unknown_query_field');
+		expect(queryIssues).toHaveLength(0);
+	});
 });

--- a/src/analyzer/consistency-checker.ts
+++ b/src/analyzer/consistency-checker.ts
@@ -304,12 +304,20 @@ function checkMissingInverses(graph: DomainGraph): AnalysisIssue[] {
 
 /**
  * Get the set of all valid field names for an entity, including behavior-added fields
+ * and belongs_to foreign key fields (which the template emits as columns even when
+ * not explicitly declared under `fields:`).
  */
 function getAvailableFieldNames(entity: ParsedEntity): string[] {
 	const entityFieldNames = Array.from(entity.fields.keys());
 	const behaviorFields = resolveBehaviorFields(entity.behaviors);
 	const behaviorFieldNames = behaviorFields.map((f) => f.name);
-	return [...new Set([...entityFieldNames, ...behaviorFieldNames])];
+	const belongsToFkNames: string[] = [];
+	for (const rel of entity.relationships.values()) {
+		if (rel.type === 'belongs_to' && rel.foreignKey) {
+			belongsToFkNames.push(rel.foreignKey);
+		}
+	}
+	return [...new Set([...entityFieldNames, ...behaviorFieldNames, ...belongsToFkNames])];
 }
 
 /**


### PR DESCRIPTION
## Summary
Fix a false-positive validation error where `queries:` entries referencing a foreign key implied by a `belongs_to` relationship were incorrectly flagged as `unknown_query_field`, because the consistency checker only considered explicitly declared `fields:` entries and behavior-added fields.

## Changes
- Extend `getAvailableFieldNames` in the consistency checker to include FK column names derived from `belongs_to` relationships, mirroring what the template actually emits
- Add three targeted regression tests covering: FK-only query, composite query mixing declared + FK fields, and a control case confirming truly nonexistent fields are still rejected

---
**Stack:** `cli-noun-verb-architecture` (PR 6 of 6)
*Managed by [stack CLI](https://github.com/dugshub/stack)*