### PR TITLE
feat(clean-lite-ps): eav: true emits paired reads + transactional compound-write use cases

### DIFF
--- a/src/__tests__/clean-lite-ps/dto-template.test.ts
+++ b/src/__tests__/clean-lite-ps/dto-template.test.ts
@@ -65,21 +65,23 @@ const agentDefinition = {
 };
 
 describe('clean-lite-ps DTO templates — Zod type leaks (issue #35)', () => {
-  describe('decimal field → z.coerce.number()', () => {
-    it('create DTO emits z.coerce.number() for decimal', () => {
+  describe('decimal field → z.coerce.string()', () => {
+    it('create DTO emits z.coerce.string() for decimal', () => {
       const locals = buildCleanLitePsLocals(agentDefinition, {});
       const output = render(CREATE_TEMPLATE, locals);
 
-      expect(output).toContain('temperature: z.coerce.number()');
-      // Bare z.number() on a decimal field is the bug we are fixing.
+      expect(output).toContain('temperature: z.coerce.string()');
+      // Drizzle returns PG numeric as a string — string all the way through
+      // keeps DTO/entity types aligned and avoids precision loss.
       expect(output).not.toMatch(/temperature:\s*z\.number\(\)/);
+      expect(output).not.toMatch(/temperature:\s*z\.coerce\.number\(\)/);
     });
 
-    it('output DTO emits z.coerce.number() for decimal', () => {
+    it('output DTO emits z.coerce.string() for decimal', () => {
       const locals = buildCleanLitePsLocals(agentDefinition, {});
       const output = render(OUTPUT_TEMPLATE, locals);
 
-      expect(output).toContain('temperature: z.coerce.number()');
+      expect(output).toContain('temperature: z.coerce.string()');
       expect(output).not.toMatch(/temperature:\s*z\.number\(\)/);
     });
 

--- a/src/__tests__/clean-lite-ps/eav-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-templates.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Template rendering tests for clean-lite-ps EAV (`eav: true`) emission.
+ *
+ * Verifies:
+ * - prompt-extension exposes findByIdWithFields / listWithFields use-case
+ *   class names and output paths, gated by `eav: true`
+ * - Paired read templates render correctly
+ * - Compound-write templates (create/update) switch to transactional shape
+ *   when eav is enabled, delegating to the entity service + FieldValueService
+ * - Controller gates GET /with-fields + GET /:id/with-fields on eav
+ * - Service injects FieldValueRepository and emits paired read methods
+ * - Module imports FieldValuesModule and registers the paired use cases
+ * - `eav` default (false) preserves the pre-existing non-EAV shape
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const TEMPLATE_ROOT = resolve(
+  import.meta.dir,
+  '../../../templates/entity/new/clean-lite-ps',
+);
+
+function readTemplate(relPath: string): string {
+  return readFileSync(resolve(TEMPLATE_ROOT, relPath), 'utf8');
+}
+
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return source;
+  return lines.slice(end + 1).join('\n');
+}
+
+function render(relPath: string, locals: Record<string, unknown>): string {
+  return ejs.render(extractBody(readTemplate(relPath)), locals, {
+    rmWhitespace: false,
+  });
+}
+
+const baseEntity = {
+  entity: {
+    name: 'opportunity',
+    plural: 'opportunities',
+    table: 'opportunities',
+    family: 'synced',
+  },
+  fields: {
+    name: { type: 'string', required: true },
+  },
+  relationships: {},
+  behaviors: ['timestamps'],
+};
+
+const eavEntity = { ...baseEntity, eav: true };
+
+describe('clean-lite-ps eav templates — prompt-extension wiring', () => {
+  it('exposes paired read use-case class names', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+
+    expect(locals.eavEnabled).toBe(true);
+    expect(locals.classNames.findByIdWithFieldsUseCase).toBe(
+      'FindOpportunityByIdWithFieldsUseCase',
+    );
+    expect(locals.classNames.listWithFieldsUseCase).toBe(
+      'ListOpportunitiesWithFieldsUseCase',
+    );
+  });
+
+  it('exposes paired read output paths when eav is true', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+
+    expect(locals.clpOutputPaths.findByIdWithFieldsUseCase).toBe(
+      'src/modules/opportunities/use-cases/find-opportunity-by-id-with-fields.use-case.ts',
+    );
+    expect(locals.clpOutputPaths.listWithFieldsUseCase).toBe(
+      'src/modules/opportunities/use-cases/list-opportunities-with-fields.use-case.ts',
+    );
+  });
+
+  it('nulls paired read output paths when eav is omitted (default)', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+
+    expect(locals.eavEnabled).toBe(false);
+    expect(locals.clpOutputPaths.findByIdWithFieldsUseCase).toBeNull();
+    expect(locals.clpOutputPaths.listWithFieldsUseCase).toBeNull();
+  });
+});
+
+describe('clean-lite-ps eav templates — paired read use cases', () => {
+  it('find-by-id-with-fields delegates to service.findByIdWithFields', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('use-cases/find-by-id-with-fields.ejs.t', locals);
+
+    expect(output).toContain('export class FindOpportunityByIdWithFieldsUseCase');
+    expect(output).toContain(
+      "import { OpportunityService } from '../opportunity.service';",
+    );
+    expect(output).toContain(
+      '(Opportunity & { fields: Record<string, unknown> }) | null',
+    );
+    expect(output).toContain('return this.service.findByIdWithFields(id);');
+  });
+
+  it('list-with-fields delegates to service.listWithFields', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('use-cases/list-with-fields.ejs.t', locals);
+
+    expect(output).toContain('export class ListOpportunitiesWithFieldsUseCase');
+    expect(output).toContain(
+      'Array<Opportunity & { fields: Record<string, unknown> }>',
+    );
+    expect(output).toContain('return this.service.listWithFields();');
+  });
+});
+
+describe('clean-lite-ps eav templates — compound-write use cases', () => {
+  it('create.ejs.t emits the transactional compound-write shape when eav is true', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('use-cases/create.ejs.t', locals);
+
+    // Imports — EAV-specific plumbing.
+    expect(output).toContain("import { DRIZZLE_DB } from '@shared/constants/tokens';");
+    expect(output).toContain("import { toEavRows } from '@shared/eav-helpers';");
+    expect(output).toContain(
+      "import { FieldValueService } from '../../field_values/field_value.service';",
+    );
+
+    // Constructor composes entity service + FieldValueService + DRIZZLE_DB.
+    expect(output).toContain('private readonly opportunitys: OpportunityService,');
+    expect(output).toContain('private readonly fields: FieldValueService,');
+    expect(output).toContain('@Inject(DRIZZLE_DB) private readonly db: DrizzleDB,');
+
+    // Execute body splits { fields, ...core } and runs in a tx.
+    expect(output).toContain('this.db.transaction(async (tx) =>');
+    expect(output).toContain('const { fields, ...core } = dto;');
+    expect(output).toContain(
+      'const entity = await this.opportunitys.create(core as CreateOpportunityDto, tx);',
+    );
+    expect(output).toContain(
+      "await this.fields.upsertMany(toEavRows(entity.id, 'opportunity', fields), tx);",
+    );
+    expect(output).toContain('return entity;');
+  });
+
+  it('create.ejs.t preserves the one-line shape when eav is false', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+    const output = render('use-cases/create.ejs.t', locals);
+
+    expect(output).toContain('return this.service.create(dto);');
+    expect(output).not.toContain('transaction');
+    expect(output).not.toContain('FieldValueService');
+    expect(output).not.toContain('DRIZZLE_DB');
+  });
+
+  it('update.ejs.t emits the transactional compound-write shape when eav is true', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('use-cases/update.ejs.t', locals);
+
+    expect(output).toContain(
+      'async execute(\n    id: string,\n    dto: UpdateOpportunityDto & { fields?: Record<string, unknown> },\n  ): Promise<Opportunity | null>',
+    );
+    expect(output).toContain(
+      'const entity = await this.opportunitys.update(id, core as UpdateOpportunityDto, tx);',
+    );
+    expect(output).toContain('if (!entity) return null;');
+    expect(output).toContain(
+      "await this.fields.upsertMany(toEavRows(entity.id, 'opportunity', fields), tx);",
+    );
+  });
+
+  it('update.ejs.t preserves the one-line shape when eav is false', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+    const output = render('use-cases/update.ejs.t', locals);
+
+    expect(output).toContain('return this.service.update(id, dto);');
+    expect(output).not.toContain('transaction');
+    expect(output).not.toContain('FieldValueService');
+  });
+});
+
+describe('clean-lite-ps eav templates — service rendering', () => {
+  it('injects FieldValueRepository and emits paired read methods when eav is true', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('service.ejs.t', locals);
+
+    expect(output).toContain(
+      "import { FieldValueRepository } from '../field_values/field_value.repository';",
+    );
+    expect(output).toContain(
+      "import { mergeEavRows } from '@shared/eav-helpers';",
+    );
+    expect(output).toContain('private readonly fieldValueRepository: FieldValueRepository,');
+    expect(output).toContain('async findByIdWithFields(');
+    expect(output).toContain('async listWithFields(');
+    expect(output).toContain(
+      "await this.fieldValueRepository.findByEntityIdAndType(id, 'opportunity');",
+    );
+    expect(output).toContain('mergeEavRows(rows)');
+  });
+
+  it('omits EAV wiring when eav is false (default)', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+    const output = render('service.ejs.t', locals);
+
+    expect(output).not.toContain('FieldValueRepository');
+    expect(output).not.toContain('mergeEavRows');
+    expect(output).not.toContain('findByIdWithFields');
+    expect(output).not.toContain('listWithFields');
+  });
+});
+
+describe('clean-lite-ps eav templates — controller rendering', () => {
+  it('adds GET /with-fields + GET /:id/with-fields routes when eav is true', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('controller.ejs.t', locals);
+
+    expect(output).toContain(
+      "import { FindOpportunityByIdWithFieldsUseCase } from './use-cases/find-opportunity-by-id-with-fields.use-case';",
+    );
+    expect(output).toContain(
+      "import { ListOpportunitiesWithFieldsUseCase } from './use-cases/list-opportunities-with-fields.use-case';",
+    );
+    expect(output).toContain(
+      'private readonly findByIdWithFieldsUseCase: FindOpportunityByIdWithFieldsUseCase,',
+    );
+    expect(output).toContain(
+      'private readonly listWithFieldsUseCase: ListOpportunitiesWithFieldsUseCase,',
+    );
+    expect(output).toContain("@Get('with-fields')");
+    expect(output).toContain("@Get(':id/with-fields')");
+    expect(output).toContain('return this.listWithFieldsUseCase.execute();');
+    expect(output).toContain('return this.findByIdWithFieldsUseCase.execute(id);');
+
+    // Ordering: static /with-fields route must be declared before the :id
+    // param route so NestJS doesn't capture "with-fields" as an id.
+    const withFieldsIdx = output.indexOf("@Get('with-fields')");
+    const byIdIdx = output.indexOf("@Get(':id')");
+    expect(withFieldsIdx).toBeGreaterThan(-1);
+    expect(byIdIdx).toBeGreaterThan(-1);
+    expect(withFieldsIdx).toBeLessThan(byIdIdx);
+  });
+
+  it('omits EAV routes when eav is false (default)', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+    const output = render('controller.ejs.t', locals);
+
+    expect(output).not.toContain('with-fields');
+    expect(output).not.toContain('FindOpportunityByIdWithFieldsUseCase');
+    expect(output).not.toContain('ListOpportunitiesWithFieldsUseCase');
+  });
+});
+
+describe('clean-lite-ps eav templates — module rendering', () => {
+  it('imports FieldValuesModule and registers paired use cases when eav is true', () => {
+    const locals = buildCleanLitePsLocals(eavEntity, {});
+    const output = render('module.ejs.t', locals);
+
+    expect(output).toContain(
+      "import { FieldValuesModule } from '../field_values/field_values.module';",
+    );
+    expect(output).toContain(
+      "import { FindOpportunityByIdWithFieldsUseCase } from './use-cases/find-opportunity-by-id-with-fields.use-case';",
+    );
+    expect(output).toContain(
+      "import { ListOpportunitiesWithFieldsUseCase } from './use-cases/list-opportunities-with-fields.use-case';",
+    );
+    expect(output).toContain('FieldValuesModule,');
+    expect(output).toContain('FindOpportunityByIdWithFieldsUseCase,');
+    expect(output).toContain('ListOpportunitiesWithFieldsUseCase,');
+  });
+
+  it('omits EAV wiring when eav is false (default)', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+    const output = render('module.ejs.t', locals);
+
+    expect(output).not.toContain('FieldValuesModule');
+    expect(output).not.toContain('WithFieldsUseCase');
+  });
+});
+
+describe('clean-lite-ps eav templates — composition with generate.writes', () => {
+  it('suppresses compound writes but keeps paired reads when writes:false + eav:true', () => {
+    const def = { ...eavEntity, generate: { writes: false } };
+    const locals = buildCleanLitePsLocals(def, {});
+
+    expect(locals.generateWrites).toBe(false);
+    expect(locals.eavEnabled).toBe(true);
+    expect(locals.clpOutputPaths.createUseCase).toBeNull();
+    expect(locals.clpOutputPaths.updateUseCase).toBeNull();
+    expect(locals.clpOutputPaths.deleteUseCase).toBeNull();
+    expect(locals.clpOutputPaths.findByIdWithFieldsUseCase).not.toBeNull();
+    expect(locals.clpOutputPaths.listWithFieldsUseCase).not.toBeNull();
+  });
+});

--- a/src/__tests__/clean-lite-ps/eav-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-templates.test.ts
@@ -141,7 +141,7 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     );
 
     // Constructor composes entity service + FieldValueService + DRIZZLE_DB.
-    expect(output).toContain('private readonly opportunitys: OpportunityService,');
+    expect(output).toContain('private readonly opportunities: OpportunityService,');
     expect(output).toContain('private readonly fields: FieldValueService,');
     expect(output).toContain('@Inject(DRIZZLE_DB) private readonly db: DrizzleDB,');
 
@@ -149,7 +149,7 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     expect(output).toContain('this.db.transaction(async (tx) =>');
     expect(output).toContain('const { fields, ...core } = dto;');
     expect(output).toContain(
-      'const entity = await this.opportunitys.create(core as CreateOpportunityDto, tx);',
+      'const entity = await this.opportunities.create(core as CreateOpportunityDto, tx);',
     );
 
     // Calls the service-level compound helper — NOT toEavRows / upsertMany.
@@ -185,7 +185,7 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
       'dto: UpdateOpportunityDto & { fields?: Record<string, unknown> },',
     );
     expect(output).toContain(
-      'const entity = await this.opportunitys.update(id, core as UpdateOpportunityDto, tx);',
+      'const entity = await this.opportunities.update(id, core as UpdateOpportunityDto, tx);',
     );
     expect(output).toContain('if (!entity) return null;');
 

--- a/src/__tests__/clean-lite-ps/eav-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-templates.test.ts
@@ -135,7 +135,8 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     const output = render('use-cases/create.ejs.t', locals);
 
     // Imports — EAV-specific plumbing.
-    expect(output).toContain("import { DRIZZLE_DB } from '@shared/constants/tokens';");
+    expect(output).toContain("import { DRIZZLE } from '@shared/constants/tokens';");
+    expect(output).toContain("import type { DrizzleClient } from '@shared/types/drizzle';");
     expect(output).toContain(
       "import { FieldValueService } from '../../field_values/field_value.service';",
     );
@@ -143,7 +144,7 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     // Constructor composes entity service + FieldValueService + DRIZZLE_DB.
     expect(output).toContain('private readonly opportunities: OpportunityService,');
     expect(output).toContain('private readonly fields: FieldValueService,');
-    expect(output).toContain('@Inject(DRIZZLE_DB) private readonly db: DrizzleDB,');
+    expect(output).toContain('@Inject(DRIZZLE) private readonly db: DrizzleClient,');
 
     // Execute body splits { fields, ...core } and runs in a tx.
     expect(output).toContain('this.db.transaction(async (tx) =>');
@@ -174,7 +175,7 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     expect(output).toContain('return this.service.create(dto);');
     expect(output).not.toContain('transaction');
     expect(output).not.toContain('FieldValueService');
-    expect(output).not.toContain('DRIZZLE_DB');
+    expect(output).not.toContain('DRIZZLE');
   });
 
   it('update.ejs.t emits the transactional compound-write shape when eav is true', () => {

--- a/src/__tests__/clean-lite-ps/eav-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-templates.test.ts
@@ -6,11 +6,16 @@
  *   class names and output paths, gated by `eav: true`
  * - Paired read templates render correctly
  * - Compound-write templates (create/update) switch to transactional shape
- *   when eav is enabled, delegating to the entity service + FieldValueService
+ *   when eav is enabled, calling FieldValueService.upsertFieldsTransactional
  * - Controller gates GET /with-fields + GET /:id/with-fields on eav
- * - Service injects FieldValueRepository and emits paired read methods
+ * - Service injects FieldValueService and emits paired read methods calling
+ *   FieldValueService.findMergedByEntity
  * - Module imports FieldValuesModule and registers the paired use cases
  * - `eav` default (false) preserves the pre-existing non-EAV shape
+ *
+ * Contract: when eav:true, the generated code never reaches into
+ * FieldValueRepository or FieldDefinitionRepository directly. All EAV
+ * operations go through FieldValueService which owns the map resolution.
  */
 
 import { describe, it, expect } from 'bun:test';
@@ -131,7 +136,6 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
 
     // Imports — EAV-specific plumbing.
     expect(output).toContain("import { DRIZZLE_DB } from '@shared/constants/tokens';");
-    expect(output).toContain("import { toEavRows } from '@shared/eav-helpers';");
     expect(output).toContain(
       "import { FieldValueService } from '../../field_values/field_value.service';",
     );
@@ -147,10 +151,20 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     expect(output).toContain(
       'const entity = await this.opportunitys.create(core as CreateOpportunityDto, tx);',
     );
-    expect(output).toContain(
-      "await this.fields.upsertMany(toEavRows(entity.id, 'opportunity', fields), tx);",
-    );
-    expect(output).toContain('return entity;');
+
+    // Calls the service-level compound helper — NOT toEavRows / upsertMany.
+    expect(output).toContain('this.fields.upsertFieldsTransactional(');
+    expect(output).toContain("'opportunity',");
+    expect(output).toContain('entity.id,');
+    expect(output).toContain('core.userId,');
+    expect(output).toContain('fields,');
+    expect(output).toContain('tx,');
+
+    // No direct helper imports or repository injection.
+    expect(output).not.toContain('toEavRows');
+    expect(output).not.toContain('upsertMany');
+    expect(output).not.toContain('FieldValueRepository');
+    expect(output).not.toContain('FieldDefinitionRepository');
   });
 
   it('create.ejs.t preserves the one-line shape when eav is false', () => {
@@ -168,15 +182,19 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
     const output = render('use-cases/update.ejs.t', locals);
 
     expect(output).toContain(
-      'async execute(\n    id: string,\n    dto: UpdateOpportunityDto & { fields?: Record<string, unknown> },\n  ): Promise<Opportunity | null>',
+      'dto: UpdateOpportunityDto & { fields?: Record<string, unknown> },',
     );
     expect(output).toContain(
       'const entity = await this.opportunitys.update(id, core as UpdateOpportunityDto, tx);',
     );
     expect(output).toContain('if (!entity) return null;');
-    expect(output).toContain(
-      "await this.fields.upsertMany(toEavRows(entity.id, 'opportunity', fields), tx);",
-    );
+
+    // Update reads userId from the loaded entity (update DTO omits userId).
+    expect(output).toContain('this.fields.upsertFieldsTransactional(');
+    expect(output).toContain('entity.userId,');
+
+    expect(output).not.toContain('toEavRows');
+    expect(output).not.toContain('upsertMany');
   });
 
   it('update.ejs.t preserves the one-line shape when eav is false', () => {
@@ -190,31 +208,38 @@ describe('clean-lite-ps eav templates — compound-write use cases', () => {
 });
 
 describe('clean-lite-ps eav templates — service rendering', () => {
-  it('injects FieldValueRepository and emits paired read methods when eav is true', () => {
+  it('injects FieldValueService and emits paired read methods when eav is true', () => {
     const locals = buildCleanLitePsLocals(eavEntity, {});
     const output = render('service.ejs.t', locals);
 
     expect(output).toContain(
-      "import { FieldValueRepository } from '../field_values/field_value.repository';",
+      "import { FieldValueService } from '../field_values/field_value.service';",
     );
-    expect(output).toContain(
-      "import { mergeEavRows } from '@shared/eav-helpers';",
-    );
-    expect(output).toContain('private readonly fieldValueRepository: FieldValueRepository,');
+    expect(output).toContain('private readonly fieldValues: FieldValueService,');
     expect(output).toContain('async findByIdWithFields(');
     expect(output).toContain('async listWithFields(');
+
+    // Paired reads go through FieldValueService.findMergedByEntity — NOT
+    // directly through FieldValueRepository or FieldDefinitionRepository.
     expect(output).toContain(
-      "await this.fieldValueRepository.findByEntityIdAndType(id, 'opportunity');",
+      "await this.fieldValues.findMergedByEntity('opportunity', id);",
     );
-    expect(output).toContain('mergeEavRows(rows)');
+    expect(output).toContain(
+      "await this.fieldValues.findMergedByEntity('opportunity', entity.id);",
+    );
+
+    expect(output).not.toContain('FieldValueRepository');
+    expect(output).not.toContain('FieldDefinitionRepository');
+    expect(output).not.toContain('mergeEavRows');
+    expect(output).not.toContain('findByEntityIdAndType');
   });
 
   it('omits EAV wiring when eav is false (default)', () => {
     const locals = buildCleanLitePsLocals(baseEntity, {});
     const output = render('service.ejs.t', locals);
 
-    expect(output).not.toContain('FieldValueRepository');
-    expect(output).not.toContain('mergeEavRows');
+    expect(output).not.toContain('FieldValueService');
+    expect(output).not.toContain('findMergedByEntity');
     expect(output).not.toContain('findByIdWithFields');
     expect(output).not.toContain('listWithFields');
   });

--- a/src/__tests__/clean-lite-ps/write-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/write-templates.test.ts
@@ -129,13 +129,13 @@ describe('clean-lite-ps write templates — use-case rendering', () => {
     expect(output).toContain('return this.service.update(id, dto);');
   });
 
-  it('delete.ejs.t emits a Delete<Entity>UseCase returning nullable entity', () => {
+  it('delete.ejs.t emits a Delete<Entity>UseCase returning void', () => {
     const locals = buildCleanLitePsLocals(baseEntity, {});
     const output = render('use-cases/delete.ejs.t', locals);
 
     expect(output).toContain('export class DeleteContactUseCase');
     expect(output).toContain(
-      'async execute(id: string): Promise<Contact | null>',
+      'async execute(id: string): Promise<void>',
     );
     expect(output).toContain('return this.service.delete(id);');
   });

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -655,6 +655,28 @@ export const EntityDefinitionSchema = z
     // Per-entity generation toggles (e.g. disable write-side emission)
     generate: GenerateConfigSchema.optional(),
 
+    // EAV (entity-attribute-value) dual-write + paired reads (ADR-13).
+    // When `true`, codegen emits:
+    //   - FindXWithFieldsUseCase + ListXWithFieldsUseCase (paired reads)
+    //   - CreateX / UpdateX use cases in transactional compound-write shape
+    //     (composes entity service + FieldValueService in one db.transaction,
+    //     splits `{ fields, ...core }` from the DTO)
+    //   - GET /:id/with-fields + GET /with-fields controller routes
+    //   - Service with injected FieldValueRepository + findByIdWithFields /
+    //     listWithFields paired read methods
+    //
+    // Consumer contract (must be in place before regen):
+    //   - BaseService.create/update/delete accept optional `tx` parameter
+    //   - `@shared/eav-helpers` exports `toEavRows(entityId, entityType, fields)`
+    //     and `mergeEavRows(rows)`
+    //   - FieldValueService exposes `upsertMany(rows, tx?)` (inherited from
+    //     MetadataEntityService)
+    //   - DRIZZLE_DB injection token available via `@shared/constants/tokens`
+    //
+    // Defaults to `false` — opt in per entity that needs dynamic/custom fields.
+    eav: z.boolean().optional().default(false),
+
+
     // v2: Declarative query generation (ADR-005)
     // Generates repository + service + use case methods from declarations
     queries: z.array(QueryDeclarationSchema).optional(),

--- a/templates/entity/new/clean-lite-ps/controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/controller.ejs.t
@@ -6,6 +6,10 @@ force: true
 import { Controller, Get<% if (generateWrites) { %>, Post, Patch, Delete, Body<% } %>, Param } from '@nestjs/common';
 import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
 import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
+<% if (eavEnabled) { -%>
+import { <%= classNames.findByIdWithFieldsUseCase %> } from './use-cases/find-<%= entityName %>-by-id-with-fields.use-case';
+import { <%= classNames.listWithFieldsUseCase %> } from './use-cases/list-<%= entityNamePlural %>-with-fields.use-case';
+<% } -%>
 <% if (generateWrites) { -%>
 import { <%= classNames.createUseCase %> } from './use-cases/create-<%= entityName %>.use-case';
 import { <%= classNames.updateUseCase %> } from './use-cases/update-<%= entityName %>.use-case';
@@ -21,6 +25,10 @@ export class <%= classNames.controller %> {
     // All routes go through use cases (ADR-003 — no controller → service shortcuts)
     private readonly findByIdUseCase: <%= classNames.findByIdUseCase %>,
     private readonly listUseCase: <%= classNames.listUseCase %>,
+<% if (eavEnabled) { -%>
+    private readonly findByIdWithFieldsUseCase: <%= classNames.findByIdWithFieldsUseCase %>,
+    private readonly listWithFieldsUseCase: <%= classNames.listWithFieldsUseCase %>,
+<% } -%>
 <% if (generateWrites) { -%>
     private readonly createUseCase: <%= classNames.createUseCase %>,
     private readonly updateUseCase: <%= classNames.updateUseCase %>,
@@ -32,11 +40,24 @@ export class <%= classNames.controller %> {
   async getAll(): Promise<<%= classNames.entity %>[]> {
     return this.listUseCase.execute();
   }
-
+<% if (eavEnabled) { %>
+  @Get('with-fields')
+  async getAllWithFields(): Promise<Array<<%= classNames.entity %> & { fields: Record<string, unknown> }>> {
+    return this.listWithFieldsUseCase.execute();
+  }
+<% } %>
   @Get(':id')
   async getById(@Param('id') id: string): Promise<<%= classNames.entity %> | null> {
     return this.findByIdUseCase.execute(id);
   }
+<% if (eavEnabled) { %>
+  @Get(':id/with-fields')
+  async getByIdWithFields(
+    @Param('id') id: string,
+  ): Promise<(<%= classNames.entity %> & { fields: Record<string, unknown> }) | null> {
+    return this.findByIdWithFieldsUseCase.execute(id);
+  }
+<% } %>
 <% if (generateWrites) { %>
   @Post()
   async create(@Body() dto: <%= classNames.createDto %>): Promise<<%= classNames.entity %>> {

--- a/templates/entity/new/clean-lite-ps/controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/controller.ejs.t
@@ -73,7 +73,7 @@ export class <%= classNames.controller %> {
   }
 
   @Delete(':id')
-  async remove(@Param('id') id: string): Promise<<%= classNames.entity %> | null> {
+  async remove(@Param('id') id: string): Promise<void> {
     return this.deleteUseCase.execute(id);
   }
 <% } %>

--- a/templates/entity/new/clean-lite-ps/module.ejs.t
+++ b/templates/entity/new/clean-lite-ps/module.ejs.t
@@ -8,12 +8,19 @@ import { DatabaseModule } from '@shared/database/database.module';
 <%_ clpBelongsTo.forEach(rel => { _%>
 // import { <%= rel.relatedEntityPascal %>sModule } from '../<%= rel.relatedPlural %>/<%= rel.relatedPlural %>.module';
 <%_ }) _%>
+<% if (eavEnabled) { -%>
+import { FieldValuesModule } from '../field_values/field_values.module';
+<% } -%>
 
 import { <%= classNames.repository %> } from './<%= entityName %>.repository';
 import { <%= classNames.service %> } from './<%= entityName %>.service';
 import { <%= classNames.controller %> } from './<%= entityName %>.controller';
 import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
 import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
+<% if (eavEnabled) { -%>
+import { <%= classNames.findByIdWithFieldsUseCase %> } from './use-cases/find-<%= entityName %>-by-id-with-fields.use-case';
+import { <%= classNames.listWithFieldsUseCase %> } from './use-cases/list-<%= entityNamePlural %>-with-fields.use-case';
+<% } -%>
 <% if (generateWrites) { -%>
 import { <%= classNames.createUseCase %> } from './use-cases/create-<%= entityName %>.use-case';
 import { <%= classNames.updateUseCase %> } from './use-cases/update-<%= entityName %>.use-case';
@@ -26,6 +33,9 @@ import { declarativeQueryClasses } from './use-cases/declarative-queries';
 @Module({
   imports: [
     DatabaseModule,
+<% if (eavEnabled) { -%>
+    FieldValuesModule,
+<% } -%>
     // TODO: Add subsystem modules as needed (EventsSubsystemModule, IntegrationsSubsystemModule, etc.)
     // Cross-domain modules from relationships:
 <%_ clpBelongsTo.forEach(rel => { _%>
@@ -38,6 +48,10 @@ import { declarativeQueryClasses } from './use-cases/declarative-queries';
     <%= classNames.service %>,
     <%= classNames.findByIdUseCase %>,
     <%= classNames.listUseCase %>,
+<% if (eavEnabled) { -%>
+    <%= classNames.findByIdWithFieldsUseCase %>,
+    <%= classNames.listWithFieldsUseCase %>,
+<% } -%>
 <% if (generateWrites) { -%>
     <%= classNames.createUseCase %>,
     <%= classNames.updateUseCase %>,

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -125,9 +125,11 @@ const DRIZZLE_IMPORT_MAP = {
 const ZOD_TYPE_MAP = {
   string: 'z.string()',
   integer: 'z.number().int()',
-  // PG numeric is returned by Drizzle as a string; z.coerce.number() parses
-  // strings at the boundary while still accepting numeric JSON input.
-  decimal: 'z.coerce.number()',
+  // PG numeric is returned by Drizzle as a string (precision preservation);
+  // z.coerce.string() accepts either JSON string or number and coerces to string
+  // so the DTO type aligns with the entity type. Do arithmetic at the consumer
+  // via Number(value) or a BigNumber library.
+  decimal: 'z.coerce.string()',
   boolean: 'z.boolean()',
   uuid: 'z.string().uuid()',
   date: 'z.coerce.date()',
@@ -142,7 +144,7 @@ const ZOD_TYPE_MAP = {
 const TS_TYPE_MAP = {
   string: 'string',
   integer: 'number',
-  decimal: 'number',
+  decimal: 'string',
   boolean: 'boolean',
   uuid: 'string',
   date: 'Date',

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -185,7 +185,16 @@ function buildDrizzleChain(fieldName, field, drizzleType) {
   const required = field.required ?? false;
   const hasDefault = field.default !== undefined && field.default !== null;
 
-  let chain = `${drizzleType}('${fieldName}')`;
+  // Drizzle's `date('x')` returns the PgDateString builder by default
+  // (data type: string). Force the Date-typed variant so DTO Zod
+  // schemas using z.coerce.date() align with the entity type.
+  // `timestamp` already defaults to Date — no mode override needed.
+  let chain;
+  if (drizzleType === 'date') {
+    chain = `${drizzleType}('${fieldName}', { mode: 'date' })`;
+  } else {
+    chain = `${drizzleType}('${fieldName}')`;
+  }
 
   // Add .notNull() for non-nullable required fields
   if (required && !nullable) {

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -528,6 +528,10 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const generateBlock = definition.generate || {};
   const generateWrites = generateBlock.writes !== false;
 
+  // EAV (ADR-13) — when true, emit paired reads + transactional compound
+  // writes. Consumer must provide `@shared/eav-helpers` and `FieldValueService`.
+  const eavEnabled = definition.eav === true;
+
   // Family resolution
   const family = entity.family || 'base';
   const familyConfig = FAMILY_MAP[family] || FAMILY_MAP['base'];
@@ -571,6 +575,12 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     index: `${srcRoot}/modules/${entityNamePlural}/index.ts`,
     findByIdUseCase: `${srcRoot}/modules/${entityNamePlural}/use-cases/find-${entityName}-by-id.use-case.ts`,
     listUseCase: `${srcRoot}/modules/${entityNamePlural}/use-cases/list-${entityNamePlural}.use-case.ts`,
+    findByIdWithFieldsUseCase: eavEnabled
+      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/find-${entityName}-by-id-with-fields.use-case.ts`
+      : null,
+    listWithFieldsUseCase: eavEnabled
+      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/list-${entityNamePlural}-with-fields.use-case.ts`
+      : null,
     createUseCase: generateWrites
       ? `${srcRoot}/modules/${entityNamePlural}/use-cases/create-${entityName}.use-case.ts`
       : null,
@@ -598,6 +608,8 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     module: `${entityNamePluralPascal}Module`,
     findByIdUseCase: `Find${entityNamePascal}ByIdUseCase`,
     listUseCase: `List${entityNamePluralPascal}UseCase`,
+    findByIdWithFieldsUseCase: `Find${entityNamePascal}ByIdWithFieldsUseCase`,
+    listWithFieldsUseCase: `List${entityNamePluralPascal}WithFieldsUseCase`,
     createUseCase: `Create${entityNamePascal}UseCase`,
     updateUseCase: `Update${entityNamePascal}UseCase`,
     deleteUseCase: `Delete${entityNamePascal}UseCase`,
@@ -658,6 +670,9 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
 
     // Generation toggles
     generateWrites,
+
+    // EAV (ADR-13)
+    eavEnabled,
 
     // Output paths
     clpOutputPaths: outputPaths,

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -9,6 +9,10 @@ import { EVENT_BUS } from '@shared/constants/tokens';
 import { <%= serviceBaseClass %> } from '<%= serviceBaseImport %>';
 import { <%= classNames.repository %> } from './<%= entityName %>.repository';
 import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
+<% if (eavEnabled) { -%>
+import { FieldValueRepository } from '../field_values/field_value.repository';
+import { mergeEavRows } from '@shared/eav-helpers';
+<% } -%>
 
 @Injectable()
 export class <%= classNames.service %> extends WithAnalytics(
@@ -20,7 +24,12 @@ export class <%= classNames.service %> extends WithAnalytics(
   @Optional() @Inject(EVENT_BUS)
   protected override eventBus: any = undefined;
 
-  constructor(protected readonly repository: <%= classNames.repository %>) {
+  constructor(
+    protected readonly repository: <%= classNames.repository %>,
+<% if (eavEnabled) { -%>
+    private readonly fieldValueRepository: FieldValueRepository,
+<% } -%>
+  ) {
     super(repository);
   }
 
@@ -31,4 +40,36 @@ export class <%= classNames.service %> extends WithAnalytics(
 <%_ serviceInheritedMethods.forEach(line => { _%>
   //   <%= line %>
 <%_ }) _%>
+<% if (eavEnabled) { %>
+  /**
+   * EAV paired read (ADR-13): fetch the entity and merge dynamic `field_values`
+   * into a single `fields` bag. Cross-domain read — permitted at the service
+   * layer. Use this for frontend detail views, LLM context, exports.
+   */
+  async findByIdWithFields(
+    id: string,
+  ): Promise<(<%= classNames.entity %> & { fields: Record<string, unknown> }) | null> {
+    const entity = await this.repository.findById(id);
+    if (!entity) return null;
+    const rows = await this.fieldValueRepository.findByEntityIdAndType(id, '<%= entityName %>');
+    return { ...entity, fields: mergeEavRows(rows) };
+  }
+
+  /**
+   * EAV paired read (ADR-13): list variant. Fetches all entities then merges
+   * each one's EAV rows. Acceptable for modest result sets; page externally
+   * for large collections.
+   */
+  async listWithFields(): Promise<Array<<%= classNames.entity %> & { fields: Record<string, unknown> }>> {
+    const entities = await this.repository.list();
+    if (entities.length === 0) return [];
+    const merged = await Promise.all(
+      entities.map(async (entity) => {
+        const rows = await this.fieldValueRepository.findByEntityIdAndType(entity.id, '<%= entityName %>');
+        return { ...entity, fields: mergeEavRows(rows) };
+      }),
+    );
+    return merged;
+  }
+<% } %>
 }

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -10,8 +10,7 @@ import { <%= serviceBaseClass %> } from '<%= serviceBaseImport %>';
 import { <%= classNames.repository %> } from './<%= entityName %>.repository';
 import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
 <% if (eavEnabled) { -%>
-import { FieldValueRepository } from '../field_values/field_value.repository';
-import { mergeEavRows } from '@shared/eav-helpers';
+import { FieldValueService } from '../field_values/field_value.service';
 <% } -%>
 
 @Injectable()
@@ -27,7 +26,7 @@ export class <%= classNames.service %> extends WithAnalytics(
   constructor(
     protected readonly repository: <%= classNames.repository %>,
 <% if (eavEnabled) { -%>
-    private readonly fieldValueRepository: FieldValueRepository,
+    private readonly fieldValues: FieldValueService,
 <% } -%>
   ) {
     super(repository);
@@ -43,33 +42,33 @@ export class <%= classNames.service %> extends WithAnalytics(
 <% if (eavEnabled) { %>
   /**
    * EAV paired read (ADR-13): fetch the entity and merge dynamic `field_values`
-   * into a single `fields` bag. Cross-domain read — permitted at the service
-   * layer. Use this for frontend detail views, LLM context, exports.
+   * into a single `fields` bag. FieldValueService owns the FieldDefinition
+   * lookup internally. Use this for frontend detail views, LLM context,
+   * exports.
    */
   async findByIdWithFields(
     id: string,
   ): Promise<(<%= classNames.entity %> & { fields: Record<string, unknown> }) | null> {
     const entity = await this.repository.findById(id);
     if (!entity) return null;
-    const rows = await this.fieldValueRepository.findByEntityIdAndType(id, '<%= entityName %>');
-    return { ...entity, fields: mergeEavRows(rows) };
+    const fields = await this.fieldValues.findMergedByEntity('<%= entityName %>', id);
+    return { ...entity, fields };
   }
 
   /**
    * EAV paired read (ADR-13): list variant. Fetches all entities then merges
-   * each one's EAV rows. Acceptable for modest result sets; page externally
-   * for large collections.
+   * each one's EAV fields via FieldValueService. Acceptable for modest result
+   * sets; page externally for large collections.
    */
   async listWithFields(): Promise<Array<<%= classNames.entity %> & { fields: Record<string, unknown> }>> {
     const entities = await this.repository.list();
     if (entities.length === 0) return [];
-    const merged = await Promise.all(
+    return Promise.all(
       entities.map(async (entity) => {
-        const rows = await this.fieldValueRepository.findByEntityIdAndType(entity.id, '<%= entityName %>');
-        return { ...entity, fields: mergeEavRows(rows) };
+        const fields = await this.fieldValues.findMergedByEntity('<%= entityName %>', entity.id);
+        return { ...entity, fields };
       }),
     );
-    return merged;
   }
 <% } %>
 }

--- a/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
@@ -3,6 +3,47 @@ to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.createUseCase : 
 skip_if: "<%= typeof clpOutputPaths === 'undefined' || !clpOutputPaths.createUseCase %>"
 force: true
 ---
+<% if (eavEnabled) { -%>
+import { Injectable, Inject } from '@nestjs/common';
+import { DRIZZLE_DB } from '@shared/constants/tokens';
+import type { DrizzleDB } from '@shared/database/drizzle.types';
+import { toEavRows } from '@shared/eav-helpers';
+import { FieldValueService } from '../../field_values/field_value.service';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.createDto %> } from '../dto/create-<%= entityName %>.dto';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+/**
+ * EAV compound-write use case (ADR-13).
+ *
+ * Splits `{ fields, ...core }` from the DTO and persists both halves in a
+ * single transaction: core columns go to the <%= entityName %> table via
+ * <%= classNames.service %>, dynamic `fields` go to `field_values` via
+ * FieldValueService. Atomicity comes from the shared tx; each service
+ * still only writes its own domain.
+ */
+@Injectable()
+export class <%= classNames.createUseCase %> {
+  constructor(
+    private readonly <%= entityName %>s: <%= classNames.service %>,
+    private readonly fields: FieldValueService,
+    @Inject(DRIZZLE_DB) private readonly db: DrizzleDB,
+  ) {}
+
+  async execute(
+    dto: <%= classNames.createDto %> & { fields?: Record<string, unknown> },
+  ): Promise<<%= classNames.entity %>> {
+    return this.db.transaction(async (tx) => {
+      const { fields, ...core } = dto;
+      const entity = await this.<%= entityName %>s.create(core as <%= classNames.createDto %>, tx);
+      if (fields && Object.keys(fields).length > 0) {
+        await this.fields.upsertMany(toEavRows(entity.id, '<%= entityName %>', fields), tx);
+      }
+      return entity;
+    });
+  }
+}
+<% } else { -%>
 import { Injectable } from '@nestjs/common';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.createDto %> } from '../dto/create-<%= entityName %>.dto';
@@ -16,3 +57,4 @@ export class <%= classNames.createUseCase %> {
     return this.service.create(dto);
   }
 }
+<% } -%>

--- a/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
@@ -7,7 +7,6 @@ force: true
 import { Injectable, Inject } from '@nestjs/common';
 import { DRIZZLE_DB } from '@shared/constants/tokens';
 import type { DrizzleDB } from '@shared/database/drizzle.types';
-import { toEavRows } from '@shared/eav-helpers';
 import { FieldValueService } from '../../field_values/field_value.service';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.createDto %> } from '../dto/create-<%= entityName %>.dto';
@@ -19,8 +18,9 @@ import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
  * Splits `{ fields, ...core }` from the DTO and persists both halves in a
  * single transaction: core columns go to the <%= entityName %> table via
  * <%= classNames.service %>, dynamic `fields` go to `field_values` via
- * FieldValueService. Atomicity comes from the shared tx; each service
- * still only writes its own domain.
+ * FieldValueService.upsertFieldsTransactional (which owns the
+ * FieldDefinition lookup internally). Atomicity comes from the shared tx;
+ * each service still only writes its own domain.
  */
 @Injectable()
 export class <%= classNames.createUseCase %> {
@@ -37,7 +37,13 @@ export class <%= classNames.createUseCase %> {
       const { fields, ...core } = dto;
       const entity = await this.<%= entityName %>s.create(core as <%= classNames.createDto %>, tx);
       if (fields && Object.keys(fields).length > 0) {
-        await this.fields.upsertMany(toEavRows(entity.id, '<%= entityName %>', fields), tx);
+        await this.fields.upsertFieldsTransactional(
+          '<%= entityName %>',
+          entity.id,
+          core.userId,
+          fields,
+          tx,
+        );
       }
       return entity;
     });

--- a/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
@@ -25,7 +25,7 @@ import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
 @Injectable()
 export class <%= classNames.createUseCase %> {
   constructor(
-    private readonly <%= entityName %>s: <%= classNames.service %>,
+    private readonly <%= entityNamePlural %>: <%= classNames.service %>,
     private readonly fields: FieldValueService,
     @Inject(DRIZZLE_DB) private readonly db: DrizzleDB,
   ) {}
@@ -35,7 +35,7 @@ export class <%= classNames.createUseCase %> {
   ): Promise<<%= classNames.entity %>> {
     return this.db.transaction(async (tx) => {
       const { fields, ...core } = dto;
-      const entity = await this.<%= entityName %>s.create(core as <%= classNames.createDto %>, tx);
+      const entity = await this.<%= entityNamePlural %>.create(core as <%= classNames.createDto %>, tx);
       if (fields && Object.keys(fields).length > 0) {
         await this.fields.upsertFieldsTransactional(
           '<%= entityName %>',

--- a/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/create.ejs.t
@@ -5,8 +5,8 @@ force: true
 ---
 <% if (eavEnabled) { -%>
 import { Injectable, Inject } from '@nestjs/common';
-import { DRIZZLE_DB } from '@shared/constants/tokens';
-import type { DrizzleDB } from '@shared/database/drizzle.types';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
 import { FieldValueService } from '../../field_values/field_value.service';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.createDto %> } from '../dto/create-<%= entityName %>.dto';
@@ -27,7 +27,7 @@ export class <%= classNames.createUseCase %> {
   constructor(
     private readonly <%= entityNamePlural %>: <%= classNames.service %>,
     private readonly fields: FieldValueService,
-    @Inject(DRIZZLE_DB) private readonly db: DrizzleDB,
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
   ) {}
 
   async execute(

--- a/templates/entity/new/clean-lite-ps/use-cases/delete.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/delete.ejs.t
@@ -5,13 +5,12 @@ force: true
 ---
 import { Injectable } from '@nestjs/common';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
-import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
 
 @Injectable()
 export class <%= classNames.deleteUseCase %> {
   constructor(private readonly service: <%= classNames.service %>) {}
 
-  async execute(id: string): Promise<<%= classNames.entity %> | null> {
+  async execute(id: string): Promise<void> {
     return this.service.delete(id);
   }
 }

--- a/templates/entity/new/clean-lite-ps/use-cases/find-by-id-with-fields.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/find-by-id-with-fields.ejs.t
@@ -1,0 +1,19 @@
+---
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.findByIdWithFieldsUseCase : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' || !clpOutputPaths.findByIdWithFieldsUseCase %>"
+force: true
+---
+import { Injectable } from '@nestjs/common';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.findByIdWithFieldsUseCase %> {
+  constructor(private readonly service: <%= classNames.service %>) {}
+
+  async execute(
+    id: string,
+  ): Promise<(<%= classNames.entity %> & { fields: Record<string, unknown> }) | null> {
+    return this.service.findByIdWithFields(id);
+  }
+}

--- a/templates/entity/new/clean-lite-ps/use-cases/list-with-fields.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/list-with-fields.ejs.t
@@ -1,0 +1,17 @@
+---
+to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.listWithFieldsUseCase : null %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' || !clpOutputPaths.listWithFieldsUseCase %>"
+force: true
+---
+import { Injectable } from '@nestjs/common';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+@Injectable()
+export class <%= classNames.listWithFieldsUseCase %> {
+  constructor(private readonly service: <%= classNames.service %>) {}
+
+  async execute(): Promise<Array<<%= classNames.entity %> & { fields: Record<string, unknown> }>> {
+    return this.service.listWithFields();
+  }
+}

--- a/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
@@ -3,6 +3,48 @@ to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.updateUseCase : 
 skip_if: "<%= typeof clpOutputPaths === 'undefined' || !clpOutputPaths.updateUseCase %>"
 force: true
 ---
+<% if (eavEnabled) { -%>
+import { Injectable, Inject } from '@nestjs/common';
+import { DRIZZLE_DB } from '@shared/constants/tokens';
+import type { DrizzleDB } from '@shared/database/drizzle.types';
+import { toEavRows } from '@shared/eav-helpers';
+import { FieldValueService } from '../../field_values/field_value.service';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
+import type { <%= classNames.updateDto %> } from '../dto/update-<%= entityName %>.dto';
+import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
+
+/**
+ * EAV compound-write use case (ADR-13).
+ *
+ * Mirrors CreateUseCase: splits `{ fields, ...core }`, updates core columns
+ * via <%= classNames.service %> and upserts dynamic fields via
+ * FieldValueService in a single transaction. Returns null if the entity
+ * was not found (service.update contract).
+ */
+@Injectable()
+export class <%= classNames.updateUseCase %> {
+  constructor(
+    private readonly <%= entityName %>s: <%= classNames.service %>,
+    private readonly fields: FieldValueService,
+    @Inject(DRIZZLE_DB) private readonly db: DrizzleDB,
+  ) {}
+
+  async execute(
+    id: string,
+    dto: <%= classNames.updateDto %> & { fields?: Record<string, unknown> },
+  ): Promise<<%= classNames.entity %> | null> {
+    return this.db.transaction(async (tx) => {
+      const { fields, ...core } = dto;
+      const entity = await this.<%= entityName %>s.update(id, core as <%= classNames.updateDto %>, tx);
+      if (!entity) return null;
+      if (fields && Object.keys(fields).length > 0) {
+        await this.fields.upsertMany(toEavRows(entity.id, '<%= entityName %>', fields), tx);
+      }
+      return entity;
+    });
+  }
+}
+<% } else { -%>
 import { Injectable } from '@nestjs/common';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.updateDto %> } from '../dto/update-<%= entityName %>.dto';
@@ -16,3 +58,4 @@ export class <%= classNames.updateUseCase %> {
     return this.service.update(id, dto);
   }
 }
+<% } -%>

--- a/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
@@ -23,7 +23,7 @@ import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
 @Injectable()
 export class <%= classNames.updateUseCase %> {
   constructor(
-    private readonly <%= entityName %>s: <%= classNames.service %>,
+    private readonly <%= entityNamePlural %>: <%= classNames.service %>,
     private readonly fields: FieldValueService,
     @Inject(DRIZZLE_DB) private readonly db: DrizzleDB,
   ) {}
@@ -34,7 +34,7 @@ export class <%= classNames.updateUseCase %> {
   ): Promise<<%= classNames.entity %> | null> {
     return this.db.transaction(async (tx) => {
       const { fields, ...core } = dto;
-      const entity = await this.<%= entityName %>s.update(id, core as <%= classNames.updateDto %>, tx);
+      const entity = await this.<%= entityNamePlural %>.update(id, core as <%= classNames.updateDto %>, tx);
       if (!entity) return null;
       if (fields && Object.keys(fields).length > 0) {
         await this.fields.upsertFieldsTransactional(

--- a/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
@@ -7,7 +7,6 @@ force: true
 import { Injectable, Inject } from '@nestjs/common';
 import { DRIZZLE_DB } from '@shared/constants/tokens';
 import type { DrizzleDB } from '@shared/database/drizzle.types';
-import { toEavRows } from '@shared/eav-helpers';
 import { FieldValueService } from '../../field_values/field_value.service';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.updateDto %> } from '../dto/update-<%= entityName %>.dto';
@@ -18,8 +17,8 @@ import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
  *
  * Mirrors CreateUseCase: splits `{ fields, ...core }`, updates core columns
  * via <%= classNames.service %> and upserts dynamic fields via
- * FieldValueService in a single transaction. Returns null if the entity
- * was not found (service.update contract).
+ * FieldValueService.upsertFieldsTransactional in a single transaction.
+ * Returns null if the entity was not found.
  */
 @Injectable()
 export class <%= classNames.updateUseCase %> {
@@ -38,7 +37,13 @@ export class <%= classNames.updateUseCase %> {
       const entity = await this.<%= entityName %>s.update(id, core as <%= classNames.updateDto %>, tx);
       if (!entity) return null;
       if (fields && Object.keys(fields).length > 0) {
-        await this.fields.upsertMany(toEavRows(entity.id, '<%= entityName %>', fields), tx);
+        await this.fields.upsertFieldsTransactional(
+          '<%= entityName %>',
+          entity.id,
+          entity.userId,
+          fields,
+          tx,
+        );
       }
       return entity;
     });

--- a/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/update.ejs.t
@@ -5,8 +5,8 @@ force: true
 ---
 <% if (eavEnabled) { -%>
 import { Injectable, Inject } from '@nestjs/common';
-import { DRIZZLE_DB } from '@shared/constants/tokens';
-import type { DrizzleDB } from '@shared/database/drizzle.types';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
 import { FieldValueService } from '../../field_values/field_value.service';
 import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.updateDto %> } from '../dto/update-<%= entityName %>.dto';
@@ -25,7 +25,7 @@ export class <%= classNames.updateUseCase %> {
   constructor(
     private readonly <%= entityNamePlural %>: <%= classNames.service %>,
     private readonly fields: FieldValueService,
-    @Inject(DRIZZLE_DB) private readonly db: DrizzleDB,
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
   ) {}
 
   async execute(


### PR DESCRIPTION
## Summary

Adds an `eav: true` flag to the clean-lite-ps entity YAML schema. When set, codegen emits an EAV-aware module shape that implements the ADR-13 pattern: EAV dual-write lives in use cases that compose the entity service and a consumer-provided `FieldValueService`; EAV-merged reads live as paired methods on the service.

Composes cleanly with PR #52's `generate.writes` flag.

Dogfooded against `dealbrain-v2` as the first downstream consumer. Three PR #52 template bugs surfaced and are co-landing here (see "PR #52 bug fixes — discovered via first-consumer dogfooding" below).

### What codegen emits when `eav: true`

**Paired read use cases** (new templates):
- `FindXByIdWithFieldsUseCase` → delegates to `service.findByIdWithFields(id)`
- `ListXWithFieldsUseCase` → delegates to `service.listWithFields()`

**Service** (existing template, new branch):
- Injects consumer's `FieldValueService`
- Emits `findByIdWithFields(id)` and `listWithFields()` that call `fieldValues.findMergedByEntity(entityType, id)` and spread the result into a `fields` bag on the entity

**Compound-write use cases** (create/update templates, new branch):
- Inject entity service + `FieldValueService` + `DRIZZLE`
- Split `{ fields, ...core }` from the DTO
- Run both writes in `db.transaction(async (tx) => …)` passing the same `tx` to each service call
- Each service still only writes its own domain (atomicity via shared tx)

**Controller** (existing template, new branch):
- Adds `GET /with-fields` and `GET /:id/with-fields`
- Emits the static route before the `:id` param route so NestJS doesn't capture `"with-fields"` as an id (test asserts ordering)

**Module** (existing template, new branch):
- Imports `FieldValuesModule`
- Registers paired-read use cases as providers

### Example output (opportunity)

Create use case:
```ts
return this.db.transaction(async (tx) => {
  const { fields, ...core } = dto;
  const entity = await this.opportunities.create(core as CreateOpportunityDto, tx);
  if (fields && Object.keys(fields).length > 0) {
    await this.fields.upsertFieldsTransactional(
      'opportunity', entity.id, core.userId, fields, tx,
    );
  }
  return entity;
});
```

Service paired read:
```ts
async findByIdWithFields(id: string) {
  const entity = await this.repository.findById(id);
  if (!entity) return null;
  const fields = await this.fieldValues.findMergedByEntity('opportunity', id);
  return { ...entity, fields };
}
```

### Composition matrix

| `generate.writes` | `eav` | Emitted shape |
|---|---|---|
| `true` (default) | `false` (default) | Unchanged from PR #52 — plain one-line create/update/delete |
| `false` | `false` | Unchanged from PR #52 — reads only, no writes |
| `true` | `true` | **Compound** create/update + paired reads + `/with-fields` routes |
| `false` | `true` | Paired reads only — compound writes suppressed |

All four combinations are covered by test assertions.

## PR #52 bug fixes — discovered via first-consumer dogfooding

Three write-side template bugs surfaced while regenerating `dealbrain-v2` on this branch. None are EAV-specific — they were latent in the PR #52 write templates — but co-landing here since PR #53 is already the "EAV emits write use cases" branch under review.

**1. `delete` use case + controller return `Promise<void>`** (commit `e1729e5`)

`BaseService.delete` returns `Promise<void>`. Template declared `Promise<Entity | null>`. Every consumer got a TS2322 on the generated delete use case. Fix: template + controller both return `Promise<void>`. If consumers later want the deleted row back (soft-delete handlers, event bus), that's a base-service extension in a future PR.

**2. Decimal fields are `string` end-to-end** (commit `e1729e5`)

PG numeric columns return as `string` from Drizzle (precision preservation). Entity type was `string`. DTO emitted `z.coerce.number()` and typed the field as `number`. `service.create(dto)` failed with a string-vs-number mismatch. Fix: `ZOD_TYPE_MAP.decimal → 'z.coerce.string()'`, `TS_TYPE_MAP.decimal → 'string'`. Consumers do `Number(value)` at read sites where arithmetic is needed; no precision leaks through the DTO boundary. `dto-template.test.ts` (PR #35 regression suite) updated to assert the new behavior and guard against regression to both `z.number()` and `z.coerce.number()`.

**3. `date` columns declare `{ mode: 'date' }`** (commit `4597d5f`)

Drizzle's `date('x')` without config returns the `PgDateString` builder (data type `string`). DTOs typed the field as `Date` via `z.coerce.date()`. Mismatch at the service.create(dto) boundary on any `date`-typed field. Fix: `buildDrizzleChain` emits `date('x', { mode: 'date' })` for every YAML `date` field. `timestamp` already defaults to `Date` — no change needed there.

## Consumer contract

Consumers adopting `eav: true` must provide the following in their shared layer. These are **not** bundled into `@pattern-stack/codegen` — they stay in the consumer's `src/shared/` so consumers can evolve them independently (same pattern as `@shared/base-classes/*`).

1. **`BaseService.create/update/delete` accept an optional `tx` parameter** so the compound use case can pass its transaction handle through.

2. **`FieldValueService` exposes two compound methods** (owning the `FieldDefinition` lookup internally):
   - `upsertFieldsTransactional(entityType, entityId, userId, fields, tx): Promise<void>`
   - `findMergedByEntity(entityType, entityId): Promise<Record<string, unknown>>`

   Templates never inject `FieldValueRepository` or `FieldDefinitionRepository` directly — all EAV operations flow through `FieldValueService`.

3. **`DRIZZLE` injection token** available via `@shared/constants/tokens`, typed against a `DrizzleClient` type from `@shared/types/drizzle`.

4. **Hand-extended generated files registry** (consumer convention for tracking files that survive regen).

### First downstream implementation

`dealbrain-v2` is the trigger case for this PR. Its consumer-side work landed in three tasks (all merged):
- A0: tx on base-service + initial `eav-helpers` module
- A0.5: `upsertFieldsTransactional` + `findMergedByEntity` on `FieldValueService`
- A0.6: composite unique index on `field_values (entity_type, entity_id, field_definition_id)` + `upsertCurrentValues` conflict target

End-to-end smoke test on `dealbrain-v2` confirmed:
- `GET /opportunities/:id/with-fields` returns the opportunity merged with its seeded `field_values` bag
- `POST /opportunities` with `{ fields: { next_steps: "initial" } }` → `PATCH` with `{ fields: { next_steps: "updated" } }` produces exactly one `field_values` row, value = `"updated"`. Composite conflict target + transactional dual-write verified idempotent.

## userId resolution

Synced-family entities always carry `user_id` in the generated DTO, so:
- Create use case pulls `core.userId` after splitting `{ fields, ...core }`
- Update use case pulls `entity.userId` from the loaded entity (update DTOs omit the immutable userId)

Non-synced entities with `eav: true` aren't yet supported — prompt-extension could detect the missing `userId` and error with a clear message, but that's a follow-up; the first consumer only needs synced.

## Upstream follow-up (separate issue, not this PR)

`MetadataEntityRepository.upsertMany` currently takes a single-column conflict target. A future change will grow it to accept `string[]` for composite conflict targets, which `field_values` wants (conflict on `(entity_id, entity_type, field_definition_id)`). coord-A will file that as its own issue against codegen-patterns — out of scope here.

## Test plan

- [x] `src/__tests__/clean-lite-ps/eav-templates.test.ts` — 16 new tests, mirrors the pattern from `write-templates.test.ts`.
- [x] `src/__tests__/clean-lite-ps/write-templates.test.ts` — backward-compat canary from PR #52. All 10 pre-existing tests still pass (delete assertion updated from `Entity | null` to `void`).
- [x] `src/__tests__/clean-lite-ps/dto-template.test.ts` — PR #35 regression suite. Decimal assertion updated from `z.coerce.number()` to `z.coerce.string()`.
- [x] Full clean-lite-ps suite: **58 pass / 0 fail**.
- [x] Full `bun test`: pre-existing graph-components / CLI init / barrel-generator tests still fail identically to baseline `main`. Zero regressions.
- [x] `bun run typecheck` — clean.
- [x] Downstream smoke test on `dealbrain-v2`: full regen, typecheck clean, service boots, `/with-fields` endpoints return merged EAV rows, POST+PATCH idempotency test passes on composite unique index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)