### PR TITLE
fix(codegen): barrel generator emits snake_case for clean-lite-ps

### DIFF
--- a/src/cli/shared/barrel-generator.ts
+++ b/src/cli/shared/barrel-generator.ts
@@ -154,12 +154,14 @@ function entityFilePaths(
 	const pluralKebab = toKebabCase(plural);
 
 	if (architecture === 'clean-lite-ps') {
-		// Clean-Lite-PS templates emit at the cwd, no backendSrc prefix.
+		// Clean-Lite-PS templates currently emit directories/files using the raw
+		// snake_case `plural`/`name` values (see templates/entity/new/clean-lite-ps/
+		// prompt-extension.js). The barrel must match that on-disk layout.
 		return {
-			moduleFile: `modules/${pluralKebab}/${pluralKebab}.module.ts`,
+			moduleFile: `modules/${plural}/${plural}.module.ts`,
 			moduleClass: `${toPascalCase(plural)}Module`,
 			// Drizzle entity schema lives alongside the entity file in clean-lite-ps.
-			schemaFile: `modules/${pluralKebab}/${nameKebab}.entity.ts`,
+			schemaFile: `modules/${plural}/${name}.entity.ts`,
 		};
 	}
 


### PR DESCRIPTION
## Summary
- `clean-lite-ps` templates write files with snake_case entity names, but the barrel generator was emitting kebab-case imports
- Parent demo masked this (single-word entity names); surfaced building agentic-backend with multi-word entities (`agent_config`, `message_part`, `tool_call`)

## Test plan
- [x] Regen against agentic-backend (5 entities, 3 multi-word) — barrel imports resolve
- [x] Regen parent CRM demo — still passes