### PR TITLE
EVT-1 — domain_events schema upgrade (pool, direction, tenant_id)

### DIFF
--- a/docs/specs/EVT-1.md
+++ b/docs/specs/EVT-1.md
@@ -9,6 +9,8 @@
 
 Add `pool`, `direction`, and (conditionally) `tenant_id` columns to the `domain_events` outbox table. Add a `(pool, status, occurred_at)` composite index for pool-filtered drain queries. This PR is purely additive to the existing schema — no existing logic is changed.
 
+**Drift fix (applied during implementation):** The pre-EVT-1 schema declared zero indexes — the `(status, occurred_at)` and `(aggregate_id, aggregate_type)` indexes existed only as JSDoc comments above the table definition, with a "// add via migration when deploying" disclaimer. Per CLAUDE.md's living-docs rule and the spirit of the AC ("existing indexes preserved"), this PR promotes both pre-existing indexes into the Drizzle index callback at the same time as adding the new EVT-1 index. After this PR the schema declares **three** indexes in code (previously: zero declared, two intended).
+
 ## Context
 
 **What exists.** `runtime/subsystems/events/domain-events.schema.ts` defines the `domain_events` table with columns: `id`, `type`, `aggregate_id`, `aggregate_type`, `payload`, `occurred_at`, `processed_at`, `status`, `error`, `metadata`. Direction and pool information currently lives inside the JSON `metadata` column — this means pool-based drain filtering requires JSON unpacking on every poll row, and adds no index benefit.
@@ -54,13 +56,13 @@ Indexes:
 
 ## Acceptance Criteria
 
-- [ ] `pool text` column present, nullable.
-- [ ] `direction text` column present, nullable.
-- [ ] `tenant_id text` column present with `// conditional` annotation.
-- [ ] `(pool, status, occurred_at)` composite index declared.
-- [ ] Existing `(status, occurred_at)` and `(aggregate_id, aggregate_type)` indexes preserved.
-- [ ] `DomainEventRecord` inferred type includes the new fields.
-- [ ] Unit test: schema imports without error; column names are present.
+- [x] `pool text` column present, nullable.
+- [x] `direction text` column present, nullable.
+- [x] `tenant_id text` column present with `// conditional` annotation.
+- [x] `(pool, status, occurred_at)` composite index declared.
+- [x] Existing `(status, occurred_at)` and `(aggregate_id, aggregate_type)` indexes promoted from JSDoc comment to Drizzle declarations (drift fix — see §Overview).
+- [x] `DomainEventRecord` inferred type includes the new fields.
+- [x] Unit test: schema imports without error; column names are present.
 
 ## Testing Strategy
 

--- a/runtime/subsystems/events/domain-events.schema.ts
+++ b/runtime/subsystems/events/domain-events.schema.ts
@@ -5,11 +5,27 @@
  * same database transaction as the domain write (outbox pattern). A
  * polling process reads unprocessed rows and dispatches to subscribers.
  *
- * Indexes:
- *   - (status, occurredAt) — polling query filter
- *   - (aggregateId, aggregateType) — event replay per aggregate
+ * First-class routing columns (EVT-1):
+ *   - `pool`       — populated by DrizzleEventBus.publish() (EVT-4); enables
+ *                    pool-filtered drain queries without unpacking metadata JSON.
+ *   - `direction`  — `internal` | `external`; mirrors the routing dimension
+ *                    used by jobs' reserved `events_internal` / `events_external`
+ *                    pools.
+ *   - `tenant_id`  — conditional: emitted only when `events.multi_tenant: true`
+ *                    in `codegen.config.yaml`. The runtime source declares it
+ *                    unconditionally; EVT-8's scaffold template handles the
+ *                    config-driven include/exclude.
+ *
+ * The `metadata` JSON column continues to carry these values for protocol
+ * stability; the first-class columns are an optimization for drain filtering.
+ *
+ * Indexes (declared below in the index callback):
+ *   - (status, occurred_at)             — polling drain filter
+ *   - (aggregate_id, aggregate_type)    — event replay per aggregate
+ *   - (pool, status, occurred_at)       — per-pool drain filter (EVT-1)
  */
 import {
+  index,
   jsonb,
   pgTable,
   text,
@@ -33,10 +49,29 @@ export const domainEvents = pgTable(
     /** Error message from the last failed dispatch attempt. */
     error: text('error'),
     metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    /** Routing pool (e.g. `events_internal`, `events_external`). Populated by DrizzleEventBus.publish() in EVT-4. */
+    pool: text('pool'),
+    /** Routing direction: `internal` | `external`. Populated by DrizzleEventBus.publish() in EVT-4. */
+    direction: text('direction'),
+    // conditional: emitted only when events.multi_tenant: true
+    tenantId: text('tenant_id'),
   },
-  // Indexes: add via migration when deploying
-  // - (status, occurred_at) for polling
-  // - (aggregate_id, aggregate_type) for replay
+  (t) => ({
+    /** Polling drain filter (existing — promoted from comment to declaration in EVT-1). */
+    idxDomainEventsStatusOccurredAt: index('idx_domain_events_status_occurred_at').on(
+      t.status,
+      t.occurredAt,
+    ),
+    /** Event replay per aggregate (existing — promoted from comment to declaration in EVT-1). */
+    idxDomainEventsAggregate: index('idx_domain_events_aggregate').on(
+      t.aggregateId,
+      t.aggregateType,
+    ),
+    /** Per-pool drain filter (EVT-1). Enables DrizzleEventBus to drain a single pool without scanning all events. */
+    idxDomainEventsPoolStatusOccurredAt: index(
+      'idx_domain_events_pool_status_occurred_at',
+    ).on(t.pool, t.status, t.occurredAt),
+  }),
 );
 
 export type DomainEventRecord = InferSelectModel<typeof domainEvents>;

--- a/src/__tests__/runtime/subsystems/domain-events.schema.spec.ts
+++ b/src/__tests__/runtime/subsystems/domain-events.schema.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the domain_events Drizzle schema (EVT-1, ADR-024 Phase 1).
+ *
+ * Pure structural/metadata checks — no Postgres, no Docker. Verifies that
+ *   1. the pgTable declaration imports cleanly,
+ *   2. the new first-class routing columns are present (pool, direction, tenantId),
+ *   3. the existing columns are still there,
+ *   4. InferSelectModel resolved a concrete row type that includes the new fields.
+ *
+ * Index assertions are intentionally omitted: Drizzle stores index metadata on
+ * a non-public table symbol and there is no stable, public introspection API.
+ * The presence of the three indexes is enforced by the schema source itself
+ * (see `domain-events.schema.ts` index callback).
+ */
+import { describe, it, expect } from 'bun:test';
+import { getTableColumns } from 'drizzle-orm';
+import {
+  domainEvents,
+  type DomainEventRecord,
+} from '../../../../runtime/subsystems/events/domain-events.schema';
+
+describe('domain-events.schema — import smoke', () => {
+  it('exports the pgTable declaration as an object', () => {
+    expect(typeof domainEvents).toBe('object');
+    expect(domainEvents).not.toBeNull();
+  });
+});
+
+describe('domain_events — column presence', () => {
+  const cols = getTableColumns(domainEvents) as Record<string, unknown>;
+
+  it.each([
+    // existing columns
+    'id',
+    'type',
+    'aggregateId',
+    'aggregateType',
+    'payload',
+    'occurredAt',
+    'processedAt',
+    'status',
+    'error',
+    'metadata',
+    // EVT-1 new columns
+    'pool',
+    'direction',
+    'tenantId',
+  ])('includes column %s', (key) => {
+    expect(cols[key]).toBeDefined();
+  });
+});
+
+describe('DomainEventRecord — type-level compile check', () => {
+  it('resolves to a concrete row type that includes EVT-1 columns', () => {
+    // If InferSelectModel widened to `any`, TypeScript would not catch a
+    // shape mismatch here. The literal exercises the new fields; the test
+    // merely asserts the file compiles and the value exists at runtime.
+    const row: DomainEventRecord = {
+      id: '00000000-0000-0000-0000-000000000000',
+      type: 'opportunity.created',
+      aggregateId: 'agg-1',
+      aggregateType: 'opportunity',
+      payload: { foo: 'bar' },
+      occurredAt: new Date(),
+      processedAt: null,
+      status: 'pending',
+      error: null,
+      metadata: null,
+      pool: 'events_internal',
+      direction: 'internal',
+      tenantId: null,
+    };
+    expect(row.id).toBeDefined();
+    expect(row.pool).toBe('events_internal');
+    expect(row.direction).toBe('internal');
+    expect(row.tenantId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Add first-class routing columns to `domain_events` outbox so the drain loop can filter by pool via index instead of JSON-unpacking `metadata` on every row. Pure additive schema change — no existing logic altered.

- `pool text` (nullable) — populated by `DrizzleEventBus.publish` in EVT-4
- `direction text` (nullable) — same
- `tenant_id text` (nullable) — unconditional in runtime source with `// conditional: emitted only when events.multi_tenant: true` annotation; EVT-8's scaffold template gates the actual emission
- new composite index `(pool, status, occurred_at)` for per-pool drain

## Drift fix

The schema previously declared **zero** indexes — `(status, occurred_at)` and `(aggregate_id, aggregate_type)` lived only as JSDoc comments with a "// add via migration when deploying" disclaimer. Per [CLAUDE.md's living-docs rule](../blob/main/CLAUDE.md), promoted both into the new `(t) => ({...})` index callback alongside the new one. Style mirrors `runtime/subsystems/jobs/job-orchestration.schema.ts`.

Spec updated: `docs/specs/EVT-1.md` §Overview gained a drift-fix paragraph; the "existing indexes preserved" AC line was rewritten to reflect the promotion; AC boxes flipped to checked.

## Test plan

- [x] New spec `src/__tests__/runtime/subsystems/domain-events.schema.spec.ts` (15 tests) — import smoke, all 13 columns present, `DomainEventRecord` type-level compile check covering the three new fields
- [x] `just test-unit` — 712 pass / 0 fail
- [x] `just test-baseline` — pre-existing failure confirmed present on `main` (unrelated to this PR); no new regression

## Acceptance criteria (from `docs/specs/EVT-1.md`)

All items satisfied — see spec.

Closes #92