### PR TITLE
JOB-2 — Protocols + base types for job orchestration

### DIFF
--- a/docs/specs/JOB-2.md
+++ b/docs/specs/JOB-2.md
@@ -2,19 +2,21 @@
 
 **Issue:** JOB-2
 **Status:** Draft
-**Last Updated:** 2026-04-18
+**Last Updated:** 2026-04-20
 **Depends on:** JOB-1 (Drizzle schemas — row types imported by protocols)
 **Blocks:** JOB-3 (Drizzle backends), JOB-4 (Memory backends), JOB-7 (scopeable flag uses `ScopeRef` shape from this issue)
 
 ## Overview
 
-Define the stable public API surface for the job orchestration domain layer: three protocol interfaces (`IJobOrchestrator`, `IJobRunService`, `IJobStepService`), the `JobHandlerBase` abstract class with `JobContext<TInput>`, the `@JobHandler` decorator with its full metadata shape, the `ParentClosePolicy` enum, and injection tokens. No backend implementations ship in this PR. `IJobQueue` and everything in `runtime/subsystems/jobs/` that currently exists is untouched.
+Define the stable public API surface for the job orchestration domain layer: three protocol interfaces (`IJobOrchestrator`, `IJobRunService`, `IJobStepService`), the `JobHandlerBase` abstract class with `JobContext<TInput>`, the `@JobHandler` decorator with its full metadata shape, the `ParentClosePolicy` enum, and injection tokens. No backend implementations ship in this PR. JOB-1's Drizzle schema (tables, enums, row types) is preserved untouched; JOB-2 only adds new files alongside it.
 
 ## Context
 
-The existing `jobs/` subsystem exports `IJobQueue` — a four-method executor port (`enqueue`, `process`, `schedule`, `cancel`) backed by Drizzle, BullMQ, Redis, and Memory. It models *how to dispatch a unit of work*. It does not model runs, hierarchy, scoping, steps, or retry policy. ADR-022 adds an orchestration layer above it. `IJobQueue` remains unchanged; the orchestrator calls `IJobQueue.enqueue('job_run_tick', { runId })` internally when it needs to schedule execution.
+JOB-1 removed the legacy executor layer in its entirety — `IJobQueue`, `JOB_QUEUE`, the four backends (Drizzle/BullMQ/Redis/Memory), and `jobs.module.ts` are all gone. What remains in `runtime/subsystems/jobs/` at the start of JOB-2 is the orchestration schema (`job`, `job_run`, `job_step` tables + enums + row types) and a barrel that re-exports those symbols.
 
-JOB-2 delivers only the TypeScript types and interfaces that every downstream PR (backends, modules, templates) depends on. It is the contract — nothing else.
+ADR-022's single-layer architecture means there is no "above" and "below": the orchestrator writes `job_run` rows directly, and the JobWorker of JOB-3 polls `job_run` via `SELECT ... FOR UPDATE SKIP LOCKED`. No dispatch port sits between them.
+
+JOB-2 delivers only the TypeScript types, interfaces, and the `@JobHandler` decorator/registry that every downstream PR (backends, modules, templates) depends on. It is the contract — nothing else.
 
 ## Architecture
 
@@ -42,7 +44,7 @@ JobHandlerBase<TInput, TOutput>
 | `runtime/subsystems/jobs/job-step-service.protocol.ts` | create | `IJobStepService` with step record and fetch |
 | `runtime/subsystems/jobs/job-handler.base.ts` | create | `JobHandlerBase`, `JobContext<TInput>`, `@JobHandler` decorator, `ParentClosePolicy` enum, handler metadata types |
 | `runtime/subsystems/jobs/jobs-domain.tokens.ts` | create | `JOB_ORCHESTRATOR`, `JOB_RUN_SERVICE`, `JOB_STEP_SERVICE` Symbol tokens |
-| `runtime/subsystems/jobs/index.ts` | modify | Re-export all new types alongside existing exports |
+| `runtime/subsystems/jobs/index.ts` | modify | Re-export all new types; existing JOB-1 exports preserved |
 
 ## Interfaces
 
@@ -238,7 +240,7 @@ export const JOB_STEP_SERVICE = Symbol('JOB_STEP_SERVICE');
 3. Create `job-run-service.protocol.ts` (imports `JobRun` from step 2).
 4. Create `job-step-service.protocol.ts` (imports `JobStepRow` from JOB-1).
 5. Create `job-handler.base.ts` — full file; ensure `JOB_HANDLER_REGISTRY` is module-singleton (no circular imports).
-6. Update `runtime/subsystems/jobs/index.ts` — re-export new values with `export` and types with `export type`. Existing executor-layer exports untouched.
+6. Update `runtime/subsystems/jobs/index.ts` — re-export new values with `export` and types with `export type`. Existing JOB-1 schema exports preserved.
 
 ## Testing Strategy
 
@@ -248,7 +250,7 @@ JOB-2 ships no runtime logic, only types and the decorator registry. Tests are c
 
 **Registry test (`__tests__/job-handler.registry.test.ts`):** Import a decorated class; assert `JOB_HANDLER_REGISTRY.get('onboarding')` is populated with correct `handlerClass` and `meta`. A second handler type registers independently. Same-type double-registration overwrites (last-wins) and emits a warning log outside test env.
 
-**Token test (`__tests__/jobs-domain.tokens.test.ts`):** All three tokens are `Symbol`, distinguishable from each other and from `JOB_QUEUE`.
+**Token test (`__tests__/jobs-domain.tokens.test.ts`):** All three tokens are `Symbol` and distinguishable from each other.
 
 All three test files run under `just test-unit`.
 
@@ -260,12 +262,12 @@ All three test files run under `just test-unit`.
 - [ ] `ParentClosePolicy` enum: `Terminate | Cancel | Abandon`.
 - [ ] `@JobHandler<OnboardingInput>('onboarding', meta)` on a class extending `JobHandlerBase<OnboardingInput>` compiles; `ctx.input` is `OnboardingInput` without a cast.
 - [ ] `JobContext` does NOT have `waitFor`, `signal`, or `sleep`; comment in file notes this.
-- [ ] All three domain tokens are `Symbol` values, named distinctly from `JOB_QUEUE`.
-- [ ] `index.ts` re-exports new symbols without removing existing ones.
+- [ ] All three domain tokens are `Symbol` values, each distinct from the others.
+- [ ] `index.ts` re-exports new symbols without removing existing JOB-1 schema exports.
 
 ## Open Questions (with proposed resolutions)
 
-- [ ] **OQ-1 — `ScopeRef.entity` type.** Use a second generic parameter `TScope extends string = string` in `ScopeRef`. Default widens to `string`; JOB-7 can narrow at the call site without modifying this file.
+- [x] **OQ-1 — `ScopeRef.entity` type.** **Resolved 2026-04-20: shipped with the parameterised signature `ScopeRef<TInput, TScope extends string = string>`.** Default widens to `string`; JOB-7 narrows `TScope` to the generated `ScopeEntityType` union at the call site without modifying this file.
 
 - [ ] **OQ-2 — `ScopeEntityType` union file location (ADR-022 Open Question #5).** Proposed: emit to `src/shared/jobs/scope-entity-type.ts` in the consumer project. Reasoning: (a) generated, not runtime; (b) `src/shared/` already holds generated cross-cutting types; (c) short, predictable import path `@shared/jobs/scope-entity-type`. Must be confirmed before JOB-7 templates.
 
@@ -278,6 +280,4 @@ All three test files run under `just test-unit`.
 - ADR-022: `docs/adrs/ADR-022-job-orchestration-domain-model.md`
 - Issue breakdown: `docs/specs/ADR-022-phase-1-issues.md`
 - Protocol style reference: `runtime/subsystems/events/event-bus.protocol.ts`
-- Existing narrow executor: `runtime/subsystems/jobs/job-queue.protocol.ts`
-- Token pattern reference: `runtime/subsystems/jobs/jobs.tokens.ts`
-- Schema row types (dependency): `runtime/subsystems/jobs/job-orchestration.schema.ts` (produced by JOB-1)
+- Schema row types (live dependency): `runtime/subsystems/jobs/job-orchestration.schema.ts` (produced by JOB-1 — `JobRunRow`, `JobStepRow`, and enum value tuples imported by JOB-2 protocols)

--- a/runtime/subsystems/jobs/index.ts
+++ b/runtime/subsystems/jobs/index.ts
@@ -1,5 +1,10 @@
+// ─── JOB-1: Drizzle schema (tables, enums, row types) ──────────────────────
 export { jobs, jobRuns, jobSteps } from './job-orchestration.schema';
-export type { JobDefinitionRow, JobRunRow, JobStepRow } from './job-orchestration.schema';
+export type {
+  JobDefinitionRow,
+  JobRunRow,
+  JobStepRow,
+} from './job-orchestration.schema';
 export {
   jobRunStatusEnum,
   jobStepKindEnum,
@@ -11,5 +16,52 @@ export {
   triggerSourceEnum,
 } from './job-orchestration.schema';
 
-// Subsequent issues add: protocols (JOB-2), backends (JOB-3, JOB-4),
-// modules (JOB-5). All net-new — nothing from the old executor layer survives.
+// ─── JOB-2: domain tokens ──────────────────────────────────────────────────
+export {
+  JOB_ORCHESTRATOR,
+  JOB_RUN_SERVICE,
+  JOB_STEP_SERVICE,
+} from './jobs-domain.tokens';
+
+// ─── JOB-2: orchestrator protocol ──────────────────────────────────────────
+export type {
+  IJobOrchestrator,
+  StartOptions,
+  CancelOptions,
+  JobRun,
+} from './job-orchestrator.protocol';
+
+// ─── JOB-2: run-service protocol ───────────────────────────────────────────
+export type {
+  IJobRunService,
+  ListForScopeOptions,
+} from './job-run-service.protocol';
+
+// ─── JOB-2: step-service protocol ──────────────────────────────────────────
+export type {
+  IJobStepService,
+  RecordStepInput,
+  JobStep,
+} from './job-step-service.protocol';
+
+// ─── JOB-2: handler base, decorator, registry, policy types ────────────────
+export {
+  ParentClosePolicy,
+  JobHandlerBase,
+  JobHandler,
+  JOB_HANDLER_REGISTRY,
+  JOB_HANDLER_METADATA_KEY,
+} from './job-handler.base';
+export type {
+  RetryPolicy,
+  ConcurrencyPolicy,
+  DedupePolicy,
+  ScopeRef,
+  JobHandlerMeta,
+  StepOptions,
+  SpawnChildOptions,
+  JobContext,
+} from './job-handler.base';
+
+// Subsequent issues add: backends (JOB-3, JOB-4), modules (JOB-5).
+// All net-new — nothing from the old executor layer survives.

--- a/runtime/subsystems/jobs/job-handler.base.ts
+++ b/runtime/subsystems/jobs/job-handler.base.ts
@@ -1,0 +1,173 @@
+/**
+ * Handler base class, JobContext, @JobHandler decorator, and policy types
+ * for the job orchestration domain (ADR-022, JOB-2).
+ *
+ * User-authored jobs subclass `JobHandlerBase<TInput, TOutput>` and decorate
+ * the class with `@JobHandler<TInput>('job_type', meta)`. The decorator
+ *   1. stores metadata via `Reflect.defineMetadata` so Nest's reflector can
+ *      pick it up at module boot, and
+ *   2. populates `JOB_HANDLER_REGISTRY` — a module-singleton map consumed by
+ *      `JobWorkerModule` (JOB-5) to materialise `job` rows and resolve
+ *      handler classes during claim/execute.
+ *
+ * No runtime orchestration lives here; this file is a pure type + decorator
+ * surface so downstream PRs (JOB-3..JOB-5) can implement against a stable
+ * shape.
+ */
+// TODO(logging-subsystem): swap to ILogger once ADR-028 lands
+import type { Logger } from '@nestjs/common';
+import type { JobRun } from './job-orchestrator.protocol';
+
+// ─── ParentClosePolicy ──────────────────────────────────────────────────────
+
+/**
+ * What happens to running child runs when a parent enters a terminal state.
+ * Stored on the child at spawn; changes to the parent after spawn do NOT
+ * retroactively rewrite children.
+ */
+export enum ParentClosePolicy {
+  Terminate = 'terminate',
+  Cancel = 'cancel',
+  Abandon = 'abandon',
+}
+
+// ─── Policy types ───────────────────────────────────────────────────────────
+
+export interface RetryPolicy {
+  attempts: number;
+  backoff: 'fixed' | 'exponential';
+  baseMs: number;
+  nonRetryableErrors?: string[];
+}
+
+export interface ConcurrencyPolicy<TInput> {
+  key: (input: TInput) => string;
+  collisionMode: 'queue' | 'reject' | 'replace';
+}
+
+export interface DedupePolicy<TInput> {
+  key: (input: TInput) => string;
+  windowMs: number;
+}
+
+/**
+ * Declarative scope reference. `TScope` is parameterised so JOB-7 can narrow
+ * `entity` to the generated `ScopeEntityType` union at the call site without
+ * modifying this file (OQ-1 resolution, 2026-04-20).
+ */
+export interface ScopeRef<TInput, TScope extends string = string> {
+  entity: TScope;
+  from: (input: TInput) => string;
+}
+
+export interface JobHandlerMeta<TInput> {
+  pool?: string;
+  scope?: ScopeRef<TInput>;
+  retry?: RetryPolicy;
+  concurrency?: ConcurrencyPolicy<TInput>;
+  dedupe?: DedupePolicy<TInput>;
+  timeoutMs?: number;
+  replayFrom?: 'scratch' | 'last_step' | 'last_checkpoint';
+}
+
+// ─── Runtime option shapes ──────────────────────────────────────────────────
+
+export interface StepOptions {
+  retry?: RetryPolicy;
+  timeoutMs?: number;
+}
+
+export interface SpawnChildOptions {
+  closePolicy?: ParentClosePolicy;
+  runAt?: Date;
+  priority?: number;
+  tags?: Record<string, string>;
+}
+
+// ─── JobContext ─────────────────────────────────────────────────────────────
+
+export interface JobContext<TInput> {
+  readonly input: TInput;
+  readonly run: JobRun;
+  step<TOutput>(
+    stepId: string,
+    fn: () => Promise<TOutput>,
+    opts?: StepOptions,
+  ): Promise<TOutput>;
+  spawnChild(type: string, input: unknown, opts?: SpawnChildOptions): Promise<JobRun>;
+  readonly logger: Logger;
+  // NOT in Phase 1 — deferred to ADR-025:
+  //   waitFor(kind, token, opts)
+  //   signal(token, payload)
+  //   sleep(ms)
+}
+
+// ─── JobHandlerBase ─────────────────────────────────────────────────────────
+
+export abstract class JobHandlerBase<TInput, TOutput = unknown> {
+  abstract run(ctx: JobContext<TInput>): Promise<TOutput>;
+}
+
+// ─── Registry + decorator ───────────────────────────────────────────────────
+
+/**
+ * Module-singleton map keyed by job type. Populated by the `@JobHandler`
+ * decorator at class definition time; consumed by `JobWorkerModule` (JOB-5)
+ * to upsert `job` rows and resolve handler classes during claim/execute.
+ */
+export const JOB_HANDLER_REGISTRY = new Map<
+  string,
+  {
+    type: string;
+    meta: JobHandlerMeta<unknown>;
+    handlerClass: new (...args: unknown[]) => JobHandlerBase<unknown>;
+  }
+>();
+
+export const JOB_HANDLER_METADATA_KEY = Symbol('JobHandlerMeta');
+
+/**
+ * Class decorator that registers a handler with the job type, the full
+ * metadata shape, and the target class constructor.
+ *
+ * Duplicate-type behaviour (OQ-3, resolved 2026-04-18):
+ *   - `NODE_ENV === 'production'` → throw; silent overwrite in prod is a
+ *     correctness bug.
+ *   - `NODE_ENV === 'test'`       → silent overwrite (tests intentionally
+ *     re-register handlers).
+ *   - otherwise (dev)             → `console.warn` + overwrite. `console`
+ *     is used intentionally instead of the Nest `Logger` — decorators run
+ *     at module-load time before any Nest container exists.
+ */
+export function JobHandler<TInput>(
+  type: string,
+  meta: JobHandlerMeta<TInput>,
+): ClassDecorator {
+  return (target) => {
+    if (JOB_HANDLER_REGISTRY.has(type)) {
+      const env = process.env.NODE_ENV;
+      if (env === 'production') {
+        throw new Error(
+          `[JobHandler] Duplicate registration for job type '${type}'. ` +
+            `Each @JobHandler must declare a unique type.`,
+        );
+      }
+      if (env !== 'test') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[JobHandler] Duplicate registration for job type '${type}'. ` +
+            `Overwriting previous handler — this is almost certainly a bug.`,
+        );
+      }
+    }
+
+    Reflect.defineMetadata(JOB_HANDLER_METADATA_KEY, { type, meta }, target);
+    JOB_HANDLER_REGISTRY.set(type, {
+      type,
+      meta: meta as JobHandlerMeta<unknown>,
+      handlerClass: target as unknown as new (
+        ...args: unknown[]
+      ) => JobHandlerBase<unknown>,
+    });
+  };
+}

--- a/runtime/subsystems/jobs/job-orchestrator.protocol.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.protocol.ts
@@ -1,0 +1,89 @@
+/**
+ * IJobOrchestrator — the primary port for the job orchestration domain
+ * (ADR-022, JOB-2).
+ *
+ * Consumers (use cases, event subscribers) inject this via
+ * `@Inject(JOB_ORCHESTRATOR)` and call `start` / `cancel` / `replay`.
+ * Concrete backends (JOB-3 Drizzle, JOB-4 Memory) satisfy this contract.
+ *
+ * Single-layer architecture reminder: there is no `IJobQueue` executor port.
+ * The orchestrator writes `job_run` rows directly; the `JobWorker` of JOB-3
+ * polls `job_run` via `SELECT ... FOR UPDATE SKIP LOCKED`.
+ */
+import type { JobRunRow } from './job-orchestration.schema';
+import type { ParentClosePolicy } from './job-handler.base';
+
+/**
+ * Public return type for orchestrator reads. Re-exported as `JobRun` so
+ * protocols and consumer code don't import the raw Drizzle row name.
+ */
+export type JobRun = JobRunRow;
+
+export interface StartOptions {
+  /**
+   * Optional scope attachment. `listForScope` queries use this pair; the
+   * column is free-text (no CHECK constraint) — type safety for `entityType`
+   * lives at the TS layer via JOB-7's generated `ScopeEntityType` union.
+   */
+  scope?: { entityType: string; entityId: string };
+
+  /** Overrides the pool declared in `@JobHandler({ pool })` metadata. */
+  pool?: string;
+
+  /** Schedule the run. When omitted, run as soon as the worker claims it. */
+  runAt?: Date;
+
+  /** 0 = default; higher values claimed first by `ORDER BY priority DESC`. */
+  priority?: number;
+
+  /** Free-form routing/audit tags. Persisted on `job_run.tags`. */
+  tags?: Record<string, string>;
+
+  /** Must align with `triggerSourceEnum` values landed in JOB-1. */
+  triggerSource?: 'manual' | 'schedule' | 'event' | 'parent';
+
+  /** Optional reference to the triggering event, schedule, etc. */
+  triggerRef?: string;
+
+  /**
+   * What happens to this run's children if this run reaches a terminal
+   * state. Stored on the child at spawn time; see `ParentClosePolicy`.
+   */
+  parentClosePolicy?: ParentClosePolicy;
+
+  /** Internal — set by `ctx.spawnChild`. User code should not pass this. */
+  parentRunId?: string;
+}
+
+export interface CancelOptions {
+  /**
+   * Conceptually defaults to `true` for root cancellation — cascading via
+   * `root_run_id` is the expected behaviour when an operator cancels a
+   * run. Backends in JOB-3/JOB-4 implement the default; callers passing
+   * `false` opt into "cancel only this node, leave descendants".
+   */
+  cascade?: boolean;
+  reason?: string;
+}
+
+export interface IJobOrchestrator {
+  /**
+   * Create a `pending` `job_run` row and return it. Does NOT block waiting
+   * for the worker to pick the run up; consumers that need completion
+   * semantics should subscribe to the emitted completion event.
+   */
+  start(type: string, input: unknown, opts?: StartOptions): Promise<JobRun>;
+
+  /**
+   * Cancel a run (and, by default, its entire root-run subtree). Idempotent
+   * — cancelling an already-terminal run is a no-op.
+   */
+  cancel(runId: string, opts?: CancelOptions): Promise<void>;
+
+  /**
+   * Re-run from the policy declared in `@JobHandler({ replayFrom })`.
+   * Returns the new `job_run` row (replay always spawns a fresh row —
+   * the original is preserved for audit).
+   */
+  replay(runId: string): Promise<JobRun>;
+}

--- a/runtime/subsystems/jobs/job-run-service.protocol.ts
+++ b/runtime/subsystems/jobs/job-run-service.protocol.ts
@@ -1,0 +1,54 @@
+/**
+ * IJobRunService — scope-oriented queries and bulk operations over
+ * `job_run` rows (ADR-022, JOB-2).
+ *
+ * This is a separate port from `IJobOrchestrator` because the access
+ * pattern is different: orchestrator mutates individual runs by id;
+ * run service scans by `(scope_entity_type, scope_entity_id)`.
+ */
+import type { JobRun } from './job-orchestrator.protocol';
+
+export interface ListForScopeOptions {
+  /**
+   * Single status or set. Widens to the full `JobRun['status']` union so
+   * callers can pass values straight from `jobRunStatusEnum`.
+   */
+  status?: JobRun['status'] | JobRun['status'][];
+  jobType?: string;
+  limit?: number;
+  offset?: number;
+  orderBy?:
+    | 'created_at desc'
+    | 'created_at asc'
+    | 'run_at desc'
+    | 'run_at asc';
+}
+
+export interface IJobRunService {
+  /**
+   * Return runs attached to `(entityType, entityId)`. Backed by
+   * `idx_job_run_scope` for efficient reads.
+   */
+  listForScope(
+    entityType: string,
+    entityId: string,
+    opts?: ListForScopeOptions,
+  ): Promise<JobRun[]>;
+
+  /**
+   * Cancel every non-terminal run attached to `(entityType, entityId)`,
+   * cascading via `root_run_id`. Used e.g. when an Opportunity is closed
+   * and all its background work should stop.
+   */
+  cancelForScope(entityType: string, entityId: string): Promise<void>;
+
+  /**
+   * Push `run_at` forward on every `pending` run attached to the scope.
+   * Useful for "pause this account's background work until tomorrow".
+   */
+  rescheduleForScope(
+    entityType: string,
+    entityId: string,
+    newRunAt: Date,
+  ): Promise<void>;
+}

--- a/runtime/subsystems/jobs/job-step-service.protocol.ts
+++ b/runtime/subsystems/jobs/job-step-service.protocol.ts
@@ -1,0 +1,53 @@
+/**
+ * IJobStepService — record and fetch `job_step` rows for step-level
+ * memoization and replay (ADR-022, JOB-2).
+ *
+ * `ctx.step(id, fn)` in `JobHandlerBase` goes through this service:
+ * check for an existing `completed` row (memo hit, return `output`),
+ * otherwise record `running`, `await fn()`, terminal-state the row.
+ */
+import type { JobStepRow } from './job-orchestration.schema';
+
+export type JobStep = JobStepRow;
+
+export interface RecordStepInput {
+  jobRunId: string;
+  stepId: string;
+  /**
+   * `'task'` is the only value in `jobStepKindEnum` today; ADR-027 widens
+   * to include `tool_call | llm_call | wait | checkpoint | message`. The
+   * literal here intentionally mirrors the enum tuple in JOB-1.
+   */
+  kind: 'task';
+  seq: number;
+  input?: unknown;
+  output?: unknown;
+  error?: {
+    message: string;
+    stack?: string;
+    retryable: boolean;
+    attempt: number;
+  };
+  /**
+   * Must match the `jobStepStatusEnum` value tuple from JOB-1. Kept as a
+   * literal union here rather than `typeof jobStepStatusEnum.enumValues[number]`
+   * so protocol consumers don't need to import the schema module.
+   */
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+  startedAt?: Date;
+  finishedAt?: Date;
+  attempts?: number;
+}
+
+export interface IJobStepService {
+  /**
+   * Insert or update a `job_step` row. Backend implementations upsert on
+   * `(job_run_id, step_id)` — the `idx_job_step_run_step` unique index.
+   */
+  recordStep(input: RecordStepInput): Promise<JobStep>;
+
+  /**
+   * Lookup for memoization. Returns `null` when no prior row exists.
+   */
+  findStep(runId: string, stepId: string): Promise<JobStep | null>;
+}

--- a/runtime/subsystems/jobs/jobs-domain.tokens.ts
+++ b/runtime/subsystems/jobs/jobs-domain.tokens.ts
@@ -1,0 +1,14 @@
+/**
+ * Injection tokens for the job orchestration domain layer (ADR-022, JOB-2).
+ *
+ * Consumer code injects these symbols via `@Inject(JOB_ORCHESTRATOR)` etc.;
+ * concrete backends (JOB-3 Drizzle, JOB-4 Memory) provide the implementations
+ * through `JobsDomainModule.forRoot({ backend })` in JOB-5.
+ *
+ * Each token is a unique `Symbol` — guaranteed distinct from every other
+ * Symbol at runtime, which is exactly the uniqueness guarantee Nest's DI
+ * container relies on for token-based lookup.
+ */
+export const JOB_ORCHESTRATOR = Symbol('JOB_ORCHESTRATOR');
+export const JOB_RUN_SERVICE = Symbol('JOB_RUN_SERVICE');
+export const JOB_STEP_SERVICE = Symbol('JOB_STEP_SERVICE');

--- a/src/__tests__/runtime/subsystems/job-handler.base.types.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-handler.base.types.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Type-level compile-check for `JobHandlerBase` + `@JobHandler` (JOB-2).
+ *
+ * The value of this file is that `tsc` must be able to infer `ctx.input`
+ * as `OnboardingInput` (with no cast) and `run`'s return as
+ * `Promise<OnboardingOutput>`. The runtime `expect(true)` below only
+ * exists so Bun counts this file as a test — the real contract is that
+ * this module compiles.
+ */
+import 'reflect-metadata';
+import { describe, it, expect } from 'bun:test';
+import {
+  JobHandler,
+  JobHandlerBase,
+  type JobContext,
+} from '../../../../runtime/subsystems/jobs/job-handler.base';
+
+interface OnboardingInput {
+  userId: string;
+  plan: 'free' | 'pro';
+}
+
+interface OnboardingOutput {
+  welcomeEmailSent: boolean;
+}
+
+@JobHandler<OnboardingInput>('onboarding.types-test', {
+  pool: 'batch',
+  retry: { attempts: 3, backoff: 'exponential', baseMs: 1000 },
+})
+class OnboardingHandler extends JobHandlerBase<OnboardingInput, OnboardingOutput> {
+  async run(ctx: JobContext<OnboardingInput>): Promise<OnboardingOutput> {
+    // Must compile with no `as` / no generic re-annotation.
+    const _userId: string = ctx.input.userId;
+    const _plan: 'free' | 'pro' = ctx.input.plan;
+
+    // `ctx.run` is the `JobRun` row type.
+    const _runId: string = ctx.run.id;
+
+    // `ctx.step` preserves its inner return type.
+    const _stepResult: Promise<number> = ctx.step('noop', async () => 1);
+
+    void _userId;
+    void _plan;
+    void _runId;
+    void _stepResult;
+
+    return { welcomeEmailSent: true };
+  }
+}
+
+describe('JobHandlerBase — type compilation', () => {
+  it('decorated handler class compiles with strict generic flow', () => {
+    // Purely existence check — the important assertion is that this file
+    // type-checks. If `ctx.input` widened to `unknown`, the cast-free
+    // reads above would fail compilation.
+    expect(OnboardingHandler).toBeDefined();
+  });
+});

--- a/src/__tests__/runtime/subsystems/job-handler.registry.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-handler.registry.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Registry behaviour test for `@JobHandler` (JOB-2).
+ *
+ * Covers:
+ *   1. decorating a class populates `JOB_HANDLER_REGISTRY` with the
+ *      correct `{ type, meta, handlerClass }` shape;
+ *   2. independent types register independently;
+ *   3. in test mode (`NODE_ENV === 'test'`) same-type re-registration
+ *      silently overwrites — last wins. Tests intentionally re-register
+ *      handlers, so this is the documented behaviour;
+ *   4. in production (`NODE_ENV === 'production'`) same-type re-registration
+ *      throws. Silent overwrite in prod is a correctness bug.
+ *
+ * Every test clears the registry entries it adds in a `finally` block so
+ * parallel test files aren't polluted.
+ */
+import 'reflect-metadata';
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  JobHandler,
+  JobHandlerBase,
+  JOB_HANDLER_REGISTRY,
+  type JobContext,
+} from '../../../../runtime/subsystems/jobs/job-handler.base';
+
+interface AInput {
+  a: string;
+}
+interface BInput {
+  b: number;
+}
+
+const TYPE_A = 'registry-test.a';
+const TYPE_B = 'registry-test.b';
+const TYPE_DUP = 'registry-test.dup';
+const TYPE_PROD = 'registry-test.prod-throw';
+
+afterEach(() => {
+  JOB_HANDLER_REGISTRY.delete(TYPE_A);
+  JOB_HANDLER_REGISTRY.delete(TYPE_B);
+  JOB_HANDLER_REGISTRY.delete(TYPE_DUP);
+  JOB_HANDLER_REGISTRY.delete(TYPE_PROD);
+});
+
+describe('@JobHandler decorator — registry', () => {
+  it('populates JOB_HANDLER_REGISTRY with type, meta, handlerClass', () => {
+    @JobHandler<AInput>(TYPE_A, { pool: 'batch' })
+    class AHandler extends JobHandlerBase<AInput, void> {
+      async run(_ctx: JobContext<AInput>): Promise<void> {
+        // no-op
+      }
+    }
+
+    const entry = JOB_HANDLER_REGISTRY.get(TYPE_A);
+    expect(entry).toBeDefined();
+    expect(entry?.type).toBe(TYPE_A);
+    expect(entry?.meta.pool).toBe('batch');
+    expect(entry?.handlerClass).toBe(
+      AHandler as unknown as typeof entry.handlerClass,
+    );
+  });
+
+  it('registers independent types independently', () => {
+    @JobHandler<AInput>(TYPE_A, { pool: 'batch' })
+    class _AHandler extends JobHandlerBase<AInput, void> {
+      async run(): Promise<void> {}
+    }
+    @JobHandler<BInput>(TYPE_B, { pool: 'interactive' })
+    class _BHandler extends JobHandlerBase<BInput, void> {
+      async run(): Promise<void> {}
+    }
+
+    void _AHandler;
+    void _BHandler;
+
+    expect(JOB_HANDLER_REGISTRY.get(TYPE_A)?.meta.pool).toBe('batch');
+    expect(JOB_HANDLER_REGISTRY.get(TYPE_B)?.meta.pool).toBe('interactive');
+  });
+
+  it('in test mode, same-type re-registration silently overwrites (last wins)', () => {
+    // bun:test sets NODE_ENV='test'; guard the assumption so this test
+    // fails loudly if that ever changes.
+    expect(process.env.NODE_ENV).toBe('test');
+
+    @JobHandler<AInput>(TYPE_DUP, { pool: 'first' })
+    class _First extends JobHandlerBase<AInput, void> {
+      async run(): Promise<void> {}
+    }
+    @JobHandler<AInput>(TYPE_DUP, { pool: 'second' })
+    class Second extends JobHandlerBase<AInput, void> {
+      async run(): Promise<void> {}
+    }
+
+    void _First;
+
+    const entry = JOB_HANDLER_REGISTRY.get(TYPE_DUP);
+    expect(entry?.meta.pool).toBe('second');
+    expect(entry?.handlerClass).toBe(
+      Second as unknown as typeof entry.handlerClass,
+    );
+  });
+
+  it('in production mode, same-type re-registration throws', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      @JobHandler<AInput>(TYPE_PROD, { pool: 'batch' })
+      class _First extends JobHandlerBase<AInput, void> {
+        async run(): Promise<void> {}
+      }
+      void _First;
+
+      expect(() => {
+        @JobHandler<AInput>(TYPE_PROD, { pool: 'batch' })
+        class _Second extends JobHandlerBase<AInput, void> {
+          async run(): Promise<void> {}
+        }
+        void _Second;
+      }).toThrow(/Duplicate registration/);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+});

--- a/src/__tests__/runtime/subsystems/jobs-domain.tokens.spec.ts
+++ b/src/__tests__/runtime/subsystems/jobs-domain.tokens.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Token uniqueness test for the jobs domain layer (JOB-2).
+ *
+ * The three injection tokens must be `Symbol` values and distinct from each
+ * other — this is the only guarantee Nest's token-based DI relies on.
+ */
+import { describe, it, expect } from 'bun:test';
+import {
+  JOB_ORCHESTRATOR,
+  JOB_RUN_SERVICE,
+  JOB_STEP_SERVICE,
+} from '../../../../runtime/subsystems/jobs/jobs-domain.tokens';
+
+describe('jobs-domain.tokens', () => {
+  it('exports three Symbol tokens', () => {
+    expect(typeof JOB_ORCHESTRATOR).toBe('symbol');
+    expect(typeof JOB_RUN_SERVICE).toBe('symbol');
+    expect(typeof JOB_STEP_SERVICE).toBe('symbol');
+  });
+
+  it('each token is distinct from the others', () => {
+    expect(JOB_ORCHESTRATOR).not.toBe(JOB_RUN_SERVICE);
+    expect(JOB_ORCHESTRATOR).not.toBe(JOB_STEP_SERVICE);
+    expect(JOB_RUN_SERVICE).not.toBe(JOB_STEP_SERVICE);
+  });
+
+  it('symbols carry their name as description (aids debugging)', () => {
+    expect(JOB_ORCHESTRATOR.description).toBe('JOB_ORCHESTRATOR');
+    expect(JOB_RUN_SERVICE.description).toBe('JOB_RUN_SERVICE');
+    expect(JOB_STEP_SERVICE.description).toBe('JOB_STEP_SERVICE');
+  });
+});


### PR DESCRIPTION
## Summary

Define the stable public API surface above JOB-1's schemas. Contracts only — no backend logic (that ships in JOB-3 / JOB-4).

- Three domain service protocols: `IJobOrchestrator` (`start`/`cancel`/`replay`), `IJobRunService` (`listForScope`/`cancelForScope`/`rescheduleForScope`), `IJobStepService` (`recordStep`/`findStep`).
- `JobHandlerBase<TInput, TOutput>` + `JobContext<TInput>` with `step()` and `spawnChild()`. `waitFor`/`signal`/`sleep` deliberately omitted — deferred to ADR-025 / Phase 3 (inline comment flags this).
- `@JobHandler(type, meta)` decorator — populates a module-scope `JOB_HANDLER_REGISTRY` and `Reflect.defineMetadata`. OQ-3-resolved duplicate-type behaviour: production throws, test silent-overwrite (last wins), dev `console.warn` + overwrite.
- `ParentClosePolicy` enum; `RetryPolicy` / `ConcurrencyPolicy` / `DedupePolicy` shapes; parameterised `ScopeRef<TInput, TScope extends string = string>` (OQ-1 resolved — see `docs/specs/JOB-2.md`).
- Three `Symbol` tokens: `JOB_ORCHESTRATOR`, `JOB_RUN_SERVICE`, `JOB_STEP_SERVICE` in `jobs-domain.tokens.ts`.
- `runtime/subsystems/jobs/index.ts` preserves every JOB-1 export and adds the JOB-2 symbols grouped by value vs type.

## Spec drift fixed (living docs)

Updated `docs/specs/JOB-2.md` in-PR:
- Stripped the obsolete "`IJobQueue` untouched / orchestrator calls `IJobQueue.enqueue('job_run_tick', …)` internally" narrative — that executor layer was deleted in JOB-1; the JobWorker of JOB-3 polls `job_run` directly via `FOR UPDATE SKIP LOCKED`.
- Files-table + Implementation-Step wording: "existing executor-layer exports untouched" → "existing JOB-1 exports preserved".
- Dropped the AC clause about tokens being distinct from `JOB_QUEUE` (token removed in JOB-1).
- References: removed deleted `job-queue.protocol.ts` and `jobs.tokens.ts`; cited `job-orchestration.schema.ts` as the live dep.
- OQ-1 marked resolved 2026-04-20 with rationale.
- Last Updated → 2026-04-20. OQ-2 (ScopeEntityType union file location) remains open — JOB-7 territory.

## Test plan

- [x] `just test-unit` — 646 pass / 0 fail / 1561 expect(), ~413ms. Baseline + Docker validate out of scope (no templates, no runtime logic).
- [x] Compile-check: decorated `OnboardingHandler extends JobHandlerBase<OnboardingInput, OnboardingOutput>` — `ctx.input.userId` typed without casts.
- [x] Registry: decorator populates `JOB_HANDLER_REGISTRY` with correct shape; independent types register separately; `NODE_ENV=test` silent overwrite; `NODE_ENV=production` throws on duplicate.
- [x] Tokens: all three are `Symbol`, mutually distinct.
- [x] `reflect-metadata` present as peer `^0.2.0` + dev `^0.2.2`; test files `import 'reflect-metadata'` explicitly.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)