### PR TITLE
fix: unescape enum type annotations in declarative query templates

### DIFF
--- a/templates/entity/new/backend/application/queries/declarative-queries.ejs.t
+++ b/templates/entity/new/backend/application/queries/declarative-queries.ejs.t
@@ -22,7 +22,7 @@ export class <%= q.useCaseClassName %> {
 		private readonly repository: I<%= className %>Repository,
 	) {}
 
-	async execute(<%= q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
+	async execute(<%- q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
 		return this.repository.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
 	}
 }

--- a/templates/entity/new/clean-lite-ps/use-cases/declarative-queries.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/declarative-queries.ejs.t
@@ -20,7 +20,7 @@ import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
 export class <%= q.useCaseClassName %> {
   constructor(private readonly repository: <%= classNames.repository %>) {}
 
-  async execute(<%= q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
+  async execute(<%- q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
     return this.repository.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
   }
 }


### PR DESCRIPTION
## Summary
Fix HTML-escaping of enum types in declarative query templates by switching EJS output tags from escape mode (`<%=`) to raw mode (`<%-`) for TypeScript parameter lists, preventing single quotes in union types from being corrupted into `&#39;` entities.

## Changes
- Switch `execute()` parameter interpolation from `<%=` to `<%-` in both the full clean-architecture and clean-lite-ps declarative query templates
- Applies to any `tsType` containing single quotes — primarily enum fields rendered as TypeScript union literals (e.g., `'prospect' | 'qualified'`)

---
**Stack:** `cli-noun-verb-architecture` (PR 7 of 7)
*Managed by [stack CLI](https://github.com/dugshub/stack)*