### PR TITLE
EVT-5 — MemoryEventBus pool awareness + unit test suite

### DIFF
--- a/.claude/skills/events/SKILL.md
+++ b/.claude/skills/events/SKILL.md
@@ -78,7 +78,7 @@ Files that ship to the consumer app (not templates):
 - `runtime/subsystems/events/event-bus.protocol.ts` — `IEventBus`, `DomainEvent`
 - `runtime/subsystems/events/domain-events.schema.ts` — outbox table (will gain `pool`/`direction` columns in Phase A)
 - `runtime/subsystems/events/event-bus.drizzle-backend.ts` — outbox poller (`FOR UPDATE SKIP LOCKED`)
-- `runtime/subsystems/events/event-bus.memory-backend.ts` — sync test backend, exposes `publishedEvents[]` and `clear()`
+- `runtime/subsystems/events/event-bus.memory-backend.ts` — sync test backend, exposes `publishedEvents[]`, `publishedEventsForPool()`, `publishedEventsForDirection()`, `clear()`; accepts `opts.pools` for pool-filtered dispatch that mirrors the Drizzle drain (EVT-5)
 - `runtime/subsystems/events/event-bus.redis-backend.ts` — alternate backend
 - `runtime/subsystems/events/events.module.ts` — `EventsModule.forRoot({ backend })`, `global: true`
 - `runtime/subsystems/events/events.tokens.ts` — `EVENT_BUS` symbol

--- a/.claude/skills/events/protocol-and-backends.md
+++ b/.claude/skills/events/protocol-and-backends.md
@@ -70,15 +70,22 @@ Strengths: zero new infra beyond Postgres; transactional guarantee; survives pro
 
 `runtime/subsystems/events/event-bus.memory-backend.ts`. Synchronous, in-process.
 
-- **`publish(event)`** — pushes into a `publishedEvents[]` array, dispatches to handlers immediately. **Ignores `tx`** — there is no transactional semantic in memory.
-- **`publishMany(events)`** — calls `publish` in a loop.
+- **`publish(event)`** — pushes into a `publishedEvents[]` array, dispatches to handlers immediately (subject to the pool filter; see below). **Ignores `tx`** — there is no transactional semantic in memory.
+- **`publishMany(events)`** — calls `publish` in a loop (per-event pool filtering applies).
 - **`subscribe(type, handler)`** — same Map-based registry as Drizzle.
 - **`clear()`** — test helper; drops all published events and handlers. Call in `beforeEach`.
-- **`publishedEvents`** — public array for test assertions (`expect(bus.publishedEvents).toContainEqual({...})`).
+- **`publishedEvents`** — public array for test assertions (`expect(bus.publishedEvents).toContainEqual({...})`). Always the complete log; not affected by the pool filter.
+- **`publishedEventsForPool(pool)` / `publishedEventsForDirection(direction)`** — filtered views for targeted assertions (e.g. "only change events were emitted from this use case").
 
 Use in every test that touches the events subsystem. Swap via `EventsModule.forRoot({ backend: 'memory' })`.
 
-**Key test property:** dispatch is synchronous. `await bus.publish(event)` returns only after all subscribers have handled the event. Tests do not need `waitFor` / timers. This is different from Drizzle, where dispatch is async via the polling loop.
+**Pool awareness (EVT-5).** `MemoryEventBus` accepts the same `EventsModuleOptions` (via `@Optional() @Inject(EVENTS_MODULE_OPTIONS)`) as `DrizzleEventBus`, including `opts.pools`. Behaviour mirrors the Drizzle drain:
+- `opts.pools` undefined or empty array → no filter, all events dispatched (Drizzle's WHERE uses `pools && pools.length > 0`; memory matches).
+- `opts.pools` non-empty → handler only fires when `event.metadata.pool` is in the list. Events outside the pool (including those with no `metadata.pool`) are still pushed to `publishedEvents` but not dispatched.
+
+Direct construction still works for unit tests: `new MemoryEventBus()` defaults to `{ backend: 'memory' }` and dispatches everything.
+
+**Key test property:** dispatch is synchronous. `await bus.publish(event)` returns only after all subscribers have handled the event (if dispatch happens at all). Tests do not need `waitFor` / timers. This is different from Drizzle, where dispatch is async via the polling loop.
 
 ### Redis backend
 

--- a/docs/specs/EVT-5.md
+++ b/docs/specs/EVT-5.md
@@ -1,7 +1,7 @@
 # EVT-5 — Memory Backend Upgrade + Unit Test Suite
 
 **Issue:** EVT-5
-**Status:** Stub
+**Status:** Shipped
 **Phase:** ADR-024 Phase 1
 **Depends on:** EVT-4 (behavioral contract to match).
 **Blocks:** EVT-6 (module wiring needs both backends ready).
@@ -14,19 +14,20 @@ Upgrade `MemoryEventBus` with pool awareness for test assertions. Write a unit t
 
 **What exists.** `MemoryEventBus` stores published events in `publishedEvents[]` and dispatches synchronously. It exposes `clear()`. No pool awareness — test authors can only assert the full set of published events, not events by pool.
 
-**What this PR adds.** `publishedEventsForPool(pool)` helper and pool-filter behavior that mirrors the Drizzle backend's per-process restriction. The memory backend remains synchronous (dispatch immediate, no polling interval) — pool filtering affects which events are dispatched to handlers, not which events are stored.
+**What this PR adds.** `publishedEventsForPool(pool)` and `publishedEventsForDirection(direction)` helpers, plus pool-filter behaviour that mirrors the Drizzle backend's per-process restriction. The memory backend remains synchronous (dispatch immediate, no polling interval) — pool filtering affects which events are dispatched to handlers, not which events are stored.
 
 **Why pool-filtered dispatch matters for testing.** When testing components that set up isolated drain workers (e.g. an inbound-webhook worker vs. a change-event worker), the memory backend should behave the same way: events published to `events_inbound` should not be dispatched to a process configured for `events_change` only.
 
 ## Architecture
 
 ```
-MemoryEventBus (opts?: { pools?: string[] })
+MemoryEventBus (opts?: EventsModuleOptions)
   ├── publishedEvents: DomainEvent[]   ← all published events (unchanged)
-  ├── publishedEventsForPool(pool)     ← NEW: filter by pool metadata
+  ├── publishedEventsForPool(pool)     ← filter by metadata.pool
+  ├── publishedEventsForDirection(dir) ← filter by metadata.direction
   ├── publish(event)
-  │   ├── push to publishedEvents
-  │   └── dispatch to handlers only if event.metadata?.pool in opts.pools (or pools unset)
+  │   ├── push to publishedEvents (always)
+  │   └── dispatch to handlers only if shouldDispatch(event)
   └── clear() → clears publishedEvents and handlers (unchanged)
 ```
 
@@ -34,68 +35,75 @@ MemoryEventBus (opts?: { pools?: string[] })
 
 | File | Action | Purpose |
 |------|--------|---------|
-| `runtime/subsystems/events/event-bus.memory-backend.ts` | modify | Pool awareness |
-| `runtime/subsystems/events/__tests__/event-bus.unit.test.ts` | new | Unit test suite |
+| `runtime/subsystems/events/event-bus.memory-backend.ts` | modify | Pool awareness + helpers |
+| `src/__tests__/runtime/subsystems/event-bus.spec.ts` | extend | Add `MemoryEventBus — pool awareness` block |
 
 ## Interfaces
 
 ```ts
-export interface MemoryEventBusOptions {
-  pools?: string[];  // restrict dispatch to these pools; undefined = dispatch all
-}
-
 @Injectable()
 export class MemoryEventBus implements IEventBus {
   readonly publishedEvents: DomainEvent[] = [];  // unchanged
 
-  /** Filter published events by pool (from metadata.pool). */
-  publishedEventsForPool(pool: string): DomainEvent[] {
-    return this.publishedEvents.filter(e => e.metadata?.['pool'] === pool);
+  constructor(
+    @Optional() @Inject(EVENTS_MODULE_OPTIONS) opts?: EventsModuleOptions,
+  ) {
+    this.opts = opts ?? { backend: 'memory' };
   }
+
+  /** Filter published events by pool (from metadata.pool). */
+  publishedEventsForPool(pool: string): DomainEvent[];
 
   /** Filter published events by direction (from metadata.direction). */
-  publishedEventsForDirection(direction: string): DomainEvent[] {
-    return this.publishedEvents.filter(e => e.metadata?.['direction'] === direction);
-  }
+  publishedEventsForDirection(direction: string): DomainEvent[];
 
-  clear(): void { ... } // unchanged
+  clear(): void; // unchanged
 }
 ```
 
 ## Implementation Steps
 
-1. Add optional `MemoryEventBusOptions` constructor parameter (or injection token for NestJS context).
-2. In `publish(event)`, after pushing to `publishedEvents`, check if `opts.pools` is set. If set and `event.metadata?.pool` is not in the list, skip `dispatch(event)` (still store in `publishedEvents`).
+1. Add optional `EventsModuleOptions` constructor parameter via `@Optional() @Inject(EVENTS_MODULE_OPTIONS)` — mirrors the `DrizzleEventBus` constructor shape.
+2. In `publish(event)`, always push to `publishedEvents`. Then check `shouldDispatch(event)`: if `opts.pools` is a non-empty array and `event.metadata?.pool` is not in it, skip `dispatch()`.
 3. Add `publishedEventsForPool(pool: string): DomainEvent[]` helper.
 4. Add `publishedEventsForDirection(direction: string): DomainEvent[]` helper.
-5. Write unit test suite:
-   - publish/subscribe round trip (unchanged behavior)
-   - `publishedEventsForPool` returns correct subset
-   - pool-restricted dispatch: events with non-matching pool are stored but not dispatched
-   - `publishMany` dispatches all events
-   - `clear()` resets state
-   - handler error propagates synchronously
+5. Extend `src/__tests__/runtime/subsystems/event-bus.spec.ts` with a new `describe('MemoryEventBus — pool awareness', ...)` block covering:
+   - `publishedEventsForPool` returns correct subset (and empty on miss).
+   - `publishedEventsForDirection` returns correct subset for inbound / outbound.
+   - Pool-restricted dispatch: events with non-matching pool are stored but not dispatched.
+   - Pool-restricted dispatch: matching events ARE dispatched.
+   - `pools: undefined` (default) dispatches everything.
+   - `pools: []` (empty array) dispatches everything — matches Drizzle's `pools && pools.length > 0` gate.
+   - Event without `metadata` under a pool filter is not dispatched.
+   - `publishMany` applies per-event filtering.
+   - `clear()` resets `publishedEvents` after pool-filtered publishes.
 6. Ensure all tests are in `just test-unit` (no Docker).
 
 ## Acceptance Criteria
 
-- [ ] `publishedEventsForPool('events_change')` returns only events where `metadata.pool === 'events_change'`.
-- [ ] `publishedEventsForDirection('inbound')` returns only events where `metadata.direction === 'inbound'`.
-- [ ] When initialized with `pools: ['events_change']`, `publish` with `metadata.pool = 'events_inbound'` stores the event in `publishedEvents` but does NOT dispatch to handlers.
-- [ ] When initialized with `pools: undefined`, all events are dispatched (backwards-compatible).
-- [ ] Unit test suite covers all the behaviors above.
-- [ ] All tests pass in `just test-unit`.
+- [x] `publishedEventsForPool('events_change')` returns only events where `metadata.pool === 'events_change'`.
+- [x] `publishedEventsForDirection('inbound')` returns only events where `metadata.direction === 'inbound'`.
+- [x] When initialized with `pools: ['events_change']`, `publish` with `metadata.pool = 'events_inbound'` stores the event in `publishedEvents` but does NOT dispatch to handlers.
+- [x] When initialized with `pools: undefined`, all events are dispatched (backwards-compatible).
+- [x] Unit test suite covers all the behaviours above.
+- [x] All tests pass in `just test-unit`.
 
 ## Testing Strategy
 
-Pure in-process unit tests. No NestJS test harness needed for the backend class itself. Create `MemoryEventBus` directly with and without pool options; assert behavior via `publishedEvents`, `publishedEventsForPool`, and mock handler call counts.
+Pure in-process unit tests. No NestJS test harness needed for the backend class itself. Create `MemoryEventBus` directly with and without pool options; assert behavior via `publishedEvents`, `publishedEventsForPool`, `publishedEventsForDirection`, and mock handler call counts.
 
-## Open Questions
+## Implementation Notes (post-ship)
 
-None blocking.
+- **Tests extend the existing spec file, not a new one.** The original plan in this spec named a new file at `runtime/subsystems/events/__tests__/event-bus.unit.test.ts`. That's not the repo convention — runtime-subsystem tests live in `src/__tests__/runtime/subsystems/*.spec.ts`, and `event-bus.spec.ts` already existed there with ~17 MemoryEventBus tests and ~9 DrizzleEventBus tests from EVT-4. The pool-awareness tests were added as a new top-level `describe('MemoryEventBus — pool awareness', ...)` block in that file. Creating a parallel `*.unit.test.ts` file would have split tests across two locations for no reason.
+- **Options shape reused, no `MemoryEventBusOptions` introduced.** The original draft contemplated a dedicated `MemoryEventBusOptions` type. Final implementation reuses `EventsModuleOptions` (same injection token, same shape) to keep both backends DI-symmetric. `MemoryEventBus` only reads `opts.pools`, so widening its own type wouldn't have bought anything and would have risked drift between backend option surfaces.
+- **Empty-pools semantics: treat as "no filter".** Chosen to match the `DrizzleEventBus.processBatch` WHERE clause, which uses `pools && pools.length > 0` as the gate on the `inArray` fragment. An empty array falls through to the status-only predicate and drains every row. The memory backend does the same: `pools: []` dispatches all events. Documented in the `shouldDispatch` method comment in `event-bus.memory-backend.ts`.
+- **Events without `metadata.pool` are out of every configured pool.** When `opts.pools` is non-empty, events missing `metadata.pool` never match and are not dispatched. This mirrors `inArray(pool, [...])` semantics, where `NULL pool` never satisfies the predicate.
+- **Test count delta:** baseline 795 unit tests → 806 after adding 11 pool-awareness tests (one more than the ~10 estimated, to cover both inbound and outbound direction filtering independently).
+- **`publishedEventsForTenant` helper intentionally omitted.** The AC and the interface block only call out `pool` and `direction` helpers. Adding a tenant helper is cheap but out of scope; the raw `publishedEvents.filter(e => e.metadata?.tenantId === t)` is fine for ad hoc assertions until EVT-6 needs it.
 
 ## References
 
 - `docs/adrs/ADR-024-events-domain-formalization.md` §"Drizzle backend upgrade" (memory mirrors this)
 - `runtime/subsystems/events/event-bus.memory-backend.ts` — current implementation
+- `runtime/subsystems/events/event-bus.drizzle-backend.ts` — constructor shape reference (EVT-4)
 - `docs/specs/JOB-4.md` — reference for memory backend unit test patterns

--- a/runtime/subsystems/events/event-bus.memory-backend.ts
+++ b/runtime/subsystems/events/event-bus.memory-backend.ts
@@ -6,9 +6,23 @@
  *
  * Use this backend in tests to assert event publication without a database.
  * Swap via EventsModule.forRoot({ backend: 'memory' }).
+ *
+ * Pool awareness (EVT-5):
+ * - Mirrors the `DrizzleEventBus` per-process restriction (EVT-4). When
+ *   `opts.pools` is set, `publish`/`publishMany` still push the event into
+ *   `publishedEvents` (so test code can assert the full set of emitted
+ *   events regardless of pool filter), but handlers are NOT invoked for
+ *   events whose `metadata.pool` is outside the configured pools.
+ * - `publishedEventsForPool(pool)` and `publishedEventsForDirection(dir)`
+ *   helpers are provided for targeted assertions.
+ * - Shares the `EventsModuleOptions` shape (same token as Drizzle) rather
+ *   than introducing a memory-only options type — the surface is the same
+ *   and keeping them unified avoids drift between backends.
  */
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import type { DomainEvent, IEventBus } from './event-bus.protocol';
+import { EVENTS_MODULE_OPTIONS } from './events.tokens';
+import type { EventsModuleOptions } from './events.module';
 
 @Injectable()
 export class MemoryEventBus implements IEventBus {
@@ -18,10 +32,26 @@ export class MemoryEventBus implements IEventBus {
   readonly publishedEvents: DomainEvent[] = [];
 
   private readonly handlers = new Map<string, Set<(event: DomainEvent) => Promise<void>>>();
+  private readonly opts: EventsModuleOptions;
+
+  constructor(
+    @Optional() @Inject(EVENTS_MODULE_OPTIONS) opts?: EventsModuleOptions,
+  ) {
+    // Default so direct construction (e.g. `new MemoryEventBus()` from a
+    // unit test outside NestJS DI) keeps working without an explicit
+    // options object.
+    this.opts = opts ?? { backend: 'memory' };
+  }
 
   async publish(event: DomainEvent): Promise<void> {
+    // Always record the event — even if this process is configured with a
+    // pool filter that excludes it. Test code relies on `publishedEvents`
+    // being a complete log of what was published, not a filtered view.
     this.publishedEvents.push(event);
-    await this.dispatch(event);
+
+    if (this.shouldDispatch(event)) {
+      await this.dispatch(event);
+    }
   }
 
   async publishMany(events: DomainEvent[]): Promise<void> {
@@ -51,6 +81,36 @@ export class MemoryEventBus implements IEventBus {
   clear(): void {
     this.publishedEvents.length = 0;
     this.handlers.clear();
+  }
+
+  /** Filter published events by `metadata.pool`. */
+  publishedEventsForPool(pool: string): DomainEvent[] {
+    return this.publishedEvents.filter((e) => e.metadata?.['pool'] === pool);
+  }
+
+  /** Filter published events by `metadata.direction`. */
+  publishedEventsForDirection(direction: string): DomainEvent[] {
+    return this.publishedEvents.filter((e) => e.metadata?.['direction'] === direction);
+  }
+
+  /**
+   * Decide whether `event` should be dispatched to handlers given the
+   * current pool filter.
+   *
+   * Semantics (mirroring `DrizzleEventBus.processBatch`):
+   * - `opts.pools` undefined  → dispatch everything (no filter).
+   * - `opts.pools` empty array → treated as "no filter" to match the
+   *   Drizzle backend, where `pools && pools.length > 0` is the gate on
+   *   the `inArray` WHERE clause. Empty arrays dispatch everything.
+   * - `opts.pools` non-empty  → dispatch only when `event.metadata.pool`
+   *   is in the list. Events without `metadata.pool` do NOT match — they
+   *   are out of all configured pools by definition.
+   */
+  private shouldDispatch(event: DomainEvent): boolean {
+    const pools = this.opts.pools;
+    if (!pools || pools.length === 0) return true;
+    const eventPool = event.metadata?.['pool'];
+    return typeof eventPool === 'string' && pools.includes(eventPool);
   }
 
   private async dispatch(event: DomainEvent): Promise<void> {

--- a/src/__tests__/runtime/subsystems/event-bus.spec.ts
+++ b/src/__tests__/runtime/subsystems/event-bus.spec.ts
@@ -238,6 +238,152 @@ describe('MemoryEventBus', () => {
 });
 
 // ============================================================================
+// MemoryEventBus — pool awareness (EVT-5)
+// ============================================================================
+
+describe('MemoryEventBus — pool awareness', () => {
+  // --------------------------------------------------------------------------
+  // publishedEventsForPool / publishedEventsForDirection helpers
+  // --------------------------------------------------------------------------
+  describe('publishedEventsForPool', () => {
+    it('returns only events whose metadata.pool matches', async () => {
+      const bus = new MemoryEventBus();
+      await bus.publish(makeEvent({ id: '1', metadata: { pool: 'events_change' } }));
+      await bus.publish(makeEvent({ id: '2', metadata: { pool: 'events_inbound' } }));
+      await bus.publish(makeEvent({ id: '3', metadata: { pool: 'events_change' } }));
+
+      const changeEvents = bus.publishedEventsForPool('events_change');
+      expect(changeEvents).toHaveLength(2);
+      expect(changeEvents.map((e) => e.id)).toEqual(['1', '3']);
+    });
+
+    it('returns an empty array when no events match the pool', async () => {
+      const bus = new MemoryEventBus();
+      await bus.publish(makeEvent({ metadata: { pool: 'events_inbound' } }));
+      expect(bus.publishedEventsForPool('events_change')).toEqual([]);
+    });
+  });
+
+  describe('publishedEventsForDirection', () => {
+    it('returns only inbound events', async () => {
+      const bus = new MemoryEventBus();
+      await bus.publish(makeEvent({ id: '1', metadata: { direction: 'inbound' } }));
+      await bus.publish(makeEvent({ id: '2', metadata: { direction: 'change' } }));
+      await bus.publish(makeEvent({ id: '3', metadata: { direction: 'inbound' } }));
+
+      const inbound = bus.publishedEventsForDirection('inbound');
+      expect(inbound).toHaveLength(2);
+      expect(inbound.map((e) => e.id)).toEqual(['1', '3']);
+    });
+
+    it('returns only outbound events', async () => {
+      const bus = new MemoryEventBus();
+      await bus.publish(makeEvent({ id: '1', metadata: { direction: 'outbound' } }));
+      await bus.publish(makeEvent({ id: '2', metadata: { direction: 'change' } }));
+
+      const outbound = bus.publishedEventsForDirection('outbound');
+      expect(outbound).toHaveLength(1);
+      expect(outbound[0].id).toBe('1');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // pool-filtered dispatch
+  // --------------------------------------------------------------------------
+  describe('pool-filtered dispatch', () => {
+    it('stores events outside the configured pool but does NOT dispatch them', async () => {
+      const bus = new MemoryEventBus({ backend: 'memory', pools: ['events_change'] });
+      const received: DomainEvent[] = [];
+      bus.subscribe('test_event', async (e) => { received.push(e); });
+
+      const outOfPool = makeEvent({ id: 'oop', metadata: { pool: 'events_inbound' } });
+      await bus.publish(outOfPool);
+
+      // Recorded for assertions, but handler never ran.
+      expect(bus.publishedEvents).toHaveLength(1);
+      expect(bus.publishedEvents[0]).toBe(outOfPool);
+      expect(received).toHaveLength(0);
+    });
+
+    it('dispatches events whose pool is in the configured list', async () => {
+      const bus = new MemoryEventBus({ backend: 'memory', pools: ['events_change'] });
+      const received: DomainEvent[] = [];
+      bus.subscribe('test_event', async (e) => { received.push(e); });
+
+      const inPool = makeEvent({ metadata: { pool: 'events_change' } });
+      await bus.publish(inPool);
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toBe(inPool);
+    });
+
+    it('dispatches all events when pools is undefined (backwards-compat)', async () => {
+      const bus = new MemoryEventBus(); // no opts
+      const received: DomainEvent[] = [];
+      bus.subscribe('test_event', async (e) => { received.push(e); });
+
+      await bus.publish(makeEvent({ id: '1', metadata: { pool: 'events_change' } }));
+      await bus.publish(makeEvent({ id: '2', metadata: { pool: 'events_inbound' } }));
+      await bus.publish(makeEvent({ id: '3' })); // no metadata
+
+      expect(received).toHaveLength(3);
+    });
+
+    it('treats an empty pools array as "no filter" (matches DrizzleEventBus)', async () => {
+      // DrizzleEventBus's WHERE uses `pools && pools.length > 0`, so an
+      // empty array drops to the status-only predicate and drains
+      // everything. MemoryEventBus mirrors that semantic.
+      const bus = new MemoryEventBus({ backend: 'memory', pools: [] });
+      const received: DomainEvent[] = [];
+      bus.subscribe('test_event', async (e) => { received.push(e); });
+
+      await bus.publish(makeEvent({ id: '1', metadata: { pool: 'events_change' } }));
+      await bus.publish(makeEvent({ id: '2', metadata: { pool: 'events_inbound' } }));
+
+      expect(received).toHaveLength(2);
+    });
+
+    it('does NOT dispatch events without metadata when pools is set', async () => {
+      const bus = new MemoryEventBus({ backend: 'memory', pools: ['events_change'] });
+      const received: DomainEvent[] = [];
+      bus.subscribe('test_event', async (e) => { received.push(e); });
+
+      await bus.publish(makeEvent()); // no metadata at all
+
+      expect(bus.publishedEvents).toHaveLength(1); // still recorded
+      expect(received).toHaveLength(0);           // but not dispatched
+    });
+
+    it('publishMany filters per-event: only matching-pool events dispatch', async () => {
+      const bus = new MemoryEventBus({ backend: 'memory', pools: ['events_change'] });
+      const received: string[] = [];
+      bus.subscribe('test_event', async (e) => { received.push(e.id); });
+
+      await bus.publishMany([
+        makeEvent({ id: 'a', metadata: { pool: 'events_change' } }),
+        makeEvent({ id: 'b', metadata: { pool: 'events_inbound' } }),
+        makeEvent({ id: 'c', metadata: { pool: 'events_change' } }),
+        makeEvent({ id: 'd', metadata: { pool: 'events_outbound' } }),
+      ]);
+
+      // All four are recorded; only two matching dispatched.
+      expect(bus.publishedEvents).toHaveLength(4);
+      expect(received).toEqual(['a', 'c']);
+    });
+
+    it('clear() resets publishedEvents after pool-filtered publishes', async () => {
+      const bus = new MemoryEventBus({ backend: 'memory', pools: ['events_change'] });
+      await bus.publish(makeEvent({ metadata: { pool: 'events_change' } }));
+      await bus.publish(makeEvent({ metadata: { pool: 'events_inbound' } }));
+      expect(bus.publishedEvents).toHaveLength(2);
+
+      bus.clear();
+      expect(bus.publishedEvents).toHaveLength(0);
+    });
+  });
+});
+
+// ============================================================================
 // DrizzleEventBus (mocked Drizzle client — no Docker)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Brings `MemoryEventBus` to behavioral parity with the post-EVT-4 (#107) `DrizzleEventBus` so in-process tests for per-pool drain workers behave the same way as production:

- Optional `EVENTS_MODULE_OPTIONS` injection mirroring Drizzle's constructor shape (`@Optional() @Inject(EVENTS_MODULE_OPTIONS)`). Direct `new MemoryEventBus()` still works — defaulted opts.
- New helpers: `publishedEventsForPool(pool)` and `publishedEventsForDirection(direction)` for test assertions over the in-memory log.
- `dispatch()` gated by `shouldDispatch(event)`: when `opts.pools` is non-empty, only events whose `metadata.pool` is in the list are dispatched to handlers. **Every published event is still appended to `publishedEvents` regardless of pool filter** — tests can inspect the full publication log.
- Empty `opts.pools` (`[]`) treated as "no filter", matching Drizzle's `pools && pools.length > 0` gating in `processBatch`.
- Events without `metadata.pool` are treated as out-of-pool when `opts.pools` is non-empty — mirrors SQL `inArray(pool, [...])` against `NULL`.

## Design decisions

- **Reused `EventsModuleOptions`** (the same token + shape wired by EVT-4) instead of introducing a separate `MemoryEventBusOptions` type — symmetric DI with Drizzle, one source of truth for backend options.
- **No `publishedEventsForTenant` helper** — out of AC scope.

## Docs updated (living-docs)

- `docs/specs/EVT-5.md` — Stub → Shipped; Implementation Notes cover the test-file-location drift fix (extended existing `src/__tests__/runtime/subsystems/event-bus.spec.ts` rather than creating a new file under `runtime/`), the `EventsModuleOptions` reuse, empty-pools semantics, and the test delta (795 → 806).
- `.claude/skills/events/protocol-and-backends.md` — Memory backend section rewritten to document the new helpers, opts injection, and empty-pools rule.
- `.claude/skills/events/SKILL.md` — runtime snapshot bullet for the memory backend now lists the new helpers and references EVT-5.

## Test plan

- [x] +11 tests in `src/__tests__/runtime/subsystems/event-bus.spec.ts` under `describe('MemoryEventBus — pool awareness', ...)` — covering all AC items plus mixed-pool `publishMany`, empty-pools-as-no-filter, no-metadata events under non-empty pools, positive/negative dispatch cases, and `clear()` after pool-filtered publishes.
- [x] `just test-unit` — **806 pass / 0 fail** (795 → 806)
- [x] `just test-baseline` — pre-existing `deals.module.ts` / `contacts.module.ts` diff only; no new regression
- [x] `bun run typecheck` — zero errors
- [x] No Docker needed (pure in-process)

## Acceptance criteria

All 6 AC items from `docs/specs/EVT-5.md` verified by validator.

Closes #96