### PR TITLE
fix(init-scaffold): tokens shim re-exports all runtime tokens

### DIFF
--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -186,10 +186,13 @@ export class DatabaseModule {}
 function tokensShim(cwd: string): string {
 	const rt = resolveRuntimePathFor(cwd, 'src/shared/constants');
 	return `/**
- * Re-export DRIZZLE injection token from the codegen runtime.
+ * Re-export every injection token from the codegen runtime.
  * Generated code imports from '@shared/constants/tokens'.
+ *
+ * Uses star-export so new runtime tokens (DRIZZLE, EVENT_BUS, future)
+ * are picked up automatically without editing this shim.
  */
-export { DRIZZLE } from '${rt}/constants/tokens';
+export * from '${rt}/constants/tokens';
 `;
 }
 


### PR DESCRIPTION
**Stack:** `upstream-fixes` (PR 4 of 6)

---
*Managed by [stack CLI](https://github.com/dugshub/stack)*