### PR TITLE
feat(clean-lite-ps): slim EAV consumer contract via init scaffold + eav_value_table flag

### DIFF
--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -171,6 +171,22 @@ src/shared/constants/tokens.ts
 src/shared/subsystems/events/event-bus.protocol.ts  # transitive dep of base-service + lifecycle-events
 ```
 
+### Runtime validation pipe
+
+```
+src/shared/pipes/zod-validation.pipe.ts             # @Body() validation for generated write routes
+```
+
+Generated controllers wrap their `@Body()` params with `new ZodValidationPipe(CreateXSchema)` — the pipe runs the DTO's Zod schema at request time, throws `BadRequestException` on failure, returns parsed data on success. No consumer wiring required.
+
+### EAV helpers
+
+```
+src/shared/eav-helpers.ts                           # toEavRows + mergeEavRows for eav_value_table services
+```
+
+Pure helpers used by services generated for entities declaring `eav_value_table: true`. Caller supplies the field-definition id/key maps; helpers are sync + allocation-light.
+
 **Keeping vendored files in sync with the runtime.** Re-running `codegen project init --force` will overwrite them with the current runtime contents. If you upgrade `@pattern-stack/codegen`, re-run init to pull the matching base classes. Treat the vendored files as generated output — don't hand-edit them; if you need to override behavior, subclass them in your own module instead.
 
 ## `schema.ts` wiring
@@ -237,6 +253,79 @@ database:
 ```
 
 `paths.generated` must sit inside your `tsconfig.json` `"include"` globs — otherwise TS won't typecheck the barrel.
+
+## EAV dual-write — opt-in per entity
+
+Two YAML flags light up the EAV (entity-attribute-value) surface. Both default to `false` — entities that don't declare them get the non-EAV shape unchanged.
+
+### `eav: true` on owning entities
+
+Declare this on the entity that has a dynamic `fields` bag alongside its core columns (e.g. `opportunity`, `account`, `contact`).
+
+```yaml
+# entities/opportunity.yaml
+entity:
+  name: opportunity
+  family: synced
+eav: true
+fields:
+  name:
+    type: string
+    required: true
+  # ... core columns
+```
+
+Codegen emits:
+
+- `Create<Entity>UseCase` / `Update<Entity>UseCase` in transactional compound-write shape — splits `{ fields, ...core }` from the DTO and runs both halves in `db.transaction(async (tx) => ...)`.
+- `Find<Entity>ByIdWithFieldsUseCase` / `List<Entity>sWithFieldsUseCase` — paired reads that merge the EAV `fields` bag onto the entity.
+- `GET /<entity>/:id/with-fields` + `GET /<entity>/with-fields` routes on the controller.
+- `findByIdWithFields` + `listWithFields` methods on the service.
+- Module imports of the paired value-table module so DI resolves.
+
+### `eav_value_table: true` on the value-table entity
+
+Declare this on the entity that IS the value table (e.g. `field_value`). Paired with `eav_definition_table: <singular-entity-name>` pointing at the field-definitions entity.
+
+```yaml
+# entities/field_value.yaml
+entity:
+  name: field_value
+  family: metadata
+eav_value_table: true
+eav_definition_table: field_definition
+fields:
+  entity_type:
+    type: string
+    required: true
+  entity_id:
+    type: uuid
+    required: true
+  field_definition_id:
+    type: uuid
+    required: true
+  user_id:
+    type: uuid
+    required: true
+  value:
+    type: json
+    required: true
+```
+
+Codegen emits:
+
+- `upsertCurrentValues(rows, tx?)` on the repository — composite `(entity_type, entity_id, field_definition_id)` conflict target, so repeated upserts update a row in place rather than appending.
+- `upsertFieldsTransactional(entityType, entityId, userId, fields, tx?)` on the service — resolves field keys to definition ids internally (via the injected definition repo) and delegates to the repo's upsert.
+- `findMergedByEntity(entityType, entityId)` on the service — reads value rows + definitions in parallel, collapses via `mergeEavRows` into a flat `{ key: value }` bag.
+- Auto-imports the paired field-definitions module so DI resolves.
+
+**v1 assumption:** `eav_value_table: true` expects a NOT-NULL `user_id` column on the value table. A future `eav_user_scoped: false` flag will relax this for audit/system EAV with no user context.
+
+### What the consumer has to author for EAV
+
+Nothing beyond the YAML flags. Every consumer contract item — tx-aware base classes, the EAV helpers, the composite conflict-target upsert — ships via `codegen project init` (the vendored runtime files above) or via the generated templates.
+
+The one thing consumers do own: creating `field_definition` rows before they reference them. `upsertFieldsTransactional` silently skips keys with no definition; auto-create is a later step.
 
 ## Verification
 

--- a/runtime/base-classes/base-repository.ts
+++ b/runtime/base-classes/base-repository.ts
@@ -12,7 +12,7 @@
 import { eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { PgTableWithColumns, PgColumn } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
-import type { DrizzleClient } from '../types/drizzle';
+import type { DrizzleClient, DrizzleTx } from '../types/drizzle';
 
 // ============================================================================
 // Interfaces
@@ -63,6 +63,17 @@ export abstract class BaseRepository<TEntity> {
 
   constructor(db: DrizzleClient) {
     this.db = db;
+  }
+
+  /**
+   * Pick the runner for a write: the caller-supplied transaction handle
+   * if present, otherwise the repository's own client. Keeps the `tx`
+   * parameter purely additive — callers without a transaction call as
+   * before. Used by the write methods below + consumer overrides (e.g.
+   * the generated `upsertCurrentValues` on EAV value tables).
+   */
+  protected runner(tx?: DrizzleTx): DrizzleClient {
+    return tx ?? this.db;
   }
 
   // ============================================================================
@@ -157,9 +168,9 @@ export abstract class BaseRepository<TEntity> {
   /**
    * Insert a new entity. Timestamps are auto-injected when timestamps=true.
    */
-  async create(input: Partial<TEntity>): Promise<TEntity> {
+  async create(input: Partial<TEntity>, tx?: DrizzleTx): Promise<TEntity> {
     const data = this.withTimestamps(input as Record<string, unknown>, 'create');
-    const rows = await this.db
+    const rows = await this.runner(tx)
       .insert(this.table)
       .values(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
       .returning();
@@ -170,9 +181,9 @@ export abstract class BaseRepository<TEntity> {
    * Update an existing entity by id. updatedAt is auto-injected when timestamps=true.
    * Returns the updated entity.
    */
-  async update(id: string, input: Partial<TEntity>): Promise<TEntity> {
+  async update(id: string, input: Partial<TEntity>, tx?: DrizzleTx): Promise<TEntity> {
     const data = this.withTimestamps(input as Record<string, unknown>, 'update');
-    const rows = await this.db
+    const rows = await this.runner(tx)
       .update(this.table)
       .set(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
       .where(eq(this.table['id'], id))
@@ -185,14 +196,15 @@ export abstract class BaseRepository<TEntity> {
    * - softDelete=true: sets deletedAt to current timestamp
    * - softDelete=false: hard-deletes the row
    */
-  async delete(id: string): Promise<void> {
+  async delete(id: string, tx?: DrizzleTx): Promise<void> {
+    const runner = this.runner(tx);
     if (this.behaviors.softDelete) {
-      await this.db
+      await runner
         .update(this.table)
         .set({ deletedAt: new Date() } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
         .where(eq(this.table['id'], id));
     } else {
-      await this.db
+      await runner
         .delete(this.table)
         .where(eq(this.table['id'], id));
     }
@@ -203,8 +215,8 @@ export abstract class BaseRepository<TEntity> {
    * Default naive implementation — family repositories override with
    * proper conflict-target upsert (e.g., CrmEntityRepository).
    */
-  async upsertMany(inputs: Array<Partial<TEntity>>): Promise<TEntity[]> {
-    return Promise.all(inputs.map((input) => this.create(input)));
+  async upsertMany(inputs: Array<Partial<TEntity>>, tx?: DrizzleTx): Promise<TEntity[]> {
+    return Promise.all(inputs.map((input) => this.create(input, tx)));
   }
 
   // ============================================================================

--- a/runtime/base-classes/base-service.ts
+++ b/runtime/base-classes/base-service.ts
@@ -41,9 +41,9 @@ export interface IBaseRepository<TEntity> {
   list(options?: unknown): Promise<TEntity[]>;
   count(where?: unknown): Promise<number>;
   exists(id: string): Promise<boolean>;
-  create(input: Partial<TEntity>): Promise<TEntity>;
-  update(id: string, input: Partial<TEntity>): Promise<TEntity>;
-  delete(id: string): Promise<void>;
+  create(input: Partial<TEntity>, tx?: unknown): Promise<TEntity>;
+  update(id: string, input: Partial<TEntity>, tx?: unknown): Promise<TEntity>;
+  delete(id: string, tx?: unknown): Promise<void>;
 }
 
 // ============================================================================
@@ -112,8 +112,8 @@ export abstract class BaseService<TRepo extends IBaseRepository<TEntity>, TEntit
    * Insert a new entity.
    * Emits a LIFECYCLE 'created' event with entity snapshot.
    */
-  async create(input: Partial<TEntity>): Promise<TEntity> {
-    const result = await this.repository.create(input);
+  async create(input: Partial<TEntity>, tx?: unknown): Promise<TEntity> {
+    const result = await this.repository.create(input, tx);
 
     if (this._shouldEmit()) {
       const snap = entitySnapshot(result as Record<string, unknown>);
@@ -129,7 +129,7 @@ export abstract class BaseService<TRepo extends IBaseRepository<TEntity>, TEntit
    * Update an existing entity by id.
    * Emits a LIFECYCLE 'updated' event + CHANGE events for each modified field.
    */
-  async update(id: string, input: Partial<TEntity>): Promise<TEntity> {
+  async update(id: string, input: Partial<TEntity>, tx?: unknown): Promise<TEntity> {
     // Snapshot before for change diffing
     let before: Record<string, unknown> | undefined;
     if (this._shouldEmit()) {
@@ -139,7 +139,7 @@ export abstract class BaseService<TRepo extends IBaseRepository<TEntity>, TEntit
       }
     }
 
-    const result = await this.repository.update(id, input);
+    const result = await this.repository.update(id, input, tx);
 
     if (this._shouldEmit()) {
       const after = entitySnapshot(result as Record<string, unknown>);
@@ -163,8 +163,8 @@ export abstract class BaseService<TRepo extends IBaseRepository<TEntity>, TEntit
    * Delete an entity by id.
    * Emits a LIFECYCLE 'deleted' event.
    */
-  async delete(id: string): Promise<void> {
-    await this.repository.delete(id);
+  async delete(id: string, tx?: unknown): Promise<void> {
+    await this.repository.delete(id, tx);
 
     if (this._shouldEmit()) {
       const event = buildLifecycleEvent(this.entityName!, 'deleted', id);

--- a/runtime/base-classes/metadata-entity-repository.ts
+++ b/runtime/base-classes/metadata-entity-repository.ts
@@ -9,6 +9,7 @@
 import { eq, and, desc } from 'drizzle-orm';
 import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
 import { BaseRepository } from './base-repository';
+import type { DrizzleTx } from '../types/drizzle';
 
 export abstract class MetadataEntityRepository<TEntity> extends BaseRepository<TEntity> {
   /**
@@ -17,20 +18,22 @@ export abstract class MetadataEntityRepository<TEntity> extends BaseRepository<T
    */
   async upsertMany(
     inputs: Array<Partial<TEntity>>,
-    conflictTarget?: keyof PgTableWithColumns<any>['_']['columns'], // eslint-disable-line @typescript-eslint/no-explicit-any
+    tx?: DrizzleTx,
+    options?: { conflictTarget?: keyof PgTableWithColumns<any>['_']['columns'] }, // eslint-disable-line @typescript-eslint/no-explicit-any
   ): Promise<TEntity[]> {
     if (inputs.length === 0) return [];
+    const conflictTarget = options?.conflictTarget;
 
-    // Fall back to base class naive upsert when no conflict target provided
+    // Fall back to base class naive upsert when no conflict target provided.
     if (!conflictTarget) {
-      return super.upsertMany(inputs);
+      return super.upsertMany(inputs, tx);
     }
 
     const data = inputs.map((input) =>
       this.withTimestamps(input as Record<string, unknown>, 'create'),
     );
 
-    const rows = await this.db
+    const rows = await this.runner(tx)
       .insert(this.table)
       .values(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
       .onConflictDoUpdate({

--- a/runtime/base-classes/metadata-entity-service.ts
+++ b/runtime/base-classes/metadata-entity-service.ts
@@ -11,7 +11,7 @@ export interface IMetadataEntityRepository<TEntity> extends IBaseRepository<TEnt
   findByEntityIdAndType(entityId: string, entityType: string): Promise<TEntity[]>;
   listByEntityId(entityId: string): Promise<TEntity[]>;
   listHistoryByEntityId(entityId: string): Promise<TEntity[]>;
-  upsertMany(inputs: Array<Partial<TEntity>>, conflictTarget: string): Promise<TEntity[]>;
+  upsertMany(inputs: Array<Partial<TEntity>>, tx?: unknown, options?: { conflictTarget?: string }): Promise<TEntity[]>;
 }
 
 export abstract class MetadataEntityService<
@@ -42,7 +42,7 @@ export abstract class MetadataEntityService<
   /**
    * Bulk upsert metadata values.
    */
-  upsertValues(inputs: Array<Partial<TEntity>>, conflictTarget: string): Promise<TEntity[]> {
-    return this.repository.upsertMany(inputs, conflictTarget);
+  upsertValues(inputs: Array<Partial<TEntity>>, conflictTarget: string, tx?: unknown): Promise<TEntity[]> {
+    return this.repository.upsertMany(inputs, tx, { conflictTarget });
   }
 }

--- a/runtime/eav-helpers.ts
+++ b/runtime/eav-helpers.ts
@@ -1,0 +1,74 @@
+/**
+ * EAV helpers
+ *
+ * Small, pure utilities used by services that dual-write to the EAV value
+ * table alongside their own table.
+ *
+ * - `toEavRows` builds value-table insert rows from a flat `{ key: value }`
+ *   bag, resolving the `fieldDefinitionId` via a caller-supplied map.
+ *   Callers own the field-definitions lookup / cache.
+ * - `mergeEavRows` inverts: given value-table rows + a definition `id -> key`
+ *   map, collapses them into a flat `{ key: value }` bag.
+ *
+ * Both are sync + allocation-light. They do not touch the DB.
+ */
+
+/**
+ * Map of field key -> field_definitions.id, scoped to a single entityType.
+ */
+export type FieldDefinitionIdMap = ReadonlyMap<string, string>;
+
+/**
+ * Minimal shape of a value-table row accepted by toEavRows output. Consumers
+ * pass their entity's `Insert` type; these are the columns the helper sets.
+ */
+export interface EavInsertShape {
+  entityId: string;
+  entityType: string;
+  userId: string;
+  fieldDefinitionId: string;
+  value: unknown;
+}
+
+/**
+ * Build value-table insert rows from a flat field bag. Keys present in
+ * `fields` but missing from `fieldDefIds` are skipped — caller is expected
+ * to ensure the definitions exist (first-cut; auto-create is a later step).
+ */
+export function toEavRows(
+  entityId: string,
+  entityType: string,
+  userId: string,
+  fields: Record<string, unknown>,
+  fieldDefIds: FieldDefinitionIdMap,
+): EavInsertShape[] {
+  const rows: EavInsertShape[] = [];
+  for (const [key, value] of Object.entries(fields)) {
+    const fieldDefinitionId = fieldDefIds.get(key);
+    if (!fieldDefinitionId) continue;
+    rows.push({ entityId, entityType, userId, fieldDefinitionId, value });
+  }
+  return rows;
+}
+
+/**
+ * Collapse EAV rows back into a flat `{ key: value }` bag.
+ *
+ * Accepts bare value-table rows plus a separate `id -> { key }` map. Later
+ * rows win if the same key appears more than once. Call with temporal
+ * filtering already applied (e.g. validTo IS NULL) — this function does not
+ * interpret validFrom / validTo.
+ */
+export function mergeEavRows(
+  rows: Array<{ fieldDefinitionId: string | null; value: unknown }>,
+  defsById: ReadonlyMap<string, { key: string }>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const row of rows) {
+    if (!row.fieldDefinitionId) continue;
+    const def = defsById.get(row.fieldDefinitionId);
+    if (!def) continue;
+    out[def.key] = row.value;
+  }
+  return out;
+}

--- a/runtime/pipes/zod-validation.pipe.ts
+++ b/runtime/pipes/zod-validation.pipe.ts
@@ -1,0 +1,32 @@
+/**
+ * ZodValidationPipe
+ *
+ * NestJS pipe that runs a Zod schema against the pipe's input and:
+ *   - returns parsed, coerced data on success,
+ *   - throws a BadRequestException with `result.error.flatten()` on failure.
+ *
+ * Generated controllers wire it into write-route @Body():
+ *   @Body(new ZodValidationPipe(CreateXSchema)) dto: CreateXDto
+ *
+ * One pipe instance per route (cheap — instantiated at module load). Keeps
+ * validation explicit in the generated code; no metadata/reflection magic.
+ */
+import {
+  BadRequestException,
+  Injectable,
+  type PipeTransform,
+} from '@nestjs/common';
+import type { ZodTypeAny } from 'zod';
+
+@Injectable()
+export class ZodValidationPipe<T extends ZodTypeAny> implements PipeTransform {
+  constructor(private readonly schema: T) {}
+
+  transform(value: unknown): unknown {
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new BadRequestException(result.error.flatten());
+    }
+    return result.data;
+  }
+}

--- a/runtime/types/drizzle.ts
+++ b/runtime/types/drizzle.ts
@@ -13,3 +13,11 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DrizzleClient = NodePgDatabase<any>;
+
+/**
+ * A transaction-capable Drizzle handle. Structurally compatible with
+ * DrizzleClient — either the root client or a tx callback handle from
+ * `db.transaction((tx) => ...)` satisfies it, so writes can run in a
+ * caller-owned transaction without changing repository internals.
+ */
+export type DrizzleTx = DrizzleClient;

--- a/src/__tests__/clean-lite-ps/eav-value-table-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-value-table-templates.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Template tests for `eav_value_table: true` emission (task #23).
+ *
+ * A value-table entity (e.g. field_value) declares:
+ *   eav_value_table: true
+ *   eav_definition_table: field_definition
+ *
+ * Codegen emits the compound methods directly into the generated service
+ * and repository, wires the paired definitions module into the value-table
+ * module, and scaffolds the shared EAV helpers into the consumer's shared
+ * layer via `codegen init` (covered in a sibling test file). No hand
+ * extension on the consumer side.
+ *
+ * Contract lock:
+ *   - Repository: `upsertCurrentValues(rows, tx?)` with composite
+ *     (entity_type, entity_id, field_definition_id) conflict target.
+ *   - Service: `upsertFieldsTransactional(entityType, entityId, userId, fields, tx)`
+ *     and `findMergedByEntity(entityType, entityId)`, resolving
+ *     definition-key↔id internally via an injected definition-table repo.
+ *   - Module: auto-imports the definitions module so DI resolves.
+ *
+ * Entities without `eav_value_table: true` keep the existing shape.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+import { safeValidateEntityDefinition } from '../../schema/entity-definition.schema.js';
+
+const TEMPLATE_ROOT = resolve(
+  import.meta.dir,
+  '../../../templates/entity/new/clean-lite-ps',
+);
+
+function readTemplate(relPath: string): string {
+  return readFileSync(resolve(TEMPLATE_ROOT, relPath), 'utf8');
+}
+
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return source;
+  return lines.slice(end + 1).join('\n');
+}
+
+function render(relPath: string, locals: Record<string, unknown>): string {
+  return ejs.render(extractBody(readTemplate(relPath)), locals, {
+    rmWhitespace: false,
+  });
+}
+
+const valueEntity = {
+  entity: {
+    name: 'field_value',
+    plural: 'field_values',
+    table: 'field_values',
+    family: 'metadata',
+  },
+  eav_value_table: true,
+  eav_definition_table: 'field_definition',
+  fields: {
+    entity_type: { type: 'string', required: true },
+    entity_id: { type: 'uuid', required: true },
+    field_definition_id: { type: 'uuid', required: true },
+    user_id: { type: 'uuid', required: true },
+    value: { type: 'json', required: true },
+  },
+  relationships: {},
+  behaviors: ['timestamps'],
+};
+
+const entityWithoutFlag = {
+  ...valueEntity,
+  eav_value_table: undefined,
+  eav_definition_table: undefined,
+};
+
+describe('clean-lite-ps eav_value_table — schema validation', () => {
+  it('accepts a value-table entity with the paired flags', () => {
+    const result = safeValidateEntityDefinition(valueEntity);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects eav_value_table: true without eav_definition_table', () => {
+    const bad = { ...valueEntity, eav_definition_table: undefined };
+    const result = safeValidateEntityDefinition(bad);
+    expect(result.success).toBe(false);
+    const msgs = JSON.stringify(result.error?.issues ?? []);
+    expect(msgs).toContain('eav_definition_table');
+  });
+
+  it('accepts entity without either eav flag', () => {
+    const result = safeValidateEntityDefinition(entityWithoutFlag);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('clean-lite-ps eav_value_table — prompt-extension locals', () => {
+  it('exposes eavValueTable + definition entity metadata', () => {
+    const locals = buildCleanLitePsLocals(valueEntity, {});
+
+    expect(locals.eavValueTable).toBe(true);
+    expect(locals.eavDefinitionEntity).toBe('field_definition');
+    expect(locals.eavDefinitionEntityPlural).toBe('field_definitions');
+    expect(locals.eavDefinitionPascal).toBe('FieldDefinition');
+    expect(locals.eavDefinitionPluralPascal).toBe('FieldDefinitions');
+  });
+
+  it('zeros the metadata when the flag is absent', () => {
+    const locals = buildCleanLitePsLocals(entityWithoutFlag, {});
+
+    expect(locals.eavValueTable).toBe(false);
+    expect(locals.eavDefinitionEntity).toBeNull();
+    expect(locals.eavDefinitionEntityPlural).toBeNull();
+    expect(locals.eavDefinitionPascal).toBeNull();
+    expect(locals.eavDefinitionPluralPascal).toBeNull();
+  });
+});
+
+describe('clean-lite-ps eav_value_table — repository emission', () => {
+  it('emits upsertCurrentValues with composite conflict target when flag set', () => {
+    const locals = buildCleanLitePsLocals(valueEntity, {});
+    const output = render('repository.ejs.t', locals);
+
+    expect(output).toContain('async upsertCurrentValues(');
+    expect(output).toContain('tx?: DrizzleTx');
+    expect(output).toContain("import { sql } from 'drizzle-orm';");
+    expect(output).toContain("import type { DrizzleClient, DrizzleTx } from '@shared/types/drizzle';");
+    expect(output).toContain('onConflictDoUpdate');
+    expect(output).toContain("this.table['entityType']");
+    expect(output).toContain("this.table['entityId']");
+    expect(output).toContain("this.table['fieldDefinitionId']");
+    // Runner threaded through the tx.
+    expect(output).toContain('this.runner(tx)');
+  });
+
+  it('omits upsertCurrentValues when the flag is absent', () => {
+    const locals = buildCleanLitePsLocals(entityWithoutFlag, {});
+    const output = render('repository.ejs.t', locals);
+
+    expect(output).not.toContain('upsertCurrentValues');
+    expect(output).not.toContain('onConflictDoUpdate');
+    expect(output).not.toContain('DrizzleTx');
+  });
+});
+
+describe('clean-lite-ps eav_value_table — service emission', () => {
+  it('emits compound methods + imports when flag set', () => {
+    const locals = buildCleanLitePsLocals(valueEntity, {});
+    const output = render('service.ejs.t', locals);
+
+    // Imports: helpers + DrizzleTx + definition repo.
+    expect(output).toContain("import { toEavRows, mergeEavRows } from '@shared/eav-helpers';");
+    expect(output).toContain("import type { DrizzleTx } from '@shared/types/drizzle';");
+    expect(output).toContain(
+      "import { FieldDefinitionRepository } from '../field_definitions/field_definition.repository';",
+    );
+
+    // Constructor injection of the definition repo.
+    expect(output).toContain('private readonly definitionRepo: FieldDefinitionRepository,');
+
+    // Compound write signature + body markers.
+    expect(output).toContain(
+      'async upsertFieldsTransactional(\n    entityType: string,\n    entityId: string,\n    userId: string,\n    fields: Record<string, unknown>,\n    tx?: DrizzleTx,\n  ): Promise<void>',
+    );
+    expect(output).toContain('toEavRows(entityId, entityType, userId, fields, defIdByKey)');
+    expect(output).toContain('this.repository.upsertCurrentValues(');
+
+    // Merged read + Promise.all shape.
+    expect(output).toContain('async findMergedByEntity(');
+    expect(output).toContain('this.repository.findByEntityIdAndType(entityId, entityType)');
+    expect(output).toContain('this.definitionRepo.list()');
+    expect(output).toContain('mergeEavRows(rows as any, defsById)');
+  });
+
+  it('omits compound methods when flag is absent', () => {
+    const locals = buildCleanLitePsLocals(entityWithoutFlag, {});
+    const output = render('service.ejs.t', locals);
+
+    expect(output).not.toContain('upsertFieldsTransactional');
+    expect(output).not.toContain('findMergedByEntity');
+    expect(output).not.toContain('toEavRows');
+    expect(output).not.toContain('FieldDefinitionRepository');
+  });
+});
+
+describe('clean-lite-ps eav_value_table — module emission', () => {
+  it('imports the paired definitions module when flag set', () => {
+    const locals = buildCleanLitePsLocals(valueEntity, {});
+    const output = render('module.ejs.t', locals);
+
+    expect(output).toContain(
+      "import { FieldDefinitionsModule } from '../field_definitions/field_definitions.module';",
+    );
+    expect(output).toContain('FieldDefinitionsModule,');
+  });
+
+  it('omits the paired-module import when flag is absent', () => {
+    const locals = buildCleanLitePsLocals(entityWithoutFlag, {});
+    const output = render('module.ejs.t', locals);
+
+    expect(output).not.toContain('FieldDefinitionsModule');
+    expect(output).not.toContain('field_definitions.module');
+  });
+});
+
+describe('clean-lite-ps eav_value_table — composition with eav on owning entities', () => {
+  it('handles a graph where one entity is eav_value_table + another is eav-enabled', () => {
+    // Simulate the dealbrain-v2 shape: field_value is the value table,
+    // opportunity is an eav-enabled owner.
+    const valueLocals = buildCleanLitePsLocals(valueEntity, {});
+    const opportunityEntity = {
+      entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', family: 'synced' },
+      eav: true,
+      fields: { name: { type: 'string', required: true }, user_id: { type: 'uuid', required: true } },
+      relationships: {},
+      behaviors: ['timestamps'],
+    };
+    const opportunityLocals = buildCleanLitePsLocals(opportunityEntity, {});
+
+    // Value table has compound writes + definition module import.
+    expect(valueLocals.eavValueTable).toBe(true);
+    expect(valueLocals.eavEnabled).toBe(false);
+
+    // Owner has paired reads + compound use cases, no value-table methods.
+    expect(opportunityLocals.eavEnabled).toBe(true);
+    expect(opportunityLocals.eavValueTable).toBe(false);
+    expect(opportunityLocals.clpOutputPaths.findByIdWithFieldsUseCase).not.toBeNull();
+  });
+});

--- a/src/__tests__/cli/project.test.ts
+++ b/src/__tests__/cli/project.test.ts
@@ -174,6 +174,22 @@ describe('buildInitPlan', () => {
 		expect(plan.summary.architecture).toBe('clean-lite-ps');
 	});
 
+	test('plans the ZodValidationPipe scaffold under src/shared/pipes (task #23)', async () => {
+		const cwd = mkTempDir('zodpipe');
+		const ctx = await loadContext({ cwd, skipDetection: true });
+		const plan = await buildInitPlan(ctx, { cwd, skipScan: true });
+		const paths = plan.entries.map((e) => e.relPath);
+		expect(paths).toContain('src/shared/pipes/zod-validation.pipe.ts');
+	});
+
+	test('plans @shared/eav-helpers scaffold (task #23)', async () => {
+		const cwd = mkTempDir('eavhelpers');
+		const ctx = await loadContext({ cwd, skipDetection: true });
+		const plan = await buildInitPlan(ctx, { cwd, skipScan: true });
+		const paths = plan.entries.map((e) => e.relPath);
+		expect(paths).toContain('src/shared/eav-helpers.ts');
+	});
+
 	test('skips existing files (idempotent)', async () => {
 		const cwd = mkTempDir('idempotent');
 		fs.writeFileSync(path.join(cwd, 'codegen.config.yaml'), '# existing\n');

--- a/src/__tests__/runtime/base-classes/base-repository.spec.ts
+++ b/src/__tests__/runtime/base-classes/base-repository.spec.ts
@@ -307,4 +307,83 @@ describe('BaseRepository', () => {
       expect((db as any).offset).toHaveBeenCalledWith(5);
     });
   });
+
+  // ==========================================================================
+  // Tx threading (task #23)
+  // ==========================================================================
+
+  describe('runner(tx)', () => {
+    it('prefers the caller-supplied tx for writes', async () => {
+      const db = makeMockDb([{ id: 'x', name: 'A' }]);
+      const tx = makeMockDb([{ id: 'x', name: 'A' }]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+
+      await repo.create({ name: 'A' }, tx);
+
+      // Write went through the tx, not the repo's own client.
+      expect((tx as any).insert).toHaveBeenCalled();
+      expect((db as any).insert).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the repo client when no tx is passed', async () => {
+      const db = makeMockDb([{ id: 'x', name: 'A' }]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+
+      await repo.create({ name: 'A' });
+
+      expect((db as any).insert).toHaveBeenCalled();
+    });
+
+    it('threads tx through update()', async () => {
+      const db = makeMockDb([{ id: 'x', name: 'B' }]);
+      const tx = makeMockDb([{ id: 'x', name: 'B' }]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+
+      await repo.update('x', { name: 'B' }, tx);
+
+      expect((tx as any).update).toHaveBeenCalled();
+      expect((db as any).update).not.toHaveBeenCalled();
+    });
+
+    it('threads tx through delete() under soft-delete', async () => {
+      const db = makeMockDb([]);
+      const tx = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table, { softDelete: true });
+
+      await repo.delete('x', tx);
+
+      // Soft-delete issues an UPDATE on the tx, not the base db.
+      expect((tx as any).update).toHaveBeenCalled();
+      expect((db as any).update).not.toHaveBeenCalled();
+    });
+
+    it('threads tx through delete() under hard-delete', async () => {
+      const db = makeMockDb([]);
+      const tx = makeMockDb([]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+
+      await repo.delete('x', tx);
+
+      expect((tx as any).delete).toHaveBeenCalled();
+      expect((db as any).delete).not.toHaveBeenCalled();
+    });
+
+    it('threads tx through upsertMany() via create()', async () => {
+      const db = makeMockDb([{ id: 'x', name: 'Z' }]);
+      const tx = makeMockDb([{ id: 'x', name: 'Z' }]);
+      const table = makeTable();
+      const repo = new TestRepository(db, table);
+
+      await repo.upsertMany([{ name: 'Z' }], tx);
+
+      expect((tx as any).insert).toHaveBeenCalled();
+      expect((db as any).insert).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/src/__tests__/runtime/base-classes/base-service.spec.ts
+++ b/src/__tests__/runtime/base-classes/base-service.spec.ts
@@ -153,7 +153,7 @@ describe('BaseService', () => {
       const result = await service.create({ name: 'Created' });
 
       expect(result).toBe(entity);
-      expect(repo.create).toHaveBeenCalledWith({ name: 'Created' });
+      expect(repo.create).toHaveBeenCalledWith({ name: 'Created' }, undefined);
     });
   });
 
@@ -166,7 +166,7 @@ describe('BaseService', () => {
       const result = await service.update('upd', { name: 'Updated' });
 
       expect(result).toBe(entity);
-      expect(repo.update).toHaveBeenCalledWith('upd', { name: 'Updated' });
+      expect(repo.update).toHaveBeenCalledWith('upd', { name: 'Updated' }, undefined);
     });
   });
 
@@ -177,7 +177,7 @@ describe('BaseService', () => {
 
       await service.delete('del-id');
 
-      expect(repo.delete).toHaveBeenCalledWith('del-id');
+      expect(repo.delete).toHaveBeenCalledWith('del-id', undefined);
     });
   });
 });

--- a/src/__tests__/runtime/base-classes/metadata-entity-service.spec.ts
+++ b/src/__tests__/runtime/base-classes/metadata-entity-service.spec.ts
@@ -82,7 +82,7 @@ describe('MetadataEntityService', () => {
 
       const result = await service.upsertValues(inputs, 'id');
       expect(result).toEqual(entities);
-      expect(repo.upsertMany).toHaveBeenCalledWith(inputs, 'id');
+      expect(repo.upsertMany).toHaveBeenCalledWith(inputs, undefined, { conflictTarget: 'id' });
     });
   });
 });

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -133,6 +133,10 @@ const VENDORED_RUNTIME_FILES: Array<{ runtime: string; target: string }> = [
 	{ runtime: 'constants/tokens.ts', target: 'src/shared/constants/tokens.ts' },
 	// Events protocol — imported transitively by base-service + lifecycle-events
 	{ runtime: 'subsystems/events/event-bus.protocol.ts', target: 'src/shared/subsystems/events/event-bus.protocol.ts' },
+	// Shared pipes — referenced by generated controllers on write routes
+	{ runtime: 'pipes/zod-validation.pipe.ts', target: 'src/shared/pipes/zod-validation.pipe.ts' },
+	// EAV helpers — referenced by generated services on `eav_value_table` entities
+	{ runtime: 'eav-helpers.ts', target: 'src/shared/eav-helpers.ts' },
 ];
 
 function databaseModuleContent(): string {

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -715,6 +715,24 @@ export const EntityDefinitionSchema = z
     // Defaults to `false` — opt in per entity that needs dynamic/custom fields.
     eav: z.boolean().optional().default(false),
 
+    // Declare this entity IS an EAV value table. When `true`, codegen emits
+    // the compound EAV methods (upsertFieldsTransactional, findMergedByEntity)
+    // on the service and the upsertCurrentValues method on the repository —
+    // no hand extension required. Companion flag `eav_definition_table`
+    // identifies the sibling entity that stores the field-key ↔ id lookup.
+    //
+    // Mutually exclusive with `eav: true` in practice — a value table holds
+    // OTHER entities' dynamic fields, it isn't itself an EAV-opt-in entity.
+    //
+    // Assumption (v1): value tables have a `user_id` column. Future
+    // `eav_user_scoped: false` flag will relax this for audit/system EAV.
+    eav_value_table: z.boolean().optional().default(false),
+
+    // Singular entity name of the field-definitions entity that pairs with
+    // this value table (matches the `target:` convention in relationship
+    // YAMLs). Required when `eav_value_table: true`; ignored otherwise.
+    eav_definition_table: z.string().optional(),
+
 
     // v2: Declarative query generation (ADR-005)
     // Generates repository + service + use case methods from declarations
@@ -732,7 +750,17 @@ export const EntityDefinitionSchema = z
     // Cube.js measure packs, custom cube name, and metric definitions
     analytics: AnalyticsBlockSchema.optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (data) => !data.eav_value_table || typeof data.eav_definition_table === 'string',
+    {
+      message:
+        "`eav_definition_table` is required when `eav_value_table: true` — " +
+        "declare the singular entity name of the paired field-definitions entity " +
+        "(e.g. `eav_definition_table: 'field_definition'`).",
+      path: ['eav_definition_table'],
+    },
+  );
 
 export type EntityDefinition = z.infer<typeof EntityDefinitionSchema>;
 

--- a/templates/entity/new/clean-lite-ps/module.ejs.t
+++ b/templates/entity/new/clean-lite-ps/module.ejs.t
@@ -11,6 +11,9 @@ import { DatabaseModule } from '@shared/database/database.module';
 <% if (eavEnabled) { -%>
 import { FieldValuesModule } from '../field_values/field_values.module';
 <% } -%>
+<% if (eavValueTable) { -%>
+import { <%= eavDefinitionPluralPascal %>Module } from '../<%= eavDefinitionEntityPlural %>/<%= eavDefinitionEntityPlural %>.module';
+<% } -%>
 
 import { <%= classNames.repository %> } from './<%= entityName %>.repository';
 import { <%= classNames.service %> } from './<%= entityName %>.service';
@@ -39,6 +42,9 @@ import { <%= classNames.searchController %> } from './<%= entityName %>-search.c
     DatabaseModule,
 <% if (eavEnabled) { -%>
     FieldValuesModule,
+<% } -%>
+<% if (eavValueTable) { -%>
+    <%= eavDefinitionPluralPascal %>Module,
 <% } -%>
     // TODO: Add subsystem modules as needed (EventsSubsystemModule, IntegrationsSubsystemModule, etc.)
     // Cross-domain modules from relationships:

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -618,6 +618,24 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // writes. Consumer must provide `@shared/eav-helpers` and `FieldValueService`.
   const eavEnabled = definition.eav === true;
 
+  // EAV value-table shape (task #23) — when true, this entity IS the value
+  // table. Templates emit compound methods (upsertFieldsTransactional,
+  // findMergedByEntity) on the service, upsertCurrentValues on the repo,
+  // and auto-wire the paired field-definitions module for DI.
+  const eavValueTable = definition.eav_value_table === true;
+  const eavDefinitionEntity = eavValueTable
+    ? (definition.eav_definition_table || null)
+    : null;
+  const eavDefinitionEntityPlural = eavDefinitionEntity
+    ? pluralize(eavDefinitionEntity)
+    : null;
+  const eavDefinitionPascal = eavDefinitionEntity
+    ? pascalCase(eavDefinitionEntity)
+    : null;
+  const eavDefinitionPluralPascal = eavDefinitionEntityPlural
+    ? pascalCase(eavDefinitionEntityPlural)
+    : null;
+
   // Family resolution
   const family = entity.family || 'base';
   const familyConfig = FAMILY_MAP[family] || FAMILY_MAP['base'];
@@ -798,6 +816,13 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
 
     // EAV (ADR-13)
     eavEnabled,
+
+    // EAV value-table (task #23) — this entity IS the value table.
+    eavValueTable,
+    eavDefinitionEntity,
+    eavDefinitionEntityPlural,
+    eavDefinitionPascal,
+    eavDefinitionPluralPascal,
     // Search query (#16)
     searchQuery: searchQueryResolved,
     hasSearchQuery: !!searchQueryResolved,

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -7,8 +7,11 @@ import { Injectable, Inject } from '@nestjs/common';
 <% if (hasDeclarativeQueries) { -%>
 import { eq<%= hasMultiFieldQuery ? ', and' : '' %><%= hasOrderedQuery ? ', desc, asc' : '' %> } from 'drizzle-orm';
 <% } -%>
+<% if (eavValueTable) { -%>
+import { sql } from 'drizzle-orm';
+<% } -%>
 import { DRIZZLE } from '@shared/constants/tokens';
-import type { DrizzleClient } from '@shared/types/drizzle';
+import type { DrizzleClient<% if (eavValueTable) { %>, DrizzleTx<% } %> } from '@shared/types/drizzle';
 import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
 <% if (hasTimestamps || hasSoftDelete) { -%>
 import type { BehaviorConfig } from '@shared/base-classes/base-repository';
@@ -55,6 +58,48 @@ export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%=
 
   // TODO: Add entity-specific query methods here.
 <% } -%>
+<% if (eavValueTable) { -%>
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // EAV compound writes (task #23) — generated from eav_value_table: true
+  // ═══════════════════════════════════════════════════════════════════════
+  /**
+   * Upsert "current" value rows keyed by the composite unique
+   * (entity_type, entity_id, field_definition_id). Used by the service's
+   * upsertFieldsTransactional to dual-write a bag of dynamic fields
+   * atomically with the owning entity. Inherited upsertMany only
+   * supports single-column conflict targets — this override uses
+   * Drizzle's `onConflictDoUpdate` with an explicit column list.
+   */
+  async upsertCurrentValues(
+    inputs: Array<Partial<<%= classNames.entity %>>>,
+    tx?: DrizzleTx,
+  ): Promise<<%= classNames.entity %>[]> {
+    if (inputs.length === 0) return [];
+    const data = inputs.map((input) =>
+      this.withTimestamps(input as Record<string, unknown>, 'create'),
+    );
+    const runner = this.runner(tx);
+    const rows = await runner
+      .insert(this.table)
+      .values(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+      .onConflictDoUpdate({
+        target: [
+          this.table['entityType'],
+          this.table['entityId'],
+          this.table['fieldDefinitionId'],
+        ],
+        set: {
+          value: sql`excluded.value`,
+          userId: sql`excluded.user_id`,
+          updatedAt: sql`excluded.updated_at`,
+        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      })
+      .returning();
+    return rows as <%= classNames.entity %>[];
+  }
+<% } -%>
+
   // Inherited from <%= repositoryBaseClass %>:
 <%_ repositoryInheritedMethods.forEach(line => { _%>
   //   <%= line %>

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -12,6 +12,11 @@ import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
 <% if (eavEnabled) { -%>
 import { FieldValueService } from '../field_values/field_value.service';
 <% } -%>
+<% if (eavValueTable) { -%>
+import { toEavRows, mergeEavRows } from '@shared/eav-helpers';
+import type { DrizzleTx } from '@shared/types/drizzle';
+import { <%= eavDefinitionPascal %>Repository } from '../<%= eavDefinitionEntityPlural %>/<%= eavDefinitionEntity %>.repository';
+<% } -%>
 
 @Injectable()
 export class <%= classNames.service %> extends WithAnalytics(
@@ -27,6 +32,9 @@ export class <%= classNames.service %> extends WithAnalytics(
     protected readonly repository: <%= classNames.repository %>,
 <% if (eavEnabled) { -%>
     private readonly fieldValues: FieldValueService,
+<% } -%>
+<% if (eavValueTable) { -%>
+    private readonly definitionRepo: <%= eavDefinitionPascal %>Repository,
 <% } -%>
   ) {
     super(repository);
@@ -69,6 +77,48 @@ export class <%= classNames.service %> extends WithAnalytics(
         return { ...entity, fields };
       }),
     );
+  }
+<% } %>
+<% if (eavValueTable) { %>
+  /**
+   * EAV compound write (task #23) — upserts a bag of dynamic fields onto
+   * an owning entity in a single transaction. Resolves field keys to
+   * definition ids internally (by reading <%= eavDefinitionPascal %>Repository),
+   * so use-cases inject only this service. Unknown keys are skipped; the
+   * caller is expected to have created the definitions first (auto-create
+   * is a later step).
+   */
+  async upsertFieldsTransactional(
+    entityType: string,
+    entityId: string,
+    userId: string,
+    fields: Record<string, unknown>,
+    tx?: DrizzleTx,
+  ): Promise<void> {
+    if (!fields || Object.keys(fields).length === 0) return;
+    const allDefs = await this.definitionRepo.list();
+    const defs = allDefs.filter((d) => (d as any).entityType === entityType);
+    const defIdByKey = new Map(defs.map((d) => [d.key, d.id]));
+    const rows = toEavRows(entityId, entityType, userId, fields, defIdByKey);
+    if (rows.length === 0) return;
+    await this.repository.upsertCurrentValues(rows as Array<Partial<<%= classNames.entity %>>>, tx);
+  }
+
+  /**
+   * EAV paired read (task #23) — returns the current merged `{ key: value }`
+   * bag for one owning entity. Resolves definition ids to keys internally.
+   */
+  async findMergedByEntity(
+    entityType: string,
+    entityId: string,
+  ): Promise<Record<string, unknown>> {
+    const [rows, allDefs] = await Promise.all([
+      this.repository.findByEntityIdAndType(entityId, entityType),
+      this.definitionRepo.list(),
+    ]);
+    const defs = allDefs.filter((d) => (d as any).entityType === entityType);
+    const defsById = new Map(defs.map((d) => [d.id, { key: d.key }]));
+    return mergeEavRows(rows as any, defsById);
   }
 <% } %>
 }


### PR DESCRIPTION
Stacked on #54. Stacked chain: `main ← #53 ← #54 ← #55`.

Collapses the EAV adoption surface from a 5-item consumer contract (see #53 body) to: **run `codegen project init`, declare `eav: true` on entities, declare `eav_value_table: true` on your value table.** Everything that isn't genuinely consumer-varying moves into codegen.

## Changes

### 1. Template emission for the value-table shape (commit `dad0459`)

New schema flags at the root of entity YAML:

- `eav_value_table: true` — declares THIS entity IS an EAV value table.
- `eav_definition_table: <singular-entity-name>` — identifies the paired field-definitions entity. Required when `eav_value_table: true`.

When set, codegen emits:

- **Repository** gains `upsertCurrentValues(rows, tx?)` with a composite `(entity_type, entity_id, field_definition_id)` conflict target via Drizzle's `onConflictDoUpdate`. Set block uses `excluded.*` refs so repeated upserts update in place.
- **Service** gains:
  - `upsertFieldsTransactional(entityType, entityId, userId, fields, tx?)` — resolves field keys to definition ids internally (via the injected definition repo's `list()` + filter by entity_type), builds rows via `toEavRows`, delegates to the repository's upsert. Unknown keys skipped; caller is expected to have created definitions first.
  - `findMergedByEntity(entityType, entityId)` — reads value rows + definitions in parallel, collapses via `mergeEavRows`.
  - Constructor injection of `<DefinitionPascal>Repository`.
- **Module** auto-imports `<DefinitionPlural>Module` so DI resolves the definition repo.

Uses `list()` + filter (not `findByEntityType`) so consumers don't need a paired declarative query on the definition entity. Definition tables are tiny metadata — full-scan is fine.

Schema refinement: `eav_definition_table` is required when `eav_value_table: true`, with an error message that explains the fix.

### 2. Tx-aware runtime base classes + scaffold additions (commit `f79ec80`)

Ports the consumer-side A0 work into the upstream runtime:

- `BaseRepository.runner(tx)` helper — trivial selector that returns the tx or the repo's own client. All write methods (`create`, `update`, `delete`, `upsertMany`) accept optional `tx?: DrizzleTx` and thread through `runner()`. Reads unchanged.
- `BaseService.create/update/delete` accept + forward `tx?` to the repository. `IBaseRepository` widened.
- `MetadataEntityRepository.upsertMany` signature reordered from `(inputs, conflictTarget?)` to `(inputs, tx?, options?)` to stay assignable to the widened base. `conflictTarget` moves into the options object. `IMetadataEntityRepository` + `MetadataEntityService.upsertValues` updated to match.
- `DrizzleTx` type alias added to `runtime/types/drizzle.ts`.

Scaffold additions (vendored via `codegen project init`):

- `runtime/pipes/zod-validation.pipe.ts` — the NestJS PipeTransform from PR #54's consumer contract. Generated controllers reference it via `@Body(new ZodValidationPipe(Schema))`.
- `runtime/eav-helpers.ts` — `toEavRows` + `mergeEavRows` pure helpers. Used by the generated service in (1).

`VENDORED_RUNTIME_FILES` in `src/cli/shared/init-scaffold.ts` extended to target these at `src/shared/pipes/zod-validation.pipe.ts` and `src/shared/eav-helpers.ts` respectively.

### 3. Docs (commit `bcacdbf`)

`docs/CONSUMER-SETUP.md`:
- Adds sections for the new `pipes/` and `eav-helpers.ts` scaffold files.
- New top-level "EAV dual-write — opt-in per entity" section documenting both flags (`eav: true` on owners, `eav_value_table: true` on the value table), what each emits, the `user_id` v1 assumption, and the minimal consumer obligation ("author field_definition rows before referencing them").

## Consumer impact — dealbrain-v2 follow-up

After this merges upstream and dealbrain-v2 bumps `@pattern-stack/codegen`:

1. Re-run `codegen project init --force` → picks up the new vendored scaffolds.
2. `field_value.yaml` adds `eav_value_table: true` + `eav_definition_table: field_definition`.
3. Regenerate → compound methods emit directly. Hand extensions on `FieldValueService` (A0.5) and `FieldValueRepository` (A0.6) become deletable.
4. `docs/hand-extended-generated-files.md` registry shrinks from 4 entries to 1 (only the composite unique-index on `field_value.entity.ts` remains, and even that could move into a codegen feature in a future PR).
5. A0's consumer-side base-service edits become redundant — init restores the scaffold version.

## Dependencies

- Stacked on #54. When #54 merges to main, GitHub auto-retargets this PR. When #53 + #54 both merge, this targets main.
- Template contract matches dealbrain-v2's A0.5/A0.6 semantics exactly — no consumer adjustment needed beyond the re-init + YAML edit.

## Tests

- **Template emission**: `src/__tests__/clean-lite-ps/eav-value-table-templates.test.ts` — 12 tests covering schema validation (flag-pair accepted, half-specified rejected, absence accepted), prompt-extension locals, repository + service + module emission (imports, signatures, method bodies), and end-to-end composition (`eav: true` owner + `eav_value_table: true` value table in the same graph).
- **Runtime tx threading**: `src/__tests__/runtime/base-classes/base-repository.spec.ts` gains 6 new tests covering `runner(tx)` preferring the tx over the repo client on create/update/delete/upsertMany, plus the fall-through case. Existing 19 tests pinned to the old signatures updated.
- **Init scaffold**: `src/__tests__/cli/project.test.ts` gains 2 tests asserting the new scaffold entries (ZodValidationPipe, eav-helpers) appear in `buildInitPlan`'s output.

Full `bun test`: 587 pass / 17 fail / 10 errors — same 17/10 as baseline main (graph-components react, init-scaffold write-path, barrel-generator). Zero regressions from this PR.

Full clean-lite-ps suite: 94/94 pass.

`bun run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)