### PR TITLE
docs+skills: jobs & events subsystem expansion (ADR-022, ADR-030, skills v1)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -24,7 +24,7 @@ One `SKILL.md` containing the entire body of knowledge. No siblings.
 **Use when:** the domain has multiple sub-concerns that don't all apply to every task. Loading the full body for an agent who only needs one slice wastes context.
 
 **Examples in this project:**
-- `jobs/` — L0 `SKILL.md` (177 lines) routes to three L1 files: `handler-authoring.md`, `orchestrator-and-worker.md`, `pools-and-config.md`
+- `jobs/` — L0 `SKILL.md` (177 lines) routes to four L1 files: `handler-authoring.md`, `orchestrator-and-worker.md`, `pools-and-config.md`, `phase-roadmap.md`
 - `events/` — L0 `SKILL.md` (96 lines) routes to four L1 files: `outbox-and-transactions.md`, `event-codegen.md`, `directions-and-pools.md`, `protocol-and-backends.md`
 
 Both authored 2026-04-18 as the **template-setting v1** of progressive disclosure in this project. Future complex domains follow this shape.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,79 @@
+# Skills
+
+This directory holds Claude Code skills for the `codegen-patterns` project. Skills are auto-discovered by the harness and loaded into agent context when relevant.
+
+## Two skill shapes — pick the right one
+
+This project supports **two skill organizations**. They are not equivalent; pick deliberately.
+
+### Shape A — Flat (single-file)
+
+One `SKILL.md` containing the entire body of knowledge. No siblings.
+
+**Use when:** the domain is narrow and the entire skill comfortably fits under ~250 lines without losing structure. The cost of progressive disclosure (extra files, a routing table) outweighs the context savings.
+
+**Examples in this project:**
+- `codegen/` — CLI command reference; tight, single concept
+- `browser/`, `code-review/`, `dev-companion/`, `project-documentation/`, `run-and-monitor/`, `skill-authoring/` — narrow tools or workflows
+- `jobs/`, `events/` — domain skills authored 2026-04-18. Currently flat (177 and 96 lines respectively); cross the 300-line threshold and they split into L1.
+
+### Shape B — Progressive disclosure (L0 + L1)
+
+`SKILL.md` is a **router** (≤250 lines): mental model, non-obvious rules, and a routing table pointing at sibling L1 files. L1 files contain deep dives loaded only when the agent's task routes there.
+
+**Use when:** the domain has multiple sub-concerns that don't all apply to every task. Loading the full body for an agent who only needs one slice wastes context.
+
+**Examples in this project:** none yet — both `jobs/` and `events/` were authored 2026-04-18 as candidates for L0/L1 split, but their authors judged them small enough to remain flat. They will split when they cross the 300-line threshold (likely as Phase 2-7 work lands for jobs, and as the events codegen plan moves to ADR + spec set).
+
+## Convention (locked, see ADR-030)
+
+### Every skill (both shapes) MUST have frontmatter
+
+```yaml
+---
+name: <skill-name>           # matches directory name
+description: <one paragraph — when an agent should load this skill, with specific triggers>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash    # restrict where appropriate
+user-invocable: false        # true only if `/<name>` should be a slash command
+---
+```
+
+The `description` field is what the harness shows the LLM during skill discovery. Be concrete about *when* to load the skill, not *what* it contains. ("Use when working on @JobHandler classes" is better than "About jobs.")
+
+### L1 files do NOT have frontmatter
+
+L1 files are pulled in by reference from L0's routing table. They are not independently discoverable; they don't need it.
+
+### L0 (`SKILL.md`) structure
+
+1. **One-paragraph what-is-this.**
+2. **Mental model** — concrete enough to reason without opening L1, not so detailed that L1 becomes redundant.
+3. **Routing table** — explicit "for X, read `<file>.md`."
+4. **Non-obvious rules** — the things an agent MUST internalize (state machine values, reserved-pool rules, anti-patterns).
+5. **Do-not list** — anti-patterns and dead paths (rejected alternatives that may seem appealing).
+
+Length target: 150–250 lines. If you're past 300, push detail into L1.
+
+### L1 files
+
+Topical, focused, 100–300 lines each. No frontmatter. Cross-reference back to ADRs and specs (`docs/adrs/`, `docs/specs/`) instead of duplicating.
+
+## Discovery and loading
+
+- **CLAUDE.md** is auto-loaded into every agent context. It is the unconditional surface — keep it tight; let skills carry domain detail.
+- **Skill `description`** drives discovery: when an agent's task matches the description, the harness offers the skill.
+- **L1 files** are loaded by the agent reading them after L0's routing table directs it. Not auto-discovered.
+
+## Adding a new domain
+
+1. Decide flat vs. progressive (use the criteria above).
+2. Create `<domain>/SKILL.md` with full frontmatter.
+3. If progressive: create L1 sibling files; populate the routing table in L0.
+4. Don't update `CLAUDE.md` to describe the new domain — let the skill's `description` do that work.
+5. Read ADR-030 if you're unsure why this convention exists.
+
+## See also
+
+- `docs/adrs/ADR-030-progressive-disclosure-skills.md` — the full architectural decision and rationale
+- `docs/specs/pattern-stack-disclosure-audit.md` — the audit that informed this design
+- `~/.claude/plugins/cache/claude-brain/.../skill-authoring/SKILL.md` — frontmatter convention reference

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -23,7 +23,11 @@ One `SKILL.md` containing the entire body of knowledge. No siblings.
 
 **Use when:** the domain has multiple sub-concerns that don't all apply to every task. Loading the full body for an agent who only needs one slice wastes context.
 
-**Examples in this project:** none yet — both `jobs/` and `events/` were authored 2026-04-18 as candidates for L0/L1 split, but their authors judged them small enough to remain flat. They will split when they cross the 300-line threshold (likely as Phase 2-7 work lands for jobs, and as the events codegen plan moves to ADR + spec set).
+**Examples in this project:**
+- `jobs/` — L0 `SKILL.md` (177 lines) routes to three L1 files: `handler-authoring.md`, `orchestrator-and-worker.md`, `pools-and-config.md`
+- `events/` — L0 `SKILL.md` (96 lines) routes to four L1 files: `outbox-and-transactions.md`, `event-codegen.md`, `directions-and-pools.md`, `protocol-and-backends.md`
+
+Both authored 2026-04-18 as the **template-setting v1** of progressive disclosure in this project. Future complex domains follow this shape.
 
 ## Convention (locked, see ADR-030)
 

--- a/.claude/skills/events/SKILL.md
+++ b/.claude/skills/events/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: events
+description: Use when working on IEventBus, domain event publishing, the transactional outbox (domain_events table), subscribers, the event-codegen formalization (events/*.yaml, AppDomainEvent union, typed TypedEventBus facade, direction routing into events_* pools), or anything in runtime/subsystems/events/. Load this before touching event shape, publish/subscribe call sites, outbox polling, or cross-subsystem wiring into jobs' reserved event pools.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+user-invocable: false
+---
+
+# Events Domain Skill
+
+Events are the domain's immutable record of *something that happened*. They are written inside the same Drizzle transaction as the domain change (transactional outbox), drained asynchronously, and delivered to subscribers. This skill covers the current runtime (`IEventBus`, the `domain_events` outbox, Drizzle/Memory backends) **plus** the in-flight codegen formalization that will generate a typed event registry, typed `TypedEventBus` facade, and direction-based pool routing.
+
+## Mental model
+
+**Events vs. jobs — a sharp distinction, memorize it:**
+
+- **Events are immutable facts.** "Contact was created." "Stripe webhook arrived." "Opportunity stage changed to `won`." They have no lifecycle of their own beyond pending → processed in the outbox. Nothing about an event retries or fails in the domain sense — what retries is a *handler* or a *downstream job*.
+- **Jobs are stateful work.** They have status (`pending | running | waiting | completed | failed | canceled`), retry policies, hierarchy, scope, signals. They can be canceled, replayed, reorganized. See the jobs SKILL.md sibling.
+
+If you are tempted to put `status`, `attempts`, or `retry_policy` fields on an event — stop. You want a job. The event is the *trigger*; the job is the *work*.
+
+**Three event directions** — this is the single most important routing concern in the subsystem:
+
+| direction  | what it carries                                     | example                          | default pool       |
+|------------|-----------------------------------------------------|----------------------------------|--------------------|
+| `inbound`  | external → us. Webhooks, pub/sub, inbound email     | `stripe_payment_received`        | `events_inbound`   |
+| `change`   | internal domain mutations. Drives projections       | `contact_created`                | `events_change`    |
+| `outbound` | us → external. Webhooks fired, sync pushes          | `webhook_outbound_contact_sync`  | `events_outbound`  |
+
+Direction is a **routing** concern, not a payload concern. Payload shape is per-event-type. The same direction can carry wildly different payloads; two events with identical payloads can have different directions. Don't collapse them.
+
+**Reserved `events_*` pools** — the jobs subsystem (ADR-022, jobs SKILL.md) reserves three pools — `events_inbound`, `events_change`, `events_outbound` — *exclusively* for the IEventBus outbox drain. User `@JobHandler` decorations that target a reserved pool fail at build time. These pools exist so a slow outbound handler cannot stall change-event propagation. The Drizzle outbox drain loop claims rows by pool (see `outbox-and-transactions.md`).
+
+**The IEventBus + typed facade story:**
+
+- `IEventBus` (protocol, `runtime/subsystems/events/event-bus.protocol.ts`) stays narrow: `publish(event, tx?)`, `publishMany(events, tx?)`, `subscribe(type, handler)`. It is the hexagonal port. Backends implement it. **It does not know about the generated registry** — that would be circular coupling.
+- `TypedEventBus` (generated into `src/generated/events/bus.ts`, see `event-codegen.md`) is a thin injectable wrapper with typed overloads. It stamps `metadata.pool` and `metadata.direction` onto every publish based on the generated registry. Application code uses `TypedEventBus`; `IEventBus` is the lower-level port.
+
+For Phase 1 of the events-codegen work, `IEventBus` is unchanged. The typed facade wraps it without breaking it.
+
+## Task → L1 routing
+
+| When the task involves…                                                             | Read                            |
+|--------------------------------------------------------------------------------------|---------------------------------|
+| Publishing inside a transaction, outbox semantics, idempotency, polling             | `outbox-and-transactions.md`    |
+| The YAML formalization (`events/*.yaml`), generated types/schemas/registry, TypedEventBus facade | `event-codegen.md`  |
+| Why there are three directions, why pools are isolated, cross-link to jobs pools    | `directions-and-pools.md`       |
+| IEventBus contract, Drizzle/Memory backends, adding a new backend                   | `protocol-and-backends.md`      |
+
+## Non-obvious rules (read twice)
+
+1. **Direction is a routing concern, not a payload concern.** Two events with the same payload can have different directions because the drain lane matters. An `inbound` webhook that mirrors a `change` event is still `inbound` — the lane it drains through is what keeps external bursts from stalling internal projections.
+2. **The outbox is transactional.** `IEventBus.publish(event, tx)` inside a Drizzle transaction means the event row is part of the same write. If the transaction rolls back, the event is never persisted. No phantom events. **Always pass `tx` when publishing from a use case that also writes domain state.** Dropping `tx` silently detaches the event from the transaction — the domain write can commit while the event insert fails independently.
+3. **Events do not have a lifecycle; jobs do.** The `status` column on `domain_events` (`pending | processed | failed`) is a *delivery* state for the outbox drain, not a domain state. It is not a retry policy, not a scope, not a cancellable thing. If you need any of those, you want a job triggered by the event.
+4. **The events-codegen formalization (`events/*.yaml`) generates the union, the registry, and the facade.** `events/<name>.yaml` produces entries in `src/generated/events/`:
+   - `types.ts` — `AppDomainEvent` discriminated union, `EventOfType<T>`, `PayloadOfType<T>`
+   - `schemas.ts` — Zod payload schemas, runtime-validated at the publish boundary
+   - `registry.ts` — `eventRegistry` keyed by type with `direction`, `pool`, `aggregate`, etc.
+   - `bus.ts` — `TypedEventBus` with typed `publish<T>()` and `subscribe<T>()`
+   This system is **a plan in flight**, not yet an ADR. Shape may shift. See `event-codegen.md` for detail and `docs/specs/events-codegen-plan.md` for the source-of-truth design (8 open questions, unresolved).
+5. **Phase ordering matters.** Events codegen is a hard prerequisite for the jobs Event-to-Job Bridge (ADR-023). The bridge reads the event registry to validate trigger references, extract typed scope from payloads, and auto-assign pools. Ship events registry → ship events typed facade → *then* land the bridge. Don't skip.
+6. **Change events MAY be declared via the entity `events:` block.** At parse time the generator desugars the entity block into top-level `events/<name>.yaml` with `direction: change` and `aggregate: <entity>`. Per-entity inline blocks are sugar; they are not a second source of truth.
+7. **Entity auto-emission requires opt-in via `emits:`.** The target design (Phase C) is: entities declare `emits: [contact_created, contact_updated, ...]` in their YAML; generated use-cases emit typed events via `TypedEventBus.publish(type, aggregateId, payload, { tx })` inside the transaction. Silent auto-emission by name is being phased out.
+
+## Do not
+
+- Do not put job-style fields on events (`retry_count`, `status: pending|running|waiting|completed`, `scope`, `parent_id`, `attempts`). Those belong on `job_run`.
+- Do not call `IEventBus.publish` with untyped string types once the typed facade is generated for your project. Use `TypedEventBus.publish<'contact_created'>(...)`. The generated registry is the single source of truth for what the app emits.
+- Do not collapse `inbound | change | outbound` into a single pool. Lane isolation is the whole point — a slow outbound handler must not stall change-event propagation.
+- Do not couple two services via direct method calls when the second reacts to a state change in the first. Publish a domain event from the first service's use case (inside the transaction), subscribe from the second. Direct imports create retrograde coupling and make the reaction invisible in audit logs and tests.
+- Do not drop the `tx` parameter in `publish(event, tx)` inside a use case. The outbox guarantee *is* the `tx`.
+- Do not put arbitrary "notify Slack" / "call external API" logic in a subscriber directly. Subscribers should enqueue a job (via the jobs bridge) that lives in the `events_outbound` pool and carries retry/timeout. Handlers that make HTTP calls block the outbox drain.
+- Do not create `*.deprecated.ts`, parallel "old + new" event shapes, or migration shims. There are no external consumers yet; replace cleanly. See CLAUDE.md operating principles.
+- Do not add new protocol methods to `IEventBus` without an ADR. The narrow three-method port is deliberate — typing, routing, and metadata enrichment live in the typed facade.
+
+## Current runtime snapshot
+
+Files that ship to the consumer app (not templates):
+- `runtime/subsystems/events/event-bus.protocol.ts` — `IEventBus`, `DomainEvent`
+- `runtime/subsystems/events/domain-events.schema.ts` — outbox table (will gain `pool`/`direction` columns in Phase A)
+- `runtime/subsystems/events/event-bus.drizzle-backend.ts` — outbox poller (`FOR UPDATE SKIP LOCKED`)
+- `runtime/subsystems/events/event-bus.memory-backend.ts` — sync test backend, exposes `publishedEvents[]` and `clear()`
+- `runtime/subsystems/events/event-bus.redis-backend.ts` — alternate backend
+- `runtime/subsystems/events/events.module.ts` — `EventsModule.forRoot({ backend })`, `global: true`
+- `runtime/subsystems/events/events.tokens.ts` — `EVENT_BUS` symbol
+- `runtime/base-classes/lifecycle-events.ts` — legacy fire-and-forget auto-emission; being replaced by `emits:` declarations
+
+Generator pieces (exist as templates + future generator code):
+- `templates/subsystems/events/` — scaffolds the above into a consumer app
+- `src/generated/events/` — produced by the events-codegen plan (not yet implemented; see `event-codegen.md`)
+
+## Cross-links
+
+- Jobs SKILL.md — the reserved `events_*` pools, the Event-to-Job Bridge (ADR-023 work), why handlers should enqueue jobs rather than do heavy work inline.
+- `docs/adrs/ADR-008-subsystem-architecture.md` — the Protocol → Backend → Factory pattern events follows.
+- `docs/adrs/ADR-022-job-orchestration-domain-model.md` — the job-side story for the pools and the bridge.
+- `docs/specs/events-codegen-plan.md` — the plan for typed events, registry, facade, YAML. **Design in flight.**

--- a/.claude/skills/events/directions-and-pools.md
+++ b/.claude/skills/events/directions-and-pools.md
@@ -1,0 +1,113 @@
+# Directions & Pools
+
+The events subsystem has exactly three directions: `inbound`, `change`, `outbound`. Each drains through its own reserved pool in the jobs subsystem. This file explains the distinction, why the pools are kept separate, and how events and jobs connect across that boundary.
+
+## The three directions
+
+| direction  | what it carries                                               | example                         |
+|------------|--------------------------------------------------------------|---------------------------------|
+| `inbound`  | external → us; webhooks, pub/sub ingest, inbound email       | `stripe_payment_received`       |
+| `change`   | internal domain mutations; drives projections / reactions    | `contact_created`               |
+| `outbound` | us → external; webhooks fired, sync pushes, notifications    | `webhook_outbound_contact_sync` |
+
+**Direction is a routing concern, not a payload concern.** The direction answers the question: *which lane does this event drain through?* Two events with identical payload shapes can have different directions. The payload is determined by the domain fact; the direction is determined by where that fact came from and where it needs to fan out.
+
+Common confusions:
+- *"A `change` event notifies an external system — isn't it really outbound?"* No. The change event is the internal fact. If the reaction fans out externally, **that reaction is a separate `outbound` event** (or a job triggered by the bridge into the `outbound` pool). Keep them distinct — one domain fact can spawn multiple directional events.
+- *"An inbound webhook that mirrors a domain change — isn't it a change event?"* No. The `inbound` event records the external arrival. A handler/bridge may then publish a follow-up `change` event after it commits the domain update. Two events, two directions.
+
+## Pools (jobs-side)
+
+The jobs subsystem (ADR-022, jobs SKILL.md) defines five pools by default, three of which are **reserved** for the events subsystem:
+
+| Pool              | Queue                    | Reserved? | Purpose                                     |
+|-------------------|--------------------------|-----------|---------------------------------------------|
+| `events_inbound`  | `jobs-events-inbound`    | yes       | Drains `direction: inbound` outbox events   |
+| `events_change`   | `jobs-events-change`     | yes       | Drains `direction: change` outbox events    |
+| `events_outbound` | `jobs-events-outbound`   | yes       | Drains `direction: outbound` outbox events  |
+| `interactive`     | `jobs-interactive`       | no        | User-waiting work (renders, exports)        |
+| `batch`           | `jobs-batch`             | no        | Background user work (onboarding, ingest)   |
+
+**Reserved means:** a user `@JobHandler` class that targets a reserved pool fails at build time (caught by a module validator). Reserved pools exist *exclusively* to carry the IEventBus outbox drain traffic. No user code enqueues to them.
+
+Concurrency limits per pool are configured in `codegen.config.yaml: jobs.pools`. Defaults ship in ADR-022 (20 / 30 / 10 for inbound / change / outbound).
+
+## How event direction drives pool routing
+
+1. Every event YAML declares a `direction`.
+2. Codegen derives the default pool from direction (`inbound → events_inbound`, etc.).
+3. `TypedEventBus.publish` stamps `metadata.pool` and `metadata.direction` on every event at publish time (and, Phase A, populates first-class `pool` and `direction` columns on `domain_events`).
+4. The Drizzle outbox drain claims rows filtered by pool: each worker process drains a specific pool (or set of pools).
+5. This is how lane isolation is enforced: a slow outbound HTTP handler cannot stall inbound webhook processing cannot stall change-event projection.
+
+```
+              ┌─────────────────────────────────┐
+              │ Domain write (Drizzle txn)      │
+              │ + events.publish(...)  ─── tx   │
+              └────────────────┬────────────────┘
+                               │
+                               ▼
+              ┌─────────────────────────────────┐
+              │  domain_events outbox (Postgres)│
+              │  (pool, direction, payload)     │
+              └───────┬──────────┬──────────┬───┘
+                      │          │          │
+       events_inbound │   events_change     │ events_outbound
+                      │          │          │
+                      ▼          ▼          ▼
+              ┌──────────┐ ┌──────────┐ ┌──────────┐
+              │ Inbound  │ │ Change   │ │ Outbound │
+              │ drain    │ │ drain    │ │ drain    │
+              │ worker   │ │ worker   │ │ worker   │
+              └──────────┘ └──────────┘ └──────────┘
+```
+
+Each drain worker is a pool-filtered instance of `DrizzleEventBus` (or the same process with per-pool concurrency budgets; operational choice). The key invariant: **each direction has its own drain lane**.
+
+## Why isolation matters
+
+From ADR-022's motivating failure mode:
+
+> Outbound webhooks, inbound ingests, domain-change events, and user-triggered work all flow through the same BullMQ queue. A slow outbound handler stalls change-event propagation; a user's export queues up behind a batch onboarding job.
+
+Collapsing the three directions into one pool re-creates exactly this problem. Concrete scenarios:
+
+- **Outbound bleed.** An external webhook target goes slow (CRM rate-limits). The outbound drain's handler queue backs up. If it shares a pool with change events, the read-model projection stalls — user-facing reads start returning stale data. Symptom: "why does my contact not show up in the list" even though the create succeeded.
+- **Inbound burst.** Stripe retries a week of webhooks during an incident. The inbound drain sees 10k events in a minute. If change events share the lane, internal consistency operations (projections, cache busts) are blocked behind a queue of external events. Symptom: app-wide latency spike, unrelated to domain load.
+- **Change event avalanche.** A batch update to 50k contacts fires 50k change events. Those must not block an inbound Stripe webhook — money movement has to drain on its own schedule.
+
+**The lane is the isolation primitive.** Priority-based scheduling within a single queue is strictly weaker — under sustained load, priority-based schedulers can still starve low-priority work. Separate lanes cannot.
+
+## Event-triggered jobs — pool inheritance (OPEN QUESTION)
+
+When the Event-to-Job Bridge (ADR-023) enqueues a user job in response to an event, which pool does the triggered job land in?
+
+Proposed default (from `events-codegen-plan.md` §6 + §7 Q6): **triggered jobs default to `batch`, not the source event's reserved pool.** Rationale: the reserved `events_*` pools carry the bus drain itself; user work that reacts to an event is still user work and should land in user-pool isolation.
+
+Example:
+- Event `stripe_payment_received` drains in `events_inbound`.
+- A job `start_onboarding` is triggered by that event.
+- The bridge enqueues `start_onboarding` into `batch` (user pool), **not** `events_inbound`.
+- `events_inbound`'s drain-loop handler only does the minimum work to hand off: unpack the event, enqueue the job, done.
+
+**This is an open question in the plan.** An alternative is for triggered jobs to inherit the source pool, which simplifies back-pressure accounting but muddies reserved-pool semantics. Check `events-codegen-plan.md` §7 Q6 before assuming.
+
+## Custom pools — not for events
+
+Users can declare custom pools in `codegen.config.yaml` (e.g., an `agents` pool for long-running LLM jobs). Those pools **cannot be targets for events** — the reserved-pool set (`events_inbound | events_change | events_outbound`) is the whole legal universe of event pools. A user pool can host event-*triggered* jobs (after the bridge runs), but events themselves only ever drain through the three reserved lanes.
+
+If you find yourself wanting a fourth event pool ("events_telemetry", "events_audit"), stop and model the underlying concern differently — either split into an existing direction, or treat the thing as an audit table rather than a domain event.
+
+## Do not
+
+- Do not route events through user pools (`batch`, `interactive`). User pools host event-triggered jobs, not events themselves.
+- Do not collapse directions. "One queue with priority flags" is the failure mode the reserved-pools design exists to prevent.
+- Do not do heavy work inside the outbox drain handler. The drain handler should enqueue a job into the appropriate downstream pool and return. Long-running reactions (HTTP calls, LLM calls, multi-step workflows) belong in jobs.
+- Do not target a reserved pool from `@JobHandler`. Build-time error. The reserved pools are framework-owned.
+
+## See also
+
+- `outbox-and-transactions.md` — the drain loop pool filter
+- `event-codegen.md` — how `direction` is declared and stamped
+- Jobs SKILL.md + ADR-022 — pool definitions and worker concurrency
+- `docs/specs/events-codegen-plan.md` §6 — bridge pool inheritance (open)

--- a/.claude/skills/events/event-codegen.md
+++ b/.claude/skills/events/event-codegen.md
@@ -1,0 +1,285 @@
+# Event Codegen (YAML → typed facade)
+
+**Status: design in flight.** The full design lives in `docs/specs/events-codegen-plan.md` (draft, 2026-04-17). It has eight open questions (§7 of the plan) that are not yet resolved — the shape below may shift. Treat this file as orientation, not as a contract. When in doubt, read the plan.
+
+This file covers: what the formalization is trying to do, the `events/*.yaml` shape, the generated artifacts in `src/generated/events/`, and the typed facade usage pattern. Cross-refs `outbox-and-transactions.md` (publish semantics) and `directions-and-pools.md` (what directions drive).
+
+## Why formalize
+
+Today's shape:
+- `DomainEvent` is `{ type: string, payload: Record<string, unknown>, ... }` — untyped.
+- Subscribers pass strings: `bus.subscribe('contact_created', handler)`. No compile-time validation of the type name or payload shape.
+- No registry: the app cannot ask "what events do we emit?" at boot time.
+- The entity `events:` block generates per-entity event classes, but inbound webhooks and outbound publishes have no first-class home — they aren't entity-owned.
+- No `direction` concept → no way for the Drizzle drain to route by pool (see `directions-and-pools.md`).
+
+Target shape:
+- `events/*.yaml` declares every event, one file per type.
+- Codegen produces `AppDomainEvent` (discriminated union), Zod schemas, a runtime registry, and `TypedEventBus` — an injectable typed wrapper over `IEventBus`.
+- Every event carries `direction` in its declaration; the facade stamps `metadata.pool` and `metadata.direction` on every publish.
+- The event-to-job bridge (ADR-023) reads the registry to validate triggers.
+
+## Event YAML shape
+
+Location: `events/*.yaml` at repo root, sibling to `entities/` and `jobs/`. One file per event. Filename matches the `type` field (snake_case).
+
+```yaml
+# events/stripe_payment_received.yaml
+type: stripe_payment_received
+direction: inbound
+source: stripe              # inbound: external system name
+version: 1
+description: Stripe charge.succeeded webhook, post-signature-verification.
+payload:
+  event_id:      { type: string, description: "Stripe event id (evt_...)" }
+  customer_id:   { type: string }
+  amount_cents:  { type: number }
+  currency:      { type: string }
+  received_at:   { type: date }
+retry:
+  attempts: 5
+  backoff: exponential
+```
+
+```yaml
+# events/contact_created.yaml
+type: contact_created
+direction: change
+aggregate: contact          # must match entities/contact.yaml
+version: 1
+payload:
+  contact_id: { type: uuid }
+  account_id: { type: uuid, nullable: true }
+  created_by: { type: uuid }
+```
+
+```yaml
+# events/webhook_outbound_contact_sync.yaml
+type: webhook_outbound_contact_sync
+direction: outbound
+destination: crm
+aggregate: contact
+payload:
+  contact_id:  { type: uuid }
+  operation:   { type: string }   # "create" | "update" | "delete"
+  occurred_at: { type: date }
+```
+
+**Fields:**
+- `type` — unique snake_case business key, matches filename
+- `direction` — `inbound | change | outbound`; drives default pool
+- `aggregate` — entity name (required for `direction: change`; optional elsewhere)
+- `source` — inbound only; logical origin ("stripe", "email")
+- `destination` — outbound only; logical target ("crm", "slack")
+- `payload` — snake_case keys → camelCase TS props; types `uuid | string | number | boolean | date | json`
+- `pool` — optional override; constrained to the reserved pools of the *same category* (a `change` event cannot opt into `events_inbound`). User pools (`batch`, `interactive`) are NEVER valid targets for events.
+- `retry` — `{ attempts, backoff }`, hints surfaced to the bus
+- `version` — integer, defaults to 1 (schema evolution; not exercised yet)
+
+**Default pool from direction:**
+
+| direction  | default pool       |
+|------------|--------------------|
+| `inbound`  | `events_inbound`   |
+| `change`   | `events_change`    |
+| `outbound` | `events_outbound`  |
+
+Override is rarely needed. If you find yourself overriding, revisit the direction.
+
+## Entity `events:` block is sugar
+
+Entity YAML keeps its `events:` block. At parse time the generator **desugars** each entry into an equivalent `events/<name>.yaml` file with `direction: change` and `aggregate: <entity_name>`. This means change events can be declared either inline (entity-owned sugar) or as standalone files (e.g. when multiple entities share a change event, which is rare). Both produce the same registry entry.
+
+The current per-entity event *class* generation is replaced by the `src/generated/events/types.ts` union. Handlers (when `generate_handler: true`) still live under the entity module but import the generated interfaces.
+
+## Entity `emits:` block (required for typed auto-emission)
+
+Phase C design — not yet shipped:
+
+```yaml
+# entities/contact.yaml
+emits:
+  - contact_created
+  - contact_updated
+  - contact_deleted
+```
+
+Behavior:
+- If present, each entry must resolve to an `events/<type>.yaml` with `direction: change` and `aggregate: contact`. Missing → codegen hard error.
+- If absent, no typed auto-emission. The legacy `runtime/base-classes/lifecycle-events.ts` untyped fire-and-forget path is used (with a warning at codegen time).
+
+Once shipped, generated use-cases call the facade explicitly inside the transaction:
+
+```ts
+async execute(input: CreateContactInput): Promise<Contact> {
+  return this.db.transaction(async (tx) => {
+    const contact = await this.contacts.create(input, tx);
+    await this.events.publish('contact_created', contact.id, {
+      contactId: contact.id,
+      accountId: contact.accountId,
+      createdBy: input.actorId,
+    }, { tx });
+    return contact;
+  });
+}
+```
+
+## Generated artifacts — `src/generated/events/`
+
+Five files, all generated, none hand-edited:
+
+```
+src/generated/events/
+  types.ts         # Typed interfaces + discriminated union
+  schemas.ts       # Zod runtime schemas
+  registry.ts      # Metadata map keyed by type
+  bus.ts           # TypedEventBus facade
+  index.ts         # Re-export surface
+```
+
+### `types.ts`
+
+```ts
+export interface ContactCreatedEvent extends DomainEvent {
+  readonly type: 'contact_created';
+  readonly aggregateType: 'contact';
+  readonly payload: {
+    contactId: string;
+    accountId: string | null;
+    createdBy: string;
+  };
+}
+
+export type AppDomainEvent =
+  | StripePaymentReceivedEvent
+  | ContactCreatedEvent
+  | WebhookOutboundContactSyncEvent
+  /* ... */;
+
+export type EventTypeName = AppDomainEvent['type'];
+export type EventOfType<T extends EventTypeName> = Extract<AppDomainEvent, { type: T }>;
+export type PayloadOfType<T extends EventTypeName> = EventOfType<T>['payload'];
+```
+
+### `schemas.ts`
+
+Zod schemas per payload, plus a keyed map for boundary validation:
+
+```ts
+export const eventPayloadSchemas = {
+  stripe_payment_received: stripePaymentReceivedPayloadSchema,
+  contact_created: contactCreatedPayloadSchema,
+} as const satisfies Record<EventTypeName, z.ZodTypeAny>;
+```
+
+### `registry.ts`
+
+The runtime source of truth. Read by `TypedEventBus`, by the jobs Event-to-Job Bridge, by startup validation.
+
+```ts
+export interface EventMetadata {
+  type: EventTypeName;
+  direction: 'inbound' | 'change' | 'outbound';
+  pool: 'events_inbound' | 'events_change' | 'events_outbound';
+  aggregate?: string;
+  source?: string;
+  destination?: string;
+  version: number;
+  retry: { attempts: number; backoff: 'linear' | 'exponential' };
+}
+
+export const eventRegistry = { /* one entry per yaml */ } as const satisfies Record<EventTypeName, EventMetadata>;
+
+export function getEventMetadata<T extends EventTypeName>(type: T): EventMetadata {
+  return eventRegistry[type];
+}
+```
+
+### `bus.ts` — `TypedEventBus` facade
+
+```ts
+@Injectable()
+export class TypedEventBus {
+  constructor(@Inject(EVENT_BUS) private readonly bus: IEventBus) {}
+
+  async publish<T extends EventTypeName>(
+    type: T,
+    aggregateId: string,
+    payload: PayloadOfType<T>,
+    opts?: { tx?: DrizzleTransaction; metadata?: Record<string, unknown> },
+  ): Promise<void> {
+    const meta = getEventMetadata(type);
+    if (process.env['CODEGEN_EVENT_VALIDATE'] !== 'off') {
+      eventPayloadSchemas[type].parse(payload); // boundary validation
+    }
+    const event: DomainEvent = {
+      id: randomUUID(),
+      type,
+      aggregateId,
+      aggregateType: meta.aggregate ?? meta.source ?? meta.destination ?? type,
+      payload: payload as Record<string, unknown>,
+      occurredAt: new Date(),
+      metadata: {
+        ...opts?.metadata,
+        pool: meta.pool,
+        direction: meta.direction,
+        version: meta.version,
+      },
+    };
+    await this.bus.publish(event, opts?.tx);
+  }
+
+  subscribe<T extends EventTypeName>(
+    type: T,
+    handler: (event: EventOfType<T>) => Promise<void>,
+  ): () => void {
+    return this.bus.subscribe<EventOfType<T>>(type, handler);
+  }
+}
+```
+
+**Key properties:**
+- Typed `publish<T>()`: if you pass `'contact_created'`, the `payload` parameter must match `{ contactId, accountId, createdBy }`. Misspelled event names are compile errors.
+- Typed `subscribe<T>()`: the handler's event parameter is narrowed to `EventOfType<T>` — `event.payload.contactId` is typed without casts.
+- Every publish stamps `metadata.pool` and `metadata.direction` from the registry. The Drizzle backend reads these and populates the outbox columns at insert time; the drain loop then filters by pool.
+- The generic `IEventBus` port is unchanged. The facade wraps it.
+
+## Phase ordering (from `events-codegen-plan.md` §5)
+
+Not all of the above lands at once. The plan sequences against the jobs plan:
+
+| When                           | Events work                                              |
+|--------------------------------|----------------------------------------------------------|
+| Before jobs Phase 1            | **Phase 0** — YAML parser, registry.ts only. No facade.  |
+| Before jobs Phase 3 (bridge)   | **Phase A** — types, schemas, facade, pool columns on outbox |
+| During jobs Phase 5 (audit)    | **Phase B** — selective broadcast of JobEvent to bus     |
+| Independent of jobs            | **Phase C** — `emits:` validation, entity template rewrite |
+
+Phase 0 unblocks jobs Phase 1. Phase A unblocks the bridge. Phase C is independent and slips freely.
+
+## The 8 open questions (flagged in the plan)
+
+Do not assume these are answered:
+1. Top-level `events/*.yaml` vs. inline entity `events:` block — keep both with desugar, or drop one?
+2. `emits:` required vs. optional vs. inferred by name?
+3. Payload validation: dev-only, always-on, or configurable?
+4. `TypedEventBus` fully replaces `@Inject(EVENT_BUS)` in generated code, or they coexist?
+5. `pool` / `direction` as metadata only vs. first-class columns vs. protocol fields?
+6. Pool inheritance for event-triggered jobs — default to `batch` or the source `events_*` pool?
+7. Selective broadcast of `JobEvent` to the bus — flag on jobs YAML or codegen-config allowlist?
+8. Versioning — schema-evolution coexistence (v1/v2) or defer?
+
+If a task depends on one of these, check `docs/specs/events-codegen-plan.md` §7 first; the plan will likely be updated before implementation.
+
+## Do not
+
+- Do not invent codegen features beyond the plan. The plan has authority; this file is a summary.
+- Do not generate user-pool events. Events are always in `events_*` pools. If you want "a user job runs when this event fires," that is the Event-to-Job Bridge (ADR-023) — the event drains in `events_*`, the *bridge* enqueues a user-pool job.
+- Do not hand-edit `src/generated/events/*.ts`. They are reproduced from `events/*.yaml`.
+
+## See also
+
+- `docs/specs/events-codegen-plan.md` — full design, open questions, alternatives
+- `outbox-and-transactions.md` — how the generated facade's `publish(tx)` inherits the outbox guarantee
+- `directions-and-pools.md` — what `direction` drives downstream
+- Jobs SKILL.md → ADR-023 (Event-to-Job Bridge) — consumer of the registry

--- a/.claude/skills/events/outbox-and-transactions.md
+++ b/.claude/skills/events/outbox-and-transactions.md
@@ -1,0 +1,139 @@
+# Outbox & Transactions
+
+The events subsystem uses the **transactional outbox pattern**: domain events are inserted into the `domain_events` table as part of the same database transaction as the domain write. A background polling loop drains pending rows and dispatches them to subscribers. This document covers the publish-inside-transaction pattern, polling semantics, idempotency, and common pitfalls.
+
+## Why an outbox
+
+Two things have to be consistent:
+1. The domain row changes (e.g. a new `contact` row).
+2. Downstream systems learn about it (a subscriber projects to a read model, another service reacts, a webhook fires).
+
+If (1) commits but (2) fails — because the bus was down, or the process crashed between the commit and the publish — the domain drifts silently from its consumers. The outbox pattern fuses (1) and (2) into the same atomic write: the "publish" is just an INSERT into `domain_events` inside the same transaction. Either both happen or neither does. The separate drain loop handles delivery.
+
+This is strictly stronger than `await db.commit(); await bus.publish(...)`. It survives process crashes; the latter doesn't.
+
+## The publish-inside-transaction contract
+
+Every use case that mutates domain state **MUST** pass the transaction to `IEventBus.publish`:
+
+```ts
+// src/modules/contacts/use-cases/create-contact.use-case.ts
+async execute(input: CreateContactInput): Promise<Contact> {
+  return this.db.transaction(async (tx) => {
+    const contact = await this.contacts.create(input, tx);
+    await this.eventBus.publish(
+      {
+        id: randomUUID(),
+        type: 'contact_created',
+        aggregateId: contact.id,
+        aggregateType: 'contact',
+        occurredAt: new Date(),
+        payload: { contactId: contact.id, accountId: contact.accountId, createdBy: input.actorId },
+      },
+      tx, // ← CRITICAL: this is the outbox guarantee
+    );
+    return contact;
+  });
+}
+```
+
+Once the `TypedEventBus` facade ships (see `event-codegen.md`), the call collapses to:
+
+```ts
+await this.events.publish('contact_created', contact.id, {
+  contactId: contact.id,
+  accountId: contact.accountId,
+  createdBy: input.actorId,
+}, { tx });
+```
+
+Same guarantee; the facade stamps `id`, `occurredAt`, `metadata.pool`, `metadata.direction` from the generated registry.
+
+**Dropping `tx` silently detaches the event from the transaction.** The backend uses `tx ?? this.db` — if you don't pass `tx`, the insert runs on the top-level connection, outside the domain transaction. You lose the atomicity guarantee. This is a footgun; there is no type-level enforcement yet (see open question in `events-codegen-plan.md`).
+
+## The outbox table
+
+`runtime/subsystems/events/domain-events.schema.ts`:
+
+| Column              | Notes                                                  |
+|---------------------|--------------------------------------------------------|
+| `id` (uuid, PK)     | Event id. Used for idempotency / dedup.                |
+| `type`              | Event type discriminator (`contact_created`)           |
+| `aggregate_id`      | Producing aggregate's id                               |
+| `aggregate_type`    | `'contact'`, `'opportunity'`, etc.                     |
+| `payload` (jsonb)   | Event-specific payload                                 |
+| `occurred_at`       | Wall-clock                                             |
+| `processed_at`      | NULL until drained                                     |
+| `status`            | `pending | processed | failed`                         |
+| `error`             | Last dispatch error message                            |
+| `metadata` (jsonb)  | Routing hints; will carry `pool` and `direction`       |
+
+**Phase A additions** (from `events-codegen-plan.md` §3): `pool` (text, nullable, indexed) and `direction` (text, nullable, indexed) become first-class columns, populated at insert time from `metadata`. This lets the drain loop filter by pool without unpacking JSON on every poll.
+
+**Indexes** to add via migration when deploying:
+- `(status, occurred_at)` — polling query
+- `(aggregate_id, aggregate_type)` — event replay for an entity
+- `(pool, status, occurred_at)` — per-pool drain (Phase A)
+
+## The polling loop
+
+`runtime/subsystems/events/event-bus.drizzle-backend.ts`:
+
+```sql
+SELECT * FROM domain_events
+WHERE status = 'pending'
+ORDER BY occurred_at ASC
+LIMIT 50
+FOR UPDATE SKIP LOCKED
+```
+
+Run inside a transaction so the row is locked for the duration of dispatch. `SKIP LOCKED` means multiple worker processes can poll concurrently without double-dispatching. Default interval: 1000ms. Default batch size: 50.
+
+**Per-batch dispatch flow:**
+1. Claim rows with `FOR UPDATE SKIP LOCKED` in a read transaction.
+2. For each row: invoke all registered handlers for `event.type`.
+3. On success: `UPDATE domain_events SET status='processed', processed_at=now() WHERE id=...`.
+4. On failure: retry up to `MAX_RETRIES` (3); if still failing, `UPDATE ... SET status='failed', error=...`. Row is not re-claimed.
+
+Phase A adds pool filtering:
+
+```sql
+SELECT * FROM domain_events
+WHERE status = 'pending'
+  AND (pool = ANY($1::text[]) OR $1 IS NULL)
+ORDER BY occurred_at ASC
+LIMIT $2
+FOR UPDATE SKIP LOCKED
+```
+
+Each worker process can restrict itself to a subset of pools. E.g. an inbound-webhook worker drains `events_inbound` only; a change-event worker drains `events_change` only. This is how lane isolation is enforced at the bus layer — the jobs-side pools are the destination for event-triggered work; the bus-side pool-filtered drain is what carries events into those jobs.
+
+## Idempotency
+
+**Event `id` is the idempotency key.** The outbox row is keyed by UUID, generated once at publish time. When you need to detect "did we already handle this?" — for downstream systems, for replay scenarios, for handler reruns — the `id` is the dedup token.
+
+Rules:
+- **Do not regenerate `id` on replay.** If you re-publish an event (e.g. a webhook backfill), compute the id deterministically from the source event (Stripe's `evt_...`, Salesforce's `ReplayId`, etc.) so the outbox insert hits `ON CONFLICT (id) DO NOTHING`.
+- **Handlers should be idempotent.** The drain loop can redeliver (process crashes between dispatch and `status='processed'` update). Handlers should be safe to call twice with the same event.id. A common pattern: handlers track seen ids in a small table and short-circuit duplicates.
+- **Inbound webhook events should reuse the source system's event id.** If Stripe sends `evt_123` twice, you want the second outbox insert to fail uniquely, not create a duplicate event.
+
+## Ordering guarantees
+
+- **Events for the same aggregate arrive in insertion order** — `ORDER BY occurred_at ASC` + `SKIP LOCKED` gives FIFO per aggregate under a single worker. With multiple workers, ordering holds *probabilistically* per aggregate (same aggregate_id rarely fans to two workers in one poll cycle) but is not guaranteed.
+- **Events across aggregates are NOT strictly ordered.** Treat cross-aggregate ordering as "roughly" wall-clock, not exact. If you need strict global ordering, you're on the wrong tool.
+
+If your handler depends on strict cross-aggregate ordering — it probably shouldn't. Re-shape the computation to tolerate independent aggregate timelines.
+
+## Failure modes & what to check
+
+- **Events published outside a transaction.** Look for `publish(event)` (no `tx`) inside a `db.transaction(async (tx) => ...)` block. That's a bug — the publish is not part of the transaction.
+- **Handlers doing heavy I/O synchronously.** A handler that makes an HTTP call on every event blocks the drain batch. The drain loop serially dispatches a batch of 50. Handlers should be fast; slow work belongs in a job (see `directions-and-pools.md` — subscriber enqueues a job into `events_outbound` or a user pool).
+- **`status='failed'` rows pile up.** Something is permanently broken. Check `error` column, fix the handler, and requeue (set `status='pending'`). There's no automatic retry after the 3-attempt limit — that's intentional; infinite retry on a broken handler burns a worker.
+- **Throughput ceiling.** The outbox drain maxes around ~1000 events/s on a modest Postgres. If you blow through that, the escape hatch is a backend swap (Redis Streams, NATS) — `IEventBus.forRoot({ backend: '...' })`, no use-case changes.
+
+## See also
+
+- `protocol-and-backends.md` — IEventBus surface and backend choices
+- `directions-and-pools.md` — why the drain loop will filter by pool
+- `event-codegen.md` — how `TypedEventBus.publish` stamps metadata
+- `docs/adrs/ADR-008-subsystem-architecture.md` — the outbox-pattern rationale, memory backend semantics

--- a/.claude/skills/events/protocol-and-backends.md
+++ b/.claude/skills/events/protocol-and-backends.md
@@ -1,0 +1,161 @@
+# Protocol & Backends
+
+The events subsystem follows the **Protocol → Backend → Factory** pattern (ADR-008). This file describes the `IEventBus` port, the concrete backends (Drizzle outbox, Memory, Redis), the `EventsModule.forRoot({ backend })` wiring, and the steps to add a new backend while respecting the core/extension principle (CLAUDE.md).
+
+## Protocol — `IEventBus`
+
+Source: `runtime/subsystems/events/event-bus.protocol.ts`. Three methods, no typed generics at the port:
+
+```ts
+export interface IEventBus {
+  publish(event: DomainEvent, tx?: DrizzleTransaction): Promise<void>;
+  publishMany(events: DomainEvent[], tx?: DrizzleTransaction): Promise<void>;
+  subscribe<T extends DomainEvent = DomainEvent>(
+    eventType: string,
+    handler: (event: T) => Promise<void>,
+  ): () => void;
+}
+```
+
+`DomainEvent`:
+
+```ts
+export interface DomainEvent {
+  readonly id: string;               // UUID
+  readonly type: string;             // discriminator
+  readonly aggregateId: string;
+  readonly aggregateType: string;
+  readonly payload: Record<string, unknown>;
+  readonly occurredAt: Date;
+  readonly metadata?: Record<string, unknown>;
+}
+```
+
+**Design choice: keep the port narrow.** Typed generics live on the `TypedEventBus` facade (see `event-codegen.md`), not on `IEventBus`. Rationale:
+- The port is the hexagonal boundary — it should not depend on the generated registry (circular coupling).
+- Backends should not have to know anything about app-declared event types.
+- Typing is a consumer concern, handled one layer up.
+
+**Protocol changes land rarely and require an ADR.** Current plan (Phase A): `metadata` gains well-known keys `pool` and `direction`, and the Drizzle backend adds `pool` / `direction` columns to the outbox table. No protocol method signatures change.
+
+## Injection token
+
+`runtime/subsystems/events/events.tokens.ts` exports:
+
+```ts
+export const EVENT_BUS = Symbol('EVENT_BUS');
+```
+
+Application code injects `@Inject(EVENT_BUS) private readonly bus: IEventBus`. Once the typed facade generator lands, app code injects `TypedEventBus` directly — the facade internally injects `EVENT_BUS`.
+
+## Backends
+
+### Drizzle backend (default, production)
+
+`runtime/subsystems/events/event-bus.drizzle-backend.ts`. Postgres-backed with the transactional outbox pattern. Key properties:
+
+- **`publish(event, tx?)`** — inserts one row into `domain_events`. Uses `tx` if provided, else the top-level `DrizzleClient`. Never fails silently; throws if the DB is unreachable.
+- **`subscribe(type, handler)`** — registers in an in-memory `Map<string, Set<handler>>`. **Per-process subscription**: subscribers registered in process A do not receive events drained in process B. For multi-process setups, each process runs its own subscribers.
+- **Polling loop** — `OnModuleInit` starts a 1s-interval poll. Each cycle: `SELECT ... FOR UPDATE SKIP LOCKED LIMIT 50`, dispatch to handlers, update status. `OnModuleDestroy` stops the loop cleanly.
+- **Retry policy** — up to 3 attempts per event; on persistent failure, row is marked `status='failed'` with the error message. No automatic retry after.
+
+Strengths: zero new infra beyond Postgres; transactional guarantee; survives process crashes. Weaknesses: ~1000 events/s ceiling; polling latency floor of 1s; not real-time.
+
+**Extensions (Drizzle-specific, opt-in):**
+- `LISTEN/NOTIFY` for sub-second drain wakeups — opt-in, not portable to other backends.
+- Advisory locks to protect hot-row hotspots — Postgres-only.
+- The `pool` / `direction` columns are a Drizzle-backend optimization for the drain query; semantically the same information lives in `metadata`.
+
+### Memory backend (tests)
+
+`runtime/subsystems/events/event-bus.memory-backend.ts`. Synchronous, in-process.
+
+- **`publish(event)`** — pushes into a `publishedEvents[]` array, dispatches to handlers immediately. **Ignores `tx`** — there is no transactional semantic in memory.
+- **`publishMany(events)`** — calls `publish` in a loop.
+- **`subscribe(type, handler)`** — same Map-based registry as Drizzle.
+- **`clear()`** — test helper; drops all published events and handlers. Call in `beforeEach`.
+- **`publishedEvents`** — public array for test assertions (`expect(bus.publishedEvents).toContainEqual({...})`).
+
+Use in every test that touches the events subsystem. Swap via `EventsModule.forRoot({ backend: 'memory' })`.
+
+**Key test property:** dispatch is synchronous. `await bus.publish(event)` returns only after all subscribers have handled the event. Tests do not need `waitFor` / timers. This is different from Drizzle, where dispatch is async via the polling loop.
+
+### Redis backend
+
+`runtime/subsystems/events/event-bus.redis-backend.ts`. Present but not the default. Intended for higher-throughput / real-time fan-out. Selected via `EventsModule.forRoot({ backend: 'redis', redisUrl: '...' })`.
+
+Falls back to `REDIS_URL` env var or `redis://localhost:6379`. Note: the Redis backend does not participate in the Drizzle transaction — using `tx` with this backend is a silent no-op. Teams using Redis lose the transactional-outbox guarantee unless they layer their own outbox-table-then-publish dual-write pattern. This is called out here because it is easy to miss.
+
+## Factory — `EventsModule.forRoot`
+
+`runtime/subsystems/events/events.module.ts`:
+
+```ts
+@Module({})
+export class EventsModule {
+  static forRoot(options: EventsModuleOptions = { backend: 'drizzle' }): DynamicModule {
+    // ... returns DynamicModule with `global: true` ...
+  }
+  static forRootAsync(asyncOptions: EventsModuleAsyncOptions): DynamicModule { /* ... */ }
+}
+```
+
+Registered once in `AppModule`:
+
+```ts
+@Module({
+  imports: [
+    DatabaseModule,
+    EventsModule.forRoot({ backend: 'drizzle' }),
+    // other subsystems
+  ],
+})
+export class AppModule {}
+```
+
+`global: true` means entity modules don't need to import `EventsModule` individually — the `EVENT_BUS` token is available project-wide. Tests swap:
+
+```ts
+Test.createTestingModule({
+  imports: [EventsModule.forRoot({ backend: 'memory' })],
+});
+```
+
+## Adding a new backend
+
+Follow the core/extension principle from CLAUDE.md. The new class MUST implement every `IEventBus` method. It MAY expose additional methods, but consumers who use those methods lose portability.
+
+Steps:
+1. Create `event-bus.<name>-backend.ts` in `runtime/subsystems/events/`. Implement `IEventBus`. Decide whether `publish(event, tx?)` is transactional-outbox-capable; if not, document the gap clearly in the file header.
+2. Add the backend name to the `EventsModuleOptions['backend']` union in `events.module.ts`.
+3. Extend the `forRoot` switch to wire the new provider.
+4. Add unit tests under `runtime/subsystems/events/__tests__/` that exercise `publish / publishMany / subscribe` against the new backend.
+5. If the backend has extensions (native pub/sub, admin UI hooks, rate limiting), expose them as additional public methods on the class — do not smuggle them into `IEventBus`. Document the extensions in the file header so consumers know they are opting into backend-specific code.
+6. If the backend adds schema (e.g. Redis stream names, Kafka topics), keep that config in a sibling `<name>-backend-config.ts` file; do not add options to `EventsModuleOptions` that only apply to some backends without a discriminated union.
+
+**What not to do:**
+- Do not widen `IEventBus` to accommodate backend-specific features. If a feature can only be implemented on one backend, it belongs on the backend class's public surface, not on the port.
+- Do not flatten backend differences by pretending all backends support transactional semantics. A Redis backend does not; saying it does is a lie that will break production.
+- Do not add a new backend that claims "transactional outbox" without a concrete transactional write path (or a documented dual-write-with-outbox-table pattern).
+
+## Error handling
+
+Per ADR-008:
+- **`publish` failures propagate.** If the DB is unreachable, `publish` throws and the caller's transaction rolls back. There is no retry at this layer — retry is on the drain loop, after the transaction has committed successfully.
+- **Handler failures are caught per-handler.** `DrizzleEventBus.dispatch` runs each handler inside try/catch, logs, and re-throws the first error after the batch. On throw, the outer loop counts it as an attempt; 3 attempts → `status='failed'`.
+- **Memory backend treats handler failures differently** — it rethrows synchronously, so test assertions surface the failure immediately.
+
+## Do not
+
+- Do not add methods to `IEventBus` without an ADR.
+- Do not inject `DrizzleEventBus` directly in application code. Inject via `EVENT_BUS` or `TypedEventBus`. Direct injection breaks the port.
+- Do not bypass the factory to instantiate backends manually — `new DrizzleEventBus()` won't wire NestJS lifecycle hooks; the polling loop won't start.
+- Do not use the Redis backend and expect outbox semantics. Use Drizzle for transactional publishes; reach for Redis only after measuring an actual bottleneck.
+
+## See also
+
+- `outbox-and-transactions.md` — the Drizzle backend's outbox semantics in detail
+- `event-codegen.md` — the `TypedEventBus` facade that wraps `IEventBus`
+- `directions-and-pools.md` — Phase A changes to the Drizzle backend (pool/direction columns)
+- `docs/adrs/ADR-008-subsystem-architecture.md` — Protocol → Backend → Factory pattern
+- `CLAUDE.md` — core/extension principle

--- a/.claude/skills/jobs/SKILL.md
+++ b/.claude/skills/jobs/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: jobs
+description: Load when working anywhere in the jobs subsystem. Triggers include authoring or reviewing `@JobHandler` classes; touching `IJobOrchestrator` / `IJobRunService` / `IJobStepService` or their Drizzle/Memory backends; changes under `runtime/subsystems/jobs/`; the job worker loop, claim query, stale-claim sweeper, or graceful-shutdown logic; pool configuration under `codegen.config.yaml: jobs.*`; the jobs subsystem scaffold templates in `templates/subsystem/jobs/`; and any work referencing ADR-022 or JOB-1..JOB-8 specs.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+user-invocable: false
+---
+
+# Jobs Domain (ADR-022 Phase 1)
+
+The jobs subsystem is codegen-patterns' durable job orchestration system for generated NestJS + Drizzle apps. It models runs as first-class domain rows (queryable by scope, cancellable as trees, memoized per step) rather than hiding everything behind a narrow dispatch port. Phase 1 ships the Drizzle and Memory backends of `IJobOrchestrator`; later phases add signals, observability, and agent steps.
+
+**Authoritative sources (read when you need depth, not every time):**
+- `docs/adrs/ADR-022-job-orchestration-domain-model.md` — the decision record. Don't reproduce; link.
+- `docs/specs/JOB-1.md` … `JOB-8.md` — per-PR implementation specs (schema, protocols, backends, module, templates, scope flag, multi-tenancy).
+- `docs/specs/ADR-022-phase-1-issues.md` — issue breakdown + dependency graph.
+
+## Mental model
+
+### The triad
+
+Three Drizzle tables, one domain concept each. Do not add a fourth for "executor state" — there isn't one.
+
+| Table | Meaning | Lifetime |
+|---|---|---|
+| `job` | Row per registered handler type. Configuration materialised from decorator metadata at boot. | Long-lived; upserted on every boot via `ON CONFLICT DO UPDATE`. |
+| `job_run` | Row per execution. Durable state machine; queryable by scope; cancellable as a tree. | Permanent; archived by ops, not the framework. |
+| `job_step` | Row per checkpoint within a run. Powers memoization and granular retry. | Tied to parent run. |
+
+`parent_run_id` + `root_run_id` form the hierarchy. Runs without a parent set `root_run_id = id` at insert (client-generated UUID, no self-FK — see JOB-1).
+
+### Single-layer architecture (do not forget this)
+
+There is **no** `IJobQueue`, **no** `job_queue` table, **no** executor port. The worker polls `job_run` directly with `SELECT ... FOR UPDATE SKIP LOCKED`. One retry policy, one claim mechanism, one state location. If a historical reference ever says "enqueue on IJobQueue," it is from a deleted layer — ignore it and use `IJobOrchestrator.start(...)` instead.
+
+### Core contract + extensions
+
+Per CLAUDE.md, backends are core-contract + opt-in extensions. The core contract is `IJobOrchestrator` + `IJobRunService` + `IJobStepService`; app code against these three is portable. Extensions are backend-specific capabilities exposed additively in `codegen.config.yaml: jobs.extensions.<backend>`. Phase 1 ships:
+
+- **Drizzle backend** — core contract implemented. Extensions reserved: `listen_notify`, `poll_interval_ms`.
+- **Memory backend** — core contract for tests. No extensions.
+- **BullMQ backend** — **does not exist yet.** Reserved for Phase 6+. Do not document or pretend otherwise.
+
+When adding features, default to the core contract. Only push something into `extensions:` when it is genuinely backend-specific (e.g. Bull Board, `LISTEN/NOTIFY`).
+
+### Where code lives
+
+```
+runtime/subsystems/jobs/
+  job-orchestration.schema.ts        # JOB-1: job, job_run, job_step + enums + indexes
+  job-orchestrator.protocol.ts       # JOB-2: IJobOrchestrator
+  job-run-service.protocol.ts        # JOB-2: IJobRunService
+  job-step-service.protocol.ts       # JOB-2: IJobStepService
+  job-handler.base.ts                # JOB-2: JobHandlerBase, JobContext, @JobHandler, ParentClosePolicy
+  jobs-domain.tokens.ts              # JOB-2: JOB_ORCHESTRATOR / JOB_RUN_SERVICE / JOB_STEP_SERVICE
+  job-*.drizzle-backend.ts           # JOB-3: production backends + JobWorker
+  job-*.memory-backend.ts            # JOB-4: test backends
+  memory-job-store.ts                # JOB-4: shared in-memory store
+  jobs-domain.module.ts              # JOB-5: DynamicModule wiring tokens
+  job-worker.module.ts               # JOB-5: lifecycle, validator, registry scan
+  pool-config.loader.ts              # JOB-5: reads codegen.config.yaml: jobs.pools
+templates/subsystem/jobs/            # JOB-6: Hygen scaffold (worker.ts, main hook, config block)
+```
+
+User-authored handler classes live in the consumer app, typically under `src/jobs/` or colocated with their use case. **Jobs are TypeScript classes with `@JobHandler`. There is no jobs-as-YAML codegen — ADR-022 rejected it explicitly.**
+
+## Routing table (read only what your task needs)
+
+| Task | L1 file |
+|---|---|
+| Writing a `@JobHandler`, using `JobContext`, spawning children, memoizing work | [handler-authoring.md](./handler-authoring.md) |
+| Touching the orchestrator, worker loop, claim query, stale sweeper, graceful shutdown | [orchestrator-and-worker.md](./orchestrator-and-worker.md) |
+| Configuring pools, reading/writing `codegen.config.yaml: jobs.*`, adding custom pools, core/extension surface | [pools-and-config.md](./pools-and-config.md) |
+| Deciding what to build now vs. defer; what's Phase 1 vs. 2/3/5/6 | [phase-roadmap.md](./phase-roadmap.md) |
+
+Cross-domain: job-completion events and the events outbox drain into the three reserved `events_*` pools. See `../events/SKILL.md` (once it exists) or `runtime/subsystems/events/` for the producer side.
+
+## Non-obvious rules you MUST internalise
+
+### State machine values
+
+```
+pending → running → { completed | failed | timed_out | canceled }
+running ⇄ waiting   # schema column exists Phase 1, behaviour ships Phase 3 (ADR-025)
+```
+
+`jobRunStatusEnum` is exactly `['pending', 'running', 'waiting', 'completed', 'failed', 'timed_out', 'canceled']`. `waiting` MUST be present from Phase 1 so Phase 3 doesn't require a breaking migration. `scheduled` is not an enum value — "scheduled" means `status='pending' AND run_at > now()`, filtered at the claim query.
+
+### `parent_close_policy` semantics
+
+Stored on the **child** at spawn; later changes to the parent don't retroactively rewrite children.
+
+- `terminate` (default) — when parent enters any terminal state, running children are cancelled with `error.reason = 'parent_terminated'`.
+- `cancel` — same effect on children, but the parent's `finished_at` is set only after children finish transitioning.
+- `abandon` — children untouched; fire-and-forget.
+
+Cascade cancel walks via `root_run_id`, not recursive `parent_run_id` chases.
+
+### Reserved pools are off-limits to user handlers
+
+`events_inbound`, `events_change`, `events_outbound` are `reserved: true`. These exist for the `IEventBus` outbox drain, one pool per `DomainEvent.direction`. A user `@JobHandler({ pool: 'events_change' })` **must fail at module init** with `ReservedPoolViolationError` (JOB-5). Do not attempt to "just write to that queue" — use `IEventBus` from the events subsystem and let the bridge enqueue.
+
+Default user pool is `batch`. `interactive` must be opted in explicitly.
+
+### Concurrency collision modes
+
+Set once per job on `@JobHandler({ concurrency: { key, collisionMode } })`, not per call site.
+
+- `queue` (default) — new run accepted in `pending`; claimed only when incumbent exits non-terminal states.
+- `reject` — new enqueue throws `JobCollisionError` with the incumbent's runId.
+- `replace` — incumbent is cancelled cascade, new run starts. Matches "latest-wins" agent loops.
+
+Concurrency is **orthogonal to dedupe**. Dedupe short-circuits (returns incumbent's runId, no new row); concurrency queues (new row exists, claim is gated).
+
+### Replay modes
+
+`@JobHandler({ replayFrom })` — one of `scratch | last_step | last_checkpoint` (default `last_checkpoint`). Replay is a memoization policy only — same handler code runs all three times.
+
+- `scratch` — clear all `job_step` rows for the run, re-enter empty.
+- `last_step` — clear only the failing step's row.
+- `last_checkpoint` — clear nothing; memoized steps return cached `output`.
+
+### Step memoization contract
+
+`ctx.step(id, fn, opts?)` is the only primitive that knows about memoization.
+
+1. Look up `(job_run_id, step_id)` in `job_step`. If `status='completed'`, return `step.output` without calling `fn`.
+2. Otherwise record a `running` row, `await fn()`, upsert terminal status on success or failure. Rethrow on failure.
+
+Implications:
+- `step_id` must be **stable across replays**. Hardcode it (`'pull_emails'`) or derive from input (`\`recompute:\${ctx.input.accountId}\``) — never `Date.now()` or random.
+- `fn` should be effectively idempotent when `replayFrom='scratch'`.
+- Step output must be JSON-serialisable (it lives in `jsonb`).
+- Don't try to "step" around `spawnChild` — child runs are their own memoization root.
+
+### `JobContext` API surface — Phase 1 only
+
+```ts
+ctx.input    // typed via @JobHandler<TInput>
+ctx.run      // JobRun row (id, rootRunId, scope, tags, parentRunId, ...)
+ctx.step(id, fn, opts?)            // durable memoized step
+ctx.spawnChild(type, input, opts?) // returns child JobRun
+ctx.logger   // scoped NestJS Logger
+```
+
+**NOT in Phase 1, deferred to ADR-025:**
+- `ctx.waitFor(kind, token, opts)` — parking on signals
+- `ctx.signal(token, payload)` — resuming others
+- `ctx.sleep(ms)` — timer-driven wait
+
+The `wait_kind`, `resume_token`, `wait_deadline` columns and the `waiting` enum value exist in the Phase 1 schema as placeholders (JOB-1) but no code reads/writes them yet. Don't wire them up.
+
+### `scopeable: true` and `ScopeEntityType`
+
+Entity YAML opts in via `scopeable: true`. The codegen run emits `src/shared/jobs/scope-entity-type.ts` with a TS union of all flagged entity names. `@JobHandler` consumers reference it:
+
+```ts
+scope: { entity: 'account' satisfies ScopeEntityType, from: (i) => i.accountId }
+```
+
+DB column is plain `text` with no CHECK constraint — type safety is TS-only, on purpose (adding a new scopeable entity is code-gen only, no migration). See [handler-authoring.md](./handler-authoring.md) and `docs/specs/JOB-7.md`.
+
+## Do-not list
+
+- **Do not enqueue on `IJobQueue`.** It doesn't exist. Use `IJobOrchestrator.start(type, input, opts)`.
+- **Do not add a `job_queue` table or an executor port.** The prior two-layer design was collapsed intentionally; the single-layer claim query is the architecture.
+- **Do not write `// deprecated` or emit an upgrade command.** No users exist. Replace cleanly. See CLAUDE.md operating principles.
+- **Do not build a "uniform BullMQ/Drizzle interface that hides everything."** Core contract is the portability floor; backend extensions live under `codegen.config.yaml: jobs.extensions.<backend>`.
+- **Do not target a reserved pool** from a `@JobHandler`. Module init will throw.
+- **Do not use `Date.now()` or randomness for `step_id`.** Memoization requires stable ids.
+- **Do not invent jobs-as-YAML codegen.** ADR-022 explicitly rejected it. Users write TypeScript `@JobHandler` classes; codegen only ships the system around them.
+- **Do not call `ctx.waitFor` / `ctx.signal` / `ctx.sleep`.** Phase 3 only. If you need to pause work in Phase 1, split into parent + child runs and let `ctx.spawnChild` drive sequencing.
+- **Do not add a CHECK constraint to `scope_entity_type`.** Type safety lives at the TS layer; the column stays free-text so a new scopeable entity is codegen-only.
+- **Do not document a BullMQ backend.** It is Phase 6+ and does not exist. Mention it only as a reserved extension slot, never as available today.
+
+## Quick-start pointer
+
+For the "write a new `@JobHandler` from zero" path, jump to [handler-authoring.md](./handler-authoring.md). It walks through decorator metadata, `ctx.step` / `ctx.spawnChild`, scope wiring, and how a use case kicks the job off via the injected `IJobOrchestrator`.

--- a/.claude/skills/jobs/handler-authoring.md
+++ b/.claude/skills/jobs/handler-authoring.md
@@ -1,0 +1,209 @@
+# Handler Authoring
+
+How to write a `@JobHandler` class, use `JobContext` correctly, and plug the handler into a use case via the injected orchestrator. This is the surface most application code interacts with.
+
+Prerequisite reading: `SKILL.md` (same folder). Source of truth for shapes: `docs/specs/JOB-2.md` (protocol + decorator definitions) and `docs/adrs/ADR-022-job-orchestration-domain-model.md` §Handler API.
+
+## Minimal handler shape
+
+```ts
+import {
+  JobHandler,
+  JobHandlerBase,
+  JobContext,
+  ParentClosePolicy,
+} from '@shared/subsystems/jobs';
+import type { ScopeEntityType } from '@shared/jobs/scope-entity-type';
+
+interface OnboardingInput {
+  accountId: string;
+}
+
+interface OnboardingOutput {
+  emailCount: number;
+}
+
+@JobHandler<OnboardingInput>('onboarding', {
+  pool: 'batch',
+  scope: {
+    entity: 'account' satisfies ScopeEntityType,
+    from: (input) => input.accountId,
+  },
+  retry: { attempts: 3, backoff: 'exponential', baseMs: 1000 },
+  concurrency: {
+    key: (input) => `account:${input.accountId}`,
+    collisionMode: 'queue',
+  },
+  dedupe: {
+    key: (input) => `onboarding:${input.accountId}`,
+    windowMs: 24 * 60 * 60 * 1000,
+  },
+  timeoutMs: 60 * 60 * 1000,
+  replayFrom: 'last_checkpoint',
+})
+export class OnboardingHandler extends JobHandlerBase<OnboardingInput, OnboardingOutput> {
+  constructor(
+    private readonly emails: EmailService,
+    private readonly facts: FactService,
+  ) {
+    super();
+  }
+
+  async run(ctx: JobContext<OnboardingInput>): Promise<OnboardingOutput> {
+    const emails = await ctx.step('pull_emails', () =>
+      this.emails.pullForAccount(ctx.input.accountId),
+    );
+
+    await ctx.spawnChild(
+      'process_facts',
+      { emailIds: emails.map((e) => e.id) },
+      { closePolicy: ParentClosePolicy.Terminate },
+    );
+
+    return { emailCount: emails.length };
+  }
+}
+```
+
+The decorator registers the class into a module-local `JOB_HANDLER_REGISTRY` at class-evaluation time. `JobWorkerModule.onModuleInit` walks the registry to upsert `job` rows and validate reserved-pool assignment. For the handler to be visible at runtime it must be imported from somewhere reachable in the Nest module tree (standard provider wiring; no runtime container scan in Phase 1 — see `phase-roadmap.md`).
+
+## Decorator metadata reference
+
+All fields optional except `type` (the string positional arg). Defaults come from `FRAMEWORK_DEFAULTS` in `pool-config.loader.ts` or from the `job` table columns.
+
+| Field | Shape | Notes |
+|---|---|---|
+| `pool` | string | Default `'batch'`. Must not be `reserved: true` (`events_inbound`, `events_change`, `events_outbound`) — module init throws `ReservedPoolViolationError`. `interactive` is user-available but must be explicit. |
+| `scope` | `{ entity: TScope; from: (input) => string }` | `entity` should be `'<name>' satisfies ScopeEntityType`. `from` extracts the scoped entity's id from input at enqueue time. |
+| `retry` | `{ attempts, backoff: 'fixed' \| 'exponential', baseMs, nonRetryableErrors? }` | Run-level retry. Orthogonal to step-level retry (`ctx.step` opts). |
+| `concurrency` | `{ key: (input) => string; collisionMode: 'queue' \| 'reject' \| 'replace' }` | See `SKILL.md` for semantics. Evaluated at enqueue. |
+| `dedupe` | `{ key: (input) => string; windowMs: number }` | Collapses duplicate enqueues inside the window. Returns incumbent run id — no new row. |
+| `timeoutMs` | number | Hard wall-clock cap across all retries. Breach → `status='timed_out'`. |
+| `replayFrom` | `'scratch' \| 'last_step' \| 'last_checkpoint'` | Default `'last_checkpoint'`. Only affects behaviour on `replay(runId)`. |
+
+Constructor injection works like any Nest provider — no special setup. Declare the handler in `providers` (or an entity/feature module's providers) so Nest can resolve its deps.
+
+## Using `JobContext`
+
+`ctx.input` is typed via the decorator generic (`@JobHandler<OnboardingInput>`). No cast needed inside `run`.
+
+`ctx.run` is the current `JobRun` row: id, rootRunId, parentRunId, scope, tags, attempts, etc. Read-only from the handler's perspective.
+
+`ctx.logger` is a NestJS `Logger` scoped to the run — prefer it over `console.log` so logs carry run context.
+
+### `ctx.step(stepId, fn, opts?)` — memoised durable step
+
+Use for anything that is slow, side-effectful, or pays an external cost. The first successful run persists `output` to `job_step`; replays/retries return the cached value without calling `fn`.
+
+Rules:
+- `stepId` must be **stable across replays**. Hardcode for once-per-run work (`'pull_emails'`) or derive deterministically from input (`` `recompute:${ctx.input.accountId}` ``). Never `Date.now()`, never random, never a mutable counter.
+- `stepId` is unique per run (`(job_run_id, step_id)` unique index). Calling `ctx.step('x', …)` twice in a single run with the same id will hit the cached value the second time.
+- `fn` should return JSON-serialisable output — it's stored in a `jsonb` column.
+- Design `fn` to be effectively idempotent: under `replayFrom='scratch'` it will be called again after a replay.
+- Errors inside `fn` mark the step `failed` and rethrow. If the run has retries remaining, the whole run re-enters as `pending`; on next tick, completed siblings remain memoised and this step retries.
+
+Step-level retry (opt):
+
+```ts
+await ctx.step('fetch_profile', () => api.get(...), {
+  retry: { attempts: 2, backoff: 'fixed', baseMs: 500 },
+  timeoutMs: 30_000,
+});
+```
+
+Step retry wraps the step call only; it does not re-run the whole handler.
+
+### `ctx.spawnChild(type, input, opts?)` — launch a child run
+
+```ts
+const child = await ctx.spawnChild(
+  'process_facts',
+  { emailIds },
+  {
+    closePolicy: ParentClosePolicy.Terminate, // default; children die if parent does
+    runAt: new Date(Date.now() + 5_000),      // optional delay
+    priority: 10,
+    tags: { triggeredBy: 'onboarding' },
+  },
+);
+```
+
+- `parent_run_id` and `root_run_id` are wired automatically.
+- `closePolicy` is recorded on the child at spawn time; later parent mutation does not retroactively change it.
+- Do not use `ctx.step` to wrap `ctx.spawnChild` — the child run is its own memoisation root. Spawning is already idempotent within a handler invocation via the orchestrator's enqueue path (use `dedupe` on the child job type if you need cross-invocation idempotency).
+- `spawnChild` returns the `JobRun` row. For Phase 1 there is no built-in "await child completion" primitive — if you need sequencing, split the parent's logic across runs: parent spawns child with its own `scope`, completes immediately; a follow-up handler watches for child completion via `listForScope` (or waits for Phase 3 `ctx.waitFor`, see `phase-roadmap.md`).
+
+### What's NOT on `ctx` in Phase 1
+
+`ctx.waitFor`, `ctx.signal`, `ctx.sleep` — these land in Phase 3 (ADR-025). The `waiting` status, `wait_kind`, `resume_token`, and `wait_deadline` schema fields exist from Phase 1 as placeholders; the protocol file has an explicit comment listing them as deferred. Do not call, reference, or simulate them. If you need a delay, use `spawnChild(..., { runAt })`. If you need external coordination, split into parent + child runs and let a later tick pick up the next step.
+
+## Plugging into a use case
+
+Use cases kick off runs through the injected orchestrator token:
+
+```ts
+import { Inject, Injectable } from '@nestjs/common';
+import { JOB_ORCHESTRATOR, type IJobOrchestrator } from '@shared/subsystems/jobs';
+
+@Injectable()
+export class StartOnboardingUseCase {
+  constructor(
+    @Inject(JOB_ORCHESTRATOR) private readonly jobs: IJobOrchestrator,
+  ) {}
+
+  async execute(accountId: string) {
+    return this.jobs.start(
+      'onboarding',
+      { accountId },
+      {
+        scope: { entityType: 'account', entityId: accountId },
+        triggerSource: 'manual',
+        tags: { source: 'admin-ui' },
+      },
+    );
+  }
+}
+```
+
+Notes:
+- `start` returns the inserted `JobRun` immediately; the worker picks it up on its next poll.
+- Dedupe: if `@JobHandler.dedupe` matches an in-window prior run, `start` returns the existing run id — the caller gets idempotency for free.
+- Concurrency collision: `collisionMode: 'reject'` surfaces `JobCollisionError` synchronously; catch and handle in the use case.
+- Prefer passing `triggerSource: 'manual' | 'schedule' | 'event' | 'parent'` so the `trigger_source` column is accurate for observability.
+
+## Scope queries (managing runs by domain entity)
+
+`IJobRunService` answers "everything for this account" questions:
+
+```ts
+@Inject(JOB_RUN_SERVICE) private readonly runs: IJobRunService;
+
+await this.runs.listForScope('account', accountId, { status: 'running' });
+await this.runs.cancelForScope('account', accountId);      // cascades per close policy
+await this.runs.rescheduleForScope('account', accountId, tomorrow);
+```
+
+`entityType` is a string at the DB layer; type safety comes from `satisfies ScopeEntityType` on the caller side.
+
+## Testing a handler
+
+`@JobHandler`-decorated classes work inside `Test.createTestingModule` with `JobsDomainModule.forRoot({ backend: 'memory' })`. The memory backend is behaviour-parity with Drizzle for all Phase 1 scenarios (claim order, collision modes, step memoization, cascade cancel, dedupe, replay). See `docs/specs/JOB-4.md` §"Unit Test Suite Design" for the canonical patterns, and `runtime/subsystems/jobs/__tests__/job-worker.unit.test.ts` (added by JOB-4) for the two-tick memoization proof.
+
+Quick recipe:
+1. `Test.createTestingModule({ imports: [JobsDomainModule.forRoot({ backend: 'memory' })], providers: [YourHandler, ...deps] }).compile()`.
+2. Manually register via `MemoryJobOrchestrator.registerHandler` if your test bypasses `JobWorkerModule` — otherwise import `JobWorkerModule.forRoot({ mode: 'embedded', backend: 'memory' })` and let the normal init path register.
+3. Call `orchestrator.start('type', input)`; spin a few ticks; inspect `store.runs` + `store.steps`.
+
+## Common handler shapes
+
+- **Fan-out** — parent `ctx.step`s to load a batch, then `ctx.spawnChild` per item with `closePolicy: Terminate`. Cancel the parent → children die.
+- **Sequenced pipeline** — either chain `ctx.step` calls inside one handler (simpler) or split into dedicated handler types and `spawnChild` with `parentClosePolicy: Abandon` so each hop is independently queryable and retryable.
+- **Latest-wins agent loop** — `concurrency.collisionMode: 'replace'` serialises by `accountId` but cancels the incumbent when a newer trigger arrives.
+- **Webhook ingestion** — `dedupe.key: (input) => input.externalId` collapses replays within the window without any app-level idempotency table.
+- **Long batch with safe resume** — `replayFrom: 'last_checkpoint'` (default) + `ctx.step` per work unit → crash recovery is free, only unfinished work repeats.
+
+## When NOT to use a handler
+
+- **Synchronous request/response** — if the caller is waiting on the result, you probably want a use case, not a job. Jobs are durable because they're asynchronous.
+- **Every emission of a domain event** — those flow through `IEventBus`, not a direct `@JobHandler`. The events subsystem drains them into the reserved `events_*` pools via the bridge (Phase 2 / ADR-023).
+- **Per-request rate limiting** — the framework has no built-in request rate-limit primitive. If you need it, it's a BullMQ extension (Phase 6+), not a core contract feature.

--- a/.claude/skills/jobs/orchestrator-and-worker.md
+++ b/.claude/skills/jobs/orchestrator-and-worker.md
@@ -1,0 +1,237 @@
+# Orchestrator and Worker
+
+Internals of the Drizzle backend, the worker loop, and the lifecycle hooks. Read this when you're changing how runs are claimed, how steps are recorded, how cascade cancel propagates, how shutdown drains, or how the stale-claim sweeper works.
+
+Source of truth: `docs/specs/JOB-3.md` (Drizzle backends + `JobWorker`) and `docs/specs/JOB-4.md` (Memory backends — behaviour-parity contract).
+
+## Layer diagram
+
+```
+Consumer use case
+     │  @Inject(JOB_ORCHESTRATOR)
+     ▼
+IJobOrchestrator.start(type, input, opts)
+     │   dedupe check → collision check → INSERT job_run
+     │   NO tick enqueued — worker polls directly
+     ▼
+JobWorker (one per active pool)
+     │   setInterval → claimNext(pool) → processRun(claimed) → loop
+     ▼
+handler.run(ctx) with memoised ctx.step
+     │   UPDATE job_run SET status = …, output = … (or re-enter pending on retry)
+     ▼
+(Phase 4+) JobEventLogger → IEventBus selective broadcast
+```
+
+No transient ticks, no secondary transport table. `job_run` is the only claim source.
+
+## Protocol surface (recap from JOB-2)
+
+Three injectable protocols, three Symbol tokens:
+
+- `JOB_ORCHESTRATOR` → `IJobOrchestrator` — `start` / `cancel` / `replay`.
+- `JOB_RUN_SERVICE` → `IJobRunService` — `listForScope` / `cancelForScope` / `rescheduleForScope`.
+- `JOB_STEP_SERVICE` → `IJobStepService` — `recordStep` / `findStep`.
+
+`JobWorker` is not a protocol — it's a concrete Nest provider wired by `JobWorkerModule`. It consumes all three protocol tokens plus the pool config.
+
+## `start(type, input, opts)` — the enqueue path
+
+Order of operations (JOB-3 §1a–1e):
+
+1. Load `job` row by `type`. Missing → `JobTypeNotFoundError`.
+2. **Dedupe check.** If the job declares `dedupe_key_template`, evaluate it. Query `job_run` where `(job_type, dedupe_key)` match AND `created_at > now() - dedupe_window_ms` AND `status NOT IN ('canceled', 'failed')`. If a row exists, return it — no INSERT.
+3. **Concurrency check.** If `concurrency_key_template` set, query non-terminal runs with that key. Branch on `collision_mode`:
+   - `reject` — throw `JobCollisionError` with incumbent runId.
+   - `replace` — call `this.cancel(incumbent.id, { cascade: true, reason: 'replaced' })` and proceed.
+   - `queue` — proceed. No separate "queued" flag; the claim query naturally skips this row until the incumbent exits non-terminal (see `processRun` §concurrency gating below).
+4. **Generate id client-side** via `randomUUID()`. Resolve `rootRunId`: if `opts.parentRunId` present, load parent's `root_run_id`; otherwise use the new `id` (self-reference). Both go into a single INSERT — no nullable, no self-FK race.
+5. Return the inserted `JobRun`. Worker discovers it on next poll.
+
+Key property: `start` is **one transaction-less INSERT** (dedupe/collision checks are reads; the INSERT is a single statement). No tick enqueue, no secondary writes.
+
+## `cancel(runId, opts?)` — cascade mechanics
+
+From JOB-3 §1:
+
+1. Load target. If terminal, return (idempotent).
+2. Atomic transition: `UPDATE ... WHERE id = $runId AND status NOT IN (terminal_statuses)` with `RETURNING`. If no row returned, the run was already terminal — return idempotently.
+3. If `opts.cascade !== false` (default is to cascade from root cancellations), fetch descendants: `WHERE root_run_id = $rootRunId AND id != $runId AND status NOT IN (terminals)`. For each, branch on `parent_close_policy`:
+   - `terminate` or `cancel` → transition descendant to `canceled`.
+   - `abandon` → skip.
+
+Note the per-row update is **self-protecting**: each `UPDATE ... WHERE status NOT IN (terminals)` is atomic. No outer transaction required.
+
+`cancel` does **not** walk `parent_run_id` chains — it uses `root_run_id` to fetch the whole tree in one query. `idx_job_run_root` exists for this.
+
+## Worker loop (`job-worker.ts`)
+
+`JobWorker` is `@Injectable()`. One instance per active pool. Holds:
+- `pool: PoolDefinition`
+- `orchestrator`, `runService`, `stepService` (from DI)
+- `inFlight: Set<Promise<void>>` — tracks active `processRun` calls for shutdown drain
+- `shuttingDown: boolean`
+
+### `onModuleInit`
+
+1. `setInterval(() => void this.pollAndProcess(), opts.pollIntervalMs ?? 1000)`.
+2. `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs ?? 60_000)`.
+3. Register SIGTERM handler → `this.gracefulStop(...)`.
+
+`pollAndProcess()`:
+- If `shuttingDown` or `inFlight.size >= pool.concurrency`, return immediately.
+- `const claimed = await this.claimNext(pool.queue)`. If `null`, return.
+- Wrap `processRun(claimed)` in a promise, add to `inFlight`, remove in `.finally`.
+
+### The claim query
+
+The canonical form (JOB-3 §4 and ADR-022 §"Claim query"):
+
+```ts
+return db.transaction(async (tx) => {
+  const [candidate] = await tx
+    .select({ id: jobRuns.id })
+    .from(jobRuns)
+    .where(and(
+      eq(jobRuns.status, 'pending'),
+      eq(jobRuns.pool, pool),
+      lte(jobRuns.runAt, new Date()),
+    ))
+    .orderBy(desc(jobRuns.priority), asc(jobRuns.runAt))
+    .limit(1)
+    .for('update', { skipLocked: true });
+
+  if (!candidate) return null;
+
+  const [claimed] = await tx
+    .update(jobRuns)
+    .set({ status: 'running', claimedAt: new Date(), startedAt: new Date() })
+    .where(eq(jobRuns.id, candidate.id))
+    .returning();
+
+  return claimed;
+});
+```
+
+Properties to preserve when editing:
+- **`FOR UPDATE SKIP LOCKED`** is non-negotiable. It's how multiple workers share the table without serialising on locks.
+- Two statements inside **one transaction**. Two statements without a tx would race: another worker could claim the same row between select and update.
+- `ORDER BY priority DESC, run_at ASC` — priority first, earliest-first as tiebreak. Matches ADR-022 invariant.
+- `lte(runAt, now())` — rows with `run_at > now()` are treated as scheduled-for-later and not eligible yet.
+- Index `idx_job_run_claim` on `(status, pool, run_at)` must cover this query. If you change the WHERE, re-audit the index.
+
+### `processRun(claimed)` — the execution hot path
+
+1. Resolve handler class from `JOB_HANDLER_REGISTRY`. Missing → transition run to `failed` (defensive — JOB-5 boot validator should have caught this).
+2. **Concurrency queue gate.** If `claimed.concurrency_key` is non-null and another run with the same key is currently `running`, transition this row back to `pending` (release the claim, clear `claimed_at`) and return. Next poll reconsiders after the incumbent transitions.
+3. Build `JobContext`:
+   - `ctx.input = claimed.input`
+   - `ctx.run = claimed`
+   - `ctx.step = makeStepFn(claimed)` (see below)
+   - `ctx.spawnChild = makeSpawnFn(claimed)` (wraps `orchestrator.start` with `parentRunId` + inherited `rootRunId`)
+   - `ctx.logger = new Logger(`JobRun:${claimed.id}`)`
+4. `await handler.run(ctx)`. Capture `output`.
+5. Success: `UPDATE job_run SET status='completed', output=$output, finished_at=now()`.
+6. Error path:
+   - Increment `attempts`.
+   - Check `retry_policy.nonRetryableErrors` (matches on error class name or `.code`).
+   - If retryable and `attempts < retry_policy.attempts`: set `status='pending'`, `run_at = now() + backoff_delay(attempts)`. Next poll picks it up after delay.
+   - If exhausted: `status='failed'`, `error = serialised`. Apply parent-close-policy cascade (if this run has a parent whose policy is `terminate`, cascade).
+7. Remove from `inFlight` in `finally`.
+
+### `makeStepFn(run)` — the memoization primitive
+
+```
+fn(stepId, fn, opts?) {
+  const existing = await stepService.findStep(run.id, stepId);
+  if (existing?.status === 'completed') return existing.output;   // cache hit
+
+  await stepService.recordStep({ runId: run.id, stepId, status: 'running', ... });
+  try {
+    const output = await fn();
+    await stepService.recordStep({ runId: run.id, stepId, status: 'completed', output, ... });
+    return output;
+  } catch (err) {
+    await stepService.recordStep({ runId: run.id, stepId, status: 'failed', error: serialise(err), ... });
+    throw err;
+  }
+}
+```
+
+`recordStep` is an upsert on the `(job_run_id, step_id)` unique index — the same row is written as `running` first, then transitioned. This is intentional conflict-update behaviour; don't replace it with insert-then-update without re-auditing memoization parity across Drizzle + Memory.
+
+`findStep` returns only `completed` rows for the memoization cache (see JOB-4 §2). A step row with `status='running'` or `status='failed'` is *not* a cache hit — the handler re-runs it.
+
+## Replay modes
+
+`replay(runId)` (JOB-3 §1 equivalent, detailed in JOB-4 §4):
+
+1. Load run; assert it's in a terminal state.
+2. Read `job.replay_from`.
+3. Branch:
+   - `scratch` — delete (or archive) all `job_step` rows for this run. Next tick re-enters with empty step table.
+   - `last_step` — find the failing step; clear its row only. Completed steps remain memoised.
+   - `last_checkpoint` (default) — no step modification.
+4. Reset run fields: `status='pending'`, `attempts++`, clear `started_at` / `finished_at` / `error`. Leave `run_at` unchanged (or advance if the caller wants).
+
+**Step-clearing must be atomic with the run status reset.** See JOB-3 transaction-boundary table: replay memoization reset needs a transaction.
+
+## Stale-claim sweeper
+
+Crashed workers strand their `claimed_at` rows. Each `JobWorker` runs an interval:
+
+```sql
+UPDATE job_run
+SET status='pending', claimed_at=null
+WHERE status='running' AND claimed_at < now() - $staleThresholdMs
+RETURNING id;
+```
+
+Each `UPDATE` is atomic, and the `WHERE claimed_at < threshold` clause prevents double-recovery — once a row resets to `pending`, it no longer matches. Multiple workers running their own sweeper is safe (per JOB-3 OQ-2 resolution). No leader election needed.
+
+Invariant: **`staleThresholdMs >= 2 * max_handler_duration`.** Otherwise live work gets "recovered" mid-flight and runs twice. If your handler can legitimately run for hours, raise the threshold accordingly or split the work.
+
+`attempts` is **not** incremented by stale recovery — memoization is what protects already-completed steps. Treat sweep as "release the claim," not "count a failure."
+
+## Graceful shutdown
+
+`onModuleDestroy` / SIGTERM path:
+
+1. `shuttingDown = true` — `pollAndProcess` short-circuits.
+2. `await Promise.allSettled(inFlight)` bounded by `shutdownTimeoutMs` (default `30_000`).
+3. For any run still `running` past the timeout: `UPDATE job_run SET status='pending', claimed_at=null`. Next worker reclaims and benefits from step memoization.
+4. Clear both intervals (poll + sweep). Exit.
+
+Do not try to "finish the current step" during shutdown — `ctx.step`'s memoization is what makes aborting safe. Completed steps persist; an incomplete step's `running` row won't cache-hit on resume, so `fn` reruns.
+
+## Transaction boundaries (JOB-3 reference)
+
+| Operation | Tx? | Why |
+|---|---|---|
+| `claimNext` | Yes | Two statements must be atomic. |
+| `cancel` cascade | No | Per-row UPDATEs are self-protecting. |
+| `replay` memoization reset | Yes | Step clear + status reset must be atomic. |
+| `start` (single INSERT) | No | Single statement; poll finds the row. |
+| `recordStep` upsert | No | Unique-index upsert is atomic at DB. |
+| `findStep` | No | Read-only. |
+| `rescheduleForScope` | No | Bulk UPDATE is atomic. |
+
+When in doubt: if you can write the thing in one SQL statement and it's the only thing happening, no tx. If you have a read followed by a dependent write (or two dependent writes), tx.
+
+## Memory-backend parity
+
+`MemoryJobOrchestrator` uses a `PromiseMutex` (single-promise chain) to serialise mutating ops. Parity contract is in JOB-4 — claim ordering, dedupe, collision, memoization, cascade, replay must behave identically. Acceptable divergence: fsync/crash-recovery, index-scan perf, SKIP-LOCKED semantics (memory is single-process by definition), stale-claim sweeper (Drizzle-only; tested in integration only).
+
+If you add behaviour to the Drizzle backend, add the mirror in memory **and** update `JOB-4.md` §"Behavioural Parity Contract".
+
+## Error classification
+
+From JOB-3 §"Error Handling Strategy":
+
+- **Non-retryable / exhausted** → `job_run.error = { message, stack, retryable, attempt, code? }`, `status='failed'`, cascade fires if policy is `terminate`.
+- **Retryable, remaining attempts** → error written, `status='pending'`, `run_at = now() + backoff`.
+- **No handler** → `status='failed'` (defensive; validator should have caught at boot).
+- **Stale** → sweeper resets to `pending`; no attempts increment.
+- **Cancel on terminal** → no-op (idempotent).
+
+`retry_policy.nonRetryableErrors` is an array of error class names or `.code` strings. Match at error-capture time; if any match, skip the retry branch and go straight to `failed`.

--- a/.claude/skills/jobs/phase-roadmap.md
+++ b/.claude/skills/jobs/phase-roadmap.md
@@ -1,0 +1,101 @@
+# Phase Roadmap
+
+What's shipping in Phase 1, what's deferred, and what you must NOT build yet. Read this when a requirement sounds like it belongs to the jobs subsystem but isn't covered by `JOB-1..JOB-8` — it's probably Phase 2+ and the answer is "defer, or use the escape hatch listed below."
+
+Source of truth: `docs/adrs/ADR-022-job-orchestration-domain-model.md` §"Phase roadmap", plus the ADR-022 siblings listed there (ADR-023 / 025 / 026 / 027).
+
+## Phase 1 — Domain foundation (the current scope)
+
+Delivered by `JOB-1` through `JOB-8`:
+
+- Drizzle schemas: `job`, `job_run`, `job_step` (all indexes, all enums, Phase 3 placeholder columns in place).
+- Protocols: `IJobOrchestrator`, `IJobRunService`, `IJobStepService`.
+- Backends: Drizzle (production) + Memory (tests).
+- Base types: `JobHandlerBase`, `JobContext`, `@JobHandler`, `ParentClosePolicy`.
+- NestJS modules: `JobsDomainModule.forRoot()`, `JobWorkerModule.forRoot()`.
+- Worker entrypoints: embedded hook in `main.ts` + standalone `worker.ts`.
+- Pool config loader (five framework defaults + user pools).
+- Boot-time registry validator (Drizzle mode).
+- `scopeable: true` entity flag → generated `ScopeEntityType` TS union.
+- Multi-tenancy opt-in via `jobs.multi_tenant: true`.
+- Atlas migration docs section in `docs/CONSUMER-SETUP.md`.
+
+Nothing else in the jobs domain is Phase 1.
+
+## Phase 2 — Event-to-Job Bridge (ADR-023)
+
+Not in Phase 1. Adds:
+- `IJobBridge` protocol.
+- `job_trigger`, `bridge_delivery` tables.
+- Cron scheduler loop.
+- Event-bus subscriber that matches triggers and enqueues runs.
+
+Depends on the events subsystem's typed-event codegen work (see `../events/SKILL.md`). Until the bridge lands, trigger jobs from use cases, not directly from domain events.
+
+## Phase 3 — Coordination / signals (ADR-025)
+
+Adds `ctx.waitFor(kind, token, opts)`, `ctx.signal(token, payload)`, `ctx.sleep(ms)`. Also:
+- Timer-based auto-resume via scheduler.
+- External webhook endpoint for `resume_token` resolution.
+- Meaning for the `waiting` status and `wait_kind` / `resume_token` / `wait_deadline` columns (which already exist in schema from Phase 1).
+
+**What to do instead in Phase 1:**
+- For a delay → `ctx.spawnChild(type, input, { runAt: future })` or `@JobHandler({ retry, concurrency, … })` to shape timing declaratively.
+- For external coordination → split the workflow into parent + child handlers so each external wait is a run boundary. Subsequent triggers from webhooks or timers enqueue a follow-up handler via `IJobOrchestrator.start`.
+
+Do NOT simulate signals by polling a table or using Redis keys directly — that's the exact hack ADR-022 rejected. Wait for Phase 3 or restructure the workflow.
+
+## Phase 4 — Observability (ADR-026)
+
+Adds:
+- `job_event` audit table.
+- `JobEventLogger` service.
+- Selective `IEventBus` broadcast rules for lifecycle events.
+- Query APIs for timeline and recent-failures views.
+
+In Phase 1, observability is limited to `ctx.logger` output plus reading `job_run` / `job_step` rows directly.
+
+## Phase 5 — Agent step extensions (ADR-027)
+
+Extends `job_step.kind` enum from `'task'` (Phase 1) to include `tool_call | llm_call | wait | checkpoint | message`. Adds:
+- Cost JSONB.
+- Thread binding on `JobRun`.
+- Helper methods `ctx.recordToolCall()`, `ctx.recordLLMCall()`.
+
+For Phase 1 LLM/agent work, use plain `ctx.step` with `kind='task'`. Record cost in the step's `output` jsonb as needed. Don't try to extend the enum yet — it requires an Atlas migration on every consumer.
+
+## Phase 6 — Polish
+
+- Optional `job_artifact` table for oversized outputs (soft-limit warning at 100KB in Phase 1; hard storage comes later).
+- Admin CLI: `bun codegen jobs runs <id>`, `jobs cancel <id>`, `jobs replay <id>`.
+- Runtime-discovery registry option (`JobWorkerModule.forRoot({ discovery: 'runtime' })`).
+- Tenant-aware fair queuing.
+- BullMQ orchestrator backend (maps `JobRun → BullMQ Job`, `parent_run_id → FlowProducer`, etc.; exposes Bull Board mounting as an extension).
+
+## Explicit "do not build this yet" list
+
+Work items that look adjacent but are out of scope:
+
+| Thing | Reason it's out of scope | What to do instead |
+|---|---|---|
+| `IJobQueue` / `job_queue` table / executor port | Deleted in JOB-1 (architectural collapse). | Use `IJobOrchestrator`. Worker polls `job_run` directly. |
+| `ctx.waitFor` / `ctx.signal` / `ctx.sleep` | Phase 3 (ADR-025). | Split into parent+child or use `runAt` delays. |
+| BullMQ backend | Phase 6+. Reserved slot only. | Use Drizzle backend. |
+| Event-to-Job bridge | Phase 2 (ADR-023). | Enqueue from use cases for now. |
+| Agent step kinds (`tool_call`, `llm_call`, …) | Phase 5 (ADR-027). | Use `kind='task'` + cost in `output`. |
+| `job_event` audit table | Phase 4 (ADR-026). | Read `job_run` + `job_step`; use `ctx.logger`. |
+| Jobs-as-YAML codegen / typed `Jobs` facade | Rejected in ADR-022 (see §"Codegen scope"). | Users write TypeScript `@JobHandler` classes. |
+| Runtime DI container scan for handlers | Phase 6+. | Import handlers from a reachable module; boot validator catches drift. |
+| Admin CLI (`jobs runs`, `jobs cancel`, `jobs replay`) | Phase 6. | Scripts / direct DB queries if you need ops for now. |
+| BullMQ queue prefix config | Noted as open question in ADR-022 §"Open implementation questions #2". | Not blocking until BullMQ backend exists. |
+| Tenant-aware fair queuing | Phase 6. | Phase 1 is FIFO within pool. |
+
+## Signalling "this is deferred" in code
+
+When you add a new feature that touches the jobs subsystem, and you hit a boundary that needs Phase 2+:
+
+1. Don't invent a workaround in `runtime/subsystems/jobs/`. That's how the old `IJobQueue` tech debt happened.
+2. Write the Phase-1-compatible shape (e.g. parent+child runs, `runAt` delays).
+3. Leave a `// TODO(ADR-025)` (or `025`, `026`, `027`) comment at the call site so the future phase work can grep it.
+
+If the requirement genuinely can't wait, escalate — draft a new spec against the relevant future-phase ADR rather than sneaking the feature into Phase 1.

--- a/.claude/skills/jobs/pools-and-config.md
+++ b/.claude/skills/jobs/pools-and-config.md
@@ -1,0 +1,215 @@
+# Pools and Configuration
+
+How pools work, what lives in `codegen.config.yaml: jobs.*`, how the core/extension surface maps to backend-specific features, and how to add a new pool. Touch this file when you're editing the config schema, the pool loader, or the framework defaults.
+
+Source of truth: `docs/specs/JOB-5.md` (module + pool loader), `docs/specs/JOB-6.md` (scaffold template that emits the config block), ADR-022 §"Pools" and §"Event lanes".
+
+## What a pool is
+
+A pool is a logical lane. Each pool maps to:
+- A distinct `queue` identifier (written into `job_run.pool`).
+- One `JobWorker` instance per active pool per process.
+- A `concurrency` cap — max in-flight runs per worker process.
+
+**Pools are absolute lanes.** A high-priority `batch` run does not preempt `interactive`. If you want preemption, make a dedicated pool. This invariant exists because priority is a weaker isolation guarantee than separate claim queues — priority-based schedulers can starve; lane-based schedulers cannot.
+
+## Framework defaults (five pools)
+
+From `pool-config.loader.ts` (JOB-5 §1):
+
+| Pool | queue | concurrency | reserved | Purpose |
+|---|---|---|---|---|
+| `events_inbound` | `jobs-events-inbound` | 20 | **yes** | External → us. Webhook receivers, pub/sub consumers, inbound email ingest. |
+| `events_change` | `jobs-events-change` | 30 | **yes** | Internal domain mutations → projections. Drives downstream materialisation. |
+| `events_outbound` | `jobs-events-outbound` | 10 | **yes** | Us → external. Outbound webhooks, notifications, publishes. |
+| `interactive` | `jobs-interactive` | 20 | no | User is waiting. Exports, renders, ad-hoc one-off work. |
+| `batch` | `jobs-batch` | 5 | no | Background. Onboarding, batch ingest, agent runs. **Default for user `@JobHandler`s.** |
+
+Concurrency values ship as defaults; consumers may override non-reserved pools' `concurrency` (and `description`) in config.
+
+## Reserved pools are off-limits to user handlers
+
+The three `events_*` pools exist to carry the `IEventBus` outbox drain, routed by `DomainEvent.direction` (`inbound | change | outbound`). They are `reserved: true`. User code targeting them must fail loudly at module init:
+
+- A `@JobHandler({ pool: 'events_change' })` triggers `ReservedPoolViolationError` during `JobWorkerModule.onModuleInit`. Error lists the offending class names.
+- The loader silently preserves `reserved: true` on framework pools even if the user tries to flip it in config.
+- User-defined pools cannot set `reserved: true` — reserved is framework-only.
+
+If a user task genuinely needs to participate in the event stream, it goes through the `IEventBus` + Phase 2 bridge (ADR-023), not directly as a handler on `events_*`. See `../events/SKILL.md`.
+
+## The `jobs:` config block
+
+Emitted by `just gen-subsystem jobs` (JOB-6's `codegen-config-jobs-block.ejs.t`). Canonical shape:
+
+```yaml
+jobs:
+  # ── Backend selection (core/extension model — see CLAUDE.md) ──
+  backend: drizzle
+
+  # ── Backend-specific extensions (typed per backend) ──
+  extensions:
+    drizzle:
+      # listen_notify: true          # Phase 6+: use Postgres LISTEN/NOTIFY to wake the loop
+      poll_interval_ms: 1000
+    # bullmq:                        # Reserved slot — backend not yet implemented
+    #   bull_board:
+    #     enabled: true
+    #     mount_path: /admin/queues
+    #   redis_url: redis://...
+
+  # ── Multi-tenancy (JOB-8) ──
+  multi_tenant: false                # true → service layer enforces tenantId
+
+  # ── Worker topology ──
+  worker_mode: embedded              # embedded | standalone
+
+  # ── Pools ──
+  pools:
+    events_inbound:
+      queue: jobs-events-inbound
+      concurrency: 20
+      reserved: true
+    events_change:
+      queue: jobs-events-change
+      concurrency: 30
+      reserved: true
+    events_outbound:
+      queue: jobs-events-outbound
+      concurrency: 10
+      reserved: true
+    interactive:
+      queue: jobs-interactive
+      concurrency: 20
+    batch:
+      queue: jobs-batch
+      concurrency: 5
+```
+
+Field semantics:
+
+| Key | Who reads it | Notes |
+|---|---|---|
+| `backend` | `JobsDomainModule.forRoot` | `'drizzle'` or `'memory'`. BullMQ is a reserved slot only. |
+| `extensions.<backend>.*` | Backend class during init | Each backend reads only its own key. Unknown keys for the active backend warn, don't error (core/extension principle — swap is non-destructive). |
+| `multi_tenant` | `JobsDomainModule.forRoot` | Threads `JOBS_MULTI_TENANT` token through. Default `false`. When `true`, service methods require `tenantId` (see JOB-8). |
+| `worker_mode` | Informational + scaffold hint | `embedded` means `JobWorkerModule` imported by `AppModule`; `standalone` means run `worker.ts` separately. Switching does not change generated code — both entrypoints are always emitted. |
+| `pools.<name>.queue` | `JobWorker` | Identifier written into `job_run.pool`. Must be unique across pools. |
+| `pools.<name>.concurrency` | `JobWorker` | Per-process max in-flight. Horizontal scale multiplies. |
+| `pools.<name>.reserved` | `PoolConfigLoader` | Framework-only. User configs cannot enable. Framework pools cannot have it disabled. |
+
+## Core contract vs. extensions — the rule
+
+From CLAUDE.md:
+- **Core contract** — every backend MUST implement. App code written against `IJobOrchestrator` + `IJobRunService` + `IJobStepService` is portable across backends.
+- **Extensions** — optional, backend-specific. Live under `extensions.<backend>`.
+
+When adding a feature, ask: "Is this something every future backend can reasonably implement?"
+- Yes → put it on the core protocol (edit `job-orchestrator.protocol.ts`, thread through all backends).
+- No → it's an extension. Add it to `JobsDomainModuleOptions.extensions.<backend>`, wire only the matching backend, document that consumers opting in accept non-portable code paths.
+
+Examples of extension-shaped features (NOT core):
+- **Bull Board** (BullMQ-only admin UI) → `extensions.bullmq.bullBoard`. Phase 6+.
+- **`LISTEN/NOTIFY` wake-up** (Postgres-only) → `extensions.drizzle.listenNotify`. Drizzle only.
+- **Native rate limiters** (BullMQ queue options) → extensions.
+
+Examples of core-shaped features (NOT extensions):
+- Retry, dedupe, concurrency collision, cascade cancel, step memoization, scope queries. These are modeled on the domain side and therefore backend-agnostic.
+
+## Adding a custom pool
+
+Pure config change. To add an `agents` pool for long-running LLM work:
+
+```yaml
+jobs:
+  pools:
+    # … framework defaults preserved automatically …
+    agents:
+      queue: jobs-agents
+      concurrency: 3
+      description: "Long-running LLM/agent work"
+```
+
+Then any `@JobHandler({ pool: 'agents', … })` targets it. No code changes required. `JobWorkerModule` discovers the pool at boot, spins up a `JobWorker(pool='agents')`, starts its claim loop.
+
+If you want to restrict which pools a process services (useful for heterogeneous deploys), pass `opts.pools`:
+
+```ts
+JobWorkerModule.forRoot({ mode: 'standalone', pools: ['batch', 'agents'] })
+```
+
+Pools omitted from the list are not claimed by this process.
+
+## Pool config loader rules (JOB-5 §1)
+
+- Reads `${process.cwd()}/codegen.config.yaml` (or `configPath` argument in tests).
+- Always merges `FRAMEWORK_POOLS` first, then user-defined pools.
+- Users may override `concurrency` and `description` on non-reserved defaults.
+- Users cannot set `reserved: true` on their own pools.
+- Users cannot flip `reserved: true` → `false` on framework pools.
+- Cached in module scope after first call.
+
+## `JobsDomainModule.forRoot` — options shape
+
+From JOB-5 §3:
+
+```ts
+interface JobsDomainModuleOptions {
+  backend: 'drizzle' | 'memory';
+  extensions?: {
+    drizzle?: {
+      listenNotify?: boolean;
+      pollIntervalMs?: number;
+    };
+    // bullmq?: ...  // Phase 6+
+  };
+  multiTenant?: boolean;
+}
+```
+
+Module is `global: true`, provides `JOB_ORCHESTRATOR`, `JOB_RUN_SERVICE`, `JOB_STEP_SERVICE`, and (JOB-8) `JOBS_MULTI_TENANT`.
+
+`JobWorkerModule.forRoot` separately takes `{ mode, backend?, pools?, shutdownTimeoutMs? }` and imports `JobsDomainModule` internally. A process can import `JobsDomainModule` alone (read-only — services available, no worker running) or `JobWorkerModule` (which brings the domain module with it plus the claim loop).
+
+## Worker topology — embedded vs. standalone
+
+Both entrypoints are always scaffolded by JOB-6. The choice is operational.
+
+**Embedded** (`AppModule` imports `JobWorkerModule.forRoot({ mode: 'embedded' })`):
+- API process and workers share CPU.
+- Simplest deploy; good default for dev and small installs.
+- `jobs.worker_mode: embedded` in config is informational / hint.
+
+**Standalone** (run `worker.ts` as a separate process):
+- `main.ts` does not import `JobWorkerModule`.
+- `worker.ts` boots a bare NestJS application context (no HTTP listener) with only `DatabaseModule` + `JobsDomainModule.forRoot(...)` + `JobWorkerModule.forRoot({ mode: 'standalone' })`.
+- Scale workers independently from the API; CPU spikes on one side don't stall the other.
+
+Switching is an operational change plus the config `worker_mode` toggle. **No regeneration needed — both files ship regardless.**
+
+## Multi-tenancy surface
+
+`jobs.multi_tenant: true` is a single opt-in. Consequences (JOB-8):
+
+- `JOBS_MULTI_TENANT` token resolves to `true`.
+- All backend methods accept `tenantId` in their options types.
+- When enabled: missing `tenantId` throws `MissingTenantIdError`. Explicit `null` is allowed (cross-tenant background work).
+- Queries (claim, `listForScope`, `cancel`, etc.) filter by `tenantId` when enabled.
+- `tenant_id` column exists on `job_run` regardless of the flag — JOB-1 lands it unconditionally so flipping the flag later doesn't require a migration.
+
+Tenant-aware fair queuing is Phase 6 polish; Phase 1 is FIFO within pool.
+
+## Horizontal scale notes
+
+- **Handler upsert** under concurrent boots uses `ON CONFLICT (type) DO UPDATE SET … , updated_at = now()` (JOB-3 OQ-3). Last-writer-wins is safe because all instances of the same binary produce identical metadata.
+- **Stale sweeper** is per-worker; each `UPDATE ... WHERE claimed_at < threshold` is self-protecting. No leader election. See `orchestrator-and-worker.md` §"Stale-claim sweeper".
+- **BullMQ queue naming** (once BullMQ backend lands): if two apps share a Redis, default queue names collide. A `jobs.queue_prefix` knob is noted in ADR-022 §"Open implementation questions" as a future addition. Not in Phase 1.
+
+## Events-lane cross-reference
+
+The three `events_*` pools exist because of the events subsystem, not the jobs subsystem. Their concurrency values are tuned to event traffic:
+
+- `events_change: 30` — highest because projections fan out per mutation.
+- `events_inbound: 20` — external ingress, often bursty.
+- `events_outbound: 10` — lower to avoid overwhelming downstream receivers; also leaves headroom for retry storms.
+
+Event semantics and direction routing live in `../events/SKILL.md` (and the events subsystem code). This file owns only the pool side of the contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,15 @@ This applies to every ADR, spec, and code change. Agents that find themselves wr
 
 Avoid the "uniform interface that hides everything" trap (e.g., ORMs that pretend all databases are equivalent). The core contract guarantees portability for the 90% case; extensions let consumers leverage their chosen backend's actual strengths. Collapse abstraction layers that exist purely to preserve uniformity at the cost of feature access.
 
+**Specs and skills are living documentation — update as you work.** ADRs, specs (`docs/specs/*`), and skills (`.claude/skills/*`) describe intent at the moment they were written. Implementation always discovers things that intent missed: a clearer name, a missing edge case, a constraint the spec assumed away, an open question that turned out to have an obvious answer. When you discover any of these while working, **update the spec or skill in the same PR as the code change**. Do not "leave it for later." Do not "ask the original author." The agent doing the work has the freshest context to fix the documentation; the agent reading it next has no recourse if it is wrong.
+
+Concretely:
+- Implementing a JOB-N spec? When you finish, the spec should reflect what was actually built — close any open questions you resolved, correct any details that turned out wrong, add any constraints discovered during implementation. The spec becomes the post-implementation truth, not just the pre-implementation plan.
+- Working in a domain skill? When you find a routing table that doesn't match reality, a "do not" rule that's too vague, or a missing L1 file for a topic that came up — fix it. Skills are living documentation, not snapshots.
+- Touching an ADR's territory? If a decision was made on grounds that no longer apply (e.g., backwards compat we agreed to drop, an alternative we now want to revisit), add a dated revision note. Don't silently ignore the ADR.
+
+The cost of stale documentation compounds: every future agent reading it pays for the drift. The cost of updating it as you go is one extra paragraph per PR. Pay the small cost.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Entity-driven code generation system for full-stack TypeScript applications (v0.2). Generates Clean Architecture scaffolding from YAML entity definitions, including domain entities, repositories, use cases, DTOs, Drizzle schemas, NestJS modules, controllers, and frontend collections. Also provides infrastructure subsystem scaffolding (events, jobs, cache, storage).
 
+## Operating Principles
+
+**No backwards compatibility until we have users.** This project has no external consumers. Architectural correctness is the only criterion. Do not preserve old tables, old commands, old config keys, old doc anchors, old import paths, or old behaviors to "avoid breaking things." Replace them cleanly. Iterative snapshots are disposable. If a decision is being made on backwards-compat grounds, the decision is wrong — re-evaluate from architectural correctness alone.
+
+This applies to every ADR, spec, and code change. Agents that find themselves writing "deprecated" callouts, upgrade commands, parallel-old-and-new schemas, or migration shims should stop and ask whether the predecessor exists for any reason other than backwards compat. If not, delete it.
+
+**Backend swappability via core/extension protocols.** Subsystems that allow swappable backends (events, jobs, cache, storage, etc.) must structure their protocols as a **core contract + opt-in extensions**:
+
+- **Core contract** — every backend MUST implement. Defines the minimum capability surface guaranteed across all backends. App code written against the core is portable.
+- **Extensions** — backends MAY add features beyond the core (e.g., BullMQ backend exposing Bull Board mounting; Postgres backend exposing `LISTEN/NOTIFY`). Consumers opting into extensions accept backend-specific code paths.
+
+Avoid the "uniform interface that hides everything" trap (e.g., ORMs that pretend all databases are equivalent). The core contract guarantees portability for the 90% case; extensions let consumers leverage their chosen backend's actual strengths. Collapse abstraction layers that exist purely to preserve uniformity at the cost of feature access.
+
 ## Commands
 
 ```bash

--- a/docs/adrs/ADR-022-job-orchestration-domain-model.md
+++ b/docs/adrs/ADR-022-job-orchestration-domain-model.md
@@ -419,6 +419,17 @@ All job-related schemas are emitted as Drizzle `pgTable` declarations. Atlas con
 
 This supersedes the older `drizzle-kit push` recommendation in `docs/CONSUMER-SETUP.md` — that section will be updated to reflect the Atlas workflow as part of Phase 1.
 
+## Spec maintenance during implementation
+
+The eight Phase 1 specs (JOB-1 through JOB-8) and this ADR were authored before any code was written. They are intent-at-time-of-design, not post-implementation truth. Per the project-wide operating principle in CLAUDE.md ("Specs and skills are living documentation — update as you work"):
+
+- An agent implementing JOB-N **MUST** update `docs/specs/JOB-N.md` in the same PR as the code change. Close open questions you resolve. Correct details that turned out wrong. Add constraints discovered during implementation.
+- An agent that finds a contradiction between this ADR and reality **MUST** add a dated revision note to the affected section, not silently work around it.
+- The `.claude/skills/jobs/` skill is downstream of these specs. If you change a spec, check whether the skill's L0 routing table or L1 deep dives need to follow.
+- Open implementation questions in this ADR (Section *Open implementation questions*) and in each spec are not aspirational TODOs — they are blockers for the build agent. Resolve or escalate before merging.
+
+The cost of an out-of-date spec compounds: every future agent picking up the next phase pays for the drift. Pay the small per-PR cost.
+
 ## Phase roadmap
 
 Implementation is sequenced in six phases. Each phase is an independently reviewable PR.

--- a/docs/adrs/ADR-022-job-orchestration-domain-model.md
+++ b/docs/adrs/ADR-022-job-orchestration-domain-model.md
@@ -483,7 +483,7 @@ These are caught here so they are not lost; they do not block Phase 1.
 
 4. **Jobs as generated YAML** with a full template DSL. Prototyped in-discussion and withdrawn (see *Codegen scope* above).
 
-5. **Temporal as the backend.** Rejected for this iteration: operational cost, Node SDK maturity concerns for long-lived agent workflows, and the strategic goal of keeping codegen-patterns self-contained (Postgres + optional Redis). A Temporal-backed `IJobQueue` variant remains a future option.
+5. **Temporal as the backend.** Rejected for this iteration: operational cost, Node SDK maturity concerns for long-lived agent workflows, and the strategic goal of keeping codegen-patterns self-contained (Postgres + optional Redis). A Temporal-backed `IJobOrchestrator` backend remains a future option.
 
 ## References
 
@@ -491,4 +491,4 @@ These are caught here so they are not lost; they do not block Phase 1.
 - ADR-005 (Entity Family Base Classes) — `scopeable: true` entity flag lives next to family declarations
 - `docs/specs/job-orchestration-research.md` — synthesis of Airflow, Dagster, Temporal, Prefect, Step Functions, Inngest, LangGraph, OpenAI Assistants, CrewAI
 - `docs/specs/events-codegen-plan.md` — parallel design for typed events and direction routing
-- `runtime/subsystems/jobs/` — existing `IJobQueue` scaffold (unchanged by this ADR)
+- `runtime/subsystems/jobs/` — legacy `IJobQueue` scaffold (deleted by this ADR's Phase 1 work; see JOB-1 file deletion list)

--- a/docs/adrs/ADR-022-job-orchestration-domain-model.md
+++ b/docs/adrs/ADR-022-job-orchestration-domain-model.md
@@ -1,0 +1,494 @@
+# ADR-022 — Job Orchestration Domain Model
+
+**Status:** Draft
+**Date:** 2026-04-17
+**Owner:** Doug
+**Related:** ADR-008 (Subsystem Architecture), ADR-005 (Entity Family Base Classes)
+**Unblocks:** ADR-023 (Event-to-Job Bridge), ADR-025 (Coordination & Signals), ADR-026 (JobEvent Observability), ADR-027 (Agent Job Extensions)
+
+## Context
+
+The existing `jobs/` subsystem (ADR-008) ships `IJobQueue` — a narrow, four-method executor protocol (`enqueue`, `process`, `schedule`, `cancel`) with Drizzle, Redis, BullMQ, and Memory backends. It solves *how* to dispatch a unit of work; it does not model *what* a job is at the domain layer.
+
+In consumer apps (Dealbrain, demo app), this gap has produced known failure modes:
+
+1. **No hierarchy.** An onboarding flow enqueues `pull_emails`, `process_facts`, and `suggest_updates` as three independent `IJobQueue` tasks. When a user's onboarding is canceled, the children keep running. When one fails, the others have no awareness.
+2. **No ownership.** A BullMQ job carries `{ type, payload }`. There is no record linking it to the account, opportunity, or contact it was launched for. Queries like "show me every job for this account" or "reschedule everything tied to this opportunity" cannot be answered.
+3. **No lane isolation.** Outbound webhooks, inbound ingests, domain-change events, and user-triggered work all flow through the same BullMQ queue. A slow outbound handler stalls change-event propagation; a user's export queues up behind a batch onboarding job.
+4. **No visibility.** `IJobQueue` tracks `pending | active | completed | failed`. No parent/child timeline, no step-level breakdown, no cost tracking for LLM steps, no audit trail when a job is canceled or signaled.
+5. **No signals.** Agent jobs that need to pause for tool approval, external webhooks, or human-in-the-loop have nowhere to park. Today this is emulated with ad-hoc Redis keys or rerun-with-state hacks.
+
+The industry's prior art on this is well-mapped (see `docs/specs/job-orchestration-research.md` for the synthesis): Airflow/Dagster (definition vs. run, task instances, pools, tags), Temporal (child workflows, parent close policy, task queues, signals), Prefect (work pools, subflows), Step Functions (task tokens, pause-for-external-signal), Inngest (step memoization, concurrency keys, idempotency keys), and the agentic platforms (LangGraph interrupts, OpenAI run steps, Inngest AgentKit). The intersection of these systems is a small, stable set of concepts.
+
+This ADR locks that intersection as the domain model for `@pattern-stack/codegen`'s jobs subsystem.
+
+## Decision
+
+### Architectural spine — single layer with core/extension protocol
+
+**Revised 2026-04-18.** The original two-layer design (`IJobQueue` executor + orchestration layer above) is collapsed into a single `IJobOrchestrator` protocol. Reasoning: `IJobQueue` was a degenerate transport — used only to deliver `{type: 'job_run_tick', payload: {runId}}` wake-up messages, with the actual domain state in Postgres `job_run`. Two storage locations, two retry mechanisms (one ignored), and a port that hid every native feature of any swappable backend (BullMQ Flow Producer, Bull Board, repeatable jobs) behind a four-method dispatch primitive. The "swap transport" benefit was not real because no app code differed across backends — they all behaved identically by design.
+
+Per the project's core/extension principle (CLAUDE.md), swappable backends are now structured as:
+
+- **Core contract** — `IJobOrchestrator` (and `IJobRunService`, `IJobStepService`) define the minimum capability every backend must implement: start, cancel, replay, listForScope, basic memoized `ctx.step`, hierarchy with close policy, retry policy, dedupe, concurrency keys. App code written against the core is portable across all backends.
+- **Extensions** — backends MAY add features beyond the core. A future BullMQ backend would expose Bull Board mounting, Flow Producer parent/child, repeatable jobs, native rate limiting. The Postgres backend exposes `LISTEN/NOTIFY` hooks and advisory-lock primitives. Consumers using extensions opt into backend-specific code paths and accept they are no longer portable across backends.
+
+```
+App use case / scheduler / bridge
+        │
+        ▼
+JobService.start(type, input, scope)         ← core API surface
+JobRunService.cancel / signal / resume
+        │
+        ▼
+DrizzleJobOrchestrator (Phase 1)             ← claims rows directly from job_run
+   FOR UPDATE SKIP LOCKED on job_run         ← no separate transport table
+        │
+        ▼
+Worker loop: claim → run handler → record steps → transition state → loop
+        │
+        ▼
+JobEventLogger → IEventBus (selective broadcast)
+```
+
+Consequences:
+- One Drizzle table family for jobs (`job`, `job_run`, `job_step`). The `job_queue` table from the prior `IJobQueue` design is removed.
+- One retry policy: `Job.retry_policy` + per-step `ctx.step` options. No competing executor-level retry.
+- One claim mechanism: `JobWorker.claimNext(pool)` issues `SELECT ... FOR UPDATE SKIP LOCKED` directly against `job_run` (Drizzle backend); BullMQ backend (when added) maps to BullMQ-native claim.
+- Phase 1 ships **Drizzle backend only**. A BullMQ-orchestrator backend is Phase 6+ work, mapping `JobRun → BullMQ Job`, `parent_run_id → FlowProducer`, `concurrency_key → rate limiter`, etc. The mapping is honest: BullMQ backend exposes BullMQ-native features (Bull Board, FlowProducer) as extensions; Postgres backend exposes its own.
+- Removed: `IJobQueue` protocol, `job_queue` schema, four `IJobQueue` backends (Drizzle/BullMQ/Redis/Memory), `JobsModule.forRoot({ backend })`. The existing `runtime/subsystems/jobs/` files for `IJobQueue` are deleted, not preserved.
+
+### Codegen scope — generate the system, not user jobs
+
+codegen-patterns ships the orchestration *system*: schemas, protocols, services, backends, modules, worker entrypoints, pool wiring, and Atlas migrations. **User jobs are ordinary TypeScript classes**, not YAML. Rejected alternatives and their reasons:
+
+- **Jobs-as-YAML with generated handlers** was drafted and withdrawn. YAML can express trivial cron-shaped pipelines but cannot express branching, conditional spawn, dynamic agent tool loops, or anything where flow depends on runtime data. The declarative/imperative split added two user-facing concepts, a template DSL (`{{item.id}}`), desugaring rules, and a codegen phase, in exchange for eliminating ~15 lines of TypeScript boilerplate per job. It was not worth the surface area.
+- **Generated `Jobs` facade** (typed kickoff per job type) was rejected on the same grounds — if users want a typed facade in their app, it is seven lines of TypeScript they write once.
+
+What is codegen-owned:
+- Drizzle schemas (Section *Schema*)
+- Protocols: `IJobOrchestrator`, `IJobRunService`, `IJobStepService`
+- Services: `JobService`, `JobRunService`, `JobStepService`, `JobEventLogger`, `JobWorker`
+- Backends: Drizzle + Memory for each protocol
+- NestJS modules: `JobsDomainModule.forRoot()`, `JobWorkerModule.forRoot()`
+- Worker entrypoints: embedded `main.ts` hook + standalone `worker.ts`
+- Base classes / types: `JobHandler<TInput, TOutput>`, `JobContext<TInput>`, `@JobHandler` decorator
+- Pool config loader and queue binding
+- Atlas migration emission for all tables
+
+What users write:
+- `@JobHandler('type', meta)` decorated classes, registered via NestJS module scan.
+- Use cases that inject `IJobOrchestrator` and call `orchestrator.start('type', input, { scope })`.
+
+### The triad
+
+#### `Job`
+
+Row-per-registered-type. Configuration lives here.
+
+| Column | Type | Notes |
+|---|---|---|
+| `type` | `text` PK | Unique business key, e.g. `onboarding` |
+| `version` | `integer` | Increments on breaking input changes |
+| `pool` | `text` | One of the configured pools (Section *Pools*) |
+| `scope_entity_type` | `text?` | Nullable if the job is global |
+| `retry_policy` | `jsonb` | `{ attempts, backoff, base_ms, non_retryable_errors[] }` |
+| `timeout_ms` | `integer?` | Run-level hard cap |
+| `concurrency_key_template` | `text?` | e.g. `"account:{{input.account_id}}"` — evaluated in handler code, stored as the literal the codegen emits |
+| `collision_mode` | `enum` | `queue \| reject \| replace`, default `queue` |
+| `dedupe_key_template` | `text?` | Same evaluation as concurrency key |
+| `dedupe_window_ms` | `integer?` | Window during which duplicate enqueues collapse |
+| `priority_default` | `integer` | `0` unless overridden on enqueue |
+| `replay_from` | `enum` | `scratch \| last_step \| last_checkpoint`, default `last_checkpoint` |
+| `created_at`, `updated_at` | `timestamptz` | |
+
+`Job` rows are populated at boot from decorator metadata — the worker module walks registered `@JobHandler` classes and upserts. This is not a user-editable table at runtime; it is the materialized view of what the app knows how to run.
+
+#### `JobRun`
+
+Row-per-execution. State lives here.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `uuid` PK | |
+| `job_type` | `text` FK → `job.type` | |
+| `job_version` | `integer` | Captured at enqueue; a run continues on its original version even if `job.version` bumps |
+| `parent_run_id` | `uuid?` FK → `job_run.id` | Direct parent |
+| `root_run_id` | `uuid` | Self-reference if no parent, else the top of the tree |
+| `parent_close_policy` | `enum` | `terminate \| cancel \| abandon`, default `terminate` |
+| `scope_entity_type` | `text?` | Free text at DB, typed by generated `ScopeEntityType` union |
+| `scope_entity_id` | `text?` | UUID or other primary key |
+| `tenant_id` | `text?` | Opt-in column, present only when `codegen.config.yaml: jobs.multi_tenant: true` |
+| `tags` | `jsonb` | Freeform key/value |
+| `pool` | `text` | Resolved from `job.pool` at enqueue, cached here for claim query |
+| `priority` | `integer` | |
+| `concurrency_key` | `text?` | Evaluated from template at enqueue |
+| `dedupe_key` | `text?` | Evaluated at enqueue; `(job_type, dedupe_key)` unique within `dedupe_window_ms` |
+| `status` | `enum` | See *State machine* |
+| `input` | `jsonb` | |
+| `output` | `jsonb?` | Populated on completion |
+| `error` | `jsonb?` | `{ message, stack, retryable, attempt }` |
+| `trigger_source` | `enum` | `manual \| schedule \| event \| parent` |
+| `trigger_ref` | `text?` | `event_id \| schedule_id \| null` |
+| `run_at` | `timestamptz` | Earliest eligible tick time |
+| `started_at`, `finished_at` | `timestamptz?` | |
+| `claimed_at` | `timestamptz?` | For stale-claim recovery |
+| `attempts` | `integer` | Run-level retry counter |
+| `wait_kind` | `enum?` | See ADR-025; placeholder column added in Phase 1, semantics in Phase 3 |
+| `resume_token` | `text?` | See ADR-025 |
+| `wait_deadline` | `timestamptz?` | See ADR-025 |
+| `created_at`, `updated_at` | `timestamptz` | |
+
+**Indexes (Phase 1 required):**
+- `(status, pool, run_at)` — claim query
+- `(root_run_id)` — tree traversal
+- `(scope_entity_type, scope_entity_id)` — "show everything for this account"
+- `(job_type, dedupe_key)` partial `WHERE dedupe_key IS NOT NULL` — idempotency lookup
+- `(concurrency_key)` partial `WHERE concurrency_key IS NOT NULL AND status IN ('pending','running')` — collision check
+
+#### `JobStep`
+
+Row-per-checkpoint within a run. Memoization and granular retry live here.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `uuid` PK | |
+| `job_run_id` | `uuid` FK → `job_run.id` | |
+| `step_id` | `text` | User-chosen id, e.g. `'pull_emails'` or `'recompute:acct-123'`; unique per `(job_run_id, step_id)` |
+| `kind` | `enum` | `task` for Phase 1; extended in ADR-027 to `tool_call \| llm_call \| wait \| checkpoint \| message` |
+| `seq` | `bigint` | Monotonic within run |
+| `status` | `enum` | `pending \| running \| completed \| failed \| skipped` |
+| `input` | `jsonb?` | |
+| `output` | `jsonb?` | Memoized return value on success |
+| `error` | `jsonb?` | |
+| `attempts` | `integer` | Step-level retry counter |
+| `started_at`, `finished_at` | `timestamptz?` | |
+
+**Indexes:**
+- `(job_run_id, step_id)` unique
+- `(job_run_id, seq)` for timeline queries
+
+### State machine
+
+```
+                  ┌──────────┐
+  enqueue  ───▶   │ pending  │
+                  └────┬─────┘
+                       │ claim
+                       ▼
+                  ┌──────────┐           signal / timer
+                  │ running  │ ◀──────────────────────┐
+                  └────┬─────┘                        │
+         step ok? │    │  wait(kind)                  │
+                  │    ▼                              │
+                  │  ┌──────────┐                     │
+                  │  │ waiting  │ ────────────────────┘
+                  │  └────┬─────┘         resume
+                  │       │  deadline
+                  ▼       ▼
+              completed  failed / timed_out
+
+  any non-terminal ──cancel──▶ canceled
+```
+
+`scheduled` is a sub-state of `pending` where `run_at > now()`. Not a separate enum value; filter by `run_at` in the claim query.
+
+`waiting` is present in the schema from Phase 1 but no `JobContext.waitFor()` API is exposed until Phase 3 (ADR-025). This avoids a breaking schema migration when signals land.
+
+### Hierarchy and close policy
+
+`parent_run_id` + `root_run_id` form the tree. `parent_close_policy` is inherited by the child at spawn time and stored on its row; later changes to the parent do not retroactively alter children.
+
+Policy semantics (lifted from Temporal):
+- `terminate` — when the parent reaches any terminal state, running children transition to `canceled` with `error.reason = 'parent_terminated'`. **Default.**
+- `cancel` — same effect on children, but the parent waits for children to finish transitioning before it itself terminates. Useful when you want the parent's completion timestamp to reflect the actual end-of-work.
+- `abandon` — children are untouched; they keep running and may outlive the parent. Useful for fire-and-forget side effects.
+
+Root-level cancellation propagates through `root_run_id`: `JobRunService.cancel(runId, { cascade: true })` cancels the target and every descendant whose policy permits it.
+
+### Scoping
+
+`scope_entity_type` is the string name of an entity (`'account'`, `'opportunity'`, `'contact'`). Generated via entity-YAML opt-in:
+
+```yaml
+# entities/account.yaml
+name: account
+scopeable: true
+```
+
+At codegen, every `scopeable: true` entity contributes to the generated `ScopeEntityType` TypeScript union. DB column is `text` — no CHECK constraint — to keep Atlas migrations painless when new entities are marked scopeable. Type safety lives at the TS layer.
+
+Query surface:
+- `JobRunService.listForScope(scopeType, scopeId, opts?)` — all runs tied to a domain entity
+- `JobRunService.cancelForScope(scopeType, scopeId)` — bulk cancel (cascades per close policy)
+- `JobRunService.rescheduleForScope(scopeType, scopeId, newRunAt)` — shift a bundle
+
+These are the "reorganize everything for this account" primitives from the problem statement.
+
+### Policy
+
+**Retry — two layers, orthogonal.**
+- **Run-level** from `job.retry_policy`. If the whole run fails (handler throws uncaught, signal deadline missed, timeout), retry from the configured `replay_from` position.
+- **Step-level** from the `ctx.step(id, fn, { attempts, backoff })` call site. Retries wrap a single step call without touching earlier completed steps. Step memoization (Section *Replay*) makes this free.
+
+Both policies respect `non_retryable_errors` — an array of error class names or `.code` strings that short-circuit retries.
+
+**Concurrency key and collision.** `concurrency_key` (evaluated from the template at enqueue) serializes runs sharing the key within the pool. On collision, one of three behaviors:
+- `queue` (default) — the new run is accepted in `pending`, claimed only when the incumbent exits non-terminal states
+- `reject` — the new enqueue fails with `JobCollisionError`; caller decides whether to retry
+- `replace` — the incumbent is canceled (`cascade: true`), the new run starts. Useful for "latest state wins" agent loops and rolling batch windows
+
+Choice is a property of the Job (`job.collision_mode`), not the call site.
+
+**Dedupe key.** Independent of concurrency. `(job_type, dedupe_key)` is unique within `dedupe_window_ms`; a duplicate enqueue returns the existing run's id rather than creating a new row. Used when a use case might retry the same logical operation (e.g. webhook replay). Unlike concurrency, dedupe does not queue — it short-circuits.
+
+**Priority.** Integer, higher wins, tie-broken by `run_at ASC`. Bounded to a configured range (default `[-100, 100]`) at enqueue time to prevent runaway escalation.
+
+**Timeout.** `job.timeout_ms` is a hard wall-clock cap on total run duration across all retries. When breached, run transitions to `timed_out`. Step-level timeouts live on the `ctx.step()` call; breach fails just that step.
+
+### Replay
+
+`replay_from` is a memoization policy, not a separate code path. When a failed run is retried:
+- `scratch` — `job_step` rows for this run are soft-deleted (moved to `job_step_archive`), handler re-enters with an empty step table
+- `last_step` — only the failing step's row is cleared; earlier completed steps stay memoized; the handler re-enters and replays until it hits the empty step slot
+- `last_checkpoint` (default) — no rows cleared; handler re-enters, every `ctx.step(id, fn)` checks for a `completed` row with matching `step_id` and returns `output` without calling `fn`
+
+Three modes, one handler path. `JobContext.step()` is the only primitive that needs to know about memoization.
+
+### Pools
+
+Five framework-defined pools ship by default; users declare custom pools in `codegen.config.yaml`.
+
+```yaml
+# codegen.config.yaml (excerpt)
+jobs:
+  multi_tenant: false        # opt-in tenant_id column
+  worker_mode: embedded      # embedded | standalone
+  pools:
+    events_inbound:
+      queue: jobs-events-inbound
+      concurrency: 20
+      reserved: true
+      description: "External → us. Webhooks, pub/sub, inbound email."
+    events_change:
+      queue: jobs-events-change
+      concurrency: 30
+      reserved: true
+      description: "Internal mutations. Drives projections."
+    events_outbound:
+      queue: jobs-events-outbound
+      concurrency: 10
+      reserved: true
+      description: "Us → external. Webhooks fired, publishes, notifications."
+    interactive:
+      queue: jobs-interactive
+      concurrency: 20
+      description: "User is waiting — renders, exports, one-off work."
+    batch:
+      queue: jobs-batch
+      concurrency: 5
+      description: "Background — onboarding, ingest, agent runs."
+```
+
+Rules:
+- Each pool binds to a distinct BullMQ queue name. Workers are one-per-pool; a `batch` worker cannot starve an `interactive` worker because they consume different streams.
+- `reserved: true` pools are framework-only. User `@JobHandler` decorations that target a reserved pool fail at build time (caught by a Nest module validator). Reserved pools exist to guarantee isolation for the `IEventBus` outbox drain (Section *Event lanes*); no user code enqueues to them.
+- Default user-job pool is `batch`. A handler must opt into `interactive` explicitly; this prevents accidental fast-lane assignment for heavy work.
+- `concurrency` is per-worker-process; horizontal scale multiplies it.
+
+Adding a custom pool is a config-only change. Example: a Dealbrain app could declare a fourth user pool `agents` for long-running LLM jobs so they don't share concurrency with ingest.
+
+### Event lanes (forward reference)
+
+The three `events_*` pools exist to carry `IEventBus` outbox drain traffic, routed by `DomainEvent.direction` (`inbound | change | outbound`). Direction semantics and the event-codegen YAML model are specified in the events-planner design doc (`docs/specs/events-codegen-plan.md`) and will be formalized in a sibling ADR. This ADR commits only to: the three pools exist, they are reserved, the bus drains into them based on direction.
+
+### Claim query (Drizzle backend)
+
+ORM builder, single transaction, `FOR UPDATE SKIP LOCKED`:
+
+```ts
+async claimNext(pool: string): Promise<JobRunRow | null> {
+  return this.db.transaction(async (tx) => {
+    const [candidate] = await tx
+      .select({ id: jobRuns.id })
+      .from(jobRuns)
+      .where(and(
+        eq(jobRuns.status, 'pending'),
+        eq(jobRuns.pool, pool),
+        lte(jobRuns.runAt, new Date()),
+      ))
+      .orderBy(desc(jobRuns.priority), asc(jobRuns.runAt))
+      .limit(1)
+      .for('update', { skipLocked: true });
+
+    if (!candidate) return null;
+
+    const [claimed] = await tx
+      .update(jobRuns)
+      .set({ status: 'running', claimedAt: new Date() })
+      .where(eq(jobRuns.id, candidate.id))
+      .returning();
+
+    return claimed;
+  });
+}
+```
+
+BullMQ backend delegates to BullMQ's native atomic claim — nothing custom. Memory backend uses a single in-process mutex.
+
+### Handler API
+
+```ts
+import { JobHandler, JobContext, ParentClosePolicy } from '@pattern-stack/codegen/jobs';
+
+interface OnboardingInput {
+  accountId: string;
+}
+
+@JobHandler<OnboardingInput>('onboarding', {
+  pool: 'batch',
+  scope: { entity: 'account', from: (input) => input.accountId },
+  retry: { attempts: 3, backoff: 'exponential', baseMs: 1000 },
+  concurrency: { key: (input) => `account:${input.accountId}`, collision: 'queue' },
+  dedupe: { key: (input) => `onboarding:${input.accountId}`, windowMs: 24 * 60 * 60 * 1000 },
+  timeoutMs: 60 * 60 * 1000,
+  replayFrom: 'last_checkpoint',
+})
+export class OnboardingHandler extends JobHandlerBase<OnboardingInput> {
+  constructor(
+    private readonly emails: EmailService,
+    private readonly facts: FactService,
+  ) { super(); }
+
+  async run(ctx: JobContext<OnboardingInput>) {
+    const emails = await ctx.step('pull_emails', () =>
+      this.emails.pullForAccount(ctx.input.accountId),
+    );
+
+    await ctx.spawnChild('process_facts', {
+      emailIds: emails.map(e => e.id),
+    }, {
+      closePolicy: ParentClosePolicy.Terminate,
+    });
+
+    return { emailCount: emails.length };
+  }
+}
+```
+
+Decorator metadata is read at boot by `JobWorkerModule` to populate the `Job` table and the in-memory handler registry. TypeScript generics on `@JobHandler<TInput>` flow through to `JobContext<TInput>` so `ctx.input` is typed without casts.
+
+`JobContext` API for Phase 1:
+- `ctx.input: TInput`
+- `ctx.run: JobRun` — metadata about this run (id, scope, parent, etc.)
+- `ctx.step(id, fn, opts?)` — memoized durable step
+- `ctx.spawnChild(type, input, opts)` — spawn child JobRun
+- `ctx.logger: Logger` — scoped to this run
+
+`ctx.waitFor()`, `ctx.signal()`, `ctx.sleep()` arrive in ADR-025.
+
+### Worker lifecycle
+
+Two entrypoints, both emitted from Phase 1:
+
+- **Embedded** (default) — `JobWorkerModule.forRoot({ mode: 'embedded' })` imported by `AppModule`. API process and workers share CPU. Lowest ceremony; good for dev and small deployments.
+- **Standalone** — a separate `worker.ts` entrypoint boots a stripped NestJS context with only the worker module, no HTTP bindings. Scale workers independently; API CPU spikes cannot stall jobs and vice versa. Switch is a `codegen.config.yaml: jobs.worker_mode: 'standalone'` flip plus deploying the second binary.
+
+Codegen emits both `main.ts` and `worker.ts` on scaffold. A consumer who never deploys standalone simply never runs `worker.ts`; the file is inert.
+
+Graceful shutdown: on `SIGTERM`, workers stop claiming new ticks, wait for in-flight step functions to resolve (bounded by a configurable `shutdown_timeout_ms`, default `30000`), then exit. In-flight JobRuns transition back to `pending` with `claimed_at: null` for another worker to pick up.
+
+### Registration — static codegen, runtime discovery deferred
+
+The `@JobHandler` decorator registers a class into a module-local map at class-evaluation time. `JobWorkerModule.forRoot()` reads the map at boot. This is a code-level registry — adding a new handler requires importing it somewhere reachable from the app's module tree (standard NestJS practice).
+
+Runtime-discovery mode (`JobWorkerModule.forRoot({ discovery: 'runtime' })` that scans the DI container for decorated providers) is tracked as **Phase 6+ enhancement**. Concern: a handler that is defined but never imported will be silently invisible. A boot-time validator (shipped Phase 1) checks that every `Job` row's `type` has a registered handler and fails loudly on mismatch — that catches ~90% of drift without the complexity of container scanning.
+
+### Multi-tenancy
+
+Opt-in via `codegen.config.yaml: jobs.multi_tenant: true`. When enabled:
+- `tenant_id` column appears on `job_run` and `job_event`
+- Every service method accepts a `tenantId` and filters all queries by it
+- Worker-side, tenant-based fair queuing is Phase 6 polish; initial implementation is FIFO within a pool
+
+When disabled: column is omitted, methods have no `tenantId` parameter, generated code is simpler.
+
+### Atlas migration workflow
+
+All job-related schemas are emitted as Drizzle `pgTable` declarations. Atlas consumes the Drizzle schema via the existing Atlas + Drizzle integration (see consumer-setup doc addendum — to be written in Phase 1). Consumers run `atlas migrate diff` to generate migrations, `atlas migrate apply` to apply. codegen-patterns ships the schema; it does not ship raw SQL migrations.
+
+This supersedes the older `drizzle-kit push` recommendation in `docs/CONSUMER-SETUP.md` — that section will be updated to reflect the Atlas workflow as part of Phase 1.
+
+## Phase roadmap
+
+Implementation is sequenced in six phases. Each phase is an independently reviewable PR.
+
+### Phase 1 — Domain foundation
+Layers 1–4 of the synthesis: triad, hierarchy, scoping, policy. Schema, protocols, services, backends (Drizzle + Memory), module, worker entrypoints (both), pool wiring, `@JobHandler` decorator, boot-time registry validator, Atlas integration docs. Ships the state machine including `waiting` as a column (behavior deferred to ADR-025).
+
+### Phase 2 — Event-to-Job Bridge (ADR-023)
+`IJobBridge`, `job_trigger` and `bridge_delivery` tables, cron scheduler loop, event-bus subscriber that matches triggers and enqueues runs. Depends on events-planner's events-codegen work (for typed event references in trigger rules).
+
+### Phase 3 — Coordination (ADR-025)
+`ctx.waitFor()`, `ctx.signal()`, `ctx.sleep()`. Timer-based auto-resume via scheduler loop. Webhook endpoint for external `resume_token` resolution. No schema change — columns added in Phase 1.
+
+### Phase 4 — Observability (ADR-026)
+`job_event` audit table, `JobEventLogger` service, selective `IEventBus` broadcast rules, query APIs for timeline and recent-failures views.
+
+### Phase 5 — Agent extensions (ADR-027)
+`JobStep.kind` extended with `tool_call | llm_call | wait | checkpoint | message`. Cost JSONB. Thread binding on `JobRun`. Helper methods `ctx.recordToolCall()`, `ctx.recordLLMCall()`.
+
+### Phase 6 — Polish
+Optional `job_artifact` table for oversized outputs. Admin CLI (`bun codegen jobs runs <id>`, `jobs cancel <id>`, `jobs replay <id>`). Runtime-discovery registry option. Tenant-aware fair queuing.
+
+## Open implementation questions (non-blocking)
+
+These are caught here so they are not lost; they do not block Phase 1.
+
+1. **Stale-claim recovery.** If a worker crashes mid-tick, its `claimed_at` row is stranded. Propose: a janitor process per pool scans `status='running' AND claimed_at < now() - stale_threshold` and returns rows to `pending`. Phase 1 ships a simple time-based sweeper (default `5 min`); richer heartbeats can follow.
+2. **BullMQ queue naming collisions.** If two codegen-based apps share a Redis, pool queue names (`jobs-batch`, etc.) collide. Recommend a configurable prefix (`jobs.queue_prefix` in config, default app name).
+3. **Run output size.** JSONB is fine for small outputs; large outputs (LLM responses, report data) should go to `job_artifact` (Phase 6). Soft-limit warning in Phase 1 when output exceeds `100 KB`.
+4. **Signal auth.** External signal endpoint (`POST /jobs/signals/:resume_token`) needs an auth model. Propose opaque single-use token with rotation; detail in ADR-025.
+5. **Cross-pool priorities.** A high-priority `batch` run should still never preempt an `interactive` run — pools are absolute lanes. Document this invariant; consumers who want preemption need to add a dedicated pool.
+
+## Consequences
+
+**Positive:**
+- Jobs become first-class domain entities: queryable by scope, reorganizable by entity, cancelable as trees.
+- Lane isolation at the pool layer prevents the Dealbrain bleed where outbound webhooks stalled change events.
+- The `@JobHandler` + `JobContext` pair is a small, stable API surface. No YAML parser, no template DSL, no desugaring.
+- Replay, retry, dedupe, and concurrency are declarative properties — ops can tune them without code changes (retry policy overrides can live in config; structural properties stay on the class).
+- Forward-compatible with signals (Phase 3) and agent steps (Phase 5) — the schema reserves space without committing to semantics.
+
+**Negative:**
+- The `job_queue` table (executor-layer, used by `IJobQueue`) and the new `job_run`/`job_step` tables (orchestration-layer) live side-by-side. Two "job" concepts in the schema. Mitigated by naming: `job_queue` is the executor's queue (transient ticks); `job_run` is the domain's durable execution. Documentation must make this distinction clear. Whether `IJobQueue` itself should be retired in favor of a fused single-layer design is a separate question (the two-layer split has architectural merit beyond compat — clean swap to BullMQ/Redis backends — but is worth re-examining).
+- `@JobHandler` decorator metadata is the source of truth for `Job` rows. A handler class deleted from source but left registered in Postgres will produce dangling `Job` rows. Phase 1 validator warns; Phase 6 admin CLI adds a prune command.
+
+**Operating principle (project-wide, codified in CLAUDE.md):** No backwards-compatibility constraints until external users exist. Architectural correctness is the only criterion. No upgrade commands, no deprecated callouts, no parallel old-and-new schemas to preserve in-flight snapshots.
+
+**Deferred by this ADR (explicit):**
+- Signal / wait / resume semantics → ADR-025
+- JobEvent audit log + selective broadcast → ADR-026
+- Agent step kinds, cost, thread binding → ADR-027
+- Event-to-Job Bridge → ADR-023
+- Events codegen (YAML, typed `IEventBus`, direction routing) → cross-ADR with events-planner
+
+## Alternatives considered
+
+1. **Extend `IJobQueue` in-place.** Add `parent_id`, `scope`, `status enum` columns to `job_queue`. Rejected: conflates executor and domain concerns, blocks backend swap (Memory/Redis backends don't have schema control), and makes the existing narrow protocol a maintenance burden.
+
+2. **Airflow-style static DAG.** Jobs are fully declarative graphs of tasks. Rejected: cannot express dynamic spawn (agent tool loops, conditional onboarding branches), which is a Phase 5 requirement and a Phase 1 onboarding story.
+
+3. **Single global queue with application-level priorities.** Reject because priority is a weaker isolation guarantee than separate lanes — a priority-based scheduler can still starve low-priority work under load; lanes cannot.
+
+4. **Jobs as generated YAML** with a full template DSL. Prototyped in-discussion and withdrawn (see *Codegen scope* above).
+
+5. **Temporal as the backend.** Rejected for this iteration: operational cost, Node SDK maturity concerns for long-lived agent workflows, and the strategic goal of keeping codegen-patterns self-contained (Postgres + optional Redis). A Temporal-backed `IJobQueue` variant remains a future option.
+
+## References
+
+- ADR-008 (Subsystem Architecture) — Protocol → Backend → Factory pattern
+- ADR-005 (Entity Family Base Classes) — `scopeable: true` entity flag lives next to family declarations
+- `docs/specs/job-orchestration-research.md` — synthesis of Airflow, Dagster, Temporal, Prefect, Step Functions, Inngest, LangGraph, OpenAI Assistants, CrewAI
+- `docs/specs/events-codegen-plan.md` — parallel design for typed events and direction routing
+- `runtime/subsystems/jobs/` — existing `IJobQueue` scaffold (unchanged by this ADR)

--- a/docs/adrs/ADR-030-progressive-disclosure-skills.md
+++ b/docs/adrs/ADR-030-progressive-disclosure-skills.md
@@ -62,6 +62,20 @@ Length target: 150–250 lines. Past 300 lines, push detail into L1.
 
 A skill is best authored by an agent who has **just learned** the domain — fresh enough to remember what was confusing, structured enough to organize it. Agents deeply rooted in a domain through a long conversation suffer curse-of-knowledge bias and produce skills that under-explain. When a skill needs to be written or rewritten, prefer spawning a fresh agent with the relevant ADRs and specs as input over having the long-conversation agent author it directly. The deep-context agent reviews for technical accuracy after.
 
+### Maintenance rule — skills are living documentation
+
+Per the project operating principle in CLAUDE.md, **skills are not write-once.** An agent working in a domain whose skill is stale, drifted, or missing important context **MUST** update the skill in the same PR as the code change. Concretely:
+
+- L0 routing table missing an L1 file that should be there → add the entry
+- L1 file describing an API surface that has since shifted → correct the description
+- "Do not" rule that no longer applies (decision was reversed) → remove it
+- New "do not" rule discovered during implementation (a footgun the spec didn't anticipate) → add it
+- Frontmatter `description` that no longer accurately captures when to load → rewrite
+
+The agent doing the work has the freshest context to fix the skill; the agent reading it next has no recourse if it is wrong. Skills exist to compound knowledge across agents and time. They cannot do that if they go stale.
+
+Reviewers should expect a skill diff alongside any non-trivial domain PR. Absence of one in a domain whose skill exists is a review smell — ask why.
+
 ## Consequences
 
 **Positive:**

--- a/docs/adrs/ADR-030-progressive-disclosure-skills.md
+++ b/docs/adrs/ADR-030-progressive-disclosure-skills.md
@@ -101,5 +101,8 @@ A skill is best authored by an agent who has **just learned** the domain — fre
 
 - `docs/specs/pattern-stack-disclosure-audit.md` — the audit that informed this design
 - `.claude/skills/README.md` — quick-reference convention summary for contributors
-- `.claude/skills/jobs/`, `.claude/skills/events/` — first two domain skills authored under this convention. Both are flat (177 and 96 lines) — under the 300-line threshold for L1 split. They will split as their domains grow (jobs Phases 2-7; events codegen formalization moving from plan to ADR + spec set). They demonstrate the **frontmatter convention + L0 structure**; the L1 split itself remains a forward-looking pattern documented for when it's needed.
+- `.claude/skills/jobs/` — first progressive-disclosure skill in this project. L0 `SKILL.md` (177 lines) routes to three L1 files: `handler-authoring.md` (209 lines), `orchestrator-and-worker.md` (237 lines), `pools-and-config.md` (215 lines). Total 838 lines split across four files — agents working on a handler load only L0 + `handler-authoring.md` (~390 lines), not the full domain.
+- `.claude/skills/events/` — second progressive-disclosure skill. L0 `SKILL.md` (96 lines) routes to four L1 files: `outbox-and-transactions.md` (139 lines), `event-codegen.md` (285 lines), `directions-and-pools.md` (113 lines), `protocol-and-backends.md` (161 lines). Total 794 lines split across five files. The largest L1 (`event-codegen.md`) is the in-flight design — agents touching the typed event facade load it; agents only publishing existing events do not.
+
+These two are the **template-setting v1** of progressive disclosure for codegen-patterns. They demonstrate both the frontmatter convention and the L0/L1 split, and serve as the reference shape for future complex domains.
 - `~/.claude/plugins/cache/claude-brain/claude-brain/1.0.0/skills/skill-authoring/SKILL.md` — standard Claude Code frontmatter reference

--- a/docs/adrs/ADR-030-progressive-disclosure-skills.md
+++ b/docs/adrs/ADR-030-progressive-disclosure-skills.md
@@ -101,7 +101,7 @@ A skill is best authored by an agent who has **just learned** the domain — fre
 
 - `docs/specs/pattern-stack-disclosure-audit.md` — the audit that informed this design
 - `.claude/skills/README.md` — quick-reference convention summary for contributors
-- `.claude/skills/jobs/` — first progressive-disclosure skill in this project. L0 `SKILL.md` (177 lines) routes to three L1 files: `handler-authoring.md` (209 lines), `orchestrator-and-worker.md` (237 lines), `pools-and-config.md` (215 lines). Total 838 lines split across four files — agents working on a handler load only L0 + `handler-authoring.md` (~390 lines), not the full domain.
+- `.claude/skills/jobs/` — first progressive-disclosure skill in this project. L0 `SKILL.md` (177 lines) routes to four L1 files: `handler-authoring.md` (209), `orchestrator-and-worker.md` (237), `pools-and-config.md` (215), `phase-roadmap.md` (101). Total 939 lines split across five files — agents working on a handler load only L0 + `handler-authoring.md` (~390 lines), not the full domain.
 - `.claude/skills/events/` — second progressive-disclosure skill. L0 `SKILL.md` (96 lines) routes to four L1 files: `outbox-and-transactions.md` (139 lines), `event-codegen.md` (285 lines), `directions-and-pools.md` (113 lines), `protocol-and-backends.md` (161 lines). Total 794 lines split across five files. The largest L1 (`event-codegen.md`) is the in-flight design — agents touching the typed event facade load it; agents only publishing existing events do not.
 
 These two are the **template-setting v1** of progressive disclosure for codegen-patterns. They demonstrate both the frontmatter convention and the L0/L1 split, and serve as the reference shape for future complex domains.

--- a/docs/adrs/ADR-030-progressive-disclosure-skills.md
+++ b/docs/adrs/ADR-030-progressive-disclosure-skills.md
@@ -1,0 +1,105 @@
+# ADR-030 — Progressive Disclosure for Project Skills
+
+**Status:** Accepted
+**Date:** 2026-04-18
+**Owner:** Doug
+**Related:** ADR-008 (Subsystem Architecture)
+
+## Context
+
+`codegen-patterns` is growing in surface area: the jobs subsystem alone now has one ADR (ADR-022) plus eight implementation specs (JOB-1 through JOB-8). The events codegen formalization adds another design doc with its own emerging spec set. Future domains (Event-to-Job Bridge ADR-023, coordination ADR-025, JobEvent observability ADR-026, agent extensions ADR-027) will follow the same shape.
+
+The question is not whether to document — the docs exist and are necessary. The question is **what context an agent loads when working in this repo**.
+
+Two failure modes to avoid:
+
+1. **Underloading.** An agent works on a `@JobHandler` class without knowing that reserved `events_*` pools cannot be targeted, that `parent_close_policy` defaults to `Terminate`, that step memoization happens via `ctx.step` and not by re-running the whole handler. Agent produces code that looks plausible and is wrong. ADR-022 contains the answers, but the agent did not read it because nothing told them to.
+
+2. **Overloading.** Every agent loads ADR-022, JOB-1 through JOB-8, the events plan, the dealbrain audit, and every adjacent spec "just in case." Agents working on entity templates pay context cost for jobs detail they will never use. Cache hit rate drops; responses slow; reasoning gets diluted.
+
+The prior practice in this repo was **flat skills**: one `SKILL.md` per domain (`codegen/`, `browser/`, `code-review/`, etc.) holding the entire body of knowledge. This works at small surface area. It does not scale to a domain with one ADR + eight specs.
+
+The `pattern-stack` plugin, audited at `/Users/dug/Projects/dev/pattern-stack`, demonstrates a working alternative: **L0/L1 progressive disclosure**. One `SKILL.md` per domain (~150 lines, auto-loaded as the router) plus sibling L1 files (200–335 lines each, loaded only when the agent's task routes there). The audit (`docs/specs/pattern-stack-disclosure-audit.md`) details the mechanics.
+
+Pattern-stack's implementation skips frontmatter on its skill files and relies on prescriptive routing in agent system prompts. This works in pattern-stack's plugin context but throws away three things the standard Claude Code skill frontmatter provides at zero cost: harness-level skill discovery via `description`, tool restriction via `allowed-tools`, and explicit `user-invocable: false` to prevent accidental slash-command exposure.
+
+## Decision
+
+### Two skill shapes — choose deliberately
+
+**Flat (single-file).** One `SKILL.md`, no siblings. Used when the entire body fits comfortably under ~250 lines without losing structure. Cost of progressive disclosure (extra files, routing table maintenance) outweighs context savings. Existing skills (`codegen`, `browser`, `code-review`, `dev-companion`, `project-documentation`, `run-and-monitor`, `skill-authoring`) stay flat.
+
+**Progressive disclosure (L0 + L1).** `SKILL.md` is a router (≤250 lines: mental model, non-obvious rules, routing table). Sibling L1 files (100–300 lines each) carry deep dives, loaded only when the agent's task routes to them. Used when the domain has multiple sub-concerns that don't all apply to every task.
+
+The first two progressive-disclosure skills in this project — `jobs` and `events` — serve as the template for future complex domains.
+
+### Frontmatter is required on every skill (both shapes)
+
+Standard Claude Code skill frontmatter, on every `SKILL.md`:
+
+```yaml
+---
+name: <skill-name>
+description: <one paragraph — when an agent should load this skill, with specific triggers>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+user-invocable: false
+---
+```
+
+L1 sibling files do not have frontmatter — they are loaded by reference from L0's routing table, not by independent discovery.
+
+### L0 structure (locked)
+
+1. One-paragraph what-is-this overview
+2. Mental model — concrete enough to reason without opening L1, not so detailed L1 becomes redundant
+3. Routing table — explicit "for X, read `<file>.md`"
+4. Non-obvious rules — the things an agent MUST internalize before writing code in this domain
+5. Do-not list — anti-patterns and dead paths (especially rejected alternatives that may seem appealing)
+
+Length target: 150–250 lines. Past 300 lines, push detail into L1.
+
+### Authoring rule
+
+A skill is best authored by an agent who has **just learned** the domain — fresh enough to remember what was confusing, structured enough to organize it. Agents deeply rooted in a domain through a long conversation suffer curse-of-knowledge bias and produce skills that under-explain. When a skill needs to be written or rewritten, prefer spawning a fresh agent with the relevant ADRs and specs as input over having the long-conversation agent author it directly. The deep-context agent reviews for technical accuracy after.
+
+## Consequences
+
+**Positive:**
+
+- Agents working on a domain load focused, sufficient context. Agents working elsewhere are unburdened.
+- Frontmatter `description` enables harness-level skill discovery — agents find the right skill from the task alone, no manual routing required.
+- `allowed-tools` prevents accidental capability surface (a doc-only skill cannot edit code).
+- Routing tables in L0 make the skill's structure self-documenting; future contributors see what L1 files exist and what each covers.
+- Establishes a reusable template. Future domains follow the same shape; the cognitive overhead is paid once.
+
+**Negative:**
+
+- Two shapes mean a contributor must choose which to use. The choice is usually obvious (line count) but not always.
+- L0 routing tables drift if maintained sloppily. A new L1 file added without updating L0 is invisible. Mitigation: code review.
+- Progressive disclosure has overhead for tiny domains. The flat-vs.-progressive decision must be made deliberately, not defaulted.
+- Frontmatter `description` is what the harness uses for discovery. A vague description means the skill is not loaded when it should be. This requires care at authoring time.
+
+## Alternatives considered
+
+1. **Status quo: flat skills only.** Rejected: jobs domain alone produces ~3000 lines of spec content (eight specs at ~400 lines each). A flat skill either omits 80% of it (losing fidelity) or includes everything (defeating the discovery purpose). Progressive disclosure exists for exactly this scale.
+
+2. **No frontmatter (pattern-stack's choice).** Rejected: frontmatter costs nothing and gains harness-level discovery, tool restriction, and slash-command gating. Pattern-stack's omission appears to be incidental — their plugin model uses prescriptive routing in agent prompts, which is a different mechanism we don't have here. We preserve their L0/L1 structural insight while adding the standard frontmatter the broader Claude Code ecosystem uses.
+
+3. **Pure prescriptive routing (no frontmatter, agents told what to read in their system prompts).** Rejected: requires every agent definition to know about every skill. Frontmatter centralizes the routing rule with the skill itself, which scales as skills accumulate.
+
+4. **Single mega-skill per project.** Rejected: a single 5000-line `SKILL.md` covering jobs + events + entities + templates + everything else is the worst of both worlds — no discovery, full context cost on every load.
+
+## Migration
+
+**No migration of existing flat skills.** They work; flat is correct for their size. If a flat skill grows past ~250 lines and the structure starts to suffer, convert to progressive at that point.
+
+**New domains use progressive.** When a new complex domain emerges (the Event-to-Job Bridge in ADR-023, coordination in ADR-025, etc.), the convention is: new domain → new directory under `.claude/skills/` → progressive structure → frontmatter.
+
+**`CLAUDE.md` does not enumerate domains.** The `description` field on each skill carries the discovery information. Adding a new skill does not require a CLAUDE.md edit.
+
+## References
+
+- `docs/specs/pattern-stack-disclosure-audit.md` — the audit that informed this design
+- `.claude/skills/README.md` — quick-reference convention summary for contributors
+- `.claude/skills/jobs/`, `.claude/skills/events/` — first two domain skills authored under this convention. Both are flat (177 and 96 lines) — under the 300-line threshold for L1 split. They will split as their domains grow (jobs Phases 2-7; events codegen formalization moving from plan to ADR + spec set). They demonstrate the **frontmatter convention + L0 structure**; the L1 split itself remains a forward-looking pattern documented for when it's needed.
+- `~/.claude/plugins/cache/claude-brain/claude-brain/1.0.0/skills/skill-authoring/SKILL.md` — standard Claude Code frontmatter reference

--- a/docs/specs/ADR-022-phase-1-issues.md
+++ b/docs/specs/ADR-022-phase-1-issues.md
@@ -1,0 +1,255 @@
+# ADR-022 Phase 1 — Job Orchestration Domain Model: Issue Breakdown
+
+**Source of truth:** [ADR-022](../adrs/ADR-022-job-orchestration-domain-model.md)
+**Phase scope:** Layers 1–4 of the synthesis (triad, hierarchy, scoping, policy). Ships the complete domain foundation: schemas, protocols, services, backends, modules, worker entrypoints, pool config, decorator, boot-time validator, `scopeable` codegen flag, multi-tenancy opt-in, upgrade path, and Atlas migration docs. Does not include signals/wait (ADR-025), observability (ADR-026), or agent step kinds (ADR-027).
+
+---
+
+## Issue List
+
+### JOB-1 — Add Drizzle schemas for `job`, `job_run`, and `job_step`
+
+**Scope.** Three new `pgTable` declarations land in `runtime/subsystems/jobs/`. All columns specified in ADR-022 are present, including the Phase 3 placeholder columns (`wait_kind`, `resume_token`, `wait_deadline`) on `job_run` and the `waiting` enum value on the status column. All required indexes are declared.
+
+**Files touched.**
+- `runtime/subsystems/jobs/job-orchestration.schema.ts` (new)
+- `runtime/subsystems/jobs/index.ts` (re-export new schema symbols)
+
+**Depends on.** Nothing.
+
+**Acceptance criteria.**
+- [ ] `job`, `job_run`, and `job_step` tables are exported as Drizzle `pgTable` objects.
+- [ ] `job_run.status` enum includes `pending | running | waiting | completed | failed | timed_out | canceled`.
+- [ ] All five indexes on `job_run` (claim, tree, scope, dedupe, concurrency) are declared.
+- [ ] Both indexes on `job_step` (`(job_run_id, step_id)` unique, `(job_run_id, seq)`) are declared.
+- [ ] `tenant_id` column is present but annotated that it is conditionally emitted (note in comment; the conditional emit logic lives in JOB-7).
+- [ ] Phase 3 placeholder columns exist with a `// ADR-025` comment; no application logic references them.
+- [ ] A unit test asserts the schema can be imported without error and that expected column names are present.
+
+**Out of scope.** No migration SQL — Atlas generates that from this schema. Service logic and claim query belong in JOB-3/JOB-4.
+
+---
+
+### JOB-2 — Define protocols `IJobOrchestrator`, `IJobRunService`, `IJobStepService` and base types
+
+**Scope.** The three protocol interfaces, plus `JobHandlerBase`, `JobContext<TInput>`, `@JobHandler` decorator, `ParentClosePolicy` enum, and injection tokens. These are the stable public API surface that all backends and consumer code will depend on.
+
+**Files touched.**
+- `runtime/subsystems/jobs/job-orchestrator.protocol.ts` (new)
+- `runtime/subsystems/jobs/job-run-service.protocol.ts` (new)
+- `runtime/subsystems/jobs/job-step-service.protocol.ts` (new)
+- `runtime/subsystems/jobs/job-handler.base.ts` (new — `JobHandlerBase`, `JobContext`, `@JobHandler` decorator)
+- `runtime/subsystems/jobs/jobs-domain.tokens.ts` (new — `JOB_ORCHESTRATOR`, `JOB_RUN_SERVICE`, `JOB_STEP_SERVICE` symbols)
+- `runtime/subsystems/jobs/index.ts` (re-export all new types)
+
+**Depends on.** JOB-1 (protocols reference row types from schema).
+
+**Acceptance criteria.**
+- [ ] `IJobOrchestrator` exposes at minimum `start(type, input, opts)`, `cancel(runId, opts?)`, `replay(runId)`.
+- [ ] `IJobRunService` exposes `listForScope`, `cancelForScope`, `rescheduleForScope`.
+- [ ] `IJobStepService` exposes `recordStep`, `findStep` (sufficient for Drizzle backend in JOB-3).
+- [ ] `@JobHandler` decorator accepts `<TInput>` type parameter and a metadata object matching the ADR spec (pool, scope, retry, concurrency, dedupe, timeoutMs, replayFrom).
+- [ ] `JobContext<TInput>` exposes `ctx.input`, `ctx.run`, `ctx.step(id, fn, opts?)`, `ctx.spawnChild(type, input, opts)`, `ctx.logger`. No `ctx.waitFor()` — that is ADR-025.
+- [ ] `ParentClosePolicy` enum has `Terminate | Cancel | Abandon`.
+- [ ] All three injection tokens are `Symbol()` values exported from `jobs-domain.tokens.ts`.
+- [ ] Type-level test: a sample `OnboardingHandler extends JobHandlerBase<OnboardingInput>` compiles without casts.
+
+**Out of scope.** No backend implementations — those are JOB-3 and JOB-4.
+
+---
+
+### JOB-3 — Drizzle backends for `IJobOrchestrator`, `IJobRunService`, `IJobStepService`
+
+**Scope.** Production Postgres implementations of all three protocols, including the claim query (`FOR UPDATE SKIP LOCKED`), step memoization logic, parent-close-policy cascade, stale-claim sweeper (time-based, default 5 min threshold), and run-level retry/timeout enforcement. `JobWorker` (the tick-processing loop) also lands here as it is tightly coupled to the Drizzle transaction model.
+
+**Files touched.**
+- `runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts` (new)
+- `runtime/subsystems/jobs/job-run-service.drizzle-backend.ts` (new)
+- `runtime/subsystems/jobs/job-step-service.drizzle-backend.ts` (new)
+- `runtime/subsystems/jobs/job-worker.ts` (new — tick loop, graceful shutdown)
+- `runtime/subsystems/jobs/index.ts` (re-export)
+
+**Depends on.** JOB-1, JOB-2.
+
+**Acceptance criteria.**
+- [ ] `claimNext(pool)` runs inside a single Drizzle transaction with `FOR UPDATE SKIP LOCKED` and sets `status = 'running'`, `claimed_at = now()`.
+- [ ] Dedupe check: a duplicate enqueue within `dedupe_window_ms` returns the existing run ID, no new row.
+- [ ] Concurrency collision: `queue | reject | replace` modes are enforced at enqueue time.
+- [ ] Step memoization: `ctx.step(id, fn)` returns cached `output` when a `completed` row with matching `step_id` exists; calls `fn` otherwise.
+- [ ] `replay_from: 'scratch'` clears `job_step` rows for the run before re-entry; `last_step` clears only the failing step; `last_checkpoint` is the no-op default.
+- [ ] Stale-claim sweeper: a `setInterval`-driven loop (wired via `OnModuleInit`) returns rows where `status='running' AND claimed_at < now() - threshold` back to `pending`.
+- [ ] `JobWorker` stops claiming on `SIGTERM`, drains in-flight steps within `shutdown_timeout_ms`, then exits.
+- [ ] Integration tests (Docker Postgres): enqueue → claim → complete round trip; cascade cancel; dedupe collapse.
+
+**Out of scope.** Memory backend is JOB-4. BullMQ native claim is a no-op for Phase 1 — BullMQ backend of `IJobQueue` (executor layer) is unchanged.
+
+---
+
+### JOB-4 — Memory backends for all three protocols + unit test suite
+
+**Scope.** In-process, mutex-based implementations of `IJobOrchestrator`, `IJobRunService`, and `IJobStepService` suitable for unit tests. Must be behaviourally equivalent to the Drizzle backends for all Phase 1 scenarios (claim, memoize, cascade cancel, dedupe).
+
+**Files touched.**
+- `runtime/subsystems/jobs/job-orchestrator.memory-backend.ts` (new)
+- `runtime/subsystems/jobs/job-run-service.memory-backend.ts` (new)
+- `runtime/subsystems/jobs/job-step-service.memory-backend.ts` (new)
+- `runtime/subsystems/jobs/index.ts` (re-export)
+- `runtime/subsystems/jobs/__tests__/job-orchestrator.unit.test.ts` (new)
+- `runtime/subsystems/jobs/__tests__/job-worker.unit.test.ts` (new)
+
+**Depends on.** JOB-2 (protocols), JOB-3 (behaviour spec to match).
+
+**Acceptance criteria.**
+- [ ] Memory claim uses a synchronous mutex (not DB transaction); behaviour matches Drizzle contract.
+- [ ] All three collision modes (`queue | reject | replace`) pass the same unit test cases as the Drizzle integration tests.
+- [ ] Step memoization and replay modes are tested at unit level without Docker.
+- [ ] Cascade cancel (parent terminates → children cancel) is covered.
+- [ ] `@JobHandler`-decorated class instantiated in a test module; `ctx.step` memoises across two simulated ticks.
+- [ ] All tests run in `just test-unit` (no Docker).
+
+**Out of scope.** No BullMQ-specific claim logic — the executor-layer BullMQ backend is unchanged.
+
+---
+
+### JOB-5 — `JobsDomainModule.forRoot()` and `JobWorkerModule.forRoot()` with pool config loader
+
+**Scope.** Two NestJS `DynamicModule` factories wiring the new protocols to their backends. `JobsDomainModule` is the read/write service module (imported by `AppModule`). `JobWorkerModule` additionally starts the worker tick loop, boots the handler registry, runs the boot-time validator (every `Job` row must have a registered `@JobHandler` class), and upserts `Job` rows from decorator metadata. The pool config loader parses `codegen.config.yaml: jobs.pools`, applies the five framework defaults, validates that user handlers do not target `reserved: true` pools, and wires each pool to an `IJobQueue` queue name.
+
+**Files touched.**
+- `runtime/subsystems/jobs/jobs-domain.module.ts` (new)
+- `runtime/subsystems/jobs/job-worker.module.ts` (new)
+- `runtime/subsystems/jobs/pool-config.loader.ts` (new)
+- `runtime/subsystems/jobs/index.ts` (re-export modules)
+
+**Depends on.** JOB-2, JOB-3, JOB-4.
+
+**Acceptance criteria.**
+- [ ] `JobsDomainModule.forRoot({ backend: 'drizzle' | 'memory' })` wires all three protocol tokens; `global: true`; matches ADR-008 factory pattern.
+- [ ] `JobWorkerModule.forRoot({ mode: 'embedded' | 'standalone', pools?: [...] })` starts the claim loop for each configured pool; stops cleanly via `OnModuleDestroy`.
+- [ ] Boot-time validator: if a `Job` row exists in Postgres with no matching entry in the handler registry, module init throws with the missing type name listed.
+- [ ] `@JobHandler` classes are upserted into the `job` table on `onModuleInit`; a handler removed from source logs a warning (prune is Phase 6).
+- [ ] Pool config loader rejects a user `@JobHandler` targeting a `reserved: true` pool with a descriptive error at module init.
+- [ ] Unit test: `JobsDomainModule.forRoot({ backend: 'memory' })` boots in NestJS test harness; `JOB_ORCHESTRATOR` token resolves.
+
+**Out of scope.** Standalone worker entrypoint scaffold file (`worker.ts`) — that is JOB-6.
+
+---
+
+### JOB-6 — Hygen scaffold templates: `worker.ts`, `main.ts` hook, config block
+
+**Scope.** Generator-side additions so that `bun codegen subsystem jobs` (or the upgrade path) emits the two worker entrypoint files and adds the `jobs:` block to `codegen.config.yaml`. Templates live under `templates/subsystem/jobs/` and follow existing Hygen EJS style. The standalone `worker.ts` boots a bare NestJS context with only `JobWorkerModule`; `main.ts` gains an optional embedded import comment. The config block template writes the five default pool definitions.
+
+**Files touched.**
+- `templates/subsystem/jobs/worker.ejs.t` (new)
+- `templates/subsystem/jobs/main-hook.ejs.t` (new — inject fragment)
+- `templates/subsystem/jobs/codegen-config-jobs-block.ejs.t` (new)
+- `src/cli/commands/subsystem.command.ts` (minor — wire new job templates to `gen-subsystem jobs`)
+
+**Depends on.** JOB-5 (references module names that must be stable).
+
+**Acceptance criteria.**
+- [ ] `just gen-subsystem jobs` produces `worker.ts` and injects a `jobs:` config block in a fresh project scaffold.
+- [ ] Generated `worker.ts` imports `JobWorkerModule` and boots a NestJS app without HTTP listener.
+- [ ] Config block contains the five default pools with correct `reserved` flags.
+- [ ] Baseline snapshot test updated; `just test-baseline` passes.
+
+**Out of scope.** None at the operational-glue level — fresh installs are the only install path (no backwards-compat upgrade flow needed).
+
+---
+
+### JOB-7 — `scopeable: true` entity flag → generated `ScopeEntityType` union
+
+**Scope.** Parser and codegen additions to read `scopeable: true` from entity YAML and collect all such entity names into a generated `ScopeEntityType` TypeScript union. The union is emitted into `@shared/jobs/scope-entity-type.ts` (or equivalent project path). The Zod schema gains the `scopeable` field. No DB CHECK constraint — type safety is TS-only per ADR-022.
+
+**Files touched.**
+- `src/schema/entity-definition.schema.ts` (add `scopeable: z.boolean().optional()` to `EntityConfigSchema`)
+- `src/parser/load-entities.ts` (collect scopeable names, expose via parsed output)
+- `templates/entity/new/clean-lite-ps/` or a new `templates/shared/scope-entity-type.ejs.t` (emit the union file)
+- `src/__tests__/schema/entity-definition.schema.test.ts` (unit test for new field)
+
+**Depends on.** JOB-1 (schema uses `scope_entity_type` text column whose type this union matches), JOB-2 (protocol `scope` option in `@JobHandler` references this union).
+
+**Acceptance criteria.**
+- [ ] `scopeable: true` in an entity YAML passes Zod validation; absence or `false` also passes.
+- [ ] Parser collects all `scopeable: true` entity names across the entities directory.
+- [ ] Generator emits a `ScopeEntityType` union containing exactly the scopeable entity names.
+- [ ] An entity without `scopeable` does not appear in the union.
+- [ ] Unit test: two entities, one scopeable, one not; assert union contains only the first.
+
+**Out of scope.** Multi-tenancy column conditional emit — that is JOB-8. No generated helper methods on `JobRunService` beyond what JOB-3 already provides.
+
+---
+
+### JOB-8 — Multi-tenancy opt-in and Atlas migration docs
+
+**Scope.** Two deliverables. (1) Multi-tenancy: when `jobs.multi_tenant: true` in config, all service methods accept and enforce `tenantId` (column already exists per JOB-1's unconditional emit decision; this issue threads the flag through service-layer logic). (2) Docs: `docs/CONSUMER-SETUP.md` deletes the `drizzle-kit push` recommendation and adds an Atlas migration workflow section.
+
+**Removed (2026-04-18):** Upgrade command (`subsystem upgrade jobs`) — per project policy (no backwards compat until we have users), `subsystem install jobs` overwrites cleanly. No upgrade path needed.
+
+**Files touched.**
+- Service-layer files in `runtime/subsystems/jobs/` (orchestrator + run service backends, both Drizzle and Memory; module options + token)
+- `docs/CONSUMER-SETUP.md` (delete `drizzle-kit push` section; add Atlas section)
+
+**Depends on.** JOB-1 (schema), JOB-5 (module options).
+
+**Acceptance criteria.**
+- [ ] `codegen.config.yaml: jobs.multi_tenant: false` (default): no tenant filtering; `tenant_id` written as null.
+- [ ] `multi_tenant: true`: every service method accepts `tenantId`; missing `tenantId` throws `MissingTenantIdError`; explicit `null` allowed for cross-tenant background jobs; queries filter by `tenantId`.
+- [ ] `docs/CONSUMER-SETUP.md` contains "Atlas migration workflow" section; `drizzle-kit push` section removed.
+- [ ] A reviewer can follow the Atlas section from scratch on a clean project.
+
+**Out of scope.** Tenant-aware fair queuing (Phase 6). `job_event` table (ADR-026). Upgrade command (removed per backwards-compat policy).
+
+---
+
+## Dependency Graph
+
+```
+JOB-1 (schema)
+  └──▶ JOB-2 (protocols + base types)
+         ├──▶ JOB-3 (Drizzle backends)
+         │      └──▶ JOB-4 (Memory backends + unit tests)
+         │              └──▶ JOB-5 (modules + pool loader)
+         │                     ├──▶ JOB-6 (Hygen templates)
+         │                     │      └──▶ JOB-8 (multi-tenant + Atlas docs)
+         │                     └──▶ JOB-7 (scopeable flag)
+         │                            └──▶ JOB-8
+         └──▶ JOB-7 (also uses JOB-1 for schema column reference)
+```
+
+Simplified linear view of critical path:
+
+```
+JOB-1 → JOB-2 → JOB-3 → JOB-4 → JOB-5 → JOB-6 ─┐
+                                           JOB-7 ──┴─→ JOB-8
+```
+
+---
+
+## Suggested Sequencing
+
+**Wave 1 (parallel foundation).**
+JOB-1 (schemas) — no dependencies; unblocks everything.
+
+**Wave 2 (parallel protocol + type work).**
+JOB-2 (protocols and base types) — starts as soon as JOB-1 merges.
+
+**Wave 3 (parallel implementation).**
+JOB-3 (Drizzle backends) and JOB-7 (scopeable flag) can proceed in parallel once JOB-2 is merged. JOB-7 only needs JOB-1 and JOB-2; it does not need JOB-3.
+
+**Wave 4 (parallel close-out).**
+JOB-4 (memory backends) starts after JOB-3 merges (behavioural parity). JOB-5 (modules) starts after JOB-4 merges. JOB-6 (Hygen templates) starts after JOB-5 merges. JOB-8 (multi-tenancy + upgrade + docs) starts after JOB-5, JOB-6, and JOB-7 all merge.
+
+---
+
+## Open Questions for the Owner
+
+1. **`tenant_id` conditional emit mechanism.** The ADR says `tenant_id` appears "only when `codegen.config.yaml: jobs.multi_tenant: true`." Should this be a separate schema file that is included/excluded at scaffold time, or a runtime flag checked when `JobsDomainModule.forRoot()` runs Drizzle migrations? The two approaches have different migration-safety trade-offs.
+
+2. **Stale-claim sweeper placement.** The ADR describes a per-pool stale-claim sweeper but does not specify whether it runs as part of `JobWorker` (one sweeper per pool-worker) or as a separate singleton service in `JobsDomainModule`. With multiple worker processes, a singleton sweeper could double-recover a row that a slow worker is still processing. Clarify expected concurrency model.
+
+3. **`job` table upsert on every boot.** The ADR says `Job` rows are populated from `@JobHandler` decorator metadata at boot. If a consumer runs multiple app instances (horizontal scale), every instance will attempt the upsert concurrently. Should the upsert use `ON CONFLICT DO NOTHING`, `ON CONFLICT DO UPDATE`, or an advisory lock? The right choice affects observable `version` bump behaviour.
+
+4. **Boot-time validator in the Drizzle backend only.** The registry validator checks that every `Job` DB row has a handler. When `backend: 'memory'` is used (tests), there are no DB rows. Should the validator be skipped entirely in memory mode, or should it cross-check the in-memory registry against what would be in the DB? Clarify test-mode semantics.
+
+5. **`ScopeEntityType` union file location.** The ADR says the union is the generated output of `scopeable: true` entity flags, but does not specify where in the consumer project it lands. Candidates: `@shared/jobs/scope-entity-type.ts`, `@shared/types/scope-entity-type.ts`, or co-located with the jobs subsystem scaffold. This affects the import path in `@JobHandler` decorator usage and needs to be locked before JOB-7 templates are written.

--- a/docs/specs/JOB-1.md
+++ b/docs/specs/JOB-1.md
@@ -1,0 +1,246 @@
+# JOB-1 — Drizzle Schemas for `job`, `job_run`, `job_step`
+
+**Issue:** JOB-1
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Phase:** ADR-022 Phase 1
+**Depends on:** Nothing — this is the foundation all other JOB issues build on.
+
+## Overview
+
+This PR adds `runtime/subsystems/jobs/job-orchestration.schema.ts`, declaring three Drizzle `pgTable` objects (`jobs`, `jobRuns`, `jobSteps`) plus their enums, indexes, and `InferSelectModel` type exports. It is a pure schema file — no service logic, no NestJS providers. All subsequent Phase 1 issues depend on the row types exported here.
+
+## Context
+
+**What exists.** `runtime/subsystems/jobs/job-queue.schema.ts` declares the executor-layer `job_queue` table (pg-boss pattern: `pending | active | completed | failed | expired`, four columns, two index comments). The `index.ts` barrel re-exports `jobQueue` and `JobRow`. This table is **unchanged** by JOB-1.
+
+**What this PR adds.** A second schema file in the same directory — `job-orchestration.schema.ts` — for the orchestration-layer triad. The two "job" concepts coexist in the DB until a future retirement of `job_queue`. Naming makes this explicit: executor table stays `job_queue`; orchestration tables are `job`, `job_run`, `job_step`.
+
+## Architecture
+
+```
+job-orchestration.schema.ts
+  ├── pgEnum jobRunStatus   ('pending'|'running'|'waiting'|'completed'|'failed'|'timed_out'|'canceled')
+  ├── pgEnum jobStepKind    ('task')                       ← extended in ADR-027
+  ├── pgEnum jobStepStatus  ('pending'|'running'|'completed'|'failed'|'skipped')
+  ├── pgEnum collisionMode  ('queue'|'reject'|'replace')
+  ├── pgEnum replayFrom     ('scratch'|'last_step'|'last_checkpoint')
+  ├── pgEnum parentClosePolicy  ('terminate'|'cancel'|'abandon')
+  ├── pgEnum waitKind       (placeholder — single value 'signal' for Phase 3)
+  ├── pgTable 'job'
+  ├── pgTable 'job_run'      ──FK──▶ job.type
+  │                          ──FK──▶ job_run.id  (self, parent)
+  └── pgTable 'job_step'     ──FK──▶ job_run.id
+```
+
+No service code touches this file. JOB-2 imports the `InferSelectModel` row types to build protocol signatures. JOB-3 imports the table objects to write queries.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `runtime/subsystems/jobs/job-orchestration.schema.ts` | create | All three table declarations, enums, exported row types |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export new schema symbols alongside existing `job-queue.schema` exports |
+| `runtime/subsystems/jobs/__tests__/job-orchestration.schema.test.ts` | create | Import smoke test + column-presence assertions |
+
+## Interfaces and Column Definitions
+
+The file follows the pattern in `job-queue.schema.ts` (Drizzle imports at top, `pgTable` call, `InferSelectModel` type alias at bottom). It extends that pattern with `pgEnum` for multi-value columns and `index` / `uniqueIndex` for the required index declarations.
+
+### Enums
+
+All declared via `pgEnum(name, [...values])` and exported so JOB-2 protocols can reference value-literal types.
+
+- `jobRunStatusEnum` — name `'job_run_status'`, values `['pending', 'running', 'waiting', 'completed', 'failed', 'timed_out', 'canceled']`
+- `jobStepKindEnum` — name `'job_step_kind'`, values `['task']` — comment: `// extended in ADR-027: tool_call | llm_call | wait | checkpoint | message`
+- `jobStepStatusEnum` — name `'job_step_status'`, values `['pending', 'running', 'completed', 'failed', 'skipped']`
+- `collisionModeEnum` — name `'job_collision_mode'`, values `['queue', 'reject', 'replace']`
+- `replayFromEnum` — name `'job_replay_from'`, values `['scratch', 'last_step', 'last_checkpoint']`
+- `parentClosePolicyEnum` — name `'job_parent_close_policy'`, values `['terminate', 'cancel', 'abandon']`
+- `waitKindEnum` — name `'job_wait_kind'`, values `['signal']` — comment: `// Phase 3 placeholder — see ADR-025`
+- `triggerSourceEnum` — name `'job_trigger_source'`, values `['manual', 'schedule', 'event', 'parent']` — comment: `// Phase 2 may add more sources; requires Atlas migration`
+
+### `pgTable 'job'`
+
+Primary key: `type` as `text('type').primaryKey()` — not a UUID; the business key is the handler type string (e.g. `'onboarding'`).
+
+Columns:
+- `type`: `text`, PK
+- `version`: `integer`, `notNull`, default `1`
+- `pool`: `text`, `notNull` — references configured pool name (string, no FK — pool names are config-time, not DB-time)
+- `scopeEntityType`: `text('scope_entity_type')`, nullable — global jobs omit this
+- `retryPolicy`: `jsonb('retry_policy').notNull().$type<RetryPolicy>()` — shape: `{ attempts: number, backoff: 'fixed'|'exponential', baseMs: number, nonRetryableErrors?: string[] }`
+- `timeoutMs`: `integer('timeout_ms')`, nullable
+- `concurrencyKeyTemplate`: `text('concurrency_key_template')`, nullable
+- `collisionMode`: `collisionModeEnum('collision_mode').notNull().default('queue')`
+- `dedupeKeyTemplate`: `text('dedupe_key_template')`, nullable
+- `dedupeWindowMs`: `integer('dedupe_window_ms')`, nullable
+- `priorityDefault`: `integer('priority_default').notNull().default(0)`
+- `replayFrom`: `replayFromEnum('replay_from').notNull().default('last_checkpoint')`
+- `createdAt`: `timestamp('created_at', { withTimezone: true }).notNull().defaultNow()`
+- `updatedAt`: `timestamp('updated_at', { withTimezone: true }).notNull().defaultNow()`
+
+No table-level indexes — `type` PK is sufficient; range queries on `job` are not in scope.
+
+Exported type: `export type JobDefinitionRow = InferSelectModel<typeof jobs>`
+(Name avoids collision with the common `Job` name in application code.)
+
+### `pgTable 'job_run'`
+
+Primary key: `uuid('id').primaryKey().defaultRandom()`
+
+Columns:
+- `id`: uuid PK
+- `jobType`: `text('job_type').notNull().references(() => jobs.type)`
+- `jobVersion`: `integer('job_version').notNull()`
+- `parentRunId`: `uuid('parent_run_id').references(() => jobRuns.id)`, nullable (self-reference)
+- `rootRunId`: `uuid('root_run_id').notNull()` — no FK; service generates `id` client-side via `randomUUID()` and sets `root_run_id = id` for root runs (single INSERT, no nullable, no self-FK race)
+- `parentClosePolicy`: `parentClosePolicyEnum('parent_close_policy').notNull().default('terminate')`
+- `scopeEntityType`: `text('scope_entity_type')`, nullable
+- `scopeEntityId`: `text('scope_entity_id')`, nullable
+- `tenantId`: `text('tenant_id')`, nullable — comment: `// conditionally emitted — see JOB-8`
+- `tags`: `jsonb('tags').notNull().default({}).$type<Record<string, string>>()`
+- `pool`: `text('pool').notNull()`
+- `priority`: `integer('priority').notNull().default(0)`
+- `concurrencyKey`: `text('concurrency_key')`, nullable
+- `dedupeKey`: `text('dedupe_key')`, nullable
+- `status`: `jobRunStatusEnum('status').notNull().default('pending')`
+- `input`: `jsonb('input').notNull().$type<Record<string, unknown>>()`
+- `output`: `jsonb('output').$type<Record<string, unknown>>()`, nullable
+- `error`: `jsonb('error').$type<JobRunError>()`, nullable — shape: `{ message: string, stack?: string, retryable: boolean, attempt: number }`
+- `triggerSource`: `triggerSourceEnum('trigger_source').notNull()`
+- `triggerRef`: `text('trigger_ref')`, nullable
+- `runAt`: `timestamp('run_at', { withTimezone: true }).notNull().defaultNow()`
+- `startedAt`: `timestamp('started_at', { withTimezone: true })`, nullable
+- `finishedAt`: `timestamp('finished_at', { withTimezone: true })`, nullable
+- `claimedAt`: `timestamp('claimed_at', { withTimezone: true })`, nullable
+- `attempts`: `integer('attempts').notNull().default(0)`
+- `waitKind`: `waitKindEnum('wait_kind')`, nullable — comment: `// Phase 3 placeholder — see ADR-025`
+- `resumeToken`: `text('resume_token')`, nullable — comment: `// Phase 3 placeholder — see ADR-025`
+- `waitDeadline`: `timestamp('wait_deadline', { withTimezone: true })`, nullable — comment: `// Phase 3 placeholder — see ADR-025`
+- `createdAt`: `timestamp('created_at', { withTimezone: true }).notNull().defaultNow()`
+- `updatedAt`: `timestamp('updated_at', { withTimezone: true }).notNull().defaultNow()`
+
+**Indexes** (declared in the table's second argument object, using Drizzle `index()` / `uniqueIndex()`):
+
+| Index name | Columns / filter | Purpose |
+|---|---|---|
+| `idx_job_run_claim` | `(status, pool, run_at)` | Claim query ORDER BY priority DESC, run_at ASC |
+| `idx_job_run_root` | `(root_run_id)` | Tree traversal / cascade cancel |
+| `idx_job_run_scope` | `(scope_entity_type, scope_entity_id)` | listForScope query |
+| `idx_job_run_dedupe` | `(job_type, dedupe_key)` partial `WHERE dedupe_key IS NOT NULL` | Idempotency collapse |
+| `idx_job_run_concurrency` | `(concurrency_key)` partial `WHERE concurrency_key IS NOT NULL AND status IN ('pending','running')` | Collision check |
+
+Drizzle partial index syntax: `.where(sql\`...\`)` passed to the `index()` builder.
+
+Exported type: `export type JobRunRow = InferSelectModel<typeof jobRuns>`
+
+### `pgTable 'job_step'`
+
+Primary key: `uuid('id').primaryKey().defaultRandom()`
+
+Columns:
+- `id`: uuid PK
+- `jobRunId`: `uuid('job_run_id').notNull().references(() => jobRuns.id)`
+- `stepId`: `text('step_id').notNull()` — user-chosen stable identifier
+- `kind`: `jobStepKindEnum('kind').notNull().default('task')`
+- `seq`: `integer('seq').notNull()` — monotonic within run; `integer` (max 2B per run) is sufficient (downgraded from ADR-022's bigint; revisit only if a single run exceeds 2 billion steps, which is implausible)
+- `status`: `jobStepStatusEnum('status').notNull().default('pending')`
+- `input`: `jsonb('input').$type<Record<string, unknown>>()`, nullable
+- `output`: `jsonb('output').$type<Record<string, unknown>>()`, nullable — memoized on success
+- `error`: `jsonb('error').$type<JobRunError>()`, nullable — reuse same shape as `job_run.error`
+- `attempts`: `integer('attempts').notNull().default(0)`
+- `startedAt`: `timestamp('started_at', { withTimezone: true })`, nullable
+- `finishedAt`: `timestamp('finished_at', { withTimezone: true })`, nullable
+
+**Indexes:**
+
+| Index name | Columns | Type |
+|---|---|---|
+| `idx_job_step_run_step` | `(job_run_id, step_id)` | `uniqueIndex` — enforces no duplicate step IDs per run |
+| `idx_job_step_timeline` | `(job_run_id, seq)` | `index` — ordered timeline reads |
+
+Exported type: `export type JobStepRow = InferSelectModel<typeof jobSteps>`
+
+### Internal `$type<>` helpers to define at top of file
+
+```ts
+type RetryPolicy = {
+  attempts: number;
+  backoff: 'fixed' | 'exponential';
+  baseMs: number;
+  nonRetryableErrors?: string[];
+}
+
+type JobRunError = {
+  message: string;
+  stack?: string;
+  retryable: boolean;
+  attempt: number;
+}
+```
+
+These are not exported — they are annotation types for jsonb columns only. JOB-2 will define the full public-facing protocol types.
+
+### `index.ts` additions
+
+Add below the existing exports:
+
+```ts
+export { jobs, jobRuns, jobSteps } from './job-orchestration.schema';
+export type { JobDefinitionRow, JobRunRow, JobStepRow } from './job-orchestration.schema';
+export { jobRunStatusEnum, jobStepKindEnum, jobStepStatusEnum, collisionModeEnum, replayFromEnum, parentClosePolicyEnum, waitKindEnum, triggerSourceEnum } from './job-orchestration.schema';
+```
+
+Do not remove or change existing `job-queue.schema` exports.
+
+## Acceptance Criteria
+
+- `jobs`, `jobRuns`, `jobSteps` are exported Drizzle `pgTable` objects; a bare `import` of the file throws no errors.
+- `jobRunStatusEnum` values are exactly `['pending', 'running', 'waiting', 'completed', 'failed', 'timed_out', 'canceled']` — `waiting` must be present (reserved for ADR-025 without breaking schema migration later).
+- Five indexes on `job_run` are declared with names: `idx_job_run_claim`, `idx_job_run_root`, `idx_job_run_scope`, `idx_job_run_dedupe`, `idx_job_run_concurrency`.
+- `idx_job_run_dedupe` and `idx_job_run_concurrency` are partial indexes (`.where(...)` clause present).
+- Two indexes on `job_step` are declared: `idx_job_step_run_step` as `uniqueIndex`, `idx_job_step_timeline` as `index`.
+- `tenant_id` column is present on `job_run` (nullable `text`) with inline comment `// conditionally emitted — see JOB-8`.
+- `wait_kind`, `resume_token`, `wait_deadline` columns are present on `job_run` with inline comment `// Phase 3 placeholder — see ADR-025`; no application logic references these columns anywhere in this PR.
+- `JobDefinitionRow`, `JobRunRow`, `JobStepRow` are exported `InferSelectModel` type aliases.
+- All enum objects are exported from `index.ts`.
+- `just test-unit` passes.
+
+## Testing Strategy
+
+**Unit (no Docker, no Postgres).** `runtime/subsystems/jobs/__tests__/job-orchestration.schema.test.ts`:
+
+- Import smoke: `import { jobs, jobRuns, jobSteps } from '../job-orchestration.schema'` does not throw.
+- Column presence on `job_run`: assert `jobRuns._.columns` contains keys `id`, `jobType`, `status`, `pool`, `runAt`, `tenantId`, `waitKind`, `resumeToken`, `waitDeadline`, `rootRunId`, `parentRunId`, `concurrencyKey`, `dedupeKey`.
+- Column presence on `job_step`: assert `jobSteps._.columns` contains keys `id`, `jobRunId`, `stepId`, `seq`, `kind`, `status`, `output`.
+- Enum values: assert `jobRunStatusEnum.enumValues` includes `'waiting'` and `'timed_out'`.
+- Type check (compile-time only): assign a literal object to `JobRunRow` — verifies `InferSelectModel` resolved without `any` widening.
+
+No integration tests in this PR — JOB-3 owns the first real Postgres round-trip.
+
+## `tenant_id` — Proposed Resolution of Open Question #1
+
+**Question.** Should the conditional-emit mechanism be a separate schema file included/excluded at scaffold time, or a runtime flag checked when the module initialises migrations?
+
+**Proposed answer: land `tenant_id` unconditionally in Phase 1 (this PR), annotate it, and delegate gating to JOB-8.**
+
+Rationale:
+- The column is `nullable text`. A project that never sets it pays zero cost — no query changes, no JOIN overhead.
+- Scaffold-time file inclusion/exclusion introduces a Hygen conditional in a template that is otherwise straightforward, and means a project that later enables `multi_tenant: true` needs a new migration just to add a column (not just a service-layer change). That migration-safety risk is the stronger concern.
+- Runtime gating inside `forRoot()` (checking config and conditionally applying migrations) is complex and fragile — Drizzle schema objects are static; you cannot conditionally include a column without a second schema variant and a branch in every query that touches `tenant_id`.
+- The clean path: column always exists in the DB; JOB-8 controls whether the service layer reads/writes/filters it. A single Atlas migration diff on a `multi_tenant: false` project shows the column present and null — that is acceptable.
+
+**Action for JOB-1:** Add `tenantId` to `job_run` as a nullable column with comment `// conditionally emitted — see JOB-8`. No conditional logic in this file.
+
+## Open Questions
+
+- [x] **`triggerSource` as `text` vs. `pgEnum`.** **Resolved 2026-04-18: `pgEnum`.** Standing rule: closed value sets always use `pgEnum`. Phase 2 trigger source additions cost one Atlas migration each — tolerable for the typo-rejection benefit.
+- [x] **`rootRunId` FK constraint.** **Resolved 2026-04-18: drop the FK, keep self-reference, generate `id` client-side via `randomUUID()` so `root_run_id = id` is settable in a single INSERT. Service layer guarantees correctness; no DB-level enforcement.**
+- [x] **`seq` bigint mode.** **Resolved 2026-04-18: downgrade to `integer`. 2 billion steps per run is implausible.**
+
+## References
+
+- ADR-022: `docs/adrs/ADR-022-job-orchestration-domain-model.md`
+- Phase 1 issue breakdown: `docs/specs/ADR-022-phase-1-issues.md`
+- Pattern reference: `runtime/subsystems/jobs/job-queue.schema.ts`, `runtime/subsystems/events/domain-events.schema.ts`

--- a/docs/specs/JOB-1.md
+++ b/docs/specs/JOB-1.md
@@ -12,9 +12,11 @@ This PR adds `runtime/subsystems/jobs/job-orchestration.schema.ts`, declaring th
 
 ## Context
 
-**What exists.** `runtime/subsystems/jobs/job-queue.schema.ts` declares the executor-layer `job_queue` table (pg-boss pattern: `pending | active | completed | failed | expired`, four columns, two index comments). The `index.ts` barrel re-exports `jobQueue` and `JobRow`. This table is **unchanged** by JOB-1.
+**What exists.** `runtime/subsystems/jobs/` contains the legacy `IJobQueue` executor protocol and four backends (Drizzle/BullMQ/Redis/Memory) along with `job-queue.schema.ts` defining the pg-boss-style `job_queue` table. Per the architectural collapse decision (CLAUDE.md operating principles, ADR-022 revised spine), this entire executor layer is being removed — it was a degenerate transport that hid every native feature of any swappable backend behind a four-method dispatch port.
 
-**What this PR adds.** A second schema file in the same directory — `job-orchestration.schema.ts` — for the orchestration-layer triad. The two "job" concepts coexist in the DB until a future retirement of `job_queue`. Naming makes this explicit: executor table stays `job_queue`; orchestration tables are `job`, `job_run`, `job_step`.
+**What this PR adds.** A single new schema file `job-orchestration.schema.ts` containing the three core tables: `job`, `job_run`, `job_step`. Phase 1 ships only this single layer. There is no `job_queue` table, no executor port. Worker claim runs `SELECT ... FOR UPDATE SKIP LOCKED` directly against `job_run` (see JOB-3).
+
+**What this PR removes.** `runtime/subsystems/jobs/job-queue.schema.ts`, `job-queue.protocol.ts`, all four `job-queue.*-backend.ts` files, `jobs.module.ts`, `jobs.tokens.ts`. The `index.ts` barrel is rewritten to export only the new orchestration schema.
 
 ## Architecture
 
@@ -40,7 +42,15 @@ No service code touches this file. JOB-2 imports the `InferSelectModel` row type
 | File | Action | Purpose |
 |------|--------|---------|
 | `runtime/subsystems/jobs/job-orchestration.schema.ts` | create | All three table declarations, enums, exported row types |
-| `runtime/subsystems/jobs/index.ts` | modify | Re-export new schema symbols alongside existing `job-queue.schema` exports |
+| `runtime/subsystems/jobs/index.ts` | rewrite | Export new orchestration schema symbols only; remove all `IJobQueue` exports |
+| `runtime/subsystems/jobs/job-queue.schema.ts` | **delete** | Executor-layer table removed |
+| `runtime/subsystems/jobs/job-queue.protocol.ts` | **delete** | Executor-layer port removed |
+| `runtime/subsystems/jobs/job-queue.drizzle-backend.ts` | **delete** | Executor-layer backend removed |
+| `runtime/subsystems/jobs/job-queue.bullmq-backend.ts` | **delete** | Executor-layer backend removed (BullMQ adapter to be re-introduced at orchestrator layer in Phase 6+) |
+| `runtime/subsystems/jobs/job-queue.redis-backend.ts` | **delete** | Executor-layer backend removed |
+| `runtime/subsystems/jobs/job-queue.memory-backend.ts` | **delete** | Executor-layer backend removed |
+| `runtime/subsystems/jobs/jobs.module.ts` | **delete** | Executor-layer module removed; replaced by `JobsDomainModule` in JOB-5 |
+| `runtime/subsystems/jobs/jobs.tokens.ts` | **delete** | Executor-layer tokens removed; orchestration tokens live in `jobs-domain.tokens.ts` (JOB-2) |
 | `runtime/subsystems/jobs/__tests__/job-orchestration.schema.test.ts` | create | Import smoke test + column-presence assertions |
 
 ## Interfaces and Column Definitions
@@ -182,17 +192,28 @@ type JobRunError = {
 
 These are not exported — they are annotation types for jsonb columns only. JOB-2 will define the full public-facing protocol types.
 
-### `index.ts` additions
+### `index.ts` rewrite
 
-Add below the existing exports:
+The barrel is rewritten to export only the new orchestration surface. All `IJobQueue`-related exports (`jobQueue`, `JobRow`, `IJobQueue`, `JOB_QUEUE`, `JobsModule`, `DrizzleJobQueue`, `BullMQJobQueue`, etc.) are removed.
 
 ```ts
+// runtime/subsystems/jobs/index.ts
 export { jobs, jobRuns, jobSteps } from './job-orchestration.schema';
 export type { JobDefinitionRow, JobRunRow, JobStepRow } from './job-orchestration.schema';
-export { jobRunStatusEnum, jobStepKindEnum, jobStepStatusEnum, collisionModeEnum, replayFromEnum, parentClosePolicyEnum, waitKindEnum, triggerSourceEnum } from './job-orchestration.schema';
-```
+export {
+  jobRunStatusEnum,
+  jobStepKindEnum,
+  jobStepStatusEnum,
+  collisionModeEnum,
+  replayFromEnum,
+  parentClosePolicyEnum,
+  waitKindEnum,
+  triggerSourceEnum,
+} from './job-orchestration.schema';
 
-Do not remove or change existing `job-queue.schema` exports.
+// Subsequent issues add: protocols (JOB-2), backends (JOB-3, JOB-4),
+// modules (JOB-5). All net-new — nothing from the old executor layer survives.
+```
 
 ## Acceptance Criteria
 

--- a/docs/specs/JOB-2.md
+++ b/docs/specs/JOB-2.md
@@ -1,0 +1,283 @@
+# JOB-2 — Protocol Interfaces and Base Handler Types
+
+**Issue:** JOB-2
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Depends on:** JOB-1 (Drizzle schemas — row types imported by protocols)
+**Blocks:** JOB-3 (Drizzle backends), JOB-4 (Memory backends), JOB-7 (scopeable flag uses `ScopeRef` shape from this issue)
+
+## Overview
+
+Define the stable public API surface for the job orchestration domain layer: three protocol interfaces (`IJobOrchestrator`, `IJobRunService`, `IJobStepService`), the `JobHandlerBase` abstract class with `JobContext<TInput>`, the `@JobHandler` decorator with its full metadata shape, the `ParentClosePolicy` enum, and injection tokens. No backend implementations ship in this PR. `IJobQueue` and everything in `runtime/subsystems/jobs/` that currently exists is untouched.
+
+## Context
+
+The existing `jobs/` subsystem exports `IJobQueue` — a four-method executor port (`enqueue`, `process`, `schedule`, `cancel`) backed by Drizzle, BullMQ, Redis, and Memory. It models *how to dispatch a unit of work*. It does not model runs, hierarchy, scoping, steps, or retry policy. ADR-022 adds an orchestration layer above it. `IJobQueue` remains unchanged; the orchestrator calls `IJobQueue.enqueue('job_run_tick', { runId })` internally when it needs to schedule execution.
+
+JOB-2 delivers only the TypeScript types and interfaces that every downstream PR (backends, modules, templates) depends on. It is the contract — nothing else.
+
+## Architecture
+
+```
+Consumer use case
+      │  @Inject(JOB_ORCHESTRATOR)
+      ▼
+IJobOrchestrator ──start/cancel/replay──▶ (implemented by JOB-3/JOB-4 backends)
+      │
+      └── uses ──▶ IJobRunService   (scope queries, bulk cancel, reschedule)
+      └── uses ──▶ IJobStepService  (step record + fetch for memoization)
+
+@JobHandler decorator ──registers──▶ handler registry (consumed by JOB-5 module)
+JobHandlerBase<TInput, TOutput>
+      │
+      └── run(ctx: JobContext<TInput>): Promise<TOutput>  ← user implements this
+```
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `runtime/subsystems/jobs/job-orchestrator.protocol.ts` | create | `IJobOrchestrator`, `StartOptions`, `CancelOptions`, `JobRun` return shape |
+| `runtime/subsystems/jobs/job-run-service.protocol.ts` | create | `IJobRunService` with scope query methods |
+| `runtime/subsystems/jobs/job-step-service.protocol.ts` | create | `IJobStepService` with step record and fetch |
+| `runtime/subsystems/jobs/job-handler.base.ts` | create | `JobHandlerBase`, `JobContext<TInput>`, `@JobHandler` decorator, `ParentClosePolicy` enum, handler metadata types |
+| `runtime/subsystems/jobs/jobs-domain.tokens.ts` | create | `JOB_ORCHESTRATOR`, `JOB_RUN_SERVICE`, `JOB_STEP_SERVICE` Symbol tokens |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export all new types alongside existing exports |
+
+## Interfaces
+
+### `job-orchestrator.protocol.ts`
+
+```typescript
+import type { JobRunRow } from './job-orchestration.schema';   // from JOB-1
+
+export type JobRun = JobRunRow;
+
+export interface StartOptions {
+  scope?: { entityType: string; entityId: string };
+  pool?: string;
+  runAt?: Date;
+  priority?: number;
+  tags?: Record<string, string>;
+  triggerSource?: 'manual' | 'schedule' | 'event' | 'parent';
+  triggerRef?: string;
+  parentClosePolicy?: ParentClosePolicy;
+  parentRunId?: string;  // internal; set by spawnChild
+}
+
+export interface CancelOptions {
+  cascade?: boolean;   // default true for root cancellation
+  reason?: string;
+}
+
+export interface IJobOrchestrator {
+  start(type: string, input: unknown, opts?: StartOptions): Promise<JobRun>;
+  cancel(runId: string, opts?: CancelOptions): Promise<void>;
+  replay(runId: string): Promise<JobRun>;
+}
+```
+
+### `job-run-service.protocol.ts`
+
+```typescript
+import type { JobRun } from './job-orchestrator.protocol';
+
+export interface ListForScopeOptions {
+  status?: JobRun['status'] | JobRun['status'][];
+  jobType?: string;
+  limit?: number;
+  offset?: number;
+  orderBy?: 'created_at desc' | 'created_at asc' | 'run_at desc' | 'run_at asc';
+}
+
+export interface IJobRunService {
+  listForScope(entityType: string, entityId: string, opts?: ListForScopeOptions): Promise<JobRun[]>;
+  cancelForScope(entityType: string, entityId: string): Promise<void>;
+  rescheduleForScope(entityType: string, entityId: string, newRunAt: Date): Promise<void>;
+}
+```
+
+### `job-step-service.protocol.ts`
+
+```typescript
+import type { JobStepRow } from './job-orchestration.schema';
+
+export type JobStep = JobStepRow;
+
+export interface RecordStepInput {
+  jobRunId: string;
+  stepId: string;
+  kind: 'task';   // widened in ADR-027
+  seq: number;
+  input?: unknown;
+  output?: unknown;
+  error?: { message: string; stack?: string; retryable: boolean; attempt: number };
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+  startedAt?: Date;
+  finishedAt?: Date;
+  attempts?: number;
+}
+
+export interface IJobStepService {
+  recordStep(input: RecordStepInput): Promise<JobStep>;
+  findStep(runId: string, stepId: string): Promise<JobStep | null>;
+}
+```
+
+### `job-handler.base.ts`
+
+```typescript
+import type { Logger } from '@nestjs/common';
+import type { JobRun } from './job-orchestrator.protocol';
+
+export enum ParentClosePolicy {
+  Terminate = 'terminate',
+  Cancel = 'cancel',
+  Abandon = 'abandon',
+}
+
+export interface RetryPolicy {
+  attempts: number;
+  backoff: 'fixed' | 'exponential';
+  baseMs: number;
+  nonRetryableErrors?: string[];
+}
+
+export interface ConcurrencyPolicy<TInput> {
+  key: (input: TInput) => string;
+  collisionMode: 'queue' | 'reject' | 'replace';
+}
+
+export interface DedupePolicy<TInput> {
+  key: (input: TInput) => string;
+  windowMs: number;
+}
+
+export interface ScopeRef<TInput, TScope extends string = string> {
+  entity: TScope;
+  from: (input: TInput) => string;
+}
+
+export interface JobHandlerMeta<TInput> {
+  pool?: string;
+  scope?: ScopeRef<TInput>;
+  retry?: RetryPolicy;
+  concurrency?: ConcurrencyPolicy<TInput>;
+  dedupe?: DedupePolicy<TInput>;
+  timeoutMs?: number;
+  replayFrom?: 'scratch' | 'last_step' | 'last_checkpoint';
+}
+
+export interface StepOptions {
+  retry?: RetryPolicy;
+  timeoutMs?: number;
+}
+
+export interface SpawnChildOptions {
+  closePolicy?: ParentClosePolicy;
+  runAt?: Date;
+  priority?: number;
+  tags?: Record<string, string>;
+}
+
+export interface JobContext<TInput> {
+  readonly input: TInput;
+  readonly run: JobRun;
+  step<TOutput>(
+    stepId: string,
+    fn: () => Promise<TOutput>,
+    opts?: StepOptions,
+  ): Promise<TOutput>;
+  spawnChild(type: string, input: unknown, opts?: SpawnChildOptions): Promise<JobRun>;
+  readonly logger: Logger;
+  // NOT in Phase 1 — deferred to ADR-025:
+  //   waitFor(kind, token, opts)
+  //   signal(token, payload)
+  //   sleep(ms)
+}
+
+export abstract class JobHandlerBase<TInput, TOutput = unknown> {
+  abstract run(ctx: JobContext<TInput>): Promise<TOutput>;
+}
+
+export const JOB_HANDLER_REGISTRY = new Map<string, {
+  type: string;
+  meta: JobHandlerMeta<unknown>;
+  handlerClass: new (...args: unknown[]) => JobHandlerBase<unknown>;
+}>();
+
+export const JOB_HANDLER_METADATA_KEY = Symbol('JobHandlerMeta');
+
+export function JobHandler<TInput>(
+  type: string,
+  meta: JobHandlerMeta<TInput>,
+): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata(JOB_HANDLER_METADATA_KEY, { type, meta }, target);
+    JOB_HANDLER_REGISTRY.set(type, {
+      type,
+      meta: meta as JobHandlerMeta<unknown>,
+      handlerClass: target as unknown as new (...args: unknown[]) => JobHandlerBase<unknown>,
+    });
+  };
+}
+```
+
+### `jobs-domain.tokens.ts`
+
+```typescript
+export const JOB_ORCHESTRATOR = Symbol('JOB_ORCHESTRATOR');
+export const JOB_RUN_SERVICE  = Symbol('JOB_RUN_SERVICE');
+export const JOB_STEP_SERVICE = Symbol('JOB_STEP_SERVICE');
+```
+
+## Implementation Steps
+
+1. Create `jobs-domain.tokens.ts` (no deps).
+2. Create `job-orchestrator.protocol.ts` (imports `JobRunRow` from JOB-1).
+3. Create `job-run-service.protocol.ts` (imports `JobRun` from step 2).
+4. Create `job-step-service.protocol.ts` (imports `JobStepRow` from JOB-1).
+5. Create `job-handler.base.ts` — full file; ensure `JOB_HANDLER_REGISTRY` is module-singleton (no circular imports).
+6. Update `runtime/subsystems/jobs/index.ts` — re-export new values with `export` and types with `export type`. Existing executor-layer exports untouched.
+
+## Testing Strategy
+
+JOB-2 ships no runtime logic, only types and the decorator registry. Tests are compile-check and decorator-registration tests; no Docker required.
+
+**Compile-check test (`__tests__/job-handler.base.types.test.ts`):** A decorated `OnboardingHandler extends JobHandlerBase<OnboardingInput, OnboardingOutput>` compiles without any cast inside `run(ctx)`. Type-level assertions validate generic flow.
+
+**Registry test (`__tests__/job-handler.registry.test.ts`):** Import a decorated class; assert `JOB_HANDLER_REGISTRY.get('onboarding')` is populated with correct `handlerClass` and `meta`. A second handler type registers independently. Same-type double-registration overwrites (last-wins) and emits a warning log outside test env.
+
+**Token test (`__tests__/jobs-domain.tokens.test.ts`):** All three tokens are `Symbol`, distinguishable from each other and from `JOB_QUEUE`.
+
+All three test files run under `just test-unit`.
+
+## Acceptance Criteria (Elaborated)
+
+- [ ] `IJobOrchestrator` has exactly `start`, `cancel`, `replay`. `start` returns `Promise<JobRun>` (not `Promise<string>`).
+- [ ] `IJobRunService` has exactly `listForScope`, `cancelForScope`, `rescheduleForScope`.
+- [ ] `IJobStepService` has exactly `recordStep` and `findStep`.
+- [ ] `ParentClosePolicy` enum: `Terminate | Cancel | Abandon`.
+- [ ] `@JobHandler<OnboardingInput>('onboarding', meta)` on a class extending `JobHandlerBase<OnboardingInput>` compiles; `ctx.input` is `OnboardingInput` without a cast.
+- [ ] `JobContext` does NOT have `waitFor`, `signal`, or `sleep`; comment in file notes this.
+- [ ] All three domain tokens are `Symbol` values, named distinctly from `JOB_QUEUE`.
+- [ ] `index.ts` re-exports new symbols without removing existing ones.
+
+## Open Questions (with proposed resolutions)
+
+- [ ] **OQ-1 — `ScopeRef.entity` type.** Use a second generic parameter `TScope extends string = string` in `ScopeRef`. Default widens to `string`; JOB-7 can narrow at the call site without modifying this file.
+
+- [ ] **OQ-2 — `ScopeEntityType` union file location (ADR-022 Open Question #5).** Proposed: emit to `src/shared/jobs/scope-entity-type.ts` in the consumer project. Reasoning: (a) generated, not runtime; (b) `src/shared/` already holds generated cross-cutting types; (c) short, predictable import path `@shared/jobs/scope-entity-type`. Must be confirmed before JOB-7 templates.
+
+- [x] **OQ-3 — `JOB_HANDLER_REGISTRY` duplicate-type warning.** **Resolved 2026-04-18: warn in dev, silent in test, throw in production.** Tests intentionally re-register; dev needs visibility; production silent-overwrite is a critical correctness bug. Three-line guard at the decorator's overwrite site.
+
+- [x] **OQ-4 — `Logger` import coupling.** **Deferred 2026-04-18.** Use `@nestjs/common Logger` for now. A swappable `ILogger` subsystem (Protocol → Backend → Factory matching events/jobs/cache/storage) is tracked as future work — likely ADR-028 (Logging Subsystem). Add a `// TODO(logging-subsystem): swap to ILogger once ADR-028 lands` comment at the import site so it's grep-able when revisited.
+
+## References
+
+- ADR-022: `docs/adrs/ADR-022-job-orchestration-domain-model.md`
+- Issue breakdown: `docs/specs/ADR-022-phase-1-issues.md`
+- Protocol style reference: `runtime/subsystems/events/event-bus.protocol.ts`
+- Existing narrow executor: `runtime/subsystems/jobs/job-queue.protocol.ts`
+- Token pattern reference: `runtime/subsystems/jobs/jobs.tokens.ts`
+- Schema row types (dependency): `runtime/subsystems/jobs/job-orchestration.schema.ts` (produced by JOB-1)

--- a/docs/specs/JOB-3.md
+++ b/docs/specs/JOB-3.md
@@ -8,28 +8,29 @@
 
 ## Overview
 
-Production Postgres layer for all three orchestration-domain protocols plus the tick-processing worker loop. The densest issue in Phase 1: it owns the claim query (`FOR UPDATE SKIP LOCKED`), dedupe/concurrency enforcement at enqueue time, step memoization via `job_step` upsert, parent-close-policy cascade traversal, stale-claim recovery, and graceful shutdown on `SIGTERM`. The executor-layer `IJobQueue` is not modified; it is consumed as a dependency to schedule `job_run_tick` messages that wake the worker.
+Production Postgres backend implementing the three orchestration protocols plus the worker loop. Single-layer architecture per the architectural collapse decision (CLAUDE.md, ADR-022 revised spine): no executor layer, no `IJobQueue`, no `job_queue` table. The worker polls `job_run` directly via `SELECT ... FOR UPDATE SKIP LOCKED`, runs the handler, records steps, transitions state, and loops. This is the densest issue in Phase 1: it owns the claim query, dedupe/concurrency enforcement, step memoization via `job_step` upsert, parent-close-policy cascade, stale-claim recovery, and graceful shutdown.
 
-## Context — Orchestration Layer vs. Executor Layer
+## Context
 
-`IJobQueue` (executor layer) is a narrow port: `enqueue`, `process`, `schedule`, `cancel`. It knows nothing about `JobRun` hierarchy, scoping, retries, or memoization. It is the substrate that moves ticks between Postgres rows (or Redis, or BullMQ).
-
-The orchestration layer sits above it:
+Per the core/extension principle (CLAUDE.md), `IJobOrchestrator` is the swap point. Phase 1 ships only the Drizzle backend implementing the **core contract**. A future BullMQ orchestrator backend (Phase 6+) would map `JobRun → BullMQ Job`, `parent_run_id → FlowProducer`, etc., and expose backend-specific **extensions** (Bull Board mounting, native rate limits) — but that is not Phase 1 work.
 
 ```
 App use case
      │
      ▼
 IJobOrchestrator.start(type, input, opts)
-     │   dedupe check → collision check → insert job_run row
+     │   dedupe check → collision check → INSERT job_run
      ▼
-IJobQueue.enqueue('job_run_tick', { runId })   ← executor, unchanged
-     │
+JobWorker polling loop (per pool)
+     │   SELECT ... FOR UPDATE SKIP LOCKED on job_run WHERE status='pending' AND pool=$1
      ▼
-JobWorker: claim job_run → run handler → record steps → transition state → re-enqueue tick
+Run handler.run(ctx) with memoized ctx.step
+     │   UPDATE job_run SET status=..., output=... (or re-enter pending on retry)
+     ▼
+JobEventLogger → IEventBus (selective broadcast — Phase 5)
 ```
 
-`IJobQueue` holds transient tick pointers. `job_run` and `job_step` in Postgres hold the durable domain state. Backend swap on the executor layer does not affect orchestration logic.
+`job_run` and `job_step` are the only persistence. No transient ticks, no separate transport.
 
 ## Files
 
@@ -56,11 +57,9 @@ c. Concurrency collision check — if `concurrency_key_template` set: query `job
 - `replace` — call `this.cancel(incumbent.id, { cascade: true, reason: 'replaced' })` before proceeding
 - `queue` — proceed; claim query natively gates the new row behind the incumbent (enforced at claim time, step 4d)
 
-d. Insert `job_run` row. Resolve `rootRunId`: if `opts.parentRunId` set and `opts.rootRunId` absent, load parent's `root_run_id`; otherwise use new run's own `id` (self-reference).
+d. Generate `id` client-side via `randomUUID()`. Resolve `rootRunId`: if `opts.parentRunId` set, load parent's `root_run_id`; otherwise use the new `id` (self-reference). INSERT `job_run` row in a single statement.
 
-e. Call `this.jobQueue.enqueue('job_run_tick', { runId }, { priority: opts.priority })`.
-
-f. Return the created `JobRun`.
+e. Return the created `JobRun`. **No tick to enqueue** — the polling worker for the relevant pool will claim the row on its next loop iteration.
 
 **`cancel(runId, opts)`:**
 
@@ -86,12 +85,17 @@ c. If `opts.cascade !== false`: fetch descendants via `WHERE root_run_id = $root
 
 ### 4. `job-worker.ts`
 
-`JobWorker` is `@Injectable()`, wired by `JobWorkerModule` (JOB-5). Holds references to all three service tokens plus `IJobQueue`.
+`JobWorker` is `@Injectable()`, wired by `JobWorkerModule` (JOB-5). One worker instance per active pool; each holds references to the orchestrator, run service, and step service.
 
 **`onModuleInit()`:**
-- Register `IJobQueue.process('job_run_tick', this.handleTick)` — payload `{ runId }`
-- Start stale-claim sweeper: `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs)`
+- Start the polling loop: `setInterval(() => void this.pollAndProcess(), opts.pollIntervalMs)` (default 1000ms)
+- Start stale-claim sweeper: `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs)` (default 60s)
 - Register SIGTERM handler
+
+**`pollAndProcess()`:**
+- If `this.shuttingDown` or `this.inFlight.size >= this.pool.concurrency`, return.
+- Call `claimNext(this.pool.name)`. If `null`, return (nothing to do this tick).
+- Otherwise call `processRun(claimed)` — tracked in `this.inFlight` so shutdown can await it.
 
 **`claimNext(pool)` — ADR-022 pattern:**
 ```ts
@@ -120,18 +124,15 @@ return db.transaction(async (tx) => {
 });
 ```
 
-**`handleTick({ runId })`:**
+**`processRun(claimed)`:**
 
-a. If `this.shuttingDown`, return.
-b. Load `job_run`; return if absent or terminal.
-c. Resolve handler class from registry; fail run if missing.
-d. Concurrency queue enforcement: if `concurrency_key IS NOT NULL` and another run with same key is `running`, transition back to `pending` and return.
-e. Build `JobContext`; assign `ctx.input`, `ctx.run`, `ctx.step`, `ctx.spawnChild`, `ctx.logger`.
-f. Track promise in `this.inFlight: Set<Promise>` for shutdown.
-g. `await handler.run(ctx)`. Capture return as `output`.
-h. Success → `UPDATE job_run SET status='completed', output=$output, finished_at=now()`.
-i. Error → increment `attempts`; check `non_retryable_errors`; if not exhausted, set `status='pending'`, `run_at=now()+delay`, enqueue new tick with delay. If exhausted, set `status='failed'`. Apply parent-close-policy cascade.
-j. Remove promise from `inFlight` in finally.
+a. Resolve handler class from registry; if missing, transition run to `failed` (boot validator should have caught this — defensive only).
+b. Concurrency queue enforcement: if `claimed.concurrency_key IS NOT NULL` and another run with same key is currently `running`, transition this row back to `pending` (release the claim) and return. Next poll will re-evaluate.
+c. Build `JobContext`; assign `ctx.input = claimed.input`, `ctx.run = claimed`, `ctx.step = makeStepFn(claimed)`, `ctx.spawnChild = makeSpawnFn(claimed)`, `ctx.logger`.
+d. `await handler.run(ctx)`. Capture return as `output`.
+e. Success → `UPDATE job_run SET status='completed', output=$output, finished_at=now()`.
+f. Error → increment `attempts`; check `non_retryable_errors`; if not exhausted, set `status='pending'`, `run_at=now()+delay` (next poll claims it after the delay window). If exhausted, set `status='failed'`. Apply parent-close-policy cascade.
+g. Remove promise from `inFlight` in finally.
 
 **`ctx.step(stepId, fn, opts?)` closure (`makeStepFn(run)`):**
 - Call `stepService.findStep(run.id, stepId)`.
@@ -154,7 +155,7 @@ j. Remove promise from `inFlight` in finally.
 | `claimNext` | Yes | Atomic select + update; two statements allow race |
 | `cancel` cascade | No | Per-row updates are self-protecting |
 | `replay` memoization reset | Yes | Step deletes + status reset must be atomic |
-| `start` (insert + enqueue tick) | Best-effort | Insert first, enqueue second; failed enqueue → stale sweeper surfaces orphan |
+| `start` (single INSERT) | No | Single statement; polling worker discovers the row on next loop |
 | `recordStep` upsert | No | Unique-index upsert is atomic at DB level |
 | `findStep` | No | Read-only |
 | `rescheduleForScope` | No | Bulk UPDATE is atomic |
@@ -201,6 +202,5 @@ Proposed: `ON CONFLICT (type) DO UPDATE SET pool = EXCLUDED.pool, retry_policy =
 ## References
 
 - ADR-022 "Claim query (Drizzle backend)", "Hierarchy and close policy", "Replay", "Worker lifecycle", "Policy"
-- `runtime/subsystems/jobs/job-queue.drizzle-backend.ts` — stale sweeper pattern (`recoverStaleJobs`, `setInterval`, `onModuleInit`/`onModuleDestroy`)
-- `runtime/subsystems/events/event-bus.drizzle-backend.ts` — `@Inject(DRIZZLE)` style
-- `runtime/subsystems/jobs/job-queue.bullmq-backend.ts` — graceful shutdown drain pattern
+- `runtime/subsystems/events/event-bus.drizzle-backend.ts` — `@Inject(DRIZZLE)` style + `setInterval`/`onModuleInit`/`onModuleDestroy` lifecycle pattern
+- (The legacy `runtime/subsystems/jobs/job-queue.*-backend.ts` files were referenced in earlier drafts as patterns to copy. They are being **deleted** in JOB-1; use `event-bus.drizzle-backend.ts` as the surviving pattern reference.)

--- a/docs/specs/JOB-3.md
+++ b/docs/specs/JOB-3.md
@@ -1,0 +1,206 @@
+# JOB-3 — Drizzle Backends: `IJobOrchestrator`, `IJobRunService`, `IJobStepService`, and `JobWorker`
+
+**Issue:** JOB-3
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Depends on:** JOB-1 (schema), JOB-2 (protocols + base types)
+**Blocks:** JOB-4 (memory backends must match this behaviour spec), JOB-5 (module wiring)
+
+## Overview
+
+Production Postgres layer for all three orchestration-domain protocols plus the tick-processing worker loop. The densest issue in Phase 1: it owns the claim query (`FOR UPDATE SKIP LOCKED`), dedupe/concurrency enforcement at enqueue time, step memoization via `job_step` upsert, parent-close-policy cascade traversal, stale-claim recovery, and graceful shutdown on `SIGTERM`. The executor-layer `IJobQueue` is not modified; it is consumed as a dependency to schedule `job_run_tick` messages that wake the worker.
+
+## Context — Orchestration Layer vs. Executor Layer
+
+`IJobQueue` (executor layer) is a narrow port: `enqueue`, `process`, `schedule`, `cancel`. It knows nothing about `JobRun` hierarchy, scoping, retries, or memoization. It is the substrate that moves ticks between Postgres rows (or Redis, or BullMQ).
+
+The orchestration layer sits above it:
+
+```
+App use case
+     │
+     ▼
+IJobOrchestrator.start(type, input, opts)
+     │   dedupe check → collision check → insert job_run row
+     ▼
+IJobQueue.enqueue('job_run_tick', { runId })   ← executor, unchanged
+     │
+     ▼
+JobWorker: claim job_run → run handler → record steps → transition state → re-enqueue tick
+```
+
+`IJobQueue` holds transient tick pointers. `job_run` and `job_step` in Postgres hold the durable domain state. Backend swap on the executor layer does not affect orchestration logic.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts` | create | `IJobOrchestrator` — start, cancel, replay |
+| `runtime/subsystems/jobs/job-run-service.drizzle-backend.ts` | create | `IJobRunService` — scope queries, cascade cancel, reschedule |
+| `runtime/subsystems/jobs/job-step-service.drizzle-backend.ts` | create | `IJobStepService` — upsert step, lookup for memoization |
+| `runtime/subsystems/jobs/job-worker.ts` | create | Tick loop, claim query, graceful shutdown, stale sweeper |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export all four new classes |
+
+## Implementation Steps
+
+### 1. `job-orchestrator.drizzle-backend.ts`
+
+**`start(type, input, opts)`:**
+
+a. Load `job` row. Throw `JobTypeNotFoundError` if absent.
+
+b. Dedupe check — if `dedupe_key_template` set: evaluate key; query `job_run` where `(job_type, dedupe_key)` and `created_at > now() - dedupe_window_ms` and `status NOT IN ('canceled','failed')`. If a row exists, return it without inserting.
+
+c. Concurrency collision check — if `concurrency_key_template` set: query `job_run` where matching `concurrency_key` and `status IN ('pending','running')`. Branch on `collision_mode`:
+- `reject` — throw `JobCollisionError` with incumbent's `runId`
+- `replace` — call `this.cancel(incumbent.id, { cascade: true, reason: 'replaced' })` before proceeding
+- `queue` — proceed; claim query natively gates the new row behind the incumbent (enforced at claim time, step 4d)
+
+d. Insert `job_run` row. Resolve `rootRunId`: if `opts.parentRunId` set and `opts.rootRunId` absent, load parent's `root_run_id`; otherwise use new run's own `id` (self-reference).
+
+e. Call `this.jobQueue.enqueue('job_run_tick', { runId }, { priority: opts.priority })`.
+
+f. Return the created `JobRun`.
+
+**`cancel(runId, opts)`:**
+
+a. Load target. If terminal, return (idempotent).
+
+b. Transition target to `canceled` atomically: `UPDATE ... WHERE id = $runId AND status NOT IN (terminal_statuses)` with `RETURNING`.
+
+c. If `opts.cascade !== false`: fetch descendants via `WHERE root_run_id = $rootRunId AND id != $runId AND status NOT IN (terminals)`. For each, branch on `parent_close_policy`:
+- `terminate` or `cancel` → transition to `canceled`
+- `abandon` → skip
+
+### 2. `job-run-service.drizzle-backend.ts`
+
+- **`listForScope`:** query `job_run WHERE scope_entity_type AND scope_entity_id` with filters. Read-only, no tx.
+- **`cancelForScope`:** fetch non-terminal runs; for each, call `orchestrator.cancel(runId, { cascade: true })`. Reuses cascade logic.
+- **`rescheduleForScope`:** bulk `UPDATE run_at = $newRunAt WHERE scope AND status = 'pending'`.
+- **`findByRootRunId`:** helper for cascade cancel; not on public protocol.
+
+### 3. `job-step-service.drizzle-backend.ts`
+
+- **`recordStep`:** upsert on `(job_run_id, step_id)` unique index. On insert, generate UUID. On conflict, update `status`, `output`, `error`, `finished_at`, `attempts`. Intentional conflict-update because step row is written as `running` first, then updated to terminal.
+- **`findStep`:** `SELECT ... WHERE job_run_id = $runId AND step_id = $stepId LIMIT 1`. Returns `null` if absent. Hot path for memoization.
+
+### 4. `job-worker.ts`
+
+`JobWorker` is `@Injectable()`, wired by `JobWorkerModule` (JOB-5). Holds references to all three service tokens plus `IJobQueue`.
+
+**`onModuleInit()`:**
+- Register `IJobQueue.process('job_run_tick', this.handleTick)` — payload `{ runId }`
+- Start stale-claim sweeper: `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs)`
+- Register SIGTERM handler
+
+**`claimNext(pool)` — ADR-022 pattern:**
+```ts
+return db.transaction(async (tx) => {
+  const [candidate] = await tx
+    .select({ id: jobRuns.id })
+    .from(jobRuns)
+    .where(and(
+      eq(jobRuns.status, 'pending'),
+      eq(jobRuns.pool, pool),
+      lte(jobRuns.runAt, new Date()),
+    ))
+    .orderBy(desc(jobRuns.priority), asc(jobRuns.runAt))
+    .limit(1)
+    .for('update', { skipLocked: true });
+
+  if (!candidate) return null;
+
+  const [claimed] = await tx
+    .update(jobRuns)
+    .set({ status: 'running', claimedAt: new Date(), startedAt: new Date() })
+    .where(eq(jobRuns.id, candidate.id))
+    .returning();
+
+  return claimed;
+});
+```
+
+**`handleTick({ runId })`:**
+
+a. If `this.shuttingDown`, return.
+b. Load `job_run`; return if absent or terminal.
+c. Resolve handler class from registry; fail run if missing.
+d. Concurrency queue enforcement: if `concurrency_key IS NOT NULL` and another run with same key is `running`, transition back to `pending` and return.
+e. Build `JobContext`; assign `ctx.input`, `ctx.run`, `ctx.step`, `ctx.spawnChild`, `ctx.logger`.
+f. Track promise in `this.inFlight: Set<Promise>` for shutdown.
+g. `await handler.run(ctx)`. Capture return as `output`.
+h. Success → `UPDATE job_run SET status='completed', output=$output, finished_at=now()`.
+i. Error → increment `attempts`; check `non_retryable_errors`; if not exhausted, set `status='pending'`, `run_at=now()+delay`, enqueue new tick with delay. If exhausted, set `status='failed'`. Apply parent-close-policy cascade.
+j. Remove promise from `inFlight` in finally.
+
+**`ctx.step(stepId, fn, opts?)` closure (`makeStepFn(run)`):**
+- Call `stepService.findStep(run.id, stepId)`.
+- If `status === 'completed'`, return `step.output` (memoized).
+- Otherwise: record `running` step. Call `await fn()`. On success, upsert `completed` with `output`. On error, upsert `failed`; rethrow.
+
+**`sweepStaleClaims()`:**
+- `UPDATE job_run SET status='pending', claimed_at=null WHERE status='running' AND claimed_at < now() - $staleThresholdMs RETURNING id`. Log each at `warn`. Safe concurrency: each update is atomic; `WHERE claimed_at < threshold` prevents double-recovery.
+
+**`onModuleDestroy()` / SIGTERM:**
+- Set `shuttingDown = true`.
+- Await `Promise.allSettled([...this.inFlight])` with `shutdownTimeoutMs` (default 30000).
+- For runs still `running` past timeout: `UPDATE job_run SET status='pending', claimed_at=null`. Next worker reclaims.
+- Clear stale sweeper interval.
+
+## Transaction Boundaries
+
+| Operation | Needs Tx? | Why |
+|---|---|---|
+| `claimNext` | Yes | Atomic select + update; two statements allow race |
+| `cancel` cascade | No | Per-row updates are self-protecting |
+| `replay` memoization reset | Yes | Step deletes + status reset must be atomic |
+| `start` (insert + enqueue tick) | Best-effort | Insert first, enqueue second; failed enqueue → stale sweeper surfaces orphan |
+| `recordStep` upsert | No | Unique-index upsert is atomic at DB level |
+| `findStep` | No | Read-only |
+| `rescheduleForScope` | No | Bulk UPDATE is atomic |
+
+## Error Handling Strategy
+
+- **Non-retryable or exhausted:** structured error `{ message, stack, retryable, attempt, code? }` → `job_run.error`. Status → `failed`. Parent-close cascade fires if policy is `terminate`.
+- **Retryable, not exhausted:** error written; status back to `pending`; `run_at = now() + backoff`; new tick enqueued.
+- **No handler registered:** transition to `failed`; defensive (validator should catch this at boot per JOB-5).
+- **Stale claim (crashed worker):** sweeper resets to `pending`; no `attempts` increment (memoization protects completed steps).
+- **Cancel on terminal:** idempotent.
+
+## Acceptance Criteria
+
+- `claimNext(pool)` uses `FOR UPDATE SKIP LOCKED` in a transaction (verified via `.toSQL()` inspection + concurrent-worker integration test)
+- Dedupe collapse returns existing `runId` within window
+- Concurrency modes: `queue` serializes; `reject` throws; `replace` cancels incumbent
+- `ctx.step` memoizes across retries
+- `replay_from` modes: `scratch` clears all steps; `last_step` clears only failing; `last_checkpoint` preserves all
+- Cascade cancel respects `parent_close_policy` (terminate/cancel/abandon)
+- Stale sweeper recovers stranded `running` rows
+- SIGTERM drains in-flight, resets uncompleted runs on timeout
+
+## Testing Strategy
+
+**Integration (Docker Postgres):** enqueue→claim→complete round-trip; dedupe collapse; all three collision modes; step memoization spy; all three replay modes; cascade cancel with policy variations; stale-claim recovery; graceful shutdown drain.
+
+**Unit:** `makeStepFn` memoization path (mocked `findStep`); error classification; backoff calculation; SIGTERM timeout exceeded (slow handler mock).
+
+## Open Questions (with proposed resolutions)
+
+**OQ-2 — Stale-claim sweeper placement: per-worker vs. singleton.**
+Proposed: run sweeper on every `JobWorker` instance. The update is self-protecting: `WHERE status='running' AND claimed_at < threshold` — a row only transitions once; subsequent sweepers find no matching rows. Singleton adds coordination complexity (leader election) without meaningful advantage at Phase 1 scale. Document invariant: `staleThresholdMs >= 2 * max_handler_duration`.
+
+**OQ-3 — `job` table upsert under horizontal scale.**
+Proposed: `ON CONFLICT (type) DO UPDATE SET pool = EXCLUDED.pool, retry_policy = EXCLUDED.retry_policy, version = EXCLUDED.version, updated_at = now()`. Last-writer-wins. All instances of the same app version produce identical metadata — concurrent upserts are harmless. `DO NOTHING` is rejected: under rolling deploy, old-version instance A could leave a stale row that new-version instance B cannot overwrite. Advisory locks rejected: add latency + leak risk.
+
+## Scope Boundaries
+
+- **JOB-4** owns Memory backends (behavioural parity spec) + `JobWorker` unit tests
+- **JOB-5** owns `JobsDomainModule`, `JobWorkerModule`, boot-time validator, handler registry scan, pool config
+- `JobWorker` is backend-agnostic — used by both Drizzle and Memory via protocol injection
+
+## References
+
+- ADR-022 "Claim query (Drizzle backend)", "Hierarchy and close policy", "Replay", "Worker lifecycle", "Policy"
+- `runtime/subsystems/jobs/job-queue.drizzle-backend.ts` — stale sweeper pattern (`recoverStaleJobs`, `setInterval`, `onModuleInit`/`onModuleDestroy`)
+- `runtime/subsystems/events/event-bus.drizzle-backend.ts` — `@Inject(DRIZZLE)` style
+- `runtime/subsystems/jobs/job-queue.bullmq-backend.ts` — graceful shutdown drain pattern

--- a/docs/specs/JOB-4.md
+++ b/docs/specs/JOB-4.md
@@ -1,0 +1,234 @@
+# JOB-4 — Memory Backends + Unit Test Suite
+
+**Issue:** JOB-4
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Depends on:** JOB-2 (protocols), JOB-3 (behaviour spec to match)
+**Phase:** ADR-022 Phase 1
+
+## Overview
+
+In-process, mutex-based implementations of `IJobOrchestrator`, `IJobRunService`, and `IJobStepService` using plain TypeScript `Map` structures. Exists solely for the unit test suite: reproduces the Drizzle backends' behavioural contract for all Phase 1 scenarios — claim ordering, collision modes, step memoization, cascade cancel, dedupe window, replay modes — without a database. The unit tests against these backends are the regression gate for both memory and Drizzle.
+
+## Context
+
+Memory backends are not a simplified subset; the contract is the same, only persistence differs. Acceptable non-parity: fsync/crash-recovery, claim latency, index-scan performance, distributed locking. Not acceptable: ordering of claimed runs, collision outcomes, memoization cache hits, cascade cancel propagation, dedupe short-circuit, replay row-clearing semantics.
+
+## Architecture
+
+```
+Test module
+  └── JobsDomainModule.forRoot({ backend: 'memory' })
+        ├── MemoryJobOrchestrator   (IJobOrchestrator)
+        ├── MemoryJobRunService     (IJobRunService)
+        └── MemoryJobStepService    (IJobStepService)
+
+MemoryJobOrchestrator
+  ├── holds MemoryJobStore.runs:  Map<runId, JobRunRow>
+  ├── holds MemoryJobStore.steps: Map<runId, JobStepRow[]>
+  ├── holds MemoryJobStore.jobs:  Map<jobType, JobRow>
+  ├── uses PromiseMutex           (serializes claim + collision checks)
+  └── delegates to MemoryJobStepService (memoization)
+```
+
+All three services share the same `MemoryJobStore` instance via constructor injection. `PromiseMutex` is a private single-promise-chain mutex (not exported).
+
+## Files
+
+| File | Action | Purpose |
+|---|---|---|
+| `runtime/subsystems/jobs/job-orchestrator.memory-backend.ts` | create | `MemoryJobOrchestrator` + private `PromiseMutex` |
+| `runtime/subsystems/jobs/job-run-service.memory-backend.ts` | create | `MemoryJobRunService` |
+| `runtime/subsystems/jobs/job-step-service.memory-backend.ts` | create | `MemoryJobStepService` |
+| `runtime/subsystems/jobs/memory-job-store.ts` | create | `MemoryJobStore` shared container (exported for test resets) |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export memory classes + `MemoryJobStore` |
+| `runtime/subsystems/jobs/__tests__/job-orchestrator.unit.test.ts` | create | All Phase 1 scenarios |
+| `runtime/subsystems/jobs/__tests__/job-worker.unit.test.ts` | create | `@JobHandler` + two-tick memoization proof |
+
+## Interfaces
+
+```typescript
+// memory-job-store.ts (exported)
+export class MemoryJobStore {
+  runs: Map<string, JobRunRow> = new Map();
+  steps: Map<string, JobStepRow[]> = new Map();
+  jobs: Map<string, JobDefinitionRow> = new Map();
+  clear(): void { this.runs.clear(); this.steps.clear(); this.jobs.clear(); }
+}
+
+// job-orchestrator.memory-backend.ts (internal, not exported)
+class PromiseMutex {
+  private queue: Promise<void> = Promise.resolve();
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.queue.then(() => fn());
+    this.queue = next.then(() => {}, () => {});
+    return next;
+  }
+}
+```
+
+## Implementation Steps
+
+### 1. `MemoryJobStore` (`memory-job-store.ts`)
+
+Plain class with three Maps + `clear()`. Not `@Injectable()` — wired as `useValue` provider so tests can hold direct reference for `beforeEach` resets. Export from `index.ts`.
+
+### 2. `MemoryJobStepService`
+
+- Step storage: `Map<runId, JobStepRow[]>` from shared store.
+- `findStep(runId, stepId)`: scan array for run; return first match where `step_id === stepId AND status === 'completed'`. Return `null` if none. Non-completed steps invisible to memoization (matches Drizzle).
+- `recordStep(input)`: assign monotonic `seq` per-run, `randomUUID()` id, push to array, return row. Conflict behavior: overwrite existing entry with same `step_id`.
+- Helper methods: `clearStepsForRun(runId)` (replay=scratch), `clearStep(runId, stepId)` (replay=last_step).
+
+### 3. `PromiseMutex` (inline private in orchestrator file)
+
+Single-promise chain queuing `fn`s. `run<T>(fn)` chains onto internal queue. Swallows errors on the chain pointer (not returned result) to prevent chain-breakage.
+
+### 4. `MemoryJobOrchestrator`
+
+All mutating ops inside `mutex.run(...)`.
+
+**`start(type, input, opts)`:**
+- Resolve `JobDefinitionRow` from `store.jobs`; throw `UnknownJobTypeError` if absent.
+- Dedupe check: scan `store.runs` for non-terminal matching `(job_type, dedupe_key)` within window. Return existing if found.
+- Concurrency check (if `concurrency_key` set): find non-terminal run with matching key. Branch:
+  - `reject` → throw `JobCollisionError`
+  - `replace` → `cancel(incumbent, { cascade: true })`, then insert
+  - `queue` → simulate Drizzle's claim-time gating by setting `run_at` to a sentinel future; register incumbent `runId` as blocker; when incumbent reaches terminal state, advance blocked run's `run_at` to `now()`
+- Insert new `JobRunRow`: `status='pending'`, `created_at=now()`, `run_at=opts.runAt ?? now()`.
+- Return row.
+
+**`cancel(runId, opts)`:**
+- Load; return if already terminal.
+- Set `status='canceled'`, `finished_at=now()`.
+- If `cascade === true`: find all with `root_run_id === run.root_run_id AND id !== runId AND parent_close_policy !== 'abandon'`; recursively cancel.
+- `Cancel` policy: collect children first; cancel them before transitioning parent's `finished_at`.
+
+**`claimNext(pool)` (used by worker):**
+- Inside mutex. Filter `runs` for `status='pending' AND pool=$pool AND run_at <= now()`.
+- Sort by `priority DESC, run_at ASC`. Take first. Set `status='running', claimed_at=now()`. Return row or `null`.
+
+**`replay(runId)`:**
+- Load; assert terminal. Determine `replay_from` from `JobDefinitionRow`.
+- `scratch`: `stepService.clearStepsForRun(runId)`.
+- `last_step`: find step where `status='failed'`; `stepService.clearStep(runId, stepId)`.
+- `last_checkpoint`: no step modification.
+- Reset run fields: `status='pending'`, `attempts++`, clear `started_at`, `finished_at`, `error`.
+
+**`tick(runId)` (called by JobWorker):**
+- Load run; assert `status='running'`.
+- Resolve handler class from internal registry (populated via `registerHandler()` called by `JobWorkerModule.onModuleInit`).
+- Build `JobContext`. `ctx.step(id, fn, opts?)` calls `stepService.findStep` → return cached or invoke `fn`, then `recordStep`.
+- Execute `handler.run(ctx)`.
+- Success: `status='completed'`, `output=result`, `finished_at=now()`.
+- Error: increment `attempts`; if `< retry.attempts`, set `pending`; else `failed`, `error=serialized`.
+
+### 5. `MemoryJobRunService`
+
+- `listForScope`: linear scan of `store.runs.values()` with filters.
+- `cancelForScope`: collect non-terminal; call `orchestrator.cancel(runId, { cascade: true })` each. Orchestrator injected via constructor.
+- `rescheduleForScope`: update `run_at` on matching non-terminal runs.
+- `findById`: direct `store.runs.get(runId)`.
+
+### 6. Handler registration (memory mode)
+
+- `MemoryJobOrchestrator.registerHandler(type, meta, HandlerClass)` — populates internal registry AND `store.jobs` with in-memory `JobDefinitionRow` (replaces Drizzle upsert in memory mode).
+- `JobWorkerModule.onModuleInit` calls this for each discovered `@JobHandler`.
+
+## Behavioural Parity Contract
+
+| Scenario | Must match Drizzle |
+|---|---|
+| `claimNext` ordering (priority DESC, run_at ASC) | yes |
+| `claimNext` skips `run_at > now()` | yes |
+| Dedupe within window returns existing id, no new row | yes |
+| Dedupe outside window creates new row | yes |
+| Collision `queue` — second run stays pending until first terminal | yes |
+| Collision `reject` — throws, no insert | yes |
+| Collision `replace` — incumbent canceled, new run inserted | yes |
+| `ctx.step` memoization cache hit on re-entry | yes |
+| `replay_from: scratch` clears all prior steps | yes |
+| `replay_from: last_step` clears only failing step | yes |
+| `replay_from: last_checkpoint` preserves all | yes |
+| Cascade `Terminate` — descendants canceled | yes |
+| Cascade `Cancel` — parent waits for children | yes |
+| Cascade `Abandon` — children untouched | yes |
+| Run-level retry re-enters as `pending` | yes |
+| `replay(runId)` produces new run with correct lineage | yes |
+
+**Acceptable non-parity:** SKIP LOCKED semantics (single-process only), fsync, query perf, stale-claim sweeper (Drizzle-only; integration-test concern), tenant filtering (JOB-8).
+
+## Unit Test Suite Design
+
+### `__tests__/job-orchestrator.unit.test.ts`
+
+`MemoryJobStore.clear()` in `beforeEach`. Direct instantiation (no NestJS) for protocol-level tests.
+
+**Group 1 — Claim / queue ordering**
+- Insert three pending runs in same pool with priorities `[10, 5, 10]`, run_ats `[T-2s, T-1s, T-3s]`. Assert `claimNext` returns priority-10 with earliest run_at.
+- Insert run with `run_at = now() + 60s`. Assert `claimNext` returns `null`.
+- Two pools. Assert cross-pool isolation.
+
+**Group 2 — Collision modes**
+- `queue`: start A with `concurrency_key='acct:1'`; advance to `running`; second `start` returns new pending id; `claimNext` skips until A completes.
+- `reject`: second `start` throws `JobCollisionError`.
+- `replace`: second `start` transitions A to `canceled`; new run is pending and claimable.
+
+**Group 3 — Step memoization**
+- Run with handler invoking `ctx.step('fetch', fn)`. Tick once; assert `fn` called. Simulate second tick; assert `fn` not called again.
+- Second step not previously completed: assert called on re-entry.
+
+**Group 4 — Cascade cancel**
+- Parent + two children (policies: `Terminate`, `Abandon`). Cancel parent. Terminate child `canceled`; Abandon child `pending`.
+- Three-level `Terminate` tree: cancel root → all three canceled.
+- `Cancel` policy: parent `finished_at` set only after child terminal.
+
+**Group 5 — Dedupe**
+- `dedupe_window_ms=60000`; second start within window returns same id, single row.
+- Advance first `created_at` to `now() - 70s`; third start creates new row.
+
+**Group 6 — Replay modes**
+- `scratch`: two completed steps + failed run; replay clears steps; new run starts empty.
+- `last_step`: step A completed, step B failed; replay clears B only.
+- `last_checkpoint`: step A completed; replay + tick; `fn_A` not called (memoized); `fn_B` called.
+
+### `__tests__/job-worker.unit.test.ts`
+
+NestJS test module to prove decorator + DI integration.
+
+- `TestOnboardingHandler` decorated with `@JobHandler('test_onboarding', { pool: 'batch' })`. Mock `AccountService`. `Test.createTestingModule({ imports: [JobsDomainModule.forRoot({ backend: 'memory' })] })`. Call `orchestrator.start(...)`. Assert mock called.
+- `ctx.step` memoization: step fn mock called once across two ticks.
+
+All tests run under `just test-unit` with no Docker.
+
+## Acceptance Criteria
+
+- [ ] Three memory services implement their protocols with no public-API casts
+- [ ] All three collision modes have passing tests
+- [ ] Step memoization: fn not called on second tick if completed on first
+- [ ] Cascade cancel: `Terminate`/`Cancel`/`Abandon` behaviors correct
+- [ ] Dedupe: in-window collapse; outside-window new row
+- [ ] All three replay modes pass
+- [ ] `@JobHandler` decorated class instantiated in NestJS test module; memoizes across two ticks
+- [ ] `just test-unit` passes without Docker
+
+## Scope Boundary
+
+- BullMQ-specific claim logic: not touched; executor-layer `MemoryJobQueue` unchanged
+- `JobsDomainModule.forRoot()`, `JobWorkerModule.forRoot()`: JOB-5
+- Drizzle backends: JOB-3
+- Stale-claim sweeper: Drizzle-only; integration test in JOB-3
+
+## Open Questions (resolved)
+
+**OQ-4 — Boot-time validator in memory mode (ADR-022 #4).** Validator skipped entirely in memory mode — no DB rows to validate. Instead, `MemoryJobOrchestrator.start()` throws `UnknownJobTypeError` synchronously when type is not in in-memory registry. Equivalent protection, no DB dependency.
+
+**OQ — Concurrency `queue` simulation.** `start()` detects collision → new run stored with `run_at = MAX_DATE`; incumbent's `runId` registered as blocker; on incumbent terminal transition, blocked run's `run_at` advances to `now()`. Flag for confirmation if Drizzle-side exact semantics differ.
+
+## References
+
+- ADR-022: all sections relevant to Phase 1
+- `runtime/subsystems/events/event-bus.memory-backend.ts` — memory backend style
+- `runtime/subsystems/jobs/job-queue.memory-backend.ts` — executor-layer memory (unchanged)
+- Protocols (dependency): JOB-2 output files
+- Drizzle behaviour (matching target): JOB-3 spec

--- a/docs/specs/JOB-5.md
+++ b/docs/specs/JOB-5.md
@@ -1,0 +1,226 @@
+# JOB-5 — `JobsDomainModule.forRoot()` + `JobWorkerModule.forRoot()` with Pool Config Loader
+
+**Issue:** JOB-5
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Depends on:** JOB-2, JOB-3, JOB-4
+**Unblocks:** JOB-6 (templates), JOB-8 (multi-tenancy + upgrade + docs)
+
+## Overview
+
+Two NestJS `DynamicModule` factories plus a shared pool config loader. `JobsDomainModule` is the service module (any app process imports it to access the three protocol tokens). `JobWorkerModule` additionally boots worker claim loops, scans the `@JobHandler` registry, upserts `Job` rows from decorator metadata, and runs the boot-time validator. The pool config loader parses `codegen.config.yaml: jobs.pools`, applies framework defaults, validates reserved-pool assignment.
+
+## Architecture
+
+```
+AppModule
+  ├── JobsDomainModule.forRoot({ backend: 'drizzle' })           [global: true]
+  │     provides JOB_ORCHESTRATOR, JOB_RUN_SERVICE, JOB_STEP_SERVICE
+  │
+  └── JobWorkerModule.forRoot({ mode: 'embedded', pools?: [...] })
+        imports JobsDomainModule internally
+        on init: loadPoolConfig → scan registry → validate reserved → upsert Job rows
+                 → runBootValidator (Drizzle only) → start N JobWorkers
+        on destroy: gracefulStop each worker
+
+HandlerRegistry   (module-local Map, populated by @JobHandler at class-eval time)
+PoolConfigLoader  (reads codegen.config.yaml: jobs.pools; applies 5 framework defaults)
+```
+
+## Files
+
+| File | Action | Purpose |
+|---|---|---|
+| `runtime/subsystems/jobs/jobs-domain.module.ts` | create | `JobsDomainModule.forRoot()` — token wiring, global |
+| `runtime/subsystems/jobs/job-worker.module.ts` | create | `JobWorkerModule.forRoot()` — lifecycle, validator, registry scan |
+| `runtime/subsystems/jobs/pool-config.loader.ts` | create | Read `codegen.config.yaml: jobs.pools`; merge defaults |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export modules + types |
+| `runtime/subsystems/jobs/__tests__/jobs-domain.module.test.ts` | create | Nest harness; memory backend; token resolution |
+| `runtime/subsystems/jobs/__tests__/job-worker.module.test.ts` | create | Validator failure, reserved-pool violation, handler upsert |
+
+## Interfaces
+
+```typescript
+// pool-config.loader.ts
+export interface PoolDefinition {
+  queue: string;          // e.g. 'jobs-batch'
+  concurrency: number;
+  reserved: boolean;
+  description?: string;
+}
+export type PoolConfig = Map<string, PoolDefinition>;
+export function loadPoolConfig(configPath?: string): PoolConfig;
+
+const FRAMEWORK_POOLS: Record<string, PoolDefinition> = {
+  events_inbound:  { queue: 'jobs-events-inbound',  concurrency: 20, reserved: true  },
+  events_change:   { queue: 'jobs-events-change',   concurrency: 30, reserved: true  },
+  events_outbound: { queue: 'jobs-events-outbound', concurrency: 10, reserved: true  },
+  interactive:     { queue: 'jobs-interactive',     concurrency: 20, reserved: false },
+  batch:           { queue: 'jobs-batch',           concurrency: 5,  reserved: false },
+};
+
+// jobs-domain.module.ts
+export interface JobsDomainModuleOptions {
+  backend: 'drizzle' | 'memory';
+}
+export class JobsDomainModule {
+  static forRoot(opts: JobsDomainModuleOptions): DynamicModule;
+}
+
+// job-worker.module.ts
+export interface JobWorkerModuleOptions {
+  mode: 'embedded' | 'standalone';
+  backend?: 'drizzle' | 'memory';  // threads into internal JobsDomainModule import
+  pools?: string[];
+  shutdownTimeoutMs?: number;      // default 30_000
+}
+export class JobWorkerModule implements OnModuleInit, OnModuleDestroy {
+  static forRoot(opts: JobWorkerModuleOptions): DynamicModule;
+}
+
+// Boot validator error classes
+export class BootValidationError extends Error { missingHandlers: string[]; }
+export class ReservedPoolViolationError extends Error { offenders: Array<{ handlerClass: string; pool: string }>; }
+```
+
+## Implementation Steps
+
+### 1. `pool-config.loader.ts`
+
+- Define `FRAMEWORK_POOLS` with all five defaults.
+- `loadPoolConfig(configPath?)`: read `${process.cwd()}/codegen.config.yaml` (or `configPath` if passed) via `fs.readFileSync` + `yaml.parse`.
+- Apply defaults first; merge user-defined pools from `raw.jobs?.pools ?? {}`.
+- User config can override `concurrency` and `description` on non-reserved defaults. User CANNOT override `reserved: true` on framework pools (loader silently preserves).
+- User-defined pools cannot set `reserved: true` (reserved is framework-only).
+- Return `Map<string, PoolDefinition>`. Cache in module scope after first call.
+
+### 2. `jobs-domain.module.ts`
+
+Mirrors `EventsModule.forRoot()` shape exactly:
+
+```typescript
+@Module({})
+export class JobsDomainModule {
+  static forRoot(opts: JobsDomainModuleOptions): DynamicModule {
+    const backendClasses = opts.backend === 'memory'
+      ? { orch: MemoryJobOrchestrator, run: MemoryJobRunService, step: MemoryJobStepService }
+      : { orch: DrizzleJobOrchestrator, run: DrizzleJobRunService, step: DrizzleJobStepService };
+
+    const providers: Provider[] = [
+      { provide: JOB_ORCHESTRATOR, useClass: backendClasses.orch },
+      { provide: JOB_RUN_SERVICE,  useClass: backendClasses.run },
+      { provide: JOB_STEP_SERVICE, useClass: backendClasses.step },
+    ];
+
+    // In memory mode, also provide MemoryJobStore as a useValue singleton
+    if (opts.backend === 'memory') {
+      providers.push({ provide: MemoryJobStore, useValue: new MemoryJobStore() });
+    }
+
+    return {
+      module: JobsDomainModule,
+      global: true,
+      providers,
+      exports: [JOB_ORCHESTRATOR, JOB_RUN_SERVICE, JOB_STEP_SERVICE],
+    };
+  }
+}
+```
+
+### 3. `job-worker.module.ts`
+
+- `forRoot(opts)` returns `DynamicModule` that `imports: [JobsDomainModule.forRoot({ backend: opts.backend ?? 'drizzle' })]`.
+- Declare a `JobWorkerOrchestrator` injectable (name avoids collision) that holds `OnModuleInit`/`OnModuleDestroy` hooks. Register as provider.
+- **`onModuleInit` sequence (order critical):**
+  1. `loadPoolConfig()` → `PoolConfig`
+  2. `HandlerRegistry.getAll()` → registered entries
+  3. **Reserved-pool validation:** walk entries; if any `meta.pool` matches a `reserved: true` pool, collect offenders; if non-empty, throw `ReservedPoolViolationError` listing class names
+  4. Inject `JOB_ORCHESTRATOR`; call `orchestrator.upsertJobRows(entries, poolConfig)` (method defined on orchestrator protocol; Drizzle uses `ON CONFLICT DO UPDATE` per JOB-3 OQ-3; memory mode populates `store.jobs`)
+  5. **Boot validator (Drizzle only):** if `backend !== 'memory'`, call `runBootValidator(orchestrator, entries)` — query all `Job` rows; for each row with no matching registry entry, accumulate; if any, throw `BootValidationError`
+  6. Resolve active pool list: `opts.pools ?? allNonReservedPoolNames(poolConfig)`
+  7. For each active pool: instantiate `JobWorker(pool, poolConfig.get(pool), orchestrator)`; call `worker.start()`; store in instance array
+- **`onModuleDestroy`:** for each stored worker, `await worker.gracefulStop(opts.shutdownTimeoutMs ?? 30_000)`.
+- Module `exports: []` — it's an actor module.
+
+### 4. Handler registry access surface
+
+`@JobHandler` decorator (defined in JOB-2) populates module-local `Map` at class-evaluation time. JOB-5 adds read helpers:
+
+```typescript
+export namespace HandlerRegistry {
+  export function getAll(): HandlerRegistryEntry[];
+  export function get(type: string): HandlerRegistryEntry | undefined;
+}
+```
+
+### 5. `index.ts`
+
+Re-export `JobsDomainModule`, `JobsDomainModuleOptions`, `JobWorkerModule`, `JobWorkerModuleOptions`, `loadPoolConfig`, `PoolConfig`, `PoolDefinition`, error classes. Don't remove existing executor-layer exports.
+
+## Pool → Queue Binding
+
+Each pool maps to a distinct queue name passed to `IJobQueue.enqueue('job_run_tick', { runId }, { queue: poolDef.queue })`. `concurrency` passed to `JobWorker` as max parallel in-flight ticks — worker tracks active promises and skips `claimNext` at capacity.
+
+Defaults:
+
+| Pool | queue | concurrency |
+|---|---|---|
+| events_inbound | jobs-events-inbound | 20 |
+| events_change | jobs-events-change | 30 |
+| events_outbound | jobs-events-outbound | 10 |
+| interactive | jobs-interactive | 20 |
+| batch | jobs-batch | 5 |
+
+User-defined `agents: { queue: 'jobs-agents', concurrency: 3 }` in config becomes a sixth entry. `JobWorker` created when `agents` is in `opts.pools` (or `opts.pools` omitted).
+
+## Testing Strategy
+
+**Unit (`just test-unit`, no Docker):**
+- `JobsDomainModule.forRoot({ backend: 'memory' })` boots in `Test.createTestingModule`; all three tokens resolve
+- `JobWorkerModule` boots with well-formed handler registry (memory backend)
+- `ReservedPoolViolationError` thrown for handler with `pool: 'events_change'`; error lists offender class
+- `BootValidationError` thrown when mock orchestrator returns orphaned `Job` row (with `'orphaned_type'` not in registry)
+- `loadPoolConfig()` with no file returns five framework defaults
+- User pool merging: custom pool added; framework defaults preserved
+- User cannot flip `reserved: false` on framework pool (loader ignores)
+
+**Integration (Docker Postgres, `just test-family`):**
+- `JobWorkerModule` with `backend: 'drizzle'`: handler upsert creates `Job` row; second boot idempotent (`updated_at` bumped)
+- Validator passes after upsert; fails if row injected manually without matching handler
+
+**Horizontal scale (flagged, not tested in Phase 1):** multiple instances racing on upsert — see OQ-3 resolution below.
+
+## Acceptance Criteria
+
+- `JobsDomainModule.forRoot({ backend })` wires three tokens; `global: true`; ADR-008 factory pattern
+- `JobWorkerModule.forRoot({ mode, pools? })` starts one `JobWorker` per active pool on init; stops on destroy
+- Boot validator: missing handler → `BootValidationError` with missing type names listed
+- `@JobHandler` classes upsert into `job` table on init; missing handler (source removed) logs warning (prune → Phase 6)
+- Reserved-pool enforcement: user `@JobHandler` targeting `reserved: true` → `ReservedPoolViolationError` at init with class names
+- Validator skipped when `backend: 'memory'`
+- `loadPoolConfig` applies all five framework defaults when config absent; merges user pools; cannot flip `reserved: true`
+
+## Open Questions (resolved)
+
+**OQ-3 (reiterated from JOB-3) — Job row upsert under horizontal scale.** Use `ON CONFLICT (type) DO UPDATE SET pool=EXCLUDED.pool, retry_policy=EXCLUDED.retry_policy, updated_at=now()`. Last-writer-wins. Safe because same binary = identical metadata. Rejecting `DO NOTHING` (stale rows under rolling deploy) and advisory locks (latency + leak risk).
+
+**Validator in memory mode.** Skipped entirely. Memory-mode tests do not fail validator even with deliberately unregistered types (tests own in-memory state).
+
+**Backend threading.** `JobWorkerModuleOptions.backend` explicit (default `'drizzle'`). `JobWorkerModule` imports `JobsDomainModule.forRoot({ backend: opts.backend ?? 'drizzle' })` internally.
+
+**`loadPoolConfig` runtime vs. codegen-time.** Runs at server boot in consumer app; reads `codegen.config.yaml` from `process.cwd()`. Tests can override via `configPath` parameter.
+
+## Scope Boundary
+
+- **JOB-6** owns standalone `worker.ts` entrypoint
+- **JOB-8** owns `tenant_id` filter threading (this module's `forRoot` signature stays stable)
+- `@JobHandler` decorator definition: JOB-2 (consumed here)
+- BullMQ-native claim: executor layer; `JobsModule` (not `JobsDomainModule`) unchanged
+
+## References
+
+- ADR-022 "Pools", "Worker lifecycle", "Registration — static codegen"
+- ADR-008 — Protocol → Backend → Factory
+- `runtime/subsystems/events/events.module.ts` — module factory pattern
+- `runtime/subsystems/jobs/jobs.module.ts` — existing executor-layer factory
+- JOB-1 schema, JOB-2 protocols, JOB-3 Drizzle backends, JOB-4 memory backends

--- a/docs/specs/JOB-5.md
+++ b/docs/specs/JOB-5.md
@@ -60,9 +60,33 @@ const FRAMEWORK_POOLS: Record<string, PoolDefinition> = {
 };
 
 // jobs-domain.module.ts
+export interface DrizzleBackendExtensions {
+  /** Use Postgres LISTEN/NOTIFY to wake the polling loop. Default false. */
+  listenNotify?: boolean;
+  /** Polling interval when LISTEN/NOTIFY is off (ms). Default 1000. */
+  pollIntervalMs?: number;
+}
+
+// Future shape — Phase 6+, included here so the type system reserves the slot.
+// export interface BullMqBackendExtensions {
+//   bullBoard?: { enabled: boolean; mountPath?: string };
+//   redisUrl?: string;
+// }
+
 export interface JobsDomainModuleOptions {
   backend: 'drizzle' | 'memory';
+  /**
+   * Backend-specific extensions. Only the matching backend's extensions are
+   * read at boot; non-matching keys are ignored (with a config-validator warning).
+   * This is the core/extension protocol surface — see CLAUDE.md.
+   */
+  extensions?: {
+    drizzle?: DrizzleBackendExtensions;
+    // bullmq?: BullMqBackendExtensions;   // Phase 6+
+  };
+  multiTenant?: boolean;                    // JOB-8
 }
+
 export class JobsDomainModule {
   static forRoot(opts: JobsDomainModuleOptions): DynamicModule;
 }
@@ -155,11 +179,11 @@ export namespace HandlerRegistry {
 
 ### 5. `index.ts`
 
-Re-export `JobsDomainModule`, `JobsDomainModuleOptions`, `JobWorkerModule`, `JobWorkerModuleOptions`, `loadPoolConfig`, `PoolConfig`, `PoolDefinition`, error classes. Don't remove existing executor-layer exports.
+Re-export `JobsDomainModule`, `JobsDomainModuleOptions`, `JobWorkerModule`, `JobWorkerModuleOptions`, `loadPoolConfig`, `PoolConfig`, `PoolDefinition`, error classes. (No legacy executor-layer exports remain — JOB-1 deletes the entire `IJobQueue` surface.)
 
 ## Pool → Queue Binding
 
-Each pool maps to a distinct queue name passed to `IJobQueue.enqueue('job_run_tick', { runId }, { queue: poolDef.queue })`. `concurrency` passed to `JobWorker` as max parallel in-flight ticks — worker tracks active promises and skips `claimNext` at capacity.
+Each pool gets one `JobWorker` instance. The worker polls `job_run` for rows where `pool = poolDef.queue` (the `queue` field is reused as the pool's identifier on the `job_run` row — naming preserved for parity with future BullMQ backend mapping). `concurrency` passed to `JobWorker` as max parallel in-flight runs — worker tracks active promises and skips `claimNext` at capacity. No tick messages, no `IJobQueue`.
 
 Defaults:
 
@@ -215,12 +239,12 @@ User-defined `agents: { queue: 'jobs-agents', concurrency: 3 }` in config become
 - **JOB-6** owns standalone `worker.ts` entrypoint
 - **JOB-8** owns `tenant_id` filter threading (this module's `forRoot` signature stays stable)
 - `@JobHandler` decorator definition: JOB-2 (consumed here)
-- BullMQ-native claim: executor layer; `JobsModule` (not `JobsDomainModule`) unchanged
+- BullMQ orchestrator backend: Phase 6+ work, separate `IJobOrchestrator` implementation; not in JOB-5
 
 ## References
 
 - ADR-022 "Pools", "Worker lifecycle", "Registration — static codegen"
 - ADR-008 — Protocol → Backend → Factory
 - `runtime/subsystems/events/events.module.ts` — module factory pattern
-- `runtime/subsystems/jobs/jobs.module.ts` — existing executor-layer factory
+- `runtime/subsystems/events/events.module.ts` — closest surviving factory pattern (the legacy `runtime/subsystems/jobs/jobs.module.ts` is deleted in JOB-1)
 - JOB-1 schema, JOB-2 protocols, JOB-3 Drizzle backends, JOB-4 memory backends

--- a/docs/specs/JOB-6.md
+++ b/docs/specs/JOB-6.md
@@ -114,13 +114,39 @@ Body (YAML appended):
 
 ```yaml
 jobs:
-  multi_tenant: false       # set true to add tenant_id column (requires JOB-8)
-  worker_mode: embedded     # embedded | standalone
+  # ── Backend selection (core/extension model — see CLAUDE.md) ──
+  # 'drizzle' is the only Phase 1 backend. Future backends ('bullmq', etc.)
+  # implement the same core IJobOrchestrator contract but expose their own
+  # native features as opt-in extensions below.
+  backend: drizzle
+
+  # ── Backend-specific extensions (typed per backend) ──
+  # Each backend may publish its own extension keys. Unrecognised keys for
+  # the active backend produce a config validation warning at boot.
+  extensions:
+    drizzle:
+      # listen_notify: true        # use Postgres LISTEN/NOTIFY to wake the
+      #                            # polling loop instead of (or alongside)
+      #                            # interval polling. Disabled by default.
+      poll_interval_ms: 1000
+    # bullmq:                      # Example shape for Phase 6+ BullMQ backend.
+    #   bull_board:                # Mount Bull Board admin UI.
+    #     enabled: true
+    #     mount_path: /admin/queues
+    #   redis_url: redis://...
+
+  # ── Multi-tenancy (JOB-8) ──
+  multi_tenant: false              # true → enforce tenantId on all calls
+
+  # ── Worker topology ──
+  worker_mode: embedded            # embedded | standalone
+
+  # ── Pools (logical lanes; one worker per pool) ──
   pools:
     events_inbound:
       queue: jobs-events-inbound
       concurrency: 20
-      reserved: true
+      reserved: true               # framework-only; user @JobHandler cannot target
     events_change:
       queue: jobs-events-change
       concurrency: 30
@@ -137,7 +163,7 @@ jobs:
       concurrency: 5
 ```
 
-All five pools, `reserved: true` only on `events_*`. No `description` keys (keep scaffold minimal).
+**Design intent.** The `backend` key surfaces the architectural choice explicitly. The `extensions:` block is keyed by backend name — when a consumer switches backends, they keep only the relevant extensions and the rest become inert (validator warns rather than errors so swap is non-destructive). Comments in the scaffolded file teach the model in-place.
 
 ## Implementation Steps
 

--- a/docs/specs/JOB-6.md
+++ b/docs/specs/JOB-6.md
@@ -1,0 +1,211 @@
+# JOB-6 — Hygen Scaffold Templates: `worker.ts`, `main.ts` Hook, Config Block
+
+**Issue:** JOB-6
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Depends on:** JOB-5 (module names must be stable)
+**Blocks:** JOB-8 (`--upgrade` extends same CLI surface)
+
+## Overview
+
+Hygen templates that emit operational glue files when `bun codegen subsystem jobs` runs in a consumer project. Three templates: standalone `worker.ts` at project root, commented embedded-mode guidance injected into `src/main.ts`, and a `jobs:` block appended to `codegen.config.yaml` with all five default pools populated. `SubsystemInstallCommand` is extended to invoke Hygen after `copyRuntime`. Scaffolded once per project, not per entity.
+
+## Context
+
+ADR-022: "Codegen emits both `main.ts` and `worker.ts` on scaffold. A consumer who never deploys standalone simply never runs `worker.ts`; the file is inert." JOB-6 delivers that commitment.
+
+`templates/subsystem/jobs/` does not exist before this issue; created fresh.
+
+## Architecture
+
+```
+SubsystemInstallCommand.execute()
+  ├── copyRuntime()                            ← existing
+  └── invokeHygen({ generator: 'subsystem', action: 'jobs' })
+        ├── worker.ejs.t                       → <cwd>/worker.ts (create; skip if exists)
+        ├── main-hook.ejs.t                    → inject into <cwd>/src/main.ts (once)
+        └── codegen-config-jobs-block.ejs.t    → append to <cwd>/codegen.config.yaml (once)
+```
+
+## Files
+
+| File | Action | Purpose |
+|---|---|---|
+| `templates/subsystem/jobs/worker.ejs.t` | create | Produces `worker.ts` at project root |
+| `templates/subsystem/jobs/main-hook.ejs.t` | create | Injects embedded-mode comment block |
+| `templates/subsystem/jobs/codegen-config-jobs-block.ejs.t` | create | Appends `jobs:` config block |
+| `src/cli/commands/subsystem.ts` | modify | Invoke Hygen for `jobs` after `copyRuntime` |
+| `test/baseline/` | modify | Update snapshot |
+
+## Template Variable Model
+
+```typescript
+interface JobsScaffoldLocals {
+  appName: string;          // basename of cwd if config has no explicit name
+  workerMode: 'embedded' | 'standalone';  // default 'embedded'
+  multiTenant: boolean;     // informational only; JOB-8 emits conditional column
+  mainTsPath: string;       // default 'src/main.ts'
+  configPath: string;       // default 'codegen.config.yaml'
+  workerExists: boolean;    // computed in CLI via fs.existsSync; used in worker template skip_if
+}
+```
+
+## Template Designs
+
+### `worker.ejs.t`
+
+```
+---
+to: "<%= workerPath %>"
+skip_if: "<%= workerExists %>"
+---
+```
+
+Content (template body): minimal NestJS `NestFactory.createApplicationContext` bootstrap — no `app.listen()`. Imports `JobWorkerModule`, `DatabaseModule`, `JobsDomainModule`. Inline `WorkerAppModule` with:
+
+```ts
+@Module({
+  imports: [
+    DatabaseModule,
+    JobsDomainModule.forRoot({ backend: 'drizzle' }),
+    JobWorkerModule.forRoot({ mode: 'standalone' }),
+  ],
+})
+class WorkerAppModule {}
+```
+
+SIGTERM handler: set flag, `await app.close()`, bounded by `SHUTDOWN_TIMEOUT_MS = 30000`. `bootstrap()` called at bottom; errors → `process.exit(1)`.
+
+### `main-hook.ejs.t`
+
+```
+---
+to: "<%= mainTsPath %>"
+inject: true
+after: "NestFactory.create"
+skip_if: "JobWorkerModule"
+---
+```
+
+Body (a commented guidance block injected after `NestFactory.create(...)`):
+
+```ts
+// JOBS — Embedded worker mode (optional)
+// To run the job worker in-process (single-process deploy), add to AppModule imports:
+//   JobWorkerModule.forRoot({ mode: 'embedded' })
+// For standalone worker (separate process), use worker.ts at the project root.
+// See codegen.config.yaml jobs.worker_mode to toggle the documented default.
+```
+
+If `src/main.ts` doesn't exist, Hygen skips silently; CLI layer prints a hint.
+
+### `codegen-config-jobs-block.ejs.t`
+
+```
+---
+to: "<%= configPath %>"
+inject: true
+append: true
+skip_if: "jobs:"
+---
+```
+
+Body (YAML appended):
+
+```yaml
+jobs:
+  multi_tenant: false       # set true to add tenant_id column (requires JOB-8)
+  worker_mode: embedded     # embedded | standalone
+  pools:
+    events_inbound:
+      queue: jobs-events-inbound
+      concurrency: 20
+      reserved: true
+    events_change:
+      queue: jobs-events-change
+      concurrency: 30
+      reserved: true
+    events_outbound:
+      queue: jobs-events-outbound
+      concurrency: 10
+      reserved: true
+    interactive:
+      queue: jobs-interactive
+      concurrency: 20
+    batch:
+      queue: jobs-batch
+      concurrency: 5
+```
+
+All five pools, `reserved: true` only on `events_*`. No `description` keys (keep scaffold minimal).
+
+## Implementation Steps
+
+1. **Create `templates/subsystem/jobs/`** — no prompt.js needed; subsystem templates called directly by CLI.
+2. **Write `worker.ejs.t`** — front-matter `to`, `skip_if: workerExists`; body as above. Import path `@shared/subsystems/jobs` (consumer-side location after `copyRuntime`).
+3. **Write `main-hook.ejs.t`** — front-matter `to`, `inject: true`, `after: "NestFactory.create"`, `skip_if: "JobWorkerModule"`; body as above.
+4. **Write `codegen-config-jobs-block.ejs.t`** — front-matter `to`, `inject: true`, `append: true`, `skip_if: "jobs:"`; body as above.
+5. **Extend `SubsystemInstallCommand.execute()`** in `src/cli/commands/subsystem.ts`:
+   - After `copyRuntime(...)`: `if (this.name === 'jobs' && !this.dryRun)`
+   - Resolve template locals from config + cwd
+   - Compute `workerExists` via `fs.existsSync(path.join(ctx.cwd, 'worker.ts'))`
+   - Call `invokeHygen({ generator: 'subsystem', action: 'jobs', args: [...], cwd: ctx.cwd })`
+   - On Hygen failure: warn but exit 0 — runtime files already written; partial scaffold > hard failure
+   - Dry-run: print files Hygen would emit; skip actual invocation
+6. **Update baseline snapshot** — `just test-baseline --update` after manual walkthrough confirms output.
+
+## Interaction with Existing Jobs Subsystem
+
+- `runtime/subsystems/jobs/` (executor-layer `IJobQueue`) is copied verbatim by `copyRuntime`. JOB-6 does not touch it.
+- New Hygen templates live in `templates/subsystem/jobs/` (directory does not exist pre-JOB-6). No conflict with `templates/entity/new/`.
+- Config block `skip_if: "jobs:"` handles the case where JOB-8's upgrade command has already written a `jobs:` key.
+
+## Acceptance Criteria
+
+**Concrete walkthrough (the "four files" test plan):**
+
+1. Fresh directory; `bun codegen project init` produces `codegen.config.yaml` + scaffold.
+2. `just gen-subsystem jobs` → exits 0.
+3. Assert post-run state:
+   - `shared/subsystems/jobs/` populated with executor-layer runtime files
+   - `worker.ts` at project root — imports `JobWorkerModule.forRoot({ mode: 'standalone' })`, no `app.listen()`
+   - `codegen.config.yaml` — contains full `jobs:` block with all five pools
+   - `src/main.ts` (if exists) — contains commented JOBS guidance block
+4. Second run of `just gen-subsystem jobs`:
+   - `worker.ts` not overwritten (skip_if)
+   - `codegen.config.yaml` has no duplicate `jobs:` block
+   - `src/main.ts` has no duplicate comment block
+
+**Criteria from issue list:**
+- [ ] `worker.ts` imports `JobWorkerModule`; boots NestJS app context without HTTP listener
+- [ ] Config block has five default pools with `reserved: true` on `events_*` three
+- [ ] `just test-baseline` passes
+
+## Testing Strategy
+
+- **Baseline snapshot** — `just test-baseline` runs `subsystem install jobs` on fixture project and compares output to committed snapshots. Update as part of PR.
+- **Unit test** for template-variable resolution: extract resolution logic to pure function; test with various config inputs.
+- **Manual walkthrough** documented in PR description: fresh `bun init` project, run the commands, inspect output, verify four-files test plan passes, confirm idempotency on re-run.
+
+No Docker required. Hygen invocation tested via baseline fixture in CI.
+
+## Scope Boundary
+
+- **Does not** emit `tenant_id` conditional logic — JOB-8
+- **No upgrade path needed** — no existing users; fresh-install is the only path
+- **Does not** generate user-job handler classes — ADR-022 explicitly rejects jobs-as-YAML
+- **Does not** modify `src/main.ts` beyond commented block — uncommenting = consumer decision
+- `worker.ts` uses hard-coded `@shared/subsystems/jobs` import path — non-standard `paths.subsystems` config would produce wrong path; flagged as known limitation, not blocking; follow-up can make path template-variable-driven
+
+## Open Questions (non-blocking)
+
+- `main-hook.ejs.t` uses `after: "NestFactory.create"` as injection anchor. If consumer uses `NestFactory.createMicroservice` instead, injection silently skips. CLI should print info message when `main.ts` exists but injection result can't be confirmed. Cosmetic; scaffold still functional.
+
+## References
+
+- ADR-022 "Worker lifecycle", "Pools", "Codegen scope"
+- `docs/specs/ADR-022-phase-1-issues.md` — issue definition
+- `src/cli/commands/subsystem.ts` — existing `copyRuntime` integration
+- `src/cli/shared/hygen.ts` — `invokeHygen` helper
+- `templates/entity/new/clean-lite-ps/module.ejs.t` — Hygen front-matter reference
+- `templates/entity/new/backend/modules/core/_inject-token.ejs.t` — inject template reference

--- a/docs/specs/JOB-7.md
+++ b/docs/specs/JOB-7.md
@@ -1,0 +1,242 @@
+# JOB-7 — `scopeable: true` Entity Flag and Generated `ScopeEntityType` Union
+
+**Issue:** JOB-7
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Phase:** ADR-022 Phase 1
+**Depends on:** JOB-1 (`scope_entity_type text?` column consumes this union), JOB-2 (`ScopeRef<TInput, TScope extends string>` references this union)
+**Blocks:** JOB-8 (uses same entity scan infrastructure for `multi_tenant` flag)
+
+## Overview
+
+Add `scopeable: true` to entity YAML definitions and generate a typed `ScopeEntityType` TypeScript union and Zod enum from the set of all flagged entities. The union is written to `src/shared/jobs/scope-entity-type.ts` in the consumer project. Type safety lives at the TS layer; the `scope_entity_type` DB column remains `text` with no CHECK constraint (ADR-022 mandate). Codegen-only change: no DB migrations, no new runtime classes.
+
+## Context
+
+**What exists.** Entity YAML is validated by `EntityDefinitionSchema` (Zod) in `src/schema/entity-definition.schema.ts`. The `entity:` block is parsed by `EntityConfigSchema` which uses `.strict()` — unrecognized keys are rejected. The parser (`src/parser/load-entities.ts`) transforms validated YAML into `ParsedEntity` via `transformToEntity`. The CLI (`src/cli/commands/entity.ts`) calls Hygen per entity then runs `regenerateBarrels()` as a cross-entity post-step.
+
+`regenerateBarrels()` in `src/cli/shared/barrel-generator.ts` is the precedent: walks the entities directory, calls `loadEntityFromYaml` on each file, builds content from the full set, writes directly to disk (no Hygen). JOB-7 follows this pattern.
+
+**What JOB-7 adds.**
+1. `scopeable: z.boolean().optional()` in `EntityConfigSchema`
+2. `scopeable?: boolean` on `ParsedEntity`
+3. New `generateScopeEntityType()` in `src/cli/shared/scope-entity-type-generator.ts`
+4. Call site in `EntityNewCommand.execute()` alongside `regenerateBarrels()`
+
+No Hygen templates — direct TypeScript string generation.
+
+## Architecture
+
+```
+EntityNewCommand.execute()
+  ├── invokeEntityNew() × N           ← Hygen, unchanged
+  ├── regenerateBarrels()             ← existing post-step
+  └── generateScopeEntityType()       ← new post-step (JOB-7)
+        ├── collectScopeableNames(entitiesDir)
+        │     └── loadEntityFromYaml per file; filter scopeable === true
+        ├── buildScopeEntityTypeContent(names)  ← pure function
+        └── write src/shared/jobs/scope-entity-type.ts
+```
+
+Deterministic: full directory rescan on every invocation. Adding/removing `scopeable: true` and rerunning `entity new` always yields correct union.
+
+## Files
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/schema/entity-definition.schema.ts` | modify | Add `scopeable: z.boolean().optional()` to `EntityConfigSchema` |
+| `src/analyzer/types.ts` | modify | Add `scopeable?: boolean` to `ParsedEntity` |
+| `src/parser/load-entities.ts` | modify | Populate `entity.scopeable` in `transformToEntity` |
+| `src/cli/shared/scope-entity-type-generator.ts` | create | `generateScopeEntityType()` + helpers |
+| `src/cli/commands/entity.ts` | modify | Invoke generator after `regenerateBarrels()` |
+| `src/__tests__/schema/schema-v2.test.ts` | modify | `scopeable` field validation cases |
+| `src/__tests__/cli/scope-entity-type-generator.test.ts` | create | Unit tests for generator |
+| `test/baseline/` | modify | Update snapshot to include generated union |
+
+## Interfaces
+
+### Schema change (`entity-definition.schema.ts`)
+
+```typescript
+const EntityConfigSchema = z.object({
+  name: z.string().regex(...),
+  plural: z.string().regex(...),
+  table: z.string().regex(...),
+  folder_structure: FolderStructureSchema.optional(),
+  file_grouping: FileGroupingSchema.optional(),
+  behavior_strategy: BehaviorStrategySchema.optional(),
+  expose: z.array(ExposeLayerSchema).optional().default([...]),
+  family: z.enum([...]).optional(),
+  scopeable: z.boolean().optional(),    // ← ADD
+}).strict();
+```
+
+### `ParsedEntity` extension (`src/analyzer/types.ts`)
+
+```typescript
+export interface ParsedEntity {
+  // ... existing fields ...
+  scopeable?: boolean;   // ← ADD
+  sourcePath: string;
+}
+```
+
+### Parser population (`src/parser/load-entities.ts`)
+
+```typescript
+// inside transformToEntity, next to `family`:
+const entity: ParsedEntity = {
+  // ... existing ...
+  family: definition.entity.family,
+  scopeable: definition.entity.scopeable ?? false,   // ← ADD
+  // ... rest ...
+};
+```
+
+### Generator (`src/cli/shared/scope-entity-type-generator.ts`)
+
+```typescript
+interface ScopeEntityTypeGeneratorOptions {
+  entitiesDir: string;        // absolute
+  outputPath: string;         // absolute, default <cwd>/src/shared/jobs/scope-entity-type.ts
+  dryRun?: boolean;
+}
+
+interface ScopeEntityTypeResult {
+  outputPath: string;
+  scopeableNames: string[];   // sorted
+  written: boolean;
+  content: string;
+}
+
+function collectScopeableNames(entitiesDir: string): string[];
+// Walk directory; loadEntityFromYaml; filter; sort; return names
+
+function buildScopeEntityTypeContent(names: string[]): string;
+// Pure function. See "Generated output" below for both the non-empty and empty cases.
+
+export async function generateScopeEntityType(
+  opts: ScopeEntityTypeGeneratorOptions,
+): Promise<ScopeEntityTypeResult>;
+// Calls collect + build; fs.mkdirSync(dir, {recursive: true}); fs.writeFileSync unless dryRun
+```
+
+## Generated Output
+
+With `account` and `opportunity` as `scopeable: true`, `contact` as not:
+
+```typescript
+// AUTO-GENERATED by @pattern-stack/codegen. Do not edit.
+// Run `codegen entity new --all` to refresh.
+
+import { z } from 'zod';
+
+export type ScopeEntityType = 'account' | 'opportunity';
+
+export const SCOPE_ENTITY_TYPES = ['account', 'opportunity'] as const;
+
+export const scopeEntityTypeSchema = z.enum(['account', 'opportunity']);
+```
+
+Empty case (no scopeable entities):
+
+```typescript
+// AUTO-GENERATED by @pattern-stack/codegen. Do not edit.
+// Run `codegen entity new --all` to refresh.
+
+export type ScopeEntityType = never;
+
+export const SCOPE_ENTITY_TYPES = [] as const;
+```
+
+No Zod import when empty (`z.enum([])` is invalid).
+
+**Consumer usage** (matches JOB-2's `ScopeRef<TInput, TScope extends string>`):
+
+```typescript
+import type { ScopeEntityType } from '@shared/jobs/scope-entity-type';
+
+@JobHandler<OnboardingInput>('onboarding', {
+  scope: { entity: 'account' satisfies ScopeEntityType, from: (i) => i.accountId },
+})
+```
+
+`satisfies ScopeEntityType` enforces compile-time membership without literal widening.
+
+## Implementation Steps
+
+1. **Extend `EntityConfigSchema`** — add `scopeable: z.boolean().optional()` after `family`. `.strict()` stays.
+2. **Extend `ParsedEntity`** — add `scopeable?: boolean`.
+3. **Populate in parser** — `scopeable: definition.entity.scopeable ?? false` in `transformToEntity`.
+4. **Create generator** — `scope-entity-type-generator.ts` with `collectScopeableNames`, `buildScopeEntityTypeContent`, `generateScopeEntityType`. Match `barrel-generator.ts` style (HEADER constant, `mkdirSync`, same dry-run semantics).
+5. **Wire into `EntityNewCommand`** — after `regenerateBarrels()`, call `generateScopeEntityType({ entitiesDir, outputPath: path.resolve(ctx.cwd, 'src/shared/jobs/scope-entity-type.ts'), dryRun: this.dryRun })`. Include in dry-run report. Warn-but-don't-fail on error (matches barrel pattern). Run for both single-file and `--all` modes.
+6. **Add unit tests** — schema tests for field validation; generator tests with temp-directory fixtures.
+7. **Update baseline** — ensure one baseline fixture has `scopeable: true` so snapshot exercises non-empty path.
+
+## Acceptance Criteria
+
+- [ ] `scopeable: true` passes `EntityDefinitionSchema.parse()`
+- [ ] `scopeable: false` passes
+- [ ] Omitting `scopeable` passes (`.optional()`)
+- [ ] Non-boolean values rejected by Zod
+- [ ] `transformToEntity` produces `entity.scopeable === true` for flagged entity, `false` otherwise
+- [ ] Given `account` (scopeable) + `contact` (not): union = `'account'`; `contact` absent
+- [ ] Given zero scopeable: `ScopeEntityType = never`, no Zod import
+- [ ] Generated file has `// AUTO-GENERATED` header
+- [ ] `entity new --all` regenerates union after Hygen
+- [ ] `entity new entities/X.yaml` also regenerates (full directory rescan)
+- [ ] `--dry-run` reports planned output without writing
+- [ ] `just test-unit` + `just test-baseline` pass
+
+## Testing Strategy
+
+**Unit — Zod schema** (`schema-v2.test.ts` extension):
+- `scopeable: true` → valid
+- `scopeable: false` → valid
+- absent → valid, `undefined`
+- non-boolean → rejected
+
+**Unit — Generator** (`scope-entity-type-generator.test.ts`):
+- `buildScopeEntityTypeContent([])` → `never` form, no Zod import
+- `buildScopeEntityTypeContent(['account'])` → single-member union + Zod enum
+- `buildScopeEntityTypeContent(['account', 'opportunity'])` → sorted union
+- `collectScopeableNames(tempDir)` with two fixture YAMLs (one scopeable, one not) → returns only scopeable name
+- `generateScopeEntityType({ dryRun: true })` → `written: false`, correct `content`
+
+**Baseline**: amend existing fixture (e.g. `opportunity.yaml`) to include `scopeable: true`; snapshot includes `scope-entity-type.ts`.
+
+All tests run via `just test-unit` / `just test-baseline`. No Docker.
+
+## Scope Boundary
+
+**In scope:** YAML flag, parser collection, union generation.
+
+**Out of scope:**
+- Multi-tenancy `tenant_id` threading (JOB-8)
+- Generating helper methods on `JobRunService` — those are consumer use cases calling existing `IJobRunService.listForScope(entityType, entityId)` from JOB-2/JOB-3
+- DB CHECK constraint on `scope_entity_type` — ADR-022 prohibits
+- Per-entity Hygen template changes
+- Validating `@JobHandler` `scope.entity` value is a `ScopeEntityType` member — consumer enforces via `satisfies`
+
+## Open Questions
+
+- [x] **OQ-1 — Single-file vs. `--all` trigger.** **Resolved 2026-04-18: always rescan.** Both single-file and `--all` invocations trigger a full directory rescan and union regeneration. Cost is one directory walk (sub-millisecond at typical entity counts). Correctness over speed — silent stale-union failures would be confusing.
+
+- [x] **OQ-2 — Consumer output path.** **Resolved 2026-04-18: hardcoded `src/shared/jobs/scope-entity-type.ts` for Phase 1.** Add config override only if a real conflict surfaces.
+
+- [x] **OQ-3 — Empty Zod enum.** **Resolved 2026-04-18: omit the Zod export entirely when no scopeable entities exist.** Importers of `scopeEntityTypeSchema` get a clear "not exported" build error — correct surfacing of "there are no valid scopes." Fallbacks (`z.never()`, `z.string()`) hide the problem.
+
+- [x] **OQ-4 — `scopeable` placement.** **Confirmed: inside `entity:` block (`EntityConfigSchema`).**
+
+- [x] **OQ-5 — Sort order.** **Confirmed: alphabetical.** Deterministic; adding a new entity in the middle doesn't reorder existing entries; baseline-stable.
+
+## References
+
+- ADR-022 "Scoping" section
+- `docs/specs/ADR-022-phase-1-issues.md` — JOB-7 entry
+- `docs/specs/JOB-2.md` — `ScopeRef` generic + OQ-2 path decision
+- `src/cli/shared/barrel-generator.ts` — precedent pattern for cross-entity TS artifacts
+- `src/schema/entity-definition.schema.ts` — modification target
+- `src/parser/load-entities.ts` — modification target
+- `src/analyzer/types.ts` — modification target
+- `src/__tests__/schema/schema-v2.test.ts` — extension target

--- a/docs/specs/JOB-8.md
+++ b/docs/specs/JOB-8.md
@@ -1,0 +1,181 @@
+# JOB-8 — Multi-Tenancy Opt-In and Atlas Migration Docs
+
+**Issue:** JOB-8
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Phase:** ADR-022 Phase 1
+**Depends on:** JOB-1 (schema), JOB-5 (module options), JOB-6 (Hygen CLI surface), JOB-7 (scopeable flag — concurrent)
+
+## Overview
+
+Two deliverables.
+
+1. **Multi-tenancy opt-in.** When `codegen.config.yaml: jobs.multi_tenant: true`, the service layer accepts and enforces `tenantId` on every mutating and query method. The `tenant_id` column exists unconditionally in the DB (JOB-1 decision); JOB-8 wires the flag into module options and backend logic.
+2. **Atlas docs.** `docs/CONSUMER-SETUP.md` replaces the `drizzle-kit push` recommendation with a proper Atlas migration workflow.
+
+**Removed from scope (2026-04-18):** The upgrade command (`subsystem upgrade jobs`) was originally scoped here to preserve the existing `job_queue` table for `IJobQueue` consumers. Per project policy (no backwards compat until we have users), this is unnecessary — `subsystem install jobs` overwrites cleanly. JOB-8 is now smaller and more focused.
+
+## Context
+
+**Why `tenant_id` is not a schema conditional.** JOB-1 resolved the conditional-emit question: the column lands unconditionally as nullable `text`, annotated `// conditionally emitted — see JOB-8`. A `multi_tenant: false` project pays zero cost (column always null, no query changes). Gating lives in the service layer, not the schema. This avoids a migration for projects that enable multi-tenancy later.
+
+**Why Atlas over drizzle-kit.** The existing `drizzle-kit push` recommendation is a dev-convenience shortcut; it does not produce reviewed migration files. Phase 1 ships real migration infrastructure.
+
+## Architecture
+
+```
+Deliverable 1 — Multi-tenancy
+  codegen.config.yaml (jobs.multi_tenant: true)
+        │
+        ▼
+  JobsDomainModule.forRoot({ multiTenant: true })
+        │  provides JOBS_MULTI_TENANT token (boolean)
+        ▼
+  Drizzle/Memory backends
+        │  inject JOBS_MULTI_TENANT
+        │  when true: read tenantId from options; write to job_run.tenant_id
+        │             add eq(jobRuns.tenantId, tenantId) to claim / list queries
+        │             throw MissingTenantIdError when tenantId omitted (explicit null OK)
+        ▼
+  All protocol methods accept optional tenantId
+
+Deliverable 2 — Atlas docs
+  docs/CONSUMER-SETUP.md
+        ├── delete: "drizzle-kit push" section
+        └── add: "Atlas migration workflow" section
+```
+
+## Files
+
+| File | Action | Purpose |
+|---|---|---|
+| `runtime/subsystems/jobs/jobs-domain.module.ts` | modify | Add `multiTenant?: boolean` to options; provide `JOBS_MULTI_TENANT` token |
+| `runtime/subsystems/jobs/jobs-domain.tokens.ts` | modify | Add `JOBS_MULTI_TENANT` Symbol |
+| `runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts` | modify | Inject flag; write + filter `tenant_id` |
+| `runtime/subsystems/jobs/job-run-service.drizzle-backend.ts` | modify | Inject flag; filter queries by `tenantId` |
+| `runtime/subsystems/jobs/job-orchestrator.memory-backend.ts` | modify | Same tenant gate |
+| `runtime/subsystems/jobs/job-run-service.memory-backend.ts` | modify | Same tenant gate |
+| `runtime/subsystems/jobs/job-orchestrator.protocol.ts` | modify | Add `tenantId?: string` to `StartOptions`, `CancelOptions` |
+| `runtime/subsystems/jobs/job-run-service.protocol.ts` | modify | Add `tenantId?: string` to `ListForScopeOptions` |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export `JOBS_MULTI_TENANT` |
+| `runtime/subsystems/jobs/__tests__/multi-tenant.unit.test.ts` | create | Unit tests for both modes against memory backend |
+| `docs/CONSUMER-SETUP.md` | modify | Add "Atlas migration workflow" section; delete `drizzle-kit push` section |
+
+## Interfaces
+
+```typescript
+// jobs-domain.module.ts
+interface JobsDomainModuleOptions {
+  backend: 'drizzle' | 'memory';
+  multiTenant?: boolean;   // default false
+}
+
+// jobs-domain.tokens.ts
+export const JOBS_MULTI_TENANT = Symbol('JOBS_MULTI_TENANT');
+
+// Protocol additions (backward-compatible — fields optional)
+interface StartOptions {
+  // ... existing ...
+  tenantId?: string;   // required when JOBS_MULTI_TENANT=true; ignored when false
+}
+interface CancelOptions {
+  // ... existing ...
+  tenantId?: string;
+}
+interface ListForScopeOptions {
+  // ... existing ...
+  tenantId?: string;
+}
+
+```
+
+## Implementation Steps
+
+### 1. Multi-tenancy — tokens + module options
+
+- Add `JOBS_MULTI_TENANT` Symbol to `jobs-domain.tokens.ts`; export from `index.ts`.
+- `JobsDomainModule.forRoot(opts)`: include `{ provide: JOBS_MULTI_TENANT, useValue: opts.multiTenant ?? false }` in providers + exports.
+
+### 2. Backend injection
+
+- Inject `@Inject(JOBS_MULTI_TENANT) private readonly multiTenant: boolean` in all four backend classes.
+- **Write path** (`start()`): when `multiTenant === true`, include `tenantId: opts.tenantId ?? null` in insert. When `false`, always `null`.
+- **Query path** (`cancel`, `listForScope`, `cancelForScope`, `rescheduleForScope`, claim query): when `multiTenant === true`, add `eq(jobRuns.tenantId, opts.tenantId)` to `WHERE`. Prevents cross-tenant ops.
+- Memory backends: identical logic against `MemoryJobStore` — filter `store.runs.values()` by `r.tenantId === opts.tenantId` when flag on.
+
+### 3. Unit tests (`__tests__/multi-tenant.unit.test.ts`)
+
+- **Flag false:** `start()` writes `tenantId: null`; `listForScope` ignores `tenantId` filter; existing tests unaffected.
+- **Flag true, correct tenant:** `start({ tenantId: 'A' })` writes `'A'`; `listForScope({ tenantId: 'A' })` returns only A.
+- **Flag true, wrong tenant:** `listForScope({ tenantId: 'B' })` returns empty.
+- **Cross-tenant cancel:** `cancel(runId, { tenantId: 'B' })` when run belongs to A → no-op (not-found path, no error).
+
+All memory backend, no Docker.
+
+### 4. Atlas docs section (`docs/CONSUMER-SETUP.md`)
+
+Insert `## Atlas migration workflow` section after the existing `## schema.ts wiring` section. **Delete** the previous `drizzle-kit push` section outright.
+
+Section contents:
+- **Motivation** — `drizzle-kit push` bypasses reviewed migrations; Atlas produces versioned SQL.
+- **Prerequisites** — Atlas CLI (`brew install ariga/tap/atlas` or `curl -sSf https://atlasgo.sh | sh`); `atlas.hcl` at project root.
+- **Example `atlas.hcl`:**
+  ```hcl
+  data "external_schema" "drizzle" {
+    program = [
+      "bunx",
+      "drizzle-kit",
+      "introspect:pg",
+      "--config=drizzle.config.ts",
+    ]
+  }
+  env "local" {
+    src = data.external_schema.drizzle.url
+    url = getenv("DATABASE_URL")
+    migration {
+      dir = "file://migrations"
+    }
+  }
+  ```
+- **Workflow:**
+  1. Author or update Drizzle schema
+  2. `atlas migrate diff --env local --name <label>` → `migrations/<timestamp>_<label>.sql`
+  3. Review generated SQL
+  4. `atlas migrate apply --env local` to apply
+  5. Commit migration file alongside schema change
+- **Note:** the upgrade command (`bun codegen subsystem upgrade jobs`) emits this hint automatically.
+
+## Acceptance Criteria
+
+**Multi-tenancy**
+- [ ] `multi_tenant: false` (default): `start()` writes `tenant_id = NULL`; queries skip `tenantId` filter; existing tests unaffected
+- [ ] `multi_tenant: true`: `start({ tenantId: 'x' })` writes it; `listForScope(..., { tenantId: 'x' })` returns only x
+- [ ] Cross-tenant `cancel()` with wrong `tenantId` is no-op
+- [ ] Both flag states covered in unit tests; `just test-unit` passes
+
+**Atlas docs**
+- [ ] `CONSUMER-SETUP.md` contains `## Atlas migration workflow`
+- [ ] Documents `atlas migrate diff` + `atlas migrate apply` with example `atlas.hcl`
+- [ ] `drizzle-kit push` section removed from `CONSUMER-SETUP.md`
+- [ ] Reviewer can follow section from scratch without external references
+
+## Testing Strategy
+
+- **Unit (`just test-unit`):** `multi-tenant.unit.test.ts` — memory backend, both flag states; all assertions above. No Docker.
+- **Manual doc test:** follow Atlas section in clean demo-app checkout; verify `migrations/` populated and `apply` succeeds against local Postgres. Document in PR.
+
+## Open Questions
+
+- [x] **`tenantId` enforcement strictness.** **Resolved 2026-04-18: strict — throw `MissingTenantIdError` when `multiTenant: true` and `tenantId` is missing.** Cross-tenant data leakage is the worst class of bug; surface it loudly at the call site. Tenant-less jobs (background work spanning tenants) opt in explicitly with `tenantId: null` — explicit `null` passes; missing/`undefined` throws. No separate `multi_tenant_strict` config key.
+- [ ] **Atlas Drizzle integration version.** Pin minimum Atlas CLI version in docs. Confirm demo app's Atlas version.
+- [x] **`drizzle-kit push` section disposition.** **Resolved 2026-04-18: delete outright.** No external users to preserve doc-anchor compatibility for.
+
+## References
+
+- ADR-022 — "Multi-tenancy", "Atlas migration workflow"
+- `docs/specs/ADR-022-phase-1-issues.md` — JOB-8 entry
+- `docs/specs/JOB-1.md` — `tenant_id` unconditional column decision
+- `docs/specs/JOB-5.md` — `JobsDomainModuleOptions` shape this issue extends
+- `docs/specs/JOB-6.md` — Hygen templates the upgrade command re-invokes
+- Pattern reference: existing `SubsystemInstallCommand` in `src/cli/commands/subsystem.ts`
+- Doc to update: `docs/CONSUMER-SETUP.md`

--- a/docs/specs/dealbrain-bullmq-audit.md
+++ b/docs/specs/dealbrain-bullmq-audit.md
@@ -1,0 +1,52 @@
+# Dealbrain BullMQ Audit
+
+**Scope:** Read-only audit of `/Users/dug/Projects/dealbrain` (the actual project location — the nominal `dev/dealbrain-agent` path is empty). Single backend at `apps/backend/`.
+
+## Verdict — Pattern (2): "Native features," deeply
+
+Dealbrain uses BullMQ as a full job-orchestration platform, not a transport. It leans on FlowProducer, JobScheduler (cron), Bull Board, per-queue concurrency, and native deduplication. Ripping BullMQ out would require reimplementing ~5 distinct BullMQ capabilities. A thin `IJobQueue` transport port would leak.
+
+## Feature usage
+
+| Feature | Used? | Example |
+|---|---|---|
+| `Queue.add()` / `addBulk()` | Yes | `apps/backend/src/infrastructure/events/bullmq.service.ts:45, 89` |
+| `Worker` via `@Processor` | Yes (35+ processors) | `apps/backend/src/presentation/event-handlers/opportunity-upserted.event-handler.ts:18` |
+| **`FlowProducer` (parent/child)** | **Yes** | `apps/backend/src/infrastructure/events/bullmq.service.ts:20, 100-102`; call sites: `presentation/event-handlers/sync-gmail-emails-for-user.event-handler.ts:97`, `applications/use-cases/reprocess-failed-artifacts.use-case.ts:128`, `process-pending-artifacts.use-case.ts:123`, `start-import.use-case.ts:81`. Uses `removeDependencyOnFailure` flag. |
+| **`upsertJobScheduler` (cron)** | **Yes — 8 cron jobs** | `apps/backend/src/infrastructure/events/scheduler.service.ts` — heartbeat, gmail, calendar, granola, transcripts, transcript-retry, SF poll, notion. Patterns like `*/5 * * * *`, `0 */6 * * *`. |
+| **`attempts` + exponential `backoff`** | **Yes, globally** | `queue.module.ts:44-49` — `DEFAULT_JOB_OPTIONS = { attempts: 3, backoff: { type: 'exponential', delay: 5000 }, removeOnComplete: 100, removeOnFail: 500 }` |
+| **Per-processor `concurrency`** | **Yes, tuned per queue** | 28 processors with explicit concurrency (1, 3, 5, 10); e.g. `retry-transcript-enrichment.event-handler.ts:10` `concurrency: 1` "Single consumer to avoid racing on the pending queue" |
+| `lockDuration` / stalled tuning | Yes | `queue.module.ts:51-55` — `LONG_RUNNING_WORKER_OPTIONS = { lockDuration: 300_000, stalledInterval: 30_000, maxStalledCount: 1 }` |
+| **`jobId` dedup + `deduplication` TTL** | **Yes, heavily** | `bullmq.service.ts:47-61`; call site `sync-gmail-emails-for-user.event-handler.ts:127` with `ttl: 10 * 60 * 1000`. `PublishEventOptions` exposes both as first-class. |
+| **Bull Board dashboard** | **Yes, prod-mounted** | `apps/backend/src/main.ts:4-6, 39-65` — all 36 queues wrapped in `BullMQAdapter`, mounted at `/api/admin/queues`, gated by admin auth middleware. Deps: `@bull-board/api`, `@bull-board/express` in `package.json:34-35`. |
+| Rate limiter (`limiter: { max, duration }`) | No | Rate limiting done in app code (`p-limit`-style in `core/notion/notion.service.ts`) |
+| `priority` | No | — |
+| `QueueEvents` | No (only mocked in `app.module.spec.ts:72`) | — |
+| `job.updateProgress()` / `job.log()` | No (`updateProgress` seen is on `SyncJobRepository`, not BullMQ `Job`) | — |
+| Repeatable (`repeat:` on `add`) | Uses newer `upsertJobScheduler` API instead | — |
+
+## Queue topology
+
+**36 distinct queue names** registered in `queue.module.ts:57-94` via `BullModule.registerQueue(...)`. One queue per event/job type (e.g. `import-opportunities-queue`, `sync-gmail-emails-queue`, `artifact-created-queue`). Each queue has exactly one `@Processor` — not a mega-queue. A single `FlowProducer` named `default` registered for parent/child flows (`queue.module.ts:111`).
+
+## Is BullMQ also the event bus? Yes — and Doug already considers this a problem
+
+There is no separate event bus. The `IQueueProvider` (`apps/backend/src/domain/events/queueProvider.interface.ts`) is the sole dispatch path; every `BaseEvent` subclass hardcodes a `queueName` and is enqueued as a BullMQ job. Doug's own architecture doc at `/Users/dug/Projects/dealbrain/docs/architecture/event-and-job-system.md` (authored 2026-04-17) explicitly says:
+
+> "In our system, **events and jobs are the same thing.** … We should invest in separating a narrow event bus and a dedicated job queue…"
+> "Define `IEventBus` and `IJobQueue` as distinct interfaces — today both resolve to the same BullMQ-backed implementation under the hood."
+
+## Pain points (documented)
+
+1. **2026-04-17 onboarding incident** (`docs/incidents/2026-04-17-slow-onboarding.md`): a stuck job blocked a worker slot for up to `lockDuration=300s`; BullMQ workers outside one specific queue **don't emit Sentry transactions** (AI-2) — observability gap.
+2. **Worker-pool starvation** — "All compete for the same BullMQ worker pool at concurrency: 10. 44-min artifact gap at 17:26–18:09 confirms starvation." (incident, line 67)
+3. **Deduplication misuse** — deterministic `jobId` used to express "debounce signal," causing dropped signals when the prior job got stuck in `active` (architecture doc, §1).
+4. **Thundering herd** — `scheduler.service.ts:14-18` TODO: multiple cron jobs aligned on `*/5` forced an offset pattern workaround.
+
+## Recommendation for codegen-patterns
+
+**Yes, Dealbrain would adopt a BullMQ `IJobOrchestrator` backend — but would NOT benefit from a swappable `IJobQueue` transport port.**
+
+- They need: FlowProducer (DAGs), cron scheduling, per-queue concurrency, dedup/TTL, Bull Board, retries+backoff. These are the orchestrator's job — they define what "orchestrator" means for them.
+- They don't need: low-level queue substrate abstraction. `Queue.add`/`Worker` are implementation details under the orchestrator; a transport port would only drag the same BullMQ semantics through a thinner interface (exactly the "domain imports BullMQ primitives" smell Doug flags).
+- Recommended codegen-patterns shape: keep BullMQ **only** at the high-level `IJobOrchestrator` port (with `enqueue`, `flow`, `schedule`, `dedup` as first-class operations). Pair it with a separate `IEventBus` port (memory/outbox) — exactly the split Doug's own ADR is proposing. Dealbrain would migrate to this on day one.

--- a/docs/specs/events-codegen-plan.md
+++ b/docs/specs/events-codegen-plan.md
@@ -1,0 +1,609 @@
+# Events Codegen Formalization — Plan
+
+**Status:** Draft (first pass, 2026-04-17)
+**Owner:** Doug
+**Related:** ADR-008 (subsystem architecture), Jobs Layers 1–4 plan
+**Mirrors:** jobs codegen design (pools, generated `src/generated/` output, typed registry)
+
+## 0. Context and framing
+
+Today the events subsystem is scaffolded as a one-time copy under the consumer's
+`src/shared/subsystems/events/` tree (via `just gen-subsystem events`). It ships:
+
+- `IEventBus` — `publish / publishMany / subscribe`, transactional outbox aware
+- `DomainEvent` — untyped `type: string` + `payload: Record<string, unknown>`
+- `DrizzleEventBus` — outbox polling loop, no pool awareness
+- `MemoryEventBus` / `RedisEventBus` — alternate backends
+- `domain_events` Drizzle table — single table, no `direction` or `pool`
+- Entity YAML `events:` block — already parsed; generates per-entity event
+  classes + optional handlers via the existing entity templates
+
+What is **missing** (and is the job of this plan):
+
+1. Events are referenced by free-string `type`. There is no registry, no
+   typed `publish<T>()`, no compile-time validation of subscriptions.
+2. There is no `direction` concept on events — so the jobs bridge has no
+   way to assign the right reserved pool (`events_inbound` / `events_change` /
+   `events_outbound`).
+3. Event payload shapes live inside a single entity YAML and only cover
+   entity-CRUD cases. There is no first-class way to declare inbound webhooks
+   or outbound publishes (which are not tied to any single entity).
+4. Auto-emission from entity templates currently leans on
+   `runtime/base-classes/lifecycle-events.ts` (fire-and-forget, untyped
+   `entityName.created` strings). It works, but it does not produce typed
+   events nor register them in the registry the jobs bridge will need.
+
+The north star: events become **first-class, declared, typed, routable, and
+referenceable** — exactly like jobs. Event YAML drives the generated registry;
+the registry feeds the typed facade and the event-to-job bridge.
+
+## 1. Event YAML shape
+
+### Location and file naming
+
+Events live under `events/*.yaml` at the repo root, alongside `entities/` and
+(soon) `jobs/`. One file per event type. Filename matches the `type` (snake).
+
+```
+events/
+  contact_created.yaml
+  stripe_payment_received.yaml
+  webhook_outbound_contact_sync.yaml
+```
+
+**Alternative considered:** inline under each entity's `events:` block. Kept
+that block for `direction: change` auto-emission convenience (see §4) but
+inbound/outbound events are **not** entity-owned, so they need their own
+top-level files.
+
+### Schema (Zod sketch)
+
+```ts
+const EventDirectionSchema = z.enum(['inbound', 'change', 'outbound']);
+
+const EventPayloadFieldSchema = z.object({
+  type: z.enum(['uuid', 'string', 'number', 'boolean', 'date', 'json']),
+  nullable: z.boolean().optional().default(false),
+  description: z.string().optional(),
+});
+
+const EventDefinitionSchema = z.object({
+  type: z.string().regex(/^[a-z][a-z0-9_]*$/),
+  direction: EventDirectionSchema,
+
+  // Aggregate / source binding.
+  //   - for `change`: required, must be a declared entity name
+  //   - for `inbound`: optional, names the logical source ("stripe", "email")
+  //   - for `outbound`: optional, names the destination ("stripe", "crm")
+  aggregate: z.string().optional(),
+  source: z.string().optional(),      // inbound: external system name
+  destination: z.string().optional(), // outbound: target system name
+
+  // Payload fields — snake_case keys, generate camelCase TS properties.
+  payload: z.record(z.string(), EventPayloadFieldSchema),
+
+  // Pool is *derived* from direction unless explicitly overridden.
+  // Override is constrained to reserved pools of the same category; a `change`
+  // event cannot opt into `events_inbound`. User pools (batch/interactive) are
+  // NOT valid targets for events.
+  pool: z.enum(['events_inbound', 'events_change', 'events_outbound']).optional(),
+
+  // Routing / retry metadata surfaced to the bus backend.
+  retry: z.object({
+    attempts: z.number().int().positive().default(3),
+    backoff: z.enum(['linear', 'exponential']).default('exponential'),
+  }).optional(),
+
+  // Optional free-form metadata pinned at codegen time (e.g. schema version).
+  version: z.number().int().positive().default(1),
+  description: z.string().optional(),
+}).strict();
+```
+
+Derivation rule (`direction` → default `pool`):
+
+| direction  | default pool       |
+|------------|--------------------|
+| `inbound`  | `events_inbound`   |
+| `change`   | `events_change`    |
+| `outbound` | `events_outbound`  |
+
+### Worked examples
+
+**1. Inbound webhook**
+
+```yaml
+# events/stripe_payment_received.yaml
+type: stripe_payment_received
+direction: inbound
+source: stripe
+version: 1
+description: Stripe charge.succeeded webhook, post-signature-verification.
+payload:
+  event_id:      { type: string, description: "Stripe event id (evt_...)" }
+  customer_id:   { type: string }
+  amount_cents:  { type: number }
+  currency:      { type: string }
+  received_at:   { type: date }
+retry:
+  attempts: 5
+  backoff: exponential
+```
+
+**2. Change (entity CRUD)**
+
+```yaml
+# events/contact_created.yaml
+type: contact_created
+direction: change
+aggregate: contact          # must match entities/contact.yaml
+version: 1
+payload:
+  contact_id:  { type: uuid }
+  account_id:  { type: uuid, nullable: true }
+  created_by:  { type: uuid }
+```
+
+Change events may *also* be declared via the entity `events:` block (see §4)
+— the entity block is sugar that generates the equivalent `events/*.yaml`
+at codegen time.
+
+**3. Outbound**
+
+```yaml
+# events/webhook_outbound_contact_sync.yaml
+type: webhook_outbound_contact_sync
+direction: outbound
+destination: crm
+aggregate: contact
+version: 1
+description: Fan out contact writes to the configured CRM provider.
+payload:
+  contact_id: { type: uuid }
+  operation:  { type: string }  # "create" | "update" | "delete"
+  occurred_at: { type: date }
+retry:
+  attempts: 3
+  backoff: exponential
+```
+
+## 2. Generated artifacts in `src/generated/events/`
+
+All generated files. Hand-edits discouraged; everything is reproducible from
+`events/*.yaml`.
+
+```
+src/generated/events/
+  types.ts         # Typed interfaces + discriminated union
+  schemas.ts       # Zod runtime schemas (parity with types.ts)
+  registry.ts      # Metadata map: type → { direction, pool, aggregate, ... }
+  bus.ts           # Typed facade over IEventBus (publish<T>, subscribe<T>)
+  index.ts         # Re-export surface
+```
+
+### `types.ts`
+
+```ts
+// Generated. Do not edit.
+export interface StripePaymentReceivedEvent extends DomainEvent {
+  readonly type: 'stripe_payment_received';
+  readonly payload: {
+    eventId: string;
+    customerId: string;
+    amountCents: number;
+    currency: string;
+    receivedAt: Date;
+  };
+}
+
+export interface ContactCreatedEvent extends DomainEvent {
+  readonly type: 'contact_created';
+  readonly aggregateType: 'contact';
+  readonly payload: {
+    contactId: string;
+    accountId: string | null;
+    createdBy: string;
+  };
+}
+
+// ... one interface per event yaml
+
+export type AppDomainEvent =
+  | StripePaymentReceivedEvent
+  | ContactCreatedEvent
+  | WebhookOutboundContactSyncEvent
+  /* ... */;
+
+export type EventTypeName = AppDomainEvent['type'];
+
+export type EventOfType<T extends EventTypeName> =
+  Extract<AppDomainEvent, { type: T }>;
+
+export type PayloadOfType<T extends EventTypeName> =
+  EventOfType<T>['payload'];
+```
+
+### `schemas.ts`
+
+```ts
+export const stripePaymentReceivedPayloadSchema = z.object({
+  eventId: z.string(),
+  customerId: z.string(),
+  amountCents: z.number(),
+  currency: z.string(),
+  receivedAt: z.coerce.date(),
+});
+
+export const eventPayloadSchemas = {
+  stripe_payment_received: stripePaymentReceivedPayloadSchema,
+  contact_created: contactCreatedPayloadSchema,
+  /* ... */
+} as const satisfies Record<EventTypeName, z.ZodTypeAny>;
+```
+
+### `registry.ts`
+
+The runtime truth, keyed by `type`. The event-to-job bridge reads this.
+
+```ts
+export interface EventMetadata {
+  type: EventTypeName;
+  direction: 'inbound' | 'change' | 'outbound';
+  pool: 'events_inbound' | 'events_change' | 'events_outbound';
+  aggregate?: string;      // entity name (required for 'change')
+  source?: string;         // inbound origin
+  destination?: string;    // outbound target
+  version: number;
+  retry: { attempts: number; backoff: 'linear' | 'exponential' };
+}
+
+export const eventRegistry = {
+  stripe_payment_received: {
+    type: 'stripe_payment_received',
+    direction: 'inbound',
+    pool: 'events_inbound',
+    source: 'stripe',
+    version: 1,
+    retry: { attempts: 5, backoff: 'exponential' },
+  },
+  contact_created: { /* ... */ },
+  /* ... */
+} as const satisfies Record<EventTypeName, EventMetadata>;
+
+export function getEventMetadata<T extends EventTypeName>(type: T): EventMetadata {
+  return eventRegistry[type];
+}
+```
+
+### `bus.ts` — typed facade
+
+```ts
+@Injectable()
+export class TypedEventBus {
+  constructor(@Inject(EVENT_BUS) private readonly bus: IEventBus) {}
+
+  async publish<T extends EventTypeName>(
+    type: T,
+    aggregateId: string,
+    payload: PayloadOfType<T>,
+    opts?: { tx?: DrizzleTransaction; metadata?: Record<string, unknown> },
+  ): Promise<void> {
+    const meta = getEventMetadata(type);
+    // Validate payload at the boundary (dev/test; optional prod flag)
+    if (process.env['CODEGEN_EVENT_VALIDATE'] !== 'off') {
+      eventPayloadSchemas[type].parse(payload);
+    }
+    const event: DomainEvent = {
+      id: randomUUID(),
+      type,
+      aggregateId,
+      aggregateType: meta.aggregate ?? meta.source ?? meta.destination ?? type,
+      payload: payload as Record<string, unknown>,
+      occurredAt: new Date(),
+      metadata: {
+        ...opts?.metadata,
+        pool: meta.pool,
+        direction: meta.direction,
+        version: meta.version,
+      },
+    };
+    await this.bus.publish(event, opts?.tx);
+  }
+
+  subscribe<T extends EventTypeName>(
+    type: T,
+    handler: (event: EventOfType<T>) => Promise<void>,
+  ): () => void {
+    return this.bus.subscribe<EventOfType<T>>(type, handler);
+  }
+}
+```
+
+### `index.ts`
+
+Re-exports `AppDomainEvent`, `EventTypeName`, `eventRegistry`,
+`getEventMetadata`, `eventPayloadSchemas`, `TypedEventBus`. Consumers import
+from `@generated/events` — not from the subsystem directly.
+
+### Additional files (considered, recommended)
+
+- `src/generated/events/handlers-token.ts` — `Symbol`-keyed tokens per event
+  type so NestJS DI can inject handler sets. Useful once we introduce the
+  event-to-job bridge and want per-type handler registration.
+
+## 3. Changes to `IEventBus`
+
+**Decision: keep the protocol narrow. Put typed generics on the facade, not
+the port.** The bus is the hexagonal port — it should not know about the
+generated registry (circular coupling). The typed facade (`TypedEventBus`) is
+what application code actually uses; it owns the typed generics.
+
+### Required protocol changes
+
+1. **Add `pool` to `DomainEvent.metadata` as a well-known key.** Not a
+   dedicated field — we keep the protocol shape stable. The generated
+   facade stamps `metadata.pool` and `metadata.direction` on every publish.
+   Backends that want to route on pool can read it from metadata; backends
+   that don't care just ignore it.
+
+2. **Add a first-class column on the outbox table.** `domain_events` gets a
+   `pool` column (nullable, indexed) and a `direction` column (nullable,
+   indexed). This is a pure migration — no protocol change, but it lets
+   the Drizzle poller query by pool.
+
+3. **Drain by pool.** `DrizzleEventBus` polling gains an optional `pools`
+   filter. When multiple processes poll (e.g. an inbound-webhook worker vs
+   a batch-change worker), each can restrict itself. Default stays: drain
+   all pools.
+
+Protocol stays at its current 3 methods. No typed generic is added there.
+
+### What does *not* change
+
+- `publish(event, tx?)` / `publishMany(events, tx?)` / `subscribe(type, handler)`
+  signatures stay identical. All existing scaffolds keep working.
+- `DomainEvent` shape stays identical. `direction` lives in metadata
+  (already precedent for `category`).
+
+### Outbox drain pool routing
+
+The drain loop:
+
+```sql
+SELECT * FROM domain_events
+WHERE status = 'pending'
+  AND (pool = ANY($1::text[]) OR $1 IS NULL)
+ORDER BY occurred_at ASC
+LIMIT $2
+FOR UPDATE SKIP LOCKED
+```
+
+`pool` is populated from `metadata.pool` at insert time, or via a generated
+trigger / in-memory fill during `publish` — preferred: the generated
+`TypedEventBus.publish` passes pool both in metadata and as an explicit column
+(the backend can pluck it).
+
+## 4. Auto-emission from entity templates
+
+### Today
+
+`runtime/base-classes/lifecycle-events.ts` emits fire-and-forget
+`${entityName}.created|updated|deleted` events with `entitySnapshot` payload,
+and per-field `${entityName}.field_changed` events. Completely dynamic, no
+registry knowledge.
+
+### Target
+
+Entity templates should:
+
+1. Look up the entity's declared change events in the registry at codegen time.
+2. Generate use-case-level `publish()` calls that hit the typed facade with a
+   validated payload shape.
+3. Fall back to the untyped lifecycle emission only when no matching
+   declared event exists (bridge compatibility, clearly deprecated).
+
+### Opt-in vs. silent skip
+
+**Recommendation: require entity YAML to declare its emitted events.**
+
+Add an `emits:` list to the entity YAML:
+
+```yaml
+# entities/contact.yaml
+emits:
+  - contact_created
+  - contact_updated
+  - contact_deleted
+```
+
+Behavior:
+
+- If `emits:` is declared, the generator validates each entry resolves to
+  an `events/<type>.yaml` with `direction: change` and `aggregate: contact`.
+  Missing → codegen hard error.
+- If `emits:` is absent, no typed auto-emission — we still ship the
+  untyped `lifecycle-events.ts` fallback and warn once at codegen time:
+  *"Entity contact has no `emits:` block. Falling back to untyped lifecycle
+  events. See docs/specs/events-codegen-plan.md §4."*
+
+Rationale: silent typed emission is surprising ("where did that event come
+from?"); required declaration makes the registry the single source of truth
+for what the app emits.
+
+### Entity `events:` block (legacy sugar)
+
+The existing entity `events:` block keeps working. At parse time the
+generator **desugars** it into `events/<name>.yaml` files (with
+`direction: change`, `aggregate: <entity>`). We stop generating per-entity
+event *classes* from it — those are replaced by the `src/generated/events/`
+types. Handlers (when `generate_handler: true`) still go into the entity's
+module folder, but now import the generated types.
+
+### Code shape (sketch)
+
+Generated use case calls the facade explicitly:
+
+```ts
+// src/modules/contacts/use-cases/create-contact.use-case.ts (generated)
+async execute(input: CreateContactInput): Promise<Contact> {
+  return this.db.transaction(async (tx) => {
+    const contact = await this.contacts.create(input, tx);
+    await this.events.publish('contact_created', contact.id, {
+      contactId: contact.id,
+      accountId: contact.accountId,
+      createdBy: input.actorId,
+    }, { tx });
+    return contact;
+  });
+}
+```
+
+No more reliance on `BaseService` silently emitting events for declared
+change types — that path becomes the fallback only.
+
+## 5. Phase integration with the jobs plan
+
+The jobs plan is Layers 1–6, with the Event-to-Job Bridge sitting at Phase 3
+(triggers from event types). The bridge needs:
+
+- a canonical list of event type names
+- direction/pool metadata for pool auto-assignment
+- typed payload shapes for scope extraction
+
+Events codegen is therefore a **hard prerequisite for jobs Phase 3**. But
+pieces of it are also useful earlier:
+
+| When                              | What                                     |
+|-----------------------------------|------------------------------------------|
+| Jobs Phase 1 (definition/run)     | **Events Phase 0** — YAML + registry.ts only. Gives jobs codegen a `type-safe` lookup even before bridge. Lightweight — no facade, no auto-emission. |
+| Jobs Phase 2 (policy/hierarchy)   | No events work needed.                   |
+| **Jobs Phase 3 (event bridge)**   | **Events Phase A** — `types.ts`, `schemas.ts`, `bus.ts` facade; pool column on `domain_events`; `TypedEventBus.publish` stamps metadata. Bridge consumes registry directly. |
+| Jobs Phase 4 (waits)              | No events work needed.                   |
+| Jobs Phase 5 (JobEvent audit)     | **Events Phase B** — registry gains selective-broadcast declarations (which `JobEvent` types fan out to `IEventBus`). |
+| Jobs Phase 6 (agent extensions)   | No events work needed.                   |
+
+After jobs Phase 3 lands, do **Events Phase C** independently:
+
+- Auto-emission rewrite in entity templates (§4)
+- `emits:` validation
+- Entity `events:` block desugaring into `events/*.yaml`
+
+This final phase is independent of jobs and can slip without blocking.
+
+### Proposed ordering
+
+1. Events Phase 0 (registry-only) — block jobs Phase 1
+2. Jobs Phase 1, 2 proceed
+3. Events Phase A (typed facade + pool routing) — block jobs Phase 3
+4. Jobs Phase 3 (bridge) lands
+5. Jobs Phase 4, 5, 6 proceed; Events Phase B interleaves at jobs Phase 5
+6. Events Phase C (entity auto-emission rewrite) ships standalone
+
+## 6. Connection to the Event-to-Job Bridge
+
+### Safe reference from Job YAML
+
+```yaml
+# jobs/onboarding.yaml
+name: onboarding
+triggers:
+  - event: stripe_payment_received
+    scope:
+      entity: account
+      from: payload.customer_id   # resolved against the typed payload shape
+```
+
+Codegen-time validation:
+
+1. `event` value must exist in `eventRegistry`. Missing → hard error with
+   the closest match suggested.
+2. `scope.from` is a dotted path into the event's payload. The generator
+   walks the registry's payload shape and fails if the path doesn't exist
+   or the leaf type is not `uuid`/`string`.
+3. `scope.entity` must match an entity name; if the event is a `change`
+   event, the bridge can default `scope.entity` to the event's `aggregate`.
+
+### Generated bridge wiring
+
+For each `triggers[]` entry, generate a subscriber:
+
+```ts
+// src/generated/jobs/bridge/onboarding.trigger.ts
+@Injectable()
+export class OnboardingEventTrigger implements OnModuleInit {
+  constructor(
+    private readonly bus: TypedEventBus,
+    @Inject(JOB_QUEUE) private readonly jobs: IJobQueue,
+  ) {}
+
+  onModuleInit(): void {
+    this.bus.subscribe<'stripe_payment_received'>(
+      'stripe_payment_received',
+      async (event) => {
+        const accountId = event.payload.customerId; // typed!
+        await this.jobs.enqueue('onboarding', { accountId }, {
+          concurrencyKey: `account:${accountId}`,
+        });
+      },
+    );
+  }
+}
+```
+
+Because `TypedEventBus.subscribe<'stripe_payment_received'>` narrows the
+handler param to `StripePaymentReceivedEvent`, `payload.customerId` is
+type-checked at build time. No `as` casts in generated code.
+
+### Pool assignment on the job side
+
+When a job is triggered by an event, the generator can **auto-assign** the
+job's pool from the event's pool metadata — unless the job YAML explicitly
+overrides. This keeps user jobs off the reserved pools by default:
+
+- event `direction: inbound` → triggered job inherits `pool: batch` (user work
+  after the webhook lands), **not** `events_inbound`.
+- The reserved `events_*` pools drain the bus itself, not user jobs.
+
+This is a subtle point and probably worth an open question (#Q6).
+
+## 7. Open questions
+
+1. **Top-level `events/*.yaml` vs. inline entity `events:` block — keep both,
+   desugar, or drop one?** Proposal above keeps both, with inline as sugar
+   that desugars. Is that the right ergonomic bet, or should `change` events
+   also live in top-level files for uniformity?
+
+2. **`emits:` required, optional, or both with warning?** I proposed
+   required-with-codegen-error for declared events and a warning-with-fallback
+   for undeclared entities. Alternative: make `emits:` optional and auto-infer
+   from the entity's name (`<entity>_created` etc.), failing only if the
+   inferred YAML is missing.
+
+3. **Payload validation: dev-only, always-on, or configurable?** I sketched an
+   env-flag gate. Safer default might be always-on parse in dev/test and
+   always-off in prod, or always-on with a `.safeParse()` that logs but does
+   not throw.
+
+4. **Should `TypedEventBus` replace `@Inject(EVENT_BUS)` entirely in generated
+   code, or live alongside it?** Replacing means use cases never touch the
+   raw bus. Coexisting means handlers still use the raw bus for unknown
+   event types (e.g. from third-party subsystems). Recommendation: replace.
+
+5. **`pool` / `direction` as metadata fields vs. columns.** I proposed both
+   — metadata for protocol stability, columns for index-friendly drain
+   queries. Is the duplication worth it, or should we promote to protocol
+   fields and do a one-shot migration?
+
+6. **Pool inheritance for event-triggered jobs.** Should a job triggered by
+   an `events_inbound` event default to `batch` (my current proposal) or to
+   `events_inbound` (runs "inside" the event drain)? The latter simplifies
+   back-pressure accounting but muddies the reserved-pool semantics.
+
+7. **Selective broadcast of `JobEvent` to the bus (Phase 5).** Do we model
+   that via a `broadcast: true` flag on jobs YAML event declarations, or via
+   an allowlist in a jobs-codegen config block? Lower priority but needs a
+   call before jobs Phase 5.
+
+8. **Versioning.** I added `version` on event YAML but didn't use it. Do we
+   want schema-evolution support now (v1 and v2 coexist in the registry with
+   separate TS types) or defer? Punting feels safe; the field costs nothing.

--- a/docs/specs/pattern-stack-disclosure-audit.md
+++ b/docs/specs/pattern-stack-disclosure-audit.md
@@ -1,0 +1,105 @@
+# Pattern-Stack Progressive-Disclosure Audit
+
+Investigation of how `pattern-stack/backend-patterns` structures agent-facing docs so each agent loads only what its current task needs. Source: `/Users/dug/Projects/dev/pattern-stack/backend-patterns`.
+
+## Directory Map
+
+Pattern-stack ships a **Claude Code plugin** living in the repo itself:
+
+```
+backend-patterns/
+├── .claude-plugin/marketplace.json         # Marketplace manifest
+├── plugins/pattern-stack/                  # The plugin root
+│   ├── .claude-plugin/
+│   │   ├── plugin.json                     # Plugin manifest (name, version)
+│   │   └── marketplace.json
+│   ├── README.md                           # Human-facing overview
+│   ├── agents/                             # Agent definitions (no YAML frontmatter)
+│   │   ├── architect.md
+│   │   ├── builder.md
+│   │   └── reviewer.md
+│   └── skills/pattern-stack/               # The knowledge base (the Skill)
+│       ├── SKILL.md                        # L0 — always loaded
+│       ├── patterns-and-fields.md          # L1 — on-demand
+│       ├── building-features.md            # L1
+│       ├── building-molecules.md           # L1
+│       ├── building-organisms.md           # L1
+│       ├── infrastructure-subsystems.md    # L1  (jobs, cache, storage, events)
+│       ├── testing-patterns.md             # L1
+│       └── project-bootstrap.md            # L1
+└── .claude/                                # Project-local, NOT shipped in plugin
+    ├── agents/*.md                         # Uses YAML frontmatter (name, description)
+    ├── skills/pattern-stack/               # (empty shell; real content under plugins/)
+    ├── commands/, patterns/, ai-docs/, docs/, hooks/, status_lines/, specs/
+    └── settings.json
+```
+
+## The Progressive-Disclosure Pattern (reusable shape)
+
+Two-level knowledge hierarchy, explicitly called L0 / L1:
+
+- **L0 = `SKILL.md`** — one file per skill. Auto-loaded when the skill activates. Contains: activation blurb, an **L1 routing table** (task → filename), architecture overview, decision guides, anti-patterns, key imports. Target size ~150 lines.
+- **L1 = topic docs** — sibling markdown files in the same folder as `SKILL.md`. Each covers exactly one domain in depth (200–335 lines). Loaded only when an agent follows the L0 routing table to them.
+
+Naming conventions:
+- `SKILL.md` is the reserved L0 filename.
+- L1 files use `verb-noun.md` or `noun-noun.md` (e.g. `building-features.md`, `infrastructure-subsystems.md`).
+- No `*.detail.md`, `*.summary.md`, or `*.overview.md` — the boundary is encoded in the folder/filename scheme, not suffixes.
+
+Frontmatter conventions:
+- **Plugin-shipped** agents (`plugins/pattern-stack/agents/*.md`) and skill files use **no YAML frontmatter** — the `.claude-plugin/plugin.json` manifest and the filename itself handle registration.
+- **Project-local** `.claude/agents/*.md` files DO use YAML frontmatter (`--- name: … description: …`) so the harness can list them via `/agents`.
+- No explicit SKIP/TRIGGER rules in-file. Routing is prescriptive: each agent's system prompt tells it to read `SKILL.md` always, then read specific L1 docs keyed by the current task. Lazy-loading is driven by the agent *deciding* which L1 to read — there is no runtime gating.
+
+Cross-references:
+- `SKILL.md` has a "Task → Reference" table pointing at L1 filenames (relative paths).
+- Individual L1 files cross-reference each other inline: e.g. `building-features.md` says "see `patterns-and-fields.md` for full reference" when touching model choice.
+- Agent prompts reference the skill via `${CLAUDE_PLUGIN_ROOT}/skills/pattern-stack/SKILL.md` — the harness-supplied env var.
+
+## Two Concrete Examples
+
+**Example 1 — Jobs (inside `infrastructure-subsystems.md`).** All four subsystems (jobs, cache, storage, events, integrations, broadcast) share a single L1 file because they follow the same Protocol → Backend → Factory shape. Each gets its own `##` section with Protocol signature, backend list, usage snippet, and handler pattern. L0 only has an 8-line summary table — the 90-line jobs deep-dive sits in L1 and isn't loaded unless an agent is working with the Jobs subsystem. File: `plugins/pattern-stack/skills/pattern-stack/infrastructure-subsystems.md`.
+
+**Example 2 — Feature building.** `SKILL.md` gives you the layer rules and a "where does this code go?" table. When an agent is actually implementing a feature, it reads `building-features.md` which walks through model → schemas/input.py → schemas/output.py → service.py, with full code for each step. File: `plugins/pattern-stack/skills/pattern-stack/building-features.md`.
+
+## Plugin Registration Mechanics
+
+1. `plugins/pattern-stack/.claude-plugin/plugin.json` — required. Declares `name`, `version`, `description`, `author`, `repository`. No explicit skill/agent arrays — the harness auto-discovers anything under `agents/` and `skills/`.
+2. `plugins/pattern-stack/.claude-plugin/marketplace.json` — lists installable plugins with `source: "./"`.
+3. Top-level `.claude-plugin/marketplace.json` at repo root points at `./plugins/pattern-stack`.
+4. Install via `/plugin install pattern-stack@pattern-stack-plugins`. Loaded skills expose themselves as `pattern-stack:architect`, `pattern-stack:builder`, `pattern-stack:reviewer` — matching the agent filenames under `plugins/pattern-stack/agents/`.
+5. Agents refer to their own skill docs via `${CLAUDE_PLUGIN_ROOT}/skills/pattern-stack/…`.
+
+## Recommendation for codegen-patterns
+
+Adopt the same L0/L1 shape, but start small and inside `.claude/skills/` first (no need to go full plugin until we want to distribute).
+
+**Canonical layout** (skills live one folder per domain; each domain is self-contained):
+
+```
+codegen-patterns/.claude/skills/
+├── codegen/                             # L0 router for the whole system
+│   └── SKILL.md                         # Task→domain table; always loaded
+├── jobs/
+│   ├── SKILL.md                         # L0 for the jobs domain
+│   ├── pg-boss-backend.md               # L1 — production backend detail
+│   ├── memory-backend.md                # L1 — test backend detail
+│   ├── handlers-and-workers.md          # L1 — handler patterns, concurrency
+│   └── testing-jobs.md                  # L1 — fixtures, fake clocks
+└── events/
+    ├── SKILL.md                         # L0 for the events domain
+    ├── outbox-backend.md                # L1 — Drizzle outbox backend
+    ├── memory-backend.md                # L1
+    ├── subscribers-and-bus.md           # L1 — IEventBus usage, wiring
+    └── testing-events.md                # L1
+```
+
+Rules to adopt:
+- Each domain folder contains exactly one `SKILL.md` (L0). Keep it under ~150 lines. Must include: activation blurb, **L1 routing table**, architecture snapshot for that domain, decision guides, anti-patterns.
+- L1 files are siblings with descriptive kebab-case names. Each L1 covers one thing deeply (200–300 lines is fine).
+- No YAML frontmatter on skill files; rely on folder-as-skill discovery.
+- Agent prompts (if/when we add them) say "Always read `SKILL.md`; read L1 `X.md` when task involves X."
+- Cross-domain pointers inline: the jobs `SKILL.md` can link to `../events/SKILL.md` when explaining job-completion events.
+- Top-level `codegen/SKILL.md` (or fold into the existing top-level `CLAUDE.md`) owns the cross-domain routing table so an agent with no context can find the right L0.
+
+**First increment (jobs + events):** create the two folders above with just the L0 `SKILL.md` files plus one or two L1s each — move the detail currently sitting in `docs/specs/events-codegen-plan.md`, `docs/specs/dealbrain-bullmq-audit.md`, `runtime/subsystems/jobs/`, and `runtime/subsystems/events/` READMEs into the L1 files. Keep the top-level `CLAUDE.md` as the always-loaded surface; have it point at `.claude/skills/jobs/SKILL.md` and `.claude/skills/events/SKILL.md` via a one-line table. This gives us the split-by-domain lazy loading without committing to plugin packaging yet — we can promote to `plugins/codegen-patterns/` later using the exact manifest shape described above.


### PR DESCRIPTION
## Summary

Doc + skill content for the jobs and events subsystem expansion. Zero source code changes — all additions under `docs/` and `.claude/skills/`.

- **ADR-022** — Job orchestration domain model (505 lines)
- **ADR-030** — Progressive-disclosure skills convention
- **Job specs JOB-1…JOB-8** + `ADR-022-phase-1-issues.md` — Phase 1 job implementation roadmap
- **Events specs** — `events-codegen-plan.md`, `dealbrain-bullmq-audit.md`, `pattern-stack-disclosure-audit.md`
- **Skills** — `.claude/skills/README.md`, full `events/` and `jobs/` L0/L1 trees (SKILL.md + detail pages: protocols/backends, outbox/transactions, codegen, pools, handler authoring, orchestrator/worker, phase-roadmap)
- **CLAUDE.md** — +22 lines on living documentation convention

## Test plan

- [ ] No source changes; `just test-unit` should be unaffected
- [ ] Skills load correctly via `.claude/skills/` discovery
- [ ] ADR anchors resolve from spec cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)