### PR TITLE
JOB-3 — Drizzle backends + JobWorker

### DIFF
--- a/docs/specs/JOB-3.md
+++ b/docs/specs/JOB-3.md
@@ -2,7 +2,7 @@
 
 **Issue:** JOB-3
 **Status:** Draft
-**Last Updated:** 2026-04-18
+**Last Updated:** 2026-04-20
 **Depends on:** JOB-1 (schema), JOB-2 (protocols + base types)
 **Blocks:** JOB-4 (memory backends must match this behaviour spec), JOB-5 (module wiring)
 
@@ -70,6 +70,21 @@ b. Transition target to `canceled` atomically: `UPDATE ... WHERE id = $runId AND
 c. If `opts.cascade !== false`: fetch descendants via `WHERE root_run_id = $rootRunId AND id != $runId AND status NOT IN (terminals)`. For each, branch on `parent_close_policy`:
 - `terminate` or `cancel` → transition to `canceled`
 - `abandon` → skip
+
+**`replay(runId)` (added during JOB-3 implementation, 2026-04-20):**
+
+a. Load the target run and its `job` definition. If the run is not in a terminal status (`completed` | `failed` | `timed_out` | `canceled`), throw `JobNotReplayableError`. Phase-1 protocol signature is `replay(runId)` with no options, so the effective replay mode is read from `job.replay_from` alone — user-override lands in a later phase.
+
+b. Resolve effective `replay_from` mode:
+- `scratch` → DELETE all `job_step` rows for this run.
+- `last_step` → DELETE only non-`completed` step rows; completed steps stay memoised so `ctx.step` cache-hits on resume.
+- `last_checkpoint` → **Phase 1 collapses to `last_step`.** The schema has no explicit checkpoint markers yet; delete only non-completed step rows. The two modes diverge in a later phase once `job_step.kind === 'checkpoint'` (ADR-027) is added.
+
+c. UPDATE `job_run`: `status='pending'`, `attempts=0`, `run_at=now()`, `started_at=null`, `finished_at=null`, `claimed_at=null`, `error=null`, `output=null`.
+
+d. Wrap steps (a)+(b)+(c) in a single transaction (per the transaction-boundary table — step reset + run reset must commit together).
+
+e. Return the updated `JobRun`.
 
 ### 2. `job-run-service.drizzle-backend.ts`
 
@@ -198,6 +213,22 @@ Proposed: `ON CONFLICT (type) DO UPDATE SET pool = EXCLUDED.pool, retry_policy =
 - **JOB-4** owns Memory backends (behavioural parity spec) + `JobWorker` unit tests
 - **JOB-5** owns `JobsDomainModule`, `JobWorkerModule`, boot-time validator, handler registry scan, pool config
 - `JobWorker` is backend-agnostic — used by both Drizzle and Memory via protocol injection
+
+## Implementation Decisions (landed with JOB-3, 2026-04-20)
+
+These were resolved during implementation. Kept here so JOB-4 (memory parity) and future maintainers see the rationale.
+
+- **Template evaluation for `concurrency_key_template` and `dedupe_key_template`.** Simple `{{field}}` single-key substitution against the `input` payload — no dotted paths, no Mustache/Handlebars dependency. A missing field throws `JobTemplateFieldMissingError` synchronously at `start()` time, so misconfiguration surfaces to the caller rather than silently producing a literal `"undefined"` key that bypasses dedupe/collision checks. Exported as `evaluateKeyTemplate(template, input)` from `job-orchestrator.drizzle-backend.ts` for reuse by the Memory backend in JOB-4.
+
+- **Error classes.** Four exported from `runtime/subsystems/jobs/jobs-errors.ts`: `JobTypeNotFoundError`, `JobCollisionError` (carries `incumbent: JobRun`), `JobNotReplayableError`, `JobTemplateFieldMissingError`. All re-exported from `runtime/subsystems/jobs/index.ts`. Memory backend (JOB-4) throws the same classes for behavioural parity.
+
+- **`last_step` vs `last_checkpoint` collapse at Phase 1.** Both modes currently delete only non-`completed` step rows, because the `job_step_kind` enum carries only `'task'` at Phase 1. They diverge once ADR-027 adds `checkpoint` as a step kind: `last_checkpoint` will preserve steps up to the most recent `kind='checkpoint'` row, whereas `last_step` will continue to preserve every `completed` step. Flagged for JOB-4 parity and for the ADR-027 implementation.
+
+- **Concurrency-queue release mechanism.** When a `queue`-mode run is claimed but another run with the same `concurrency_key` is already `running`, the worker releases the claim by transitioning the row back to `pending` with `claimed_at=null, started_at=null`. The next poll re-evaluates. No separate "queued" flag — the `status='pending'` + matching-key check is sufficient and keeps the state model flat.
+
+- **Stale-sweeper placement (OQ-2).** Per-worker. The candidate select uses `FOR UPDATE SKIP LOCKED`, so simultaneous sweepers across multiple workers never collide on the same row. Invariant: `staleThresholdMs >= 2 × max_handler_duration`.
+
+- **`nextStepSeq` allocation.** SELECT-max-plus-one at step-record time. Per-run step counts are typically <100; the in-memory counter alternative drifts if the worker crashes mid-run and a replacement worker resumes via stale-claim sweep.
 
 ## References
 

--- a/docs/specs/JOB-3.md
+++ b/docs/specs/JOB-3.md
@@ -191,7 +191,7 @@ g. Remove promise from `inFlight` in finally.
 - `ctx.step` memoizes across retries
 - `replay_from` modes: `scratch` clears all steps; `last_step` clears only failing; `last_checkpoint` preserves all
 - Cascade cancel respects `parent_close_policy` (terminate/cancel/abandon)
-- Stale sweeper recovers stranded `running` rows
+- Stale sweeper: per-`JobWorker` instance, wired via `setInterval` in `onModuleInit`; uses `FOR UPDATE SKIP LOCKED` so concurrent sweepers across horizontally-scaled workers are safe (a row is recovered at most once); recovers stranded `running` rows back to `pending` (Q2 resolved 2026-04-19)
 - SIGTERM drains in-flight, resets uncompleted runs on timeout
 
 ## Testing Strategy
@@ -202,8 +202,8 @@ g. Remove promise from `inFlight` in finally.
 
 ## Open Questions (with proposed resolutions)
 
-**OQ-2 — Stale-claim sweeper placement: per-worker vs. singleton.**
-Proposed: run sweeper on every `JobWorker` instance. The update is self-protecting: `WHERE status='running' AND claimed_at < threshold` — a row only transitions once; subsequent sweepers find no matching rows. Singleton adds coordination complexity (leader election) without meaningful advantage at Phase 1 scale. Document invariant: `staleThresholdMs >= 2 * max_handler_duration`.
+**OQ-2 — Stale-claim sweeper placement. Resolved 2026-04-19.**
+Resolution: sweeper runs on every `JobWorker` instance (per-pool), wired via `setInterval` in `onModuleInit`. The sweep query uses `FOR UPDATE SKIP LOCKED`, making concurrent sweepers across horizontally-scaled workers safe — a row is recovered at most once. Singleton rejected: adds coordination complexity (leader election) without meaningful advantage at Phase 1 scale. Document invariant: `staleThresholdMs >= 2 * max_handler_duration`.
 
 **OQ-3 — `job` table upsert under horizontal scale.**
 Proposed: `ON CONFLICT (type) DO UPDATE SET pool = EXCLUDED.pool, retry_policy = EXCLUDED.retry_policy, version = EXCLUDED.version, updated_at = now()`. Last-writer-wins. All instances of the same app version produce identical metadata — concurrent upserts are harmless. `DO NOTHING` is rejected: under rolling deploy, old-version instance A could leave a stale row that new-version instance B cannot overwrite. Advisory locks rejected: add latency + leak risk.

--- a/runtime/subsystems/jobs/index.ts
+++ b/runtime/subsystems/jobs/index.ts
@@ -63,5 +63,25 @@ export type {
   JobContext,
 } from './job-handler.base';
 
-// Subsequent issues add: backends (JOB-3, JOB-4), modules (JOB-5).
+// ─── JOB-3: Drizzle backends + JobWorker ────────────────────────────────
+export { DrizzleJobOrchestrator } from './job-orchestrator.drizzle-backend';
+export { DrizzleJobRunService } from './job-run-service.drizzle-backend';
+export { DrizzleJobStepService } from './job-step-service.drizzle-backend';
+export {
+  JobWorker,
+  JOB_WORKER_OPTIONS,
+  computeBackoff,
+  classifyError,
+  buildClaimQuery,
+  buildStaleSweepQuery,
+} from './job-worker';
+export type { JobWorkerOptions } from './job-worker';
+export {
+  JobCollisionError,
+  JobNotReplayableError,
+  JobTemplateFieldMissingError,
+  JobTypeNotFoundError,
+} from './jobs-errors';
+
+// Subsequent issues add: Memory backends (JOB-4), modules (JOB-5).
 // All net-new — nothing from the old executor layer survives.

--- a/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
@@ -1,0 +1,357 @@
+/**
+ * DrizzleJobOrchestrator — Postgres-backed implementation of
+ * `IJobOrchestrator` (ADR-022, JOB-3).
+ *
+ * Single-layer architecture: `start` writes a single `job_run` row; the
+ * `JobWorker` polling loop claims it directly via `FOR UPDATE SKIP LOCKED`.
+ * No `job_queue` table, no executor port. See `docs/specs/JOB-3.md`.
+ */
+import { randomUUID } from 'node:crypto';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { and, desc, eq, gt, inArray, isNotNull, ne } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import { DRIZZLE } from '../../constants/tokens';
+import {
+  jobRuns,
+  jobs,
+  type JobDefinitionRow,
+  type JobRunRow,
+} from './job-orchestration.schema';
+import type {
+  CancelOptions,
+  IJobOrchestrator,
+  JobRun,
+  StartOptions,
+} from './job-orchestrator.protocol';
+import {
+  JobCollisionError,
+  JobNotReplayableError,
+  JobTemplateFieldMissingError,
+  JobTypeNotFoundError,
+} from './jobs-errors';
+import { jobSteps } from './job-orchestration.schema';
+
+/**
+ * Terminal statuses — transitions into these are final. Used by `cancel`
+ * (to short-circuit idempotently) and by `replay` (as the guard gate).
+ */
+export const TERMINAL_STATUSES = [
+  'completed',
+  'failed',
+  'timed_out',
+  'canceled',
+] as const;
+type TerminalStatus = (typeof TERMINAL_STATUSES)[number];
+type JobRunStatus = JobRunRow['status'];
+
+/** Statuses excluded from dedupe window matches per ADR-022. */
+const DEDUPE_EXCLUDED_STATUSES: JobRunStatus[] = ['canceled', 'failed'];
+/** Statuses that count as in-flight for concurrency collision checks. */
+const IN_FLIGHT_STATUSES: JobRunStatus[] = ['pending', 'running'];
+
+/**
+ * Substitute `{{field}}` placeholders against the input payload.
+ *
+ * Implementation decision (JOB-3, 2026-04-19): simple `{{field}}` single-key
+ * substitution, no dotted paths, no Mustache/Handlebars dependency. A missing
+ * field throws `JobTemplateFieldMissingError` synchronously — cheaper than
+ * discovering the misconfiguration at claim time.
+ */
+export function evaluateKeyTemplate(
+  template: string,
+  input: Record<string, unknown>,
+): string {
+  return template.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_match, field: string) => {
+    const value = input[field];
+    if (value === undefined || value === null) {
+      throw new JobTemplateFieldMissingError(template, field);
+    }
+    return String(value);
+  });
+}
+
+@Injectable()
+export class DrizzleJobOrchestrator implements IJobOrchestrator {
+  // TODO(logging-subsystem): swap to ILogger once ADR-028 lands
+  private readonly logger = new Logger(DrizzleJobOrchestrator.name);
+
+  constructor(@Inject(DRIZZLE) private readonly db: DrizzleClient) {}
+
+  // ==========================================================================
+  // start
+  // ==========================================================================
+
+  async start(type: string, input: unknown, opts: StartOptions = {}): Promise<JobRun> {
+    const payload = (input ?? {}) as Record<string, unknown>;
+
+    // 1a. Load job definition.
+    const [def] = await this.db
+      .select()
+      .from(jobs)
+      .where(eq(jobs.type, type))
+      .limit(1);
+    if (!def) throw new JobTypeNotFoundError(type);
+    const definition = def as JobDefinitionRow;
+
+    // 1b. Dedupe check.
+    if (definition.dedupeKeyTemplate && definition.dedupeWindowMs) {
+      const dedupeKey = evaluateKeyTemplate(definition.dedupeKeyTemplate, payload);
+      const windowStart = new Date(Date.now() - definition.dedupeWindowMs);
+      const existing = await this.db
+        .select()
+        .from(jobRuns)
+        .where(
+          and(
+            eq(jobRuns.jobType, type),
+            eq(jobRuns.dedupeKey, dedupeKey),
+            gt(jobRuns.createdAt, windowStart),
+            // status NOT IN ('canceled', 'failed')
+            notInStatus(DEDUPE_EXCLUDED_STATUSES),
+          ),
+        )
+        .orderBy(desc(jobRuns.createdAt))
+        .limit(1);
+      if (existing.length > 0) {
+        return existing[0] as JobRun;
+      }
+    }
+
+    // 1c. Concurrency collision check.
+    let concurrencyKey: string | null = null;
+    if (definition.concurrencyKeyTemplate) {
+      concurrencyKey = evaluateKeyTemplate(
+        definition.concurrencyKeyTemplate,
+        payload,
+      );
+      const inFlight = await this.db
+        .select()
+        .from(jobRuns)
+        .where(
+          and(
+            eq(jobRuns.concurrencyKey, concurrencyKey),
+            inArray(jobRuns.status, IN_FLIGHT_STATUSES),
+          ),
+        )
+        .limit(1);
+      if (inFlight.length > 0) {
+        const incumbent = inFlight[0] as JobRun;
+        switch (definition.collisionMode) {
+          case 'reject':
+            throw new JobCollisionError(type, concurrencyKey, incumbent);
+          case 'replace':
+            await this.cancel(incumbent.id, { cascade: true, reason: 'replaced' });
+            break;
+          case 'queue':
+            // Fall through — row is inserted; claim query gates it until
+            // the incumbent transitions (see JobWorker.processRun queue gate).
+            break;
+        }
+      }
+    }
+
+    // 1d. Resolve id + rootRunId, INSERT.
+    const newId = randomUUID();
+    let rootRunId: string = newId;
+    if (opts.parentRunId) {
+      const [parent] = await this.db
+        .select({ rootRunId: jobRuns.rootRunId })
+        .from(jobRuns)
+        .where(eq(jobRuns.id, opts.parentRunId))
+        .limit(1);
+      if (!parent) {
+        throw new Error(
+          `parentRunId ${opts.parentRunId} does not reference an existing job_run`,
+        );
+      }
+      rootRunId = parent.rootRunId;
+    }
+
+    const dedupeKey =
+      definition.dedupeKeyTemplate
+        ? evaluateKeyTemplate(definition.dedupeKeyTemplate, payload)
+        : null;
+
+    const [inserted] = await this.db
+      .insert(jobRuns)
+      .values({
+        id: newId,
+        jobType: type,
+        jobVersion: definition.version,
+        parentRunId: opts.parentRunId ?? null,
+        rootRunId,
+        parentClosePolicy: opts.parentClosePolicy ?? 'terminate',
+        scopeEntityType: opts.scope?.entityType ?? null,
+        scopeEntityId: opts.scope?.entityId ?? null,
+        tenantId: null, // JOB-8 wires multi-tenancy
+        tags: opts.tags ?? {},
+        pool: opts.pool ?? definition.pool,
+        priority: opts.priority ?? definition.priorityDefault,
+        concurrencyKey,
+        dedupeKey,
+        status: 'pending',
+        input: payload,
+        output: null,
+        error: null,
+        triggerSource: opts.triggerSource ?? 'manual',
+        triggerRef: opts.triggerRef ?? null,
+        runAt: opts.runAt ?? new Date(),
+        startedAt: null,
+        finishedAt: null,
+        claimedAt: null,
+        attempts: 0,
+      })
+      .returning();
+
+    return inserted as JobRun;
+  }
+
+  // ==========================================================================
+  // cancel
+  // ==========================================================================
+
+  async cancel(runId: string, opts: CancelOptions = {}): Promise<void> {
+    // Load target.
+    const [target] = await this.db
+      .select()
+      .from(jobRuns)
+      .where(eq(jobRuns.id, runId))
+      .limit(1);
+    if (!target) return;
+    if (TERMINAL_STATUSES.includes(target.status as TerminalStatus)) {
+      return; // idempotent
+    }
+
+    // Atomic transition, guarded against concurrent terminal moves.
+    const [cancelled] = await this.db
+      .update(jobRuns)
+      .set({
+        status: 'canceled',
+        finishedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(jobRuns.id, runId), notInStatus([...TERMINAL_STATUSES])),
+      )
+      .returning();
+
+    if (!cancelled) return; // lost the race; already terminal
+
+    if (opts.cascade === false) return;
+
+    // Fetch descendants and branch on parent_close_policy.
+    const descendants = await this.db
+      .select()
+      .from(jobRuns)
+      .where(
+        and(
+          eq(jobRuns.rootRunId, target.rootRunId),
+          ne(jobRuns.id, runId),
+          notInStatus([...TERMINAL_STATUSES]),
+        ),
+      );
+
+    for (const child of descendants) {
+      const policy = (child as JobRunRow).parentClosePolicy;
+      if (policy === 'abandon') continue;
+      // 'terminate' | 'cancel' — both transition the child to canceled.
+      await this.db
+        .update(jobRuns)
+        .set({
+          status: 'canceled',
+          finishedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(jobRuns.id, (child as JobRunRow).id),
+            notInStatus([...TERMINAL_STATUSES]),
+          ),
+        );
+    }
+
+    void opts.reason; // reserved for future audit logging
+  }
+
+  // ==========================================================================
+  // replay
+  // ==========================================================================
+
+  async replay(runId: string): Promise<JobRun> {
+    // Load target + its job definition (we need replay_from).
+    const [target] = await this.db
+      .select()
+      .from(jobRuns)
+      .where(eq(jobRuns.id, runId))
+      .limit(1);
+    if (!target) {
+      throw new Error(`replay: run ${runId} not found`);
+    }
+    const run = target as JobRunRow;
+    if (!TERMINAL_STATUSES.includes(run.status as TerminalStatus)) {
+      throw new JobNotReplayableError(runId, run.status);
+    }
+
+    const [def] = await this.db
+      .select()
+      .from(jobs)
+      .where(eq(jobs.type, run.jobType))
+      .limit(1);
+    if (!def) throw new JobTypeNotFoundError(run.jobType);
+    const mode = (def as JobDefinitionRow).replayFrom;
+
+    // Atomic: step reset + run reset must commit together.
+    const result = await this.db.transaction(async (tx) => {
+      if (mode === 'scratch') {
+        await tx.delete(jobSteps).where(eq(jobSteps.jobRunId, runId));
+      } else if (mode === 'last_step') {
+        // Delete only non-completed step rows — completed steps stay memoised.
+        await tx
+          .delete(jobSteps)
+          .where(
+            and(eq(jobSteps.jobRunId, runId), ne(jobSteps.status, 'completed')),
+          );
+      } else {
+        // 'last_checkpoint' — Phase 1 has no explicit checkpoint markers, so
+        // behaviour collapses to `last_step`. See docs/specs/JOB-3.md
+        // "Implementation Decisions" — planned divergence in a later phase.
+        await tx
+          .delete(jobSteps)
+          .where(
+            and(eq(jobSteps.jobRunId, runId), ne(jobSteps.status, 'completed')),
+          );
+      }
+
+      const [updated] = await tx
+        .update(jobRuns)
+        .set({
+          status: 'pending',
+          attempts: 0,
+          runAt: new Date(),
+          startedAt: null,
+          finishedAt: null,
+          claimedAt: null,
+          error: null,
+          output: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(jobRuns.id, runId))
+        .returning();
+      return updated as JobRunRow;
+    });
+
+    return result as JobRun;
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function notInStatus(statuses: JobRunStatus[]) {
+  // Drizzle's inArray composes with `not` via negation helper; use raw sql
+  // to stay readable. `inArray` + `.not()` isn't idiomatic in 0.45.
+  const negated = statuses.map((s) => ne(jobRuns.status, s));
+  return and(...negated);
+}
+
+// `isNotNull` + `gt` imports are retained for potential future use; silence
+// unused-import lint by re-exporting via `void`.
+void isNotNull;

--- a/runtime/subsystems/jobs/job-run-service.drizzle-backend.ts
+++ b/runtime/subsystems/jobs/job-run-service.drizzle-backend.ts
@@ -1,0 +1,133 @@
+/**
+ * DrizzleJobRunService — scope-oriented reads and bulk operations against
+ * `job_run` (ADR-022, JOB-3).
+ *
+ * Separate from the orchestrator because the access pattern differs: this
+ * service scans by `(scope_entity_type, scope_entity_id)` via
+ * `idx_job_run_scope`, whereas orchestrator mutates individual runs by id.
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { and, asc, desc, eq, inArray } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import { DRIZZLE } from '../../constants/tokens';
+import { jobRuns, type JobRunRow } from './job-orchestration.schema';
+import type { JobRun } from './job-orchestrator.protocol';
+import type {
+  IJobRunService,
+  ListForScopeOptions,
+} from './job-run-service.protocol';
+import type { IJobOrchestrator } from './job-orchestrator.protocol';
+import { JOB_ORCHESTRATOR } from './jobs-domain.tokens';
+
+const NON_TERMINAL_STATUSES: JobRunRow['status'][] = [
+  'pending',
+  'running',
+  'waiting',
+];
+
+@Injectable()
+export class DrizzleJobRunService implements IJobRunService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    @Inject(JOB_ORCHESTRATOR) private readonly orchestrator: IJobOrchestrator,
+  ) {}
+
+  async listForScope(
+    entityType: string,
+    entityId: string,
+    opts: ListForScopeOptions = {},
+  ): Promise<JobRun[]> {
+    const conditions = [
+      eq(jobRuns.scopeEntityType, entityType),
+      eq(jobRuns.scopeEntityId, entityId),
+    ];
+    if (opts.status) {
+      if (Array.isArray(opts.status)) {
+        conditions.push(inArray(jobRuns.status, opts.status));
+      } else {
+        conditions.push(eq(jobRuns.status, opts.status));
+      }
+    }
+    if (opts.jobType) {
+      conditions.push(eq(jobRuns.jobType, opts.jobType));
+    }
+
+    const orderCol = (() => {
+      switch (opts.orderBy) {
+        case 'created_at asc':
+          return asc(jobRuns.createdAt);
+        case 'run_at desc':
+          return desc(jobRuns.runAt);
+        case 'run_at asc':
+          return asc(jobRuns.runAt);
+        case 'created_at desc':
+        default:
+          return desc(jobRuns.createdAt);
+      }
+    })();
+
+    let q = this.db
+      .select()
+      .from(jobRuns)
+      .where(and(...conditions))
+      .orderBy(orderCol)
+      .$dynamic();
+
+    if (typeof opts.limit === 'number') {
+      q = q.limit(opts.limit);
+    }
+    if (typeof opts.offset === 'number') {
+      q = q.offset(opts.offset);
+    }
+
+    const rows = await q;
+    return rows as JobRun[];
+  }
+
+  async cancelForScope(entityType: string, entityId: string): Promise<void> {
+    const rows = await this.db
+      .select({ id: jobRuns.id })
+      .from(jobRuns)
+      .where(
+        and(
+          eq(jobRuns.scopeEntityType, entityType),
+          eq(jobRuns.scopeEntityId, entityId),
+          inArray(jobRuns.status, NON_TERMINAL_STATUSES),
+        ),
+      );
+
+    for (const { id } of rows) {
+      await this.orchestrator.cancel(id, { cascade: true });
+    }
+  }
+
+  async rescheduleForScope(
+    entityType: string,
+    entityId: string,
+    newRunAt: Date,
+  ): Promise<void> {
+    await this.db
+      .update(jobRuns)
+      .set({ runAt: newRunAt, updatedAt: new Date() })
+      .where(
+        and(
+          eq(jobRuns.scopeEntityType, entityType),
+          eq(jobRuns.scopeEntityId, entityId),
+          eq(jobRuns.status, 'pending'),
+        ),
+      );
+  }
+
+  /**
+   * Internal helper used by cascade paths (not on the public protocol).
+   * Exposed as a public method on the concrete class so infrastructure
+   * code (cascade tests, debug tools) can call it without a cast.
+   */
+  async findByRootRunId(rootRunId: string): Promise<JobRun[]> {
+    const rows = await this.db
+      .select()
+      .from(jobRuns)
+      .where(eq(jobRuns.rootRunId, rootRunId));
+    return rows as JobRun[];
+  }
+}

--- a/runtime/subsystems/jobs/job-step-service.drizzle-backend.ts
+++ b/runtime/subsystems/jobs/job-step-service.drizzle-backend.ts
@@ -1,0 +1,66 @@
+/**
+ * DrizzleJobStepService — upsert + lookup on `job_step` for replay-safe
+ * memoization (ADR-022, JOB-3).
+ *
+ * `recordStep` upserts on the `(job_run_id, step_id)` unique index — each
+ * step row is written as `running` first, then transitioned to a terminal
+ * state (`completed` / `failed` / `skipped`). `findStep` is the hot path
+ * that `ctx.step()` consults on every invocation; null on miss.
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import { DRIZZLE } from '../../constants/tokens';
+import { jobSteps, type JobStepRow } from './job-orchestration.schema';
+import type {
+  IJobStepService,
+  JobStep,
+  RecordStepInput,
+} from './job-step-service.protocol';
+
+@Injectable()
+export class DrizzleJobStepService implements IJobStepService {
+  constructor(@Inject(DRIZZLE) private readonly db: DrizzleClient) {}
+
+  async recordStep(input: RecordStepInput): Promise<JobStep> {
+    const values = {
+      jobRunId: input.jobRunId,
+      stepId: input.stepId,
+      kind: input.kind,
+      seq: input.seq,
+      status: input.status,
+      input: (input.input ?? null) as Record<string, unknown> | null,
+      output: (input.output ?? null) as Record<string, unknown> | null,
+      error: input.error ?? null,
+      attempts: input.attempts ?? 0,
+      startedAt: input.startedAt ?? null,
+      finishedAt: input.finishedAt ?? null,
+    };
+
+    const [row] = await this.db
+      .insert(jobSteps)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [jobSteps.jobRunId, jobSteps.stepId],
+        set: {
+          status: values.status,
+          output: values.output,
+          error: values.error,
+          finishedAt: values.finishedAt,
+          attempts: values.attempts,
+        },
+      })
+      .returning();
+
+    return row as JobStep;
+  }
+
+  async findStep(runId: string, stepId: string): Promise<JobStep | null> {
+    const [row] = await this.db
+      .select()
+      .from(jobSteps)
+      .where(and(eq(jobSteps.jobRunId, runId), eq(jobSteps.stepId, stepId)))
+      .limit(1);
+    return ((row as JobStepRow | undefined) ?? null) as JobStep | null;
+  }
+}

--- a/runtime/subsystems/jobs/job-worker.ts
+++ b/runtime/subsystems/jobs/job-worker.ts
@@ -1,0 +1,610 @@
+/**
+ * JobWorker — backend-agnostic tick loop for the job orchestration domain
+ * (ADR-022, JOB-3).
+ *
+ * One worker instance per active pool. On `onModuleInit` it starts two
+ * intervals: the poll loop (claim → process → repeat) and the stale-claim
+ * sweeper. On `onModuleDestroy` / SIGTERM it drains in-flight work and
+ * releases still-`running` rows back to `pending` so a replacement worker
+ * can resume with step memoization intact.
+ *
+ * The claim query is the beating heart: `SELECT … FOR UPDATE SKIP LOCKED`
+ * inside a single transaction. Multiple worker processes share the table
+ * without serialising on row locks.
+ */
+// TODO(logging-subsystem): swap to ILogger once ADR-028 lands
+import { Inject, Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
+import { and, asc, desc, eq, inArray, lt, lte, sql } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import { DRIZZLE } from '../../constants/tokens';
+import { jobRuns, type JobRunRow } from './job-orchestration.schema';
+import type { IJobOrchestrator, JobRun } from './job-orchestrator.protocol';
+import type { IJobRunService } from './job-run-service.protocol';
+import type { IJobStepService } from './job-step-service.protocol';
+import {
+  JOB_ORCHESTRATOR,
+  JOB_RUN_SERVICE,
+  JOB_STEP_SERVICE,
+} from './jobs-domain.tokens';
+import {
+  JOB_HANDLER_REGISTRY,
+  JobHandlerBase,
+  type JobContext,
+  type JobHandlerMeta,
+  type RetryPolicy,
+  type SpawnChildOptions,
+  type StepOptions,
+} from './job-handler.base';
+
+/**
+ * Options accepted by `JobWorker`. JOB-5 threads these through module
+ * `.forRoot()` config; supplied here as a plain DI-constructor argument
+ * so the worker compiles standalone.
+ */
+export interface JobWorkerOptions {
+  /** Pool name this worker claims from. Matches `job.pool`. */
+  pool: string;
+  /** Max concurrent in-flight `processRun` calls. */
+  concurrency: number;
+  /** Poll interval in ms. Default 1000. */
+  pollIntervalMs?: number;
+  /** Stale sweep interval in ms. Default 60_000. */
+  staleSweeperIntervalMs?: number;
+  /**
+   * Threshold beyond which a `running` row is presumed stranded by a
+   * crashed worker. Default 5 min. Must be >= 2× max handler duration.
+   */
+  staleThresholdMs?: number;
+  /** Max ms to wait for in-flight drain on SIGTERM. Default 30_000. */
+  shutdownTimeoutMs?: number;
+}
+
+export const JOB_WORKER_OPTIONS = Symbol('JOB_WORKER_OPTIONS');
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_STALE_SWEEPER_INTERVAL_MS = 60_000;
+const DEFAULT_STALE_THRESHOLD_MS = 5 * 60_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+const TERMINAL_STATUSES: JobRunRow['status'][] = [
+  'completed',
+  'failed',
+  'timed_out',
+  'canceled',
+];
+
+// ─── Pure helpers (exported for unit tests) ────────────────────────────────
+
+/**
+ * Backoff delay in ms for the Nth attempt (1-indexed). Supports both
+ * policy modes. Exponential is capped at `Number.MAX_SAFE_INTEGER` so
+ * pathological attempt counts don't overflow.
+ */
+export function computeBackoff(policy: RetryPolicy, attempts: number): number {
+  const base = Math.max(policy.baseMs, 0);
+  if (policy.backoff === 'fixed') {
+    return base;
+  }
+  // exponential: baseMs * 2^(attempts-1)
+  const exponent = Math.max(attempts - 1, 0);
+  if (exponent >= 53) return Number.MAX_SAFE_INTEGER; // 2^53 overflow guard
+  const raw = base * Math.pow(2, exponent);
+  if (!Number.isFinite(raw) || raw >= Number.MAX_SAFE_INTEGER) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return raw;
+}
+
+/**
+ * Decide whether an error should be retried under the given policy.
+ * Matches `nonRetryableErrors` by `.name` OR `.code`. Returns
+ *   - `'retry'` if attempts remain and the error isn't blacklisted,
+ *   - `'fail'` otherwise (terminal failure).
+ */
+export function classifyError(
+  err: unknown,
+  policy: RetryPolicy | undefined,
+  currentAttempts: number,
+): 'retry' | 'fail' {
+  if (!policy) return 'fail';
+  const errObj = err as { name?: string; code?: string } | undefined;
+  const name = errObj?.name;
+  const code = errObj?.code;
+  const nonRetryable = policy.nonRetryableErrors ?? [];
+  if (nonRetryable.some((n) => n === name || n === code)) return 'fail';
+  if (currentAttempts + 1 >= policy.attempts) return 'fail';
+  return 'retry';
+}
+
+/**
+ * Build the raw claim-candidate select. Exported so tests can inspect
+ * `.toSQL()` without spinning up the full worker. Matches JOB-3 §4 and
+ * ADR-022 "Claim query (Drizzle backend)".
+ */
+export function buildClaimQuery(db: DrizzleClient, pool: string) {
+  return db
+    .select({ id: jobRuns.id })
+    .from(jobRuns)
+    .where(
+      and(
+        eq(jobRuns.status, 'pending'),
+        eq(jobRuns.pool, pool),
+        lte(jobRuns.runAt, new Date()),
+      ),
+    )
+    .orderBy(desc(jobRuns.priority), asc(jobRuns.runAt))
+    .limit(1)
+    .for('update', { skipLocked: true });
+}
+
+/**
+ * Build the stale-claim sweep candidate select. `FOR UPDATE SKIP LOCKED`
+ * per OQ-2 resolution (2026-04-19): per-worker sweeper, safe without
+ * leader election because the update is self-gating.
+ */
+export function buildStaleSweepQuery(
+  db: DrizzleClient,
+  staleThresholdMs: number,
+) {
+  const threshold = new Date(Date.now() - staleThresholdMs);
+  return db
+    .select({ id: jobRuns.id })
+    .from(jobRuns)
+    .where(
+      and(
+        eq(jobRuns.status, 'running'),
+        lt(jobRuns.claimedAt, threshold),
+      ),
+    )
+    .for('update', { skipLocked: true });
+}
+
+// ─── Error serialisation ───────────────────────────────────────────────────
+
+function serialiseError(err: unknown, attempt: number, retryable: boolean) {
+  const e = err as { message?: string; stack?: string; code?: string } | undefined;
+  return {
+    message: (e?.message ?? String(err)) as string,
+    stack: e?.stack,
+    retryable,
+    attempt,
+  };
+}
+
+// ─── JobWorker ─────────────────────────────────────────────────────────────
+
+@Injectable()
+export class JobWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(JobWorker.name);
+  private shuttingDown = false;
+  private readonly inFlight = new Set<Promise<void>>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private sweeperTimer: ReturnType<typeof setInterval> | null = null;
+  private sigtermHandled = false;
+  private readonly sigtermHandler: () => void;
+
+  private readonly pollIntervalMs: number;
+  private readonly staleSweeperIntervalMs: number;
+  private readonly staleThresholdMs: number;
+  private readonly shutdownTimeoutMs: number;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    @Inject(JOB_ORCHESTRATOR) private readonly orchestrator: IJobOrchestrator,
+    @Inject(JOB_RUN_SERVICE) private readonly runService: IJobRunService,
+    @Inject(JOB_STEP_SERVICE) private readonly stepService: IJobStepService,
+    @Inject(JOB_WORKER_OPTIONS) private readonly options: JobWorkerOptions,
+  ) {
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.staleSweeperIntervalMs =
+      options.staleSweeperIntervalMs ?? DEFAULT_STALE_SWEEPER_INTERVAL_MS;
+    this.staleThresholdMs = options.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
+    this.shutdownTimeoutMs =
+      options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+
+    this.sigtermHandler = () => {
+      if (this.sigtermHandled) return;
+      this.sigtermHandled = true;
+      void this.onModuleDestroy();
+    };
+    void this.runService; // reserved for future scope-aware cancellation paths
+  }
+
+  // ============================================================================
+  // Lifecycle
+  // ============================================================================
+
+  onModuleInit(): void {
+    this.pollTimer = setInterval(() => {
+      void this.pollAndProcess();
+    }, this.pollIntervalMs);
+    this.sweeperTimer = setInterval(() => {
+      void this.sweepStaleClaims();
+    }, this.staleSweeperIntervalMs);
+    process.on('SIGTERM', this.sigtermHandler);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.shuttingDown) {
+      // Still drain, but don't tear intervals down twice.
+      await this.drainInFlight();
+      return;
+    }
+    this.shuttingDown = true;
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.sweeperTimer) {
+      clearInterval(this.sweeperTimer);
+      this.sweeperTimer = null;
+    }
+    process.removeListener('SIGTERM', this.sigtermHandler);
+
+    await this.drainInFlight();
+
+    // Any rows still `running` past timeout → release back to pending.
+    try {
+      await this.db
+        .update(jobRuns)
+        .set({ status: 'pending', claimedAt: null, startedAt: null })
+        .where(
+          and(eq(jobRuns.status, 'running'), eq(jobRuns.pool, this.options.pool)),
+        );
+    } catch (err) {
+      this.logger.error(`shutdown reset failed: ${(err as Error).message}`);
+    }
+  }
+
+  private async drainInFlight(): Promise<void> {
+    if (this.inFlight.size === 0) return;
+    const timeout = new Promise<void>((resolve) =>
+      setTimeout(resolve, this.shutdownTimeoutMs),
+    );
+    await Promise.race([
+      Promise.allSettled([...this.inFlight]).then(() => undefined),
+      timeout,
+    ]);
+  }
+
+  // ============================================================================
+  // Poll loop
+  // ============================================================================
+
+  async pollAndProcess(): Promise<void> {
+    if (this.shuttingDown) return;
+    if (this.inFlight.size >= this.options.concurrency) return;
+
+    let claimed: JobRunRow | null;
+    try {
+      claimed = await this.claimNext(this.options.pool);
+    } catch (err) {
+      this.logger.error(`claimNext failed: ${(err as Error).message}`);
+      return;
+    }
+    if (!claimed) return;
+
+    const run = claimed;
+    const promise = this.processRun(run).catch((err) => {
+      this.logger.error(
+        `processRun(${run.id}) unhandled: ${(err as Error).message}`,
+      );
+    });
+    this.inFlight.add(promise);
+    promise.finally(() => {
+      this.inFlight.delete(promise);
+    });
+  }
+
+  /**
+   * Claim the next runnable row from the pool. Transaction ensures the
+   * select-candidate + update-to-running pair is atomic; FOR UPDATE SKIP
+   * LOCKED lets multiple workers share the table without serialising.
+   */
+  async claimNext(pool: string): Promise<JobRunRow | null> {
+    return this.db.transaction(async (tx) => {
+      const candidates = await tx
+        .select({ id: jobRuns.id })
+        .from(jobRuns)
+        .where(
+          and(
+            eq(jobRuns.status, 'pending'),
+            eq(jobRuns.pool, pool),
+            lte(jobRuns.runAt, new Date()),
+          ),
+        )
+        .orderBy(desc(jobRuns.priority), asc(jobRuns.runAt))
+        .limit(1)
+        .for('update', { skipLocked: true });
+      const candidate = candidates[0];
+      if (!candidate) return null;
+
+      const [claimed] = await tx
+        .update(jobRuns)
+        .set({
+          status: 'running',
+          claimedAt: new Date(),
+          startedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(jobRuns.id, candidate.id))
+        .returning();
+      return (claimed ?? null) as JobRunRow | null;
+    });
+  }
+
+  // ============================================================================
+  // Stale claim sweeper
+  // ============================================================================
+
+  /**
+   * Release rows whose `claimed_at` is older than the threshold. Safe to
+   * run concurrently across workers — the two-phase tx (select-for-update
+   * then update) guarantees each stranded row is only reset once.
+   */
+  async sweepStaleClaims(): Promise<void> {
+    if (this.shuttingDown) return;
+    try {
+      await this.db.transaction(async (tx) => {
+        const threshold = new Date(Date.now() - this.staleThresholdMs);
+        const stale = await tx
+          .select({ id: jobRuns.id })
+          .from(jobRuns)
+          .where(
+            and(eq(jobRuns.status, 'running'), lt(jobRuns.claimedAt, threshold)),
+          )
+          .for('update', { skipLocked: true });
+        if (stale.length === 0) return;
+        const ids = stale.map((r) => r.id);
+        await tx
+          .update(jobRuns)
+          .set({ status: 'pending', claimedAt: null, startedAt: null })
+          .where(inArray(jobRuns.id, ids));
+        for (const id of ids) {
+          this.logger.warn(`Recovered stale claim on run ${id}`);
+        }
+      });
+    } catch (err) {
+      this.logger.error(`sweepStaleClaims failed: ${(err as Error).message}`);
+    }
+  }
+
+  // ============================================================================
+  // processRun
+  // ============================================================================
+
+  private async processRun(claimed: JobRunRow): Promise<void> {
+    const registryEntry = JOB_HANDLER_REGISTRY.get(claimed.jobType);
+
+    // (a) Missing handler — defensive; JOB-5 boot validator should have caught.
+    if (!registryEntry) {
+      this.logger.error(
+        `No handler registered for jobType='${claimed.jobType}' (run ${claimed.id})`,
+      );
+      await this.markFailed(
+        claimed,
+        new Error(`No handler registered for jobType='${claimed.jobType}'`),
+        /*finalAttempts*/ (claimed.attempts ?? 0) + 1,
+      );
+      return;
+    }
+
+    // (b) Concurrency-queue release gate — defer if another run with the
+    //     same key is already `running`.
+    if (claimed.concurrencyKey) {
+      const inflight = await this.db
+        .select({ id: jobRuns.id })
+        .from(jobRuns)
+        .where(
+          and(
+            eq(jobRuns.concurrencyKey, claimed.concurrencyKey),
+            eq(jobRuns.status, 'running'),
+          ),
+        );
+      const other = inflight.find((r) => r.id !== claimed.id);
+      if (other) {
+        await this.db
+          .update(jobRuns)
+          .set({
+            status: 'pending',
+            claimedAt: null,
+            startedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(jobRuns.id, claimed.id));
+        return;
+      }
+    }
+
+    const meta = registryEntry.meta as JobHandlerMeta<unknown>;
+    const HandlerClass = registryEntry.handlerClass;
+
+    // (c) Build JobContext. Phase 1: instantiate handler with no args.
+    //     DI-for-handlers lands with JOB-5's boot wiring.
+    const handler = new HandlerClass() as JobHandlerBase<unknown>;
+    const ctx: JobContext<unknown> = {
+      input: claimed.input,
+      run: claimed as JobRun,
+      step: this.makeStepFn(claimed),
+      spawnChild: this.makeSpawnFn(claimed),
+      logger: new Logger(`JobRun:${claimed.id}`),
+    };
+
+    const attemptsBefore = claimed.attempts ?? 0;
+    try {
+      // (d) Run the handler.
+      const output = (await handler.run(ctx)) as Record<string, unknown> | undefined;
+      // (e) Success.
+      await this.db
+        .update(jobRuns)
+        .set({
+          status: 'completed',
+          output: (output ?? {}) as Record<string, unknown>,
+          finishedAt: new Date(),
+          updatedAt: new Date(),
+          attempts: attemptsBefore + 1,
+        })
+        .where(eq(jobRuns.id, claimed.id));
+    } catch (err) {
+      // (f) Error classification + retry/fail.
+      const policy = meta.retry;
+      const decision = classifyError(err, policy, attemptsBefore);
+      const nextAttempts = attemptsBefore + 1;
+      if (decision === 'retry' && policy) {
+        const delay = computeBackoff(policy, nextAttempts);
+        await this.db
+          .update(jobRuns)
+          .set({
+            status: 'pending',
+            attempts: nextAttempts,
+            runAt: new Date(Date.now() + delay),
+            startedAt: null,
+            claimedAt: null,
+            error: serialiseError(err, nextAttempts, true),
+            updatedAt: new Date(),
+          })
+          .where(eq(jobRuns.id, claimed.id));
+      } else {
+        await this.markFailed(claimed, err, nextAttempts);
+      }
+    }
+  }
+
+  private async markFailed(
+    claimed: JobRunRow,
+    err: unknown,
+    finalAttempts: number,
+  ): Promise<void> {
+    await this.db
+      .update(jobRuns)
+      .set({
+        status: 'failed',
+        attempts: finalAttempts,
+        finishedAt: new Date(),
+        error: serialiseError(err, finalAttempts, false),
+        updatedAt: new Date(),
+      })
+      .where(eq(jobRuns.id, claimed.id));
+
+    // Parent-close-policy cascade: if this run has children under the same
+    // root_run_id and this run's own parentClosePolicy is 'terminate', cascade.
+    if (claimed.parentClosePolicy === 'terminate') {
+      try {
+        await this.orchestrator.cancel(claimed.id, {
+          cascade: true,
+          reason: 'parent-failed',
+        });
+      } catch (cascadeErr) {
+        // cancel is idempotent; failure here is unusual but not fatal.
+        this.logger.warn(
+          `cascade on failed run ${claimed.id}: ${(cascadeErr as Error).message}`,
+        );
+      }
+    }
+  }
+
+  // ============================================================================
+  // ctx.step / ctx.spawnChild builders
+  // ============================================================================
+
+  private makeStepFn(run: JobRunRow) {
+    return async <TOutput>(
+      stepId: string,
+      fn: () => Promise<TOutput>,
+      _opts?: StepOptions,
+    ): Promise<TOutput> => {
+      void _opts;
+      const existing = await this.stepService.findStep(run.id, stepId);
+      if (existing?.status === 'completed') {
+        return existing.output as TOutput;
+      }
+
+      const seq = await this.nextStepSeq(run.id);
+      const startedAt = new Date();
+      const nextAttempts = (existing?.attempts ?? 0) + 1;
+      await this.stepService.recordStep({
+        jobRunId: run.id,
+        stepId,
+        kind: 'task',
+        seq,
+        status: 'running',
+        startedAt,
+        attempts: nextAttempts,
+      });
+      try {
+        const output = await fn();
+        await this.stepService.recordStep({
+          jobRunId: run.id,
+          stepId,
+          kind: 'task',
+          seq,
+          status: 'completed',
+          output: output as Record<string, unknown> | undefined,
+          finishedAt: new Date(),
+          attempts: nextAttempts,
+        });
+        return output;
+      } catch (err) {
+        await this.stepService.recordStep({
+          jobRunId: run.id,
+          stepId,
+          kind: 'task',
+          seq,
+          status: 'failed',
+          error: serialiseError(err, nextAttempts, false),
+          finishedAt: new Date(),
+          attempts: nextAttempts,
+        });
+        throw err;
+      }
+    };
+  }
+
+  private makeSpawnFn(run: JobRunRow) {
+    return async (
+      type: string,
+      input: unknown,
+      opts?: SpawnChildOptions,
+    ): Promise<JobRun> => {
+      return this.orchestrator.start(type, input, {
+        parentRunId: run.id,
+        parentClosePolicy: opts?.closePolicy,
+        runAt: opts?.runAt,
+        priority: opts?.priority,
+        tags: opts?.tags,
+        triggerSource: 'parent',
+        triggerRef: run.id,
+      });
+    };
+  }
+
+  /**
+   * Allocate the next `seq` for a given run. SELECT-max approach — runs
+   * typically have <100 steps so the scan is cheap, and correctness across
+   * retries is more important than the microseconds saved by an in-memory
+   * counter (which would drift if the worker crashes mid-run and another
+   * worker resumes via stale-claim sweep).
+   */
+  private async nextStepSeq(runId: string): Promise<number> {
+    const [row] = await this.db.execute(
+      sql`SELECT COALESCE(MAX(seq), 0) + 1 AS next FROM job_step WHERE job_run_id = ${runId}`,
+    ) as unknown as Array<{ next: number }>;
+    // pg driver returns { rows: [...] } for raw execute; tolerate both shapes.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const maybeRows = (row as any)?.rows;
+    if (Array.isArray(maybeRows) && maybeRows.length > 0) {
+      return Number(maybeRows[0].next ?? 1);
+    }
+    if (row && typeof (row as { next?: unknown }).next !== 'undefined') {
+      return Number((row as { next: unknown }).next);
+    }
+    return 1;
+  }
+
+  // ============================================================================
+  // (suppress unused-import noise)
+  // ============================================================================
+}
+
+// Terminal statuses re-exported for JOB-4 parity imports.
+export { TERMINAL_STATUSES };

--- a/runtime/subsystems/jobs/jobs-errors.ts
+++ b/runtime/subsystems/jobs/jobs-errors.ts
@@ -1,0 +1,75 @@
+/**
+ * Typed errors for the job orchestration domain (ADR-022, JOB-3).
+ *
+ * All thrown by the Drizzle orchestrator (and mirrored by the Memory
+ * backend in JOB-4). They exist as classes so consumers can `instanceof`
+ * them in catch blocks and exception filters can map them to HTTP codes.
+ */
+import type { JobRun } from './job-orchestrator.protocol';
+
+/**
+ * `start(type, …)` was called for a job type that has no row in the `job`
+ * table. At runtime this usually means the handler was not decorated or the
+ * boot validator (JOB-5) has not registered it yet.
+ */
+export class JobTypeNotFoundError extends Error {
+  readonly name = 'JobTypeNotFoundError';
+  constructor(public readonly jobType: string) {
+    super(`No job definition registered for type '${jobType}'.`);
+  }
+}
+
+/**
+ * Thrown by `start` when `collision_mode === 'reject'` and a non-terminal
+ * run with the same `concurrency_key` already exists. Carries the incumbent
+ * so callers can surface its id or subscribe to its completion event.
+ */
+export class JobCollisionError extends Error {
+  readonly name = 'JobCollisionError';
+  constructor(
+    public readonly jobType: string,
+    public readonly concurrencyKey: string,
+    public readonly incumbent: JobRun,
+  ) {
+    super(
+      `Job type '${jobType}' has an in-flight run with concurrency_key ` +
+        `'${concurrencyKey}' (incumbent ${incumbent.id}); collision_mode=reject.`,
+    );
+  }
+}
+
+/**
+ * `replay` was called on a run that is not in a replayable terminal state
+ * (i.e. still `pending` / `running` / `waiting`). Replay always spawns
+ * fresh execution and therefore requires the source run to be settled.
+ */
+export class JobNotReplayableError extends Error {
+  readonly name = 'JobNotReplayableError';
+  constructor(
+    public readonly runId: string,
+    public readonly currentStatus: string,
+  ) {
+    super(
+      `Run ${runId} is not replayable from status '${currentStatus}'. ` +
+        `Only 'completed', 'failed', 'timed_out', and 'canceled' are eligible.`,
+    );
+  }
+}
+
+/**
+ * A `concurrency_key_template` or `dedupe_key_template` referenced a field
+ * that is not present on the input payload. Caught at `start` time so the
+ * caller sees the misconfiguration synchronously rather than at claim time.
+ */
+export class JobTemplateFieldMissingError extends Error {
+  readonly name = 'JobTemplateFieldMissingError';
+  constructor(
+    public readonly template: string,
+    public readonly field: string,
+  ) {
+    super(
+      `Template '${template}' references input field '${field}' which is ` +
+        `missing or undefined on the payload.`,
+    );
+  }
+}

--- a/src/__tests__/runtime/subsystems/job-worker.backoff.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-worker.backoff.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Backoff computation unit tests (JOB-3).
+ *
+ * Covers both `fixed` and `exponential` variants and pins the overflow
+ * guard at attempt 50+.
+ */
+import { describe, it, expect } from 'bun:test';
+import { computeBackoff } from '../../../../runtime/subsystems/jobs/job-worker';
+import type { RetryPolicy } from '../../../../runtime/subsystems/jobs/job-handler.base';
+
+describe('computeBackoff — fixed', () => {
+  const policy: RetryPolicy = { attempts: 5, backoff: 'fixed', baseMs: 250 };
+
+  it('returns baseMs regardless of attempts', () => {
+    expect(computeBackoff(policy, 1)).toBe(250);
+    expect(computeBackoff(policy, 3)).toBe(250);
+    expect(computeBackoff(policy, 100)).toBe(250);
+  });
+});
+
+describe('computeBackoff — exponential', () => {
+  const policy: RetryPolicy = { attempts: 5, backoff: 'exponential', baseMs: 100 };
+
+  it('doubles on each attempt', () => {
+    expect(computeBackoff(policy, 1)).toBe(100); // 2^0
+    expect(computeBackoff(policy, 2)).toBe(200); // 2^1
+    expect(computeBackoff(policy, 3)).toBe(400); // 2^2
+    expect(computeBackoff(policy, 4)).toBe(800); // 2^3
+  });
+
+  it('caps at MAX_SAFE_INTEGER at pathologically high attempts', () => {
+    const result = computeBackoff(policy, 50);
+    expect(result).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it('handles negative or zero baseMs without NaN', () => {
+    const zero: RetryPolicy = { attempts: 3, backoff: 'exponential', baseMs: 0 };
+    expect(computeBackoff(zero, 1)).toBe(0);
+    expect(computeBackoff(zero, 5)).toBe(0);
+  });
+});

--- a/src/__tests__/runtime/subsystems/job-worker.claim-query.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-worker.claim-query.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Claim-query SQL inspection (JOB-3 AC).
+ *
+ * Builds the claim-candidate query via the exported `buildClaimQuery` helper
+ * and asserts the generated SQL contains the four invariants from ADR-022:
+ *   - `FOR UPDATE SKIP LOCKED`
+ *   - `ORDER BY priority DESC, run_at ASC`
+ *   - `LIMIT 1`
+ *   - filters on `status = 'pending'`, `pool = $`, `run_at <=`.
+ *
+ * No Postgres — pure Drizzle `.toSQL()` inspection.
+ */
+import { describe, it, expect } from 'bun:test';
+import { drizzle } from 'drizzle-orm/pg-proxy';
+import { buildClaimQuery } from '../../../../runtime/subsystems/jobs/job-worker';
+import type { DrizzleClient } from '../../../../runtime/types/drizzle';
+
+function makeDb(): DrizzleClient {
+  // pg-proxy driver: pure callback shape, no real Postgres connection.
+  // Query-builder `.toSQL()` works without ever firing the callback.
+  return drizzle(async () => ({ rows: [] })) as unknown as DrizzleClient;
+}
+
+describe('JobWorker claim query — SQL invariants (JOB-3 AC)', () => {
+  const db = makeDb();
+  const sql = buildClaimQuery(db, 'default').toSQL();
+  const normalised = sql.sql.toUpperCase().replace(/\s+/g, ' ');
+
+  it('uses FOR UPDATE SKIP LOCKED', () => {
+    expect(normalised).toContain('FOR UPDATE SKIP LOCKED');
+  });
+
+  it('orders by priority DESC then run_at ASC', () => {
+    expect(normalised).toMatch(/ORDER BY\s+[^,]*"PRIORITY"\s+DESC,\s+[^,]*"RUN_AT"\s+ASC/);
+  });
+
+  it('limits to a single row', () => {
+    expect(normalised).toContain('LIMIT');
+    // Parameter binding is positional; at least assert LIMIT is present.
+    expect(sql.params).toContain(1);
+  });
+
+  it('filters by status = pending, pool, and run_at <= now', () => {
+    expect(normalised).toContain('"STATUS" =');
+    expect(normalised).toContain('"POOL" =');
+    expect(normalised).toContain('"RUN_AT" <=');
+    expect(sql.params).toContain('pending');
+    expect(sql.params).toContain('default');
+  });
+});

--- a/src/__tests__/runtime/subsystems/job-worker.classify-error.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-worker.classify-error.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Error classifier unit tests (JOB-3).
+ *
+ * Covers the retryable vs. non-retryable decision path used by
+ * `JobWorker.processRun`'s catch branch. `nonRetryableErrors` matches on
+ * both `.name` and `.code`.
+ */
+import { describe, it, expect } from 'bun:test';
+import { classifyError } from '../../../../runtime/subsystems/jobs/job-worker';
+import type { RetryPolicy } from '../../../../runtime/subsystems/jobs/job-handler.base';
+
+const policy: RetryPolicy = {
+  attempts: 3,
+  backoff: 'fixed',
+  baseMs: 100,
+  nonRetryableErrors: ['ValidationError', 'PERMISSION_DENIED'],
+};
+
+describe('classifyError', () => {
+  it('returns fail when no policy is provided', () => {
+    expect(classifyError(new Error('x'), undefined, 0)).toBe('fail');
+  });
+
+  it('retries a generic error while attempts remain', () => {
+    const err = new Error('transient');
+    expect(classifyError(err, policy, 0)).toBe('retry');
+    expect(classifyError(err, policy, 1)).toBe('retry');
+  });
+
+  it('fails when attempts reach the policy cap', () => {
+    const err = new Error('transient');
+    expect(classifyError(err, policy, 2)).toBe('fail');
+    expect(classifyError(err, policy, 5)).toBe('fail');
+  });
+
+  it('fails immediately for a blacklisted error.name', () => {
+    class ValidationError extends Error {
+      override name = 'ValidationError';
+    }
+    expect(classifyError(new ValidationError('bad input'), policy, 0)).toBe('fail');
+  });
+
+  it('fails immediately for a blacklisted error.code', () => {
+    const err = Object.assign(new Error('denied'), { code: 'PERMISSION_DENIED' });
+    expect(classifyError(err, policy, 0)).toBe('fail');
+  });
+
+  it('retries errors whose name/code are not in the list', () => {
+    const err = Object.assign(new Error('boom'), { code: 'UNKNOWN_NETWORK' });
+    expect(classifyError(err, policy, 0)).toBe('retry');
+  });
+});

--- a/src/__tests__/runtime/subsystems/job-worker.stale-sweeper.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-worker.stale-sweeper.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Stale-claim sweep SQL inspection (JOB-3 OQ-2 resolution).
+ *
+ * Per-worker sweeper is safe because the candidate select uses
+ * `FOR UPDATE SKIP LOCKED`, so simultaneously-firing sweepers never
+ * collide on the same row. This test pins that invariant at the SQL
+ * level.
+ */
+import { describe, it, expect } from 'bun:test';
+import { drizzle } from 'drizzle-orm/pg-proxy';
+import { buildStaleSweepQuery } from '../../../../runtime/subsystems/jobs/job-worker';
+import type { DrizzleClient } from '../../../../runtime/types/drizzle';
+
+function makeDb(): DrizzleClient {
+  return drizzle(async () => ({ rows: [] })) as unknown as DrizzleClient;
+}
+
+describe('JobWorker stale-claim sweeper — SQL invariants', () => {
+  const db = makeDb();
+  const sql = buildStaleSweepQuery(db, 5 * 60_000).toSQL();
+  const normalised = sql.sql.toUpperCase().replace(/\s+/g, ' ');
+
+  it('uses FOR UPDATE SKIP LOCKED to tolerate multi-worker races', () => {
+    expect(normalised).toContain('FOR UPDATE SKIP LOCKED');
+  });
+
+  it('filters status = running and claimed_at < threshold', () => {
+    expect(normalised).toContain('"STATUS" =');
+    expect(sql.params).toContain('running');
+    expect(normalised).toContain('"CLAIMED_AT" <');
+  });
+});


### PR DESCRIPTION
## Summary

Implement the Postgres backend for the three orchestration protocols plus the backend-agnostic worker loop. Single-layer architecture — worker polls `job_run` directly via `SELECT ... FOR UPDATE SKIP LOCKED`. No executor layer, no separate transport.

### Runtime (5 new files under `runtime/subsystems/jobs/`)

- **`job-orchestrator.drizzle-backend.ts`** — `DrizzleJobOrchestrator`:
  - `start()` — def lookup (throws `JobTypeNotFoundError`); dedupe collapse on `(job_type, dedupe_key)` within window; concurrency collision with all three modes (`reject` throws `JobCollisionError`, `replace` cancels incumbent, `queue` proceeds); client-side `randomUUID()` + `rootRunId` resolution; single INSERT.
  - `cancel()` — idempotent on terminal; atomic transition with `WHERE status NOT IN (terminals)`; cascade branches on `parent_close_policy`.
  - `replay()` — terminal-status guard; transactional step-delete + run-reset; three `replay_from` modes (`last_step` ≡ `last_checkpoint` at Phase 1, collapse documented in spec).
- **`job-run-service.drizzle-backend.ts`** — `listForScope` / `cancelForScope` (delegates to orchestrator) / `rescheduleForScope` (bulk UPDATE pending rows).
- **`job-step-service.drizzle-backend.ts`** — `onConflictDoUpdate` upsert on `(job_run_id, step_id)`; `findStep` returns null on miss.
- **`job-worker.ts`** — `JobWorker` Injectable (`OnModuleInit` + `OnModuleDestroy`):
  - Per-pool polling loop with `setInterval`.
  - Claim query via `FOR UPDATE SKIP LOCKED` inside `db.transaction`.
  - Concurrency-queue release on claim (re-sets row to `pending` if another run's already running with same key).
  - Retry vs fail classification with exponential/fixed backoff.
  - Parent-close-policy cascade on terminal failure.
  - **Stale-claim sweeper via `FOR UPDATE SKIP LOCKED`** (Q2 resolved 2026-04-19 — per-worker sweeper safe across horizontally-scaled workers; a row is recovered at most once).
  - Graceful SIGTERM drain with `shutdownTimeoutMs` race + uncompleted-run reset.
- **`jobs-errors.ts`** — `JobTypeNotFoundError`, `JobCollisionError` (carries `incumbent: JobRun`), `JobNotReplayableError`, `JobTemplateFieldMissingError`.

### Tests (4 new specs) — surgical per JOB-4's scope-boundary ownership of the full worker unit suite

- `job-worker.claim-query.spec.ts` — `.toSQL()` asserts `FOR UPDATE SKIP LOCKED` + `ORDER BY priority DESC, run_at ASC` + `LIMIT 1` + status/pool/run_at filters.
- `job-worker.stale-sweeper.spec.ts` — `.toSQL()` asserts `FOR UPDATE SKIP LOCKED` + `claimed_at <` filter.
- `job-worker.backoff.spec.ts` — `fixed` + `exponential` + overflow guard at attempt 50.
- `job-worker.classify-error.spec.ts` — retry vs fail + `nonRetryableErrors` match by `.name` and `.code`.

End-to-end memoization / shutdown / cascade / replay-modes / collision-modes / dedupe-collapse deferred to JOB-4 per spec scope boundary.

## Spec drift fixed (living docs)

Updated `docs/specs/JOB-3.md` in-PR:
- New `replay(runId)` subsection under §Implementation Steps #1 — the AC called out `replay_from` modes but the Implementation Steps didn't expand the method.
- New §Implementation Decisions section documenting: template-eval strategy (`{{field}}` substitution, missing → `JobTemplateFieldMissingError`), error-class inventory, `last_step` / `last_checkpoint` Phase-1 collapse (they diverge once ADR-027 adds `kind='checkpoint'`), concurrency-queue release mechanism, `nextStepSeq` rationale, OQ-2 per-worker sweeper reaffirmation.
- `Last Updated` → 2026-04-20.

## Test plan

- [x] `just test-unit` — 662 pass / 0 fail / 1593 expect() in ~448ms. Baseline + `just validate` out of scope (no templates, no Docker).
- [x] Claim query generates `FOR UPDATE SKIP LOCKED` via `.toSQL()` inspection.
- [x] Sweeper query generates `FOR UPDATE SKIP LOCKED` via `.toSQL()` inspection.
- [ ] Integration round-trips (claim / dedupe collapse / collision modes / step memoization / replay modes / cascade cancel / stale recovery / shutdown drain) — **JOB-4 scope** (full behavioural test suite).

## Scope hygiene

Deliberately **not** in this PR:
- Memory backends → JOB-4.
- `JobsDomainModule` / `JobWorkerModule` / pool-config loader / boot-time handler-registry validator → JOB-5.
- `scopeable: true` parsing / `ScopeEntityType` union → JOB-7 (jobs-scope peer coordinator).
- Multi-tenancy threading of `tenantId` into services → JOB-8.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)