### PR TITLE
fix(codegen): decimal → z.coerce.string() in Clean Architecture Zod map

### DIFF
--- a/src/__tests__/schema/field-type-to-zod.test.ts
+++ b/src/__tests__/schema/field-type-to-zod.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Field type → Zod mapping tests
+ *
+ * Regression coverage for issue #43: Drizzle returns PG `numeric`
+ * (YAML `decimal`) as a JS string, so the emitted Zod schema must not
+ * be `z.number()` (runtime mismatch at the DTO boundary). Mirrors the
+ * clean-lite-ps fix in #35/PR #42.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { fieldTypeToZod } from "../../schema/entity-definition.schema";
+
+describe("fieldTypeToZod (Clean Architecture)", () => {
+	it("maps decimal to a coerced string (issue #43)", () => {
+		// Drizzle returns `numeric` as a JS string. Keeping the Zod type a
+		// string preserves precision and avoids the string-leak bug.
+		expect(fieldTypeToZod.decimal).toBe("z.coerce.string()");
+		expect(fieldTypeToZod.decimal).not.toBe("z.number()");
+	});
+
+	it("keeps json as z.unknown() (already fixed alongside #35)", () => {
+		expect(fieldTypeToZod.json).toBe("z.unknown()");
+	});
+
+	it("maps integer to z.number().int()", () => {
+		expect(fieldTypeToZod.integer).toBe("z.number().int()");
+	});
+});

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -837,7 +837,11 @@ export const fieldTypeToDrizzle: Record<FieldType, string> = {
 export const fieldTypeToZod: Record<FieldType, string> = {
   string: "z.string()",
   integer: "z.number().int()",
-  decimal: "z.number()",
+  // Drizzle maps PG `numeric` to a JS string to preserve precision.
+  // Keep the Zod type as a (coerced) string so the DTO aligns with the
+  // runtime value flowing through Drizzle — parallel to the clean-lite-ps
+  // fix from #35/PR #42. See issue #43.
+  decimal: "z.coerce.string()",
   boolean: "z.boolean()",
   uuid: "z.string().uuid()",
   date: "z.date()",

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -573,7 +573,10 @@ export default {
     const zodTypes = {
       string: "z.string()",
       integer: "z.number().int()",
-      decimal: "z.number()",
+      // Drizzle returns PG `numeric` as a JS string; bare `z.number()` would
+      // reject it at the DTO boundary. Keep the value a (coerced) string —
+      // mirrors the clean-lite-ps fix from #35/PR #42. See issue #43.
+      decimal: "z.coerce.string()",
       boolean: "z.boolean()",
       uuid: "z.string().uuid()",
       date: "z.coerce.date()",


### PR DESCRIPTION
## Summary

Fixes issue #43 — the string-leak bug from #35 lived in a second place.

`src/schema/entity-definition.schema.ts#fieldTypeToZod` and the parallel
`zodTypes` map in `templates/entity/new/prompt.js` both mapped `decimal`
→ `z.number()`. Drizzle returns PG `numeric` as a JS string (to preserve
precision), so generated Clean Architecture DTOs rejected valid runtime
values at the NestJS controller boundary.

Mirrors the clean-lite-ps fix from PR #42: `decimal` now emits
`z.coerce.string()` so the value stays a string end-to-end. Consumers
that want a number can refine downstream without precision loss risk.

Note: PR #42's description says `z.coerce.number()`, but the actual
landed fix (and the test at `src/__tests__/clean-lite-ps/dto-template.test.ts`)
uses `z.coerce.string()`. This PR matches the landed behavior, not the
stale description.

## Changes

- `src/schema/entity-definition.schema.ts` — `fieldTypeToZod.decimal` → `z.coerce.string()`
- `templates/entity/new/prompt.js` — same fix in the in-template `zodTypes` map used by the Clean Architecture DTO template
- `src/__tests__/schema/field-type-to-zod.test.ts` — new regression test pinning decimal / json / integer mappings

## Test plan

- [x] `bun test src/__tests__/schema/field-type-to-zod.test.ts` — 3 pass
- [x] `bun test src/__tests__/clean-lite-ps/dto-template.test.ts` — 5 pass (unchanged)
- [x] `bun test` — 662 pass, 0 fail, 61 skip

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)