### PR TITLE
fix(clean-lite-ps): plumb hasUserTracking through prompt-extension (#38)

### DIFF
--- a/src/__tests__/clean-lite-ps/repository-template.test.ts
+++ b/src/__tests__/clean-lite-ps/repository-template.test.ts
@@ -86,6 +86,44 @@ describe('clean-lite-ps repository template — behaviors config (issue #33)', (
     expect(output).toContain('softDelete: true');
   });
 
+  // Issue #38 — hasUserTracking plumbed through prompt-extension.
+  // Previously the template hard-coded `userTracking: false` even when the
+  // entity declared `user_tracking` in its behaviors array.
+  it('emits behaviors override with userTracking: true when user_tracking behavior is present', () => {
+    const def = { ...baseEntity, behaviors: ['timestamps', 'user_tracking'] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    expect(output).toContain('protected override readonly behaviors: BehaviorConfig');
+    expect(output).toContain('timestamps: true');
+    expect(output).toContain('softDelete: false');
+    expect(output).toContain('userTracking: true');
+  });
+
+  it('emits behaviors block with only userTracking: true when user_tracking is the sole behavior', () => {
+    const def = { ...baseEntity, behaviors: ['user_tracking'] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    // The block must still be emitted (fix verified at the template
+    // `if (hasTimestamps || hasSoftDelete || hasUserTracking)` guard).
+    expect(output).toContain('protected override readonly behaviors: BehaviorConfig');
+    expect(output).toContain('timestamps: false');
+    expect(output).toContain('softDelete: false');
+    expect(output).toContain('userTracking: true');
+    expect(output).toContain(
+      "import type { BehaviorConfig } from '@shared/base-classes/base-repository';",
+    );
+  });
+
+  it('emits userTracking: false when user_tracking behavior is absent', () => {
+    const def = { ...baseEntity, behaviors: ['timestamps'] };
+    const locals = buildCleanLitePsLocals(def, {});
+    const output = renderRepository(locals);
+
+    expect(output).toContain('userTracking: false');
+  });
+
   it('omits behaviors override and BehaviorConfig import when no behaviors are declared', () => {
     const def = { ...baseEntity, behaviors: [] };
     const locals = buildCleanLitePsLocals(def, {});

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -647,6 +647,7 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const behaviorNames = behaviors.map((b) => (typeof b === 'string' ? b : b.name));
   const hasTimestamps = behaviorNames.includes('timestamps');
   const hasSoftDelete = behaviorNames.includes('soft_delete');
+  const hasUserTracking = behaviorNames.includes('user_tracking');
   const hasExternalIdTracking = behaviorNames.includes('external_id_tracking');
 
   // Process declarative queries
@@ -809,6 +810,7 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     // Behavior flags (also exposed at top level for template use)
     hasTimestamps,
     hasSoftDelete,
+    hasUserTracking,
     hasExternalIdTracking,
 
     // Generation toggles

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -13,7 +13,7 @@ import { sql } from 'drizzle-orm';
 import { DRIZZLE } from '@shared/constants/tokens';
 import type { DrizzleClient<% if (eavValueTable) { %>, DrizzleTx<% } %> } from '@shared/types/drizzle';
 import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
-<% if (hasTimestamps || hasSoftDelete) { -%>
+<% if (hasTimestamps || hasSoftDelete || hasUserTracking) { -%>
 import type { BehaviorConfig } from '@shared/base-classes/base-repository';
 <% } -%>
 import { <%= entityNamePlural %>, type <%= classNames.entity %> } from './<%= entityName %>.entity';
@@ -21,13 +21,13 @@ import { <%= entityNamePlural %>, type <%= classNames.entity %> } from './<%= en
 @Injectable()
 export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%= classNames.entity %>> {
   readonly table = <%= entityNamePlural %>;
-<% if (hasTimestamps || hasSoftDelete) { -%>
+<% if (hasTimestamps || hasSoftDelete || hasUserTracking) { -%>
 
   // Behaviors declared in YAML -> generated as config object
   protected override readonly behaviors: BehaviorConfig = {
     timestamps: <%= !!hasTimestamps %>,
     softDelete: <%= !!hasSoftDelete %>,
-    userTracking: false,
+    userTracking: <%= !!hasUserTracking %>,
   };
 <% } -%>
 


### PR DESCRIPTION
## Summary
- `prompt-extension.js` now reads `user_tracking` from the behaviors array and exposes `hasUserTracking` in template locals (was only deriving `timestamps` and `soft_delete`)
- `repository.ejs.t` interpolates `userTracking: <%= !!hasUserTracking %>` instead of hard-coding `false`, and emits the behaviors block whenever any of the three flags are set
- Adds three new cases to `repository-template.test.ts` — `user_tracking` combined with `timestamps`, `user_tracking` alone (asserts block + `BehaviorConfig` import are still emitted), and `user_tracking` absent

Same class of bug as #33, different flag. Blast radius is low today — no clean-lite-ps entity in the demo or tests uses `user_tracking` yet — but the plumbing is now correct before anyone relies on it.

## Test plan
- [x] `bun test src/__tests__/clean-lite-ps/repository-template.test.ts` — 9 pass, 0 fail
- [x] `bun test` full suite — 662 pass, 0 fail, 61 skip (baseline unchanged)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)