### PR TITLE
fix(codegen): clean-lite-ps repository emits behaviors config

### DIFF
--- a/src/__tests__/clean-lite-ps/repository-template.test.ts
+++ b/src/__tests__/clean-lite-ps/repository-template.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Template rendering tests for clean-lite-ps/repository.ejs.t
+ *
+ * These tests assert the behaviors override — covered by issue #33 — is
+ * emitted when the entity declares timestamps / soft_delete, and is omitted
+ * otherwise. This is a template-level regression test (not a baseline
+ * snapshot) because clean-lite-ps is not part of test/baseline.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const TEMPLATE_PATH = resolve(
+  import.meta.dir,
+  '../../../templates/entity/new/clean-lite-ps/repository.ejs.t',
+);
+const TEMPLATE_SOURCE = readFileSync(TEMPLATE_PATH, 'utf8');
+
+/**
+ * Strip the Hygen front-matter (the `---` block at the top) so we render
+ * only the body, matching what Hygen itself does before handing the body
+ * to EJS.
+ */
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return source;
+  return lines.slice(end + 1).join('\n');
+}
+
+function renderRepository(locals: Record<string, unknown>): string {
+  const body = extractBody(TEMPLATE_SOURCE);
+  return ejs.render(body, locals, { rmWhitespace: false });
+}
+
+const baseEntity = {
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', family: 'synced' },
+  fields: {
+    email: { type: 'string', required: true },
+  },
+  relationships: {},
+};
+
+describe('clean-lite-ps repository template — behaviors config (issue #33)', () => {
+  it('emits behaviors override with softDelete: true when soft_delete behavior is present', () => {
+    const def = { ...baseEntity, behaviors: ['timestamps', 'soft_delete'] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    expect(output).toContain('protected override readonly behaviors: BehaviorConfig');
+    expect(output).toContain('timestamps: true');
+    expect(output).toContain('softDelete: true');
+    expect(output).toContain('userTracking: false');
+    expect(output).toContain(
+      "import type { BehaviorConfig } from '@shared/base-classes/base-repository';",
+    );
+  });
+
+  it('emits behaviors override with softDelete: false when only timestamps is present', () => {
+    const def = { ...baseEntity, behaviors: ['timestamps'] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    expect(output).toContain('protected override readonly behaviors: BehaviorConfig');
+    expect(output).toContain('timestamps: true');
+    expect(output).toContain('softDelete: false');
+  });
+
+  it('emits behaviors override with timestamps: false when only soft_delete is present', () => {
+    const def = { ...baseEntity, behaviors: ['soft_delete'] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    expect(output).toContain('protected override readonly behaviors: BehaviorConfig');
+    expect(output).toContain('timestamps: false');
+    expect(output).toContain('softDelete: true');
+  });
+
+  it('omits behaviors override and BehaviorConfig import when no behaviors are declared', () => {
+    const def = { ...baseEntity, behaviors: [] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    expect(output).not.toContain('BehaviorConfig');
+    expect(output).not.toContain('protected override readonly behaviors');
+  });
+});

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -10,11 +10,23 @@ import { eq<%= hasMultiFieldQuery ? ', and' : '' %><%= hasOrderedQuery ? ', desc
 import { DRIZZLE } from '@shared/constants/tokens';
 import type { DrizzleClient } from '@shared/types/drizzle';
 import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
+<% if (hasTimestamps || hasSoftDelete) { -%>
+import type { BehaviorConfig } from '@shared/base-classes/base-repository';
+<% } -%>
 import { <%= entityNamePlural %>, type <%= classNames.entity %> } from './<%= entityName %>.entity';
 
 @Injectable()
 export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%= classNames.entity %>> {
   readonly table = <%= entityNamePlural %>;
+<% if (hasTimestamps || hasSoftDelete) { -%>
+
+  // Behaviors declared in YAML -> generated as config object
+  protected override readonly behaviors: BehaviorConfig = {
+    timestamps: <%= !!hasTimestamps %>,
+    softDelete: <%= !!hasSoftDelete %>,
+    userTracking: false,
+  };
+<% } -%>
 
   constructor(@Inject(DRIZZLE) db: DrizzleClient) {
     super(db);


### PR DESCRIPTION
## Summary

Fixes #33 — the clean-lite-ps repository template silently dropped the `soft_delete` behavior. The template never emitted a `behaviors` override on the generated subclass, so entities declaring `behaviors: [timestamps, soft_delete]` inherited `BaseRepository`'s default `{ softDelete: false }` and every `.delete()` took the hard-delete branch despite the `deleted_at` column being present.

- **Template fix** — `templates/entity/new/clean-lite-ps/repository.ejs.t` now emits a typed `BehaviorConfig` override when `hasTimestamps` or `hasSoftDelete` is set, mirroring the pattern already used by `templates/entity/new/backend/database/repository.ejs.t` (lines 51–55). The locals extension already exposed both flags — no context-builder plumbing needed.
- **Import** — `import type { BehaviorConfig } from '@shared/base-classes/base-repository'` added (only when a behavior is set). `BehaviorConfig` lives in `runtime/base-classes/base-repository.ts` and is not re-exported by the family-specific bases, so the import path points there directly.
- **Scope** — `userTracking` is hard-coded to `false`; clean-lite-ps has no YAML/context support for user-tracking yet (see follow-up below).

## Test plan

- [x] `just test-unit` — 459 tests pass across 29 files
- [x] `just test-baseline` — all snapshots match (baseline covers the Clean Architecture pipeline, not clean-lite-ps, so is unaffected by the change)
- [x] New template-rendering regression test at `src/__tests__/clean-lite-ps/repository-template.test.ts` with 4 cases:
  - `[timestamps, soft_delete]` → emits `softDelete: true` + `BehaviorConfig` import
  - `[timestamps]` only → emits `softDelete: false`
  - `[soft_delete]` only → emits `timestamps: false`
  - `[]` → no override, no import

## Follow-ups (not in this PR)

- The clean-lite-ps prompt extension doesn't surface `hasUserTracking`. Worth filing if user-tracking is ever wired into clean-lite-ps entities — today every generated repo hard-codes `userTracking: false`.