### PR TITLE
EVT-6 — EventsModule wires TYPED_EVENT_BUS + publish-side multi-tenancy

### DIFF
--- a/.claude/skills/events/SKILL.md
+++ b/.claude/skills/events/SKILL.md
@@ -80,8 +80,10 @@ Files that ship to the consumer app (not templates):
 - `runtime/subsystems/events/event-bus.drizzle-backend.ts` — outbox poller (`FOR UPDATE SKIP LOCKED`)
 - `runtime/subsystems/events/event-bus.memory-backend.ts` — sync test backend, exposes `publishedEvents[]`, `publishedEventsForPool()`, `publishedEventsForDirection()`, `clear()`; accepts `opts.pools` for pool-filtered dispatch that mirrors the Drizzle drain (EVT-5)
 - `runtime/subsystems/events/event-bus.redis-backend.ts` — alternate backend
-- `runtime/subsystems/events/events.module.ts` — `EventsModule.forRoot({ backend })`, `global: true`
-- `runtime/subsystems/events/events.tokens.ts` — `EVENT_BUS` symbol
+- `runtime/subsystems/events/events.module.ts` — `EventsModule.forRoot({ backend, multiTenant? })`, `global: true`; provides `EVENT_BUS`, `TYPED_EVENT_BUS`, `EVENTS_MULTI_TENANT`
+- `runtime/subsystems/events/events.tokens.ts` — `EVENT_BUS`, `TYPED_EVENT_BUS`, `EVENTS_MULTI_TENANT`, `EVENTS_MODULE_OPTIONS` (all string-valued), `REDIS_URL` (Symbol)
+- `runtime/subsystems/events/events-errors.ts` — `MissingTenantIdError` (thrown by `TypedEventBus.publish` when `multiTenant: true` and `metadata.tenantId` missing)
+- `runtime/subsystems/events/generated/bus.ts` — `TypedEventBus`, injects `EVENT_BUS` + `EVENTS_MULTI_TENANT`; stamps `pool` / `direction` / `version` onto publish metadata and enforces tenantId when multi-tenant mode is on
 - `runtime/base-classes/lifecycle-events.ts` — legacy fire-and-forget auto-emission; being replaced by `emits:` declarations
 
 Generator pieces (exist as templates + future generator code):

--- a/docs/specs/EVT-6.md
+++ b/docs/specs/EVT-6.md
@@ -1,24 +1,25 @@
 # EVT-6 — EventsModule Upgrade: TypedEventBus Provider + Multi-Tenancy Wiring
 
 **Issue:** EVT-6
-**Status:** Stub
+**Status:** Implemented
 **Phase:** ADR-024 Phase 1
 **Depends on:** EVT-3 (generated TypedEventBus must exist), EVT-5 (Memory backend parity).
 **Blocks:** EVT-7 (use-case templates inject TypedEventBus), EVT-8 (scaffold must emit updated module).
 
 ## Overview
 
-Wire `TypedEventBus` as an injectable `TYPED_EVENT_BUS` provider in `EventsModule`. Expand `EventsModuleOptions` with `multi_tenant?: boolean`. Add `TYPED_EVENT_BUS` injection token to `events.tokens.ts`. The module remains `global: true` — `TypedEventBus` is available project-wide without per-module imports.
+Wire `TypedEventBus` as an injectable `TYPED_EVENT_BUS` provider in `EventsModule`. Expand `EventsModuleOptions` with `multiTenant?: boolean`. Both the `TYPED_EVENT_BUS` and `EVENTS_MULTI_TENANT` injection tokens live in `events.tokens.ts`. The module remains `global: true` — `TypedEventBus` is available project-wide without per-module imports.
 
 ## Context
 
-**What exists.** `EventsModule.forRoot()` provides only `EVENT_BUS`. Application code that wants typed events has to inject `EVENT_BUS` and cast. `TypedEventBus` is a generated class (EVT-3) but nothing wires it into NestJS DI yet.
+**What exists before this PR.** `EventsModule.forRoot()` provides only `EVENT_BUS`. Application code that wants typed events has to inject `EVENT_BUS` and cast. `TypedEventBus` is a generated class (EVT-3) but nothing wires it into NestJS DI yet. The `TYPED_EVENT_BUS` token was already declared by EVT-3 with a "Provider registration lands in EVT-6" note; this PR lands it.
 
-**What this PR adds.** `TYPED_EVENT_BUS` token + provider. After this PR, use cases can inject either:
-- `@Inject(EVENT_BUS)` → `IEventBus` (raw, backwards-compatible)
+**What this PR adds.** `TYPED_EVENT_BUS` wiring + `EVENTS_MULTI_TENANT` token/provider + publish-side tenant enforcement inside `TypedEventBus`. After this PR, use cases inject either:
+
+- `@Inject(EVENT_BUS)` → `IEventBus` (raw port)
 - `TypedEventBus` (generated injectable, typed) — recommended for generated use cases
 
-Multi-tenancy: adds `EventsModuleOptions.multi_tenant` flag. When enabled, the drain loop and the `publish` path thread `tenantId` through. The exact service-layer changes mirror JOB-8 multi-tenancy for jobs.
+Multi-tenancy: `EventsModuleOptions.multiTenant` (camelCase; EVT-4 placeholder) is wired through to `TypedEventBus`. Publish-side enforcement is all this PR ships — see Implementation Notes §"Drain-side tenancy deferred".
 
 ## Architecture
 
@@ -26,79 +27,107 @@ Multi-tenancy: adds `EventsModuleOptions.multi_tenant` flag. When enabled, the d
 EventsModule.forRoot({
   backend: 'drizzle',
   pools: ['events_change'],
-  multi_tenant: false,
+  multiTenant: false,
 })
-  ├── provides EVENT_BUS    → DrizzleEventBus (unchanged path)
-  ├── provides TYPED_EVENT_BUS → TypedEventBus (NEW, wraps EVENT_BUS)
-  └── provides EVENTS_MULTI_TENANT → false token
-  
+  ├── provides EVENT_BUS            → DrizzleEventBus
+  ├── provides TypedEventBus        → TypedEventBus (class)
+  ├── provides TYPED_EVENT_BUS      → useExisting: TypedEventBus
+  └── provides EVENTS_MULTI_TENANT  → useValue: false
+
 EventsModule.forRoot({ backend: 'memory' })
-  ├── provides EVENT_BUS    → MemoryEventBus
-  └── provides TYPED_EVENT_BUS → TypedEventBus (wraps memory bus)
+  ├── provides EVENT_BUS            → MemoryEventBus
+  ├── provides TypedEventBus        → TypedEventBus (class)
+  ├── provides TYPED_EVENT_BUS      → useExisting: TypedEventBus
+  └── provides EVENTS_MULTI_TENANT  → useValue: false
 ```
+
+`TYPED_EVENT_BUS` is a `useExisting` alias for the `TypedEventBus` class. This makes `moduleRef.get(TYPED_EVENT_BUS)` and `moduleRef.get(TypedEventBus)` return the same instance.
 
 ## Files
 
 | File | Action | Purpose |
 |------|--------|---------|
-| `runtime/subsystems/events/events.tokens.ts` | modify | Add `TYPED_EVENT_BUS`, `EVENTS_MULTI_TENANT` symbols |
-| `runtime/subsystems/events/events.module.ts` | modify | Wire TypedEventBus + multi_tenant option |
-| `runtime/subsystems/events/index.ts` | modify | Re-export `TypedEventBus`, `TYPED_EVENT_BUS`, `EVENTS_MULTI_TENANT` |
+| `runtime/subsystems/events/events.tokens.ts` | modify | Add `EVENTS_MULTI_TENANT`. `TYPED_EVENT_BUS` already shipped in EVT-3. |
+| `runtime/subsystems/events/events.module.ts` | modify | Wire `TypedEventBus`, `TYPED_EVENT_BUS`, `EVENTS_MULTI_TENANT` in all three `forRoot` branches + `forRootAsync`. |
+| `runtime/subsystems/events/events-errors.ts` | create | `MissingTenantIdError` (mirrors jobs-errors.ts). |
+| `runtime/subsystems/events/generated/bus.ts` | modify | `TypedEventBus` constructor now also injects `EVENTS_MULTI_TENANT`; `publish()` throws `MissingTenantIdError` when `multiTenant === true` and `tenantId` absent. |
+| `runtime/subsystems/events/index.ts` | modify | Re-export `EVENTS_MULTI_TENANT`, `MissingTenantIdError`. |
+| `src/cli/shared/event-codegen-generator.ts` | modify | Emit the updated `TypedEventBus` constructor + multi-tenant check. |
+| `test/baseline/runtime/subsystems/events/generated/bus.ts` | modify | Baseline snapshot refresh matching the new generator output. |
+| `src/__tests__/runtime/subsystems/events-module.spec.ts` | create | NestJS test harness coverage (`Test.createTestingModule`). |
+| `src/__tests__/cli/event-codegen-generator.test.ts` | modify | Assertions updated for new imports + multi-tenant check. |
 
 ## Interfaces
 
 ```ts
-// events.tokens.ts
-export const EVENT_BUS = Symbol('EVENT_BUS');
-export const TYPED_EVENT_BUS = Symbol('TYPED_EVENT_BUS');  // NEW
-export const EVENTS_MULTI_TENANT = Symbol('EVENTS_MULTI_TENANT');  // NEW
+// events.tokens.ts — existing + new
+export const EVENT_BUS = 'EVENT_BUS' as const;
+export const TYPED_EVENT_BUS = 'TYPED_EVENT_BUS' as const;      // shipped in EVT-3
+export const EVENTS_MULTI_TENANT = 'EVENTS_MULTI_TENANT' as const; // NEW
+export const EVENTS_MODULE_OPTIONS = 'EVENTS_MODULE_OPTIONS' as const;
+export const REDIS_URL = Symbol('REDIS_URL');
 
 // events.module.ts
 export interface EventsModuleOptions {
   backend: 'drizzle' | 'memory' | 'redis';
   redisUrl?: string;
   pools?: string[];
-  multi_tenant?: boolean;  // NEW — default false
+  multiTenant?: boolean; // default false
 }
 ```
 
-`TypedEventBus` is provided as `useClass: TypedEventBus` (it injects `EVENT_BUS` internally). NestJS resolves the internal injection automatically since `EVENT_BUS` is in the same global module.
-
 ## Implementation Steps
 
-1. Add `TYPED_EVENT_BUS` and `EVENTS_MULTI_TENANT` to `events.tokens.ts`.
-2. Add `multi_tenant?: boolean` to `EventsModuleOptions`.
-3. In `EventsModule.forRoot()`, add two providers:
-   - `{ provide: TYPED_EVENT_BUS, useClass: TypedEventBus }` — NestJS handles `@Inject(EVENT_BUS)` injection inside `TypedEventBus`.
-   - `{ provide: EVENTS_MULTI_TENANT, useValue: options.multi_tenant ?? false }`.
-4. Add `TypedEventBus` to the `providers` array so NestJS can instantiate it. Export `TYPED_EVENT_BUS`.
-5. Update `forRootAsync()` to thread the same providers.
-6. Multi-tenancy plumbing: `DrizzleEventBus` receives `EVENTS_MULTI_TENANT` token; when `true`, drain queries filter by `tenant_id`. `TypedEventBus.publish()` reads `opts.metadata?.tenantId` and threads through to `bus.publish()`.
-7. Unit test: `EventsModule.forRoot({ backend: 'memory' })` boots; `TYPED_EVENT_BUS` resolves; `TypedEventBus.publish<T>()` dispatches through the memory bus.
-8. Unit test: `multi_tenant: true` with no `tenantId` in metadata → throws `MissingTenantIdError` (or the events equivalent — check ADR-024 for the agreed exception name).
+1. Add `EVENTS_MULTI_TENANT` token to `events.tokens.ts` (string-valued — see Implementation Notes).
+2. Create `events-errors.ts` with `MissingTenantIdError`, mirroring `jobs-errors.ts` style.
+3. Update `TypedEventBus` constructor in `runtime/subsystems/events/generated/bus.ts` AND the generator in `src/cli/shared/event-codegen-generator.ts` to inject `EVENTS_MULTI_TENANT` as a second constructor arg. Refresh the baseline snapshot.
+4. In `TypedEventBus.publish`:
+   - Read `tenantId` from `opts?.metadata?.['tenantId']`.
+   - If `this.multiTenant && tenantId == null` → throw `MissingTenantIdError(type)`.
+   - Otherwise fall through; `metadata` spreads `opts.metadata` first, so tenantId persists into the outbox (EVT-4 already writes `metadata.tenantId` into `domain_events.tenant_id`).
+5. In `EventsModule.forRoot()`, register three new providers across every branch (drizzle / memory / redis) and in `forRootAsync`:
+   - `TypedEventBus` (the class itself)
+   - `{ provide: TYPED_EVENT_BUS, useExisting: TypedEventBus }`
+   - `{ provide: EVENTS_MULTI_TENANT, useValue: options.multiTenant ?? false }`
+   Export `TYPED_EVENT_BUS` and `EVENTS_MULTI_TENANT` alongside `EVENT_BUS`.
+6. NestJS unit tests in `src/__tests__/runtime/subsystems/events-module.spec.ts` (see Testing Strategy).
+
+## Implementation Notes
+
+**Drain-side tenancy deferred.** The original spec described "`DrizzleEventBus` receives `EVENTS_MULTI_TENANT` token; when true, drain queries filter by tenant_id." That remains architecturally unclear — ADR-024 §Multi-tenancy is non-specific about *where* the tenant context comes from at drain time (per-process env? per-request ALS? a scheduler?). Publish-side enforcement (`TypedEventBus` throws when required tenantId is absent) is sufficient to guarantee every outbox row has a tenantId when the module opts in; drain-side filtering can ship once the tenant-context model is settled. Tracked as a follow-up.
+
+**Token naming divergence from jobs.** `EVENTS_MULTI_TENANT` is a string (`'EVENTS_MULTI_TENANT' as const`); `JOBS_MULTI_TENANT` in the jobs subsystem is a `Symbol`. The events subsystem chose string constants from the start (see `EVENT_BUS`, `EVENTS_MODULE_OPTIONS`) so tokens match by value across import boundaries; keeping the whole `events.tokens.ts` consistent on that choice beats uniformity with jobs. Documented inline in `events.tokens.ts`.
+
+**camelCase option name.** EVT-4 landed `multiTenant?: boolean` (camelCase) on `EventsModuleOptions`. Earlier spec drafts said `multi_tenant`; the TypeScript reality is camelCase and stays that way.
+
+**`TYPED_EVENT_BUS` pre-shipped.** EVT-3 already added `TYPED_EVENT_BUS` to `events.tokens.ts` with a "Provider registration lands in EVT-6" JSDoc. This PR lands the provider — no token changes.
 
 ## Acceptance Criteria
 
-- [ ] `TYPED_EVENT_BUS` token exported from `events.tokens.ts`.
-- [ ] `EventsModule.forRoot({ backend: 'memory' })` provides `TYPED_EVENT_BUS` token resolving to `TypedEventBus`.
-- [ ] `TypedEventBus` is `global: true` (inherited from module).
-- [ ] `EventsModuleOptions.multi_tenant` defaults to `false`.
-- [ ] `multi_tenant: false`: no tenant filtering, no `tenantId` parameter required.
-- [ ] `multi_tenant: true`: drain loop filters by `tenant_id`; missing `tenantId` in publish throws.
-- [ ] Unit test: module boots in NestJS test harness with memory backend; both tokens resolve.
+- [x] `EVENTS_MULTI_TENANT` token exported from `events.tokens.ts`.
+- [x] `MissingTenantIdError` exported from `runtime/subsystems/events/events-errors.ts` and re-exported from the package barrel.
+- [x] `EventsModule.forRoot({ backend: 'memory' })` provides `TYPED_EVENT_BUS` token resolving to a `TypedEventBus` instance.
+- [x] `EventsModule` is `global: true` (DynamicModule shape + cross-module resolution verified in tests).
+- [x] `EventsModuleOptions.multiTenant` defaults to `false`; `EVENTS_MULTI_TENANT` provider reflects resolved value.
+- [x] `multiTenant: false`: no tenantId required; `TypedEventBus.publish` succeeds without metadata.
+- [x] `multiTenant: true`: missing tenantId in publish throws `MissingTenantIdError`; provided tenantId is preserved on `event.metadata`.
+- [x] `forRootAsync` path wires the same providers from an async factory.
+- [x] Unit test: module boots in NestJS test harness with memory backend; both tokens resolve.
+- [x] Generator output (`buildBusContent`) + runtime file + baseline snapshot all byte-identical.
+- [ ] ~Drain loop filters by tenant_id when `multiTenant: true`.~ **Deferred** — see Implementation Notes §"Drain-side tenancy deferred".
 
 ## Testing Strategy
 
-NestJS `Test.createTestingModule` unit test. No Docker needed — memory backend only.
+NestJS `Test.createTestingModule` unit tests covering memory backend. No Docker needed. The Drizzle and Redis branches are asserted at the `DynamicModule` shape level (providers array + exports list) without compiling — compiling them would require pulling in a real Drizzle client / Redis connection. Their runtime wiring is exercised by `just test-family` / `just test-integration`.
 
 ## Open Questions
 
-- **EVT-Q6** (TypedEventBus replaces EVENT_BUS in generated code): resolution affects whether both tokens are exported as first-class symbols in `index.ts` or only `TYPED_EVENT_BUS` is recommended.
-- Exact exception class name for missing `tenantId` — follow jobs pattern (`MissingTenantIdError`) or events-specific name?
+- **EVT-Q6** (TypedEventBus replaces EVENT_BUS in generated code): unresolved. Does not block EVT-6. The `EVENT_BUS` token remains exported; typed callers inject `TypedEventBus` (or `TYPED_EVENT_BUS`), untyped callers still have the raw port.
 
 ## References
 
 - `docs/adrs/ADR-024-events-domain-formalization.md` §"Multi-tenancy"
 - `docs/specs/JOB-5.md` — module wiring pattern
-- `docs/specs/JOB-8.md` — multi-tenancy wiring pattern
-- `runtime/subsystems/events/events.module.ts` — current module (start from this)
+- `docs/specs/JOB-8.md` — multi-tenancy wiring pattern (jobs analog)
+- `runtime/subsystems/events/events.module.ts` — updated module
+- `runtime/subsystems/jobs/jobs-errors.ts` — error-class style mirror

--- a/runtime/subsystems/events/events-errors.ts
+++ b/runtime/subsystems/events/events-errors.ts
@@ -1,0 +1,30 @@
+/**
+ * Typed errors for the events subsystem (ADR-024, EVT-6).
+ *
+ * All thrown from the publish path of `TypedEventBus`. They exist as
+ * classes so consumers can `instanceof` them in catch blocks and
+ * exception filters can map them to HTTP codes.
+ */
+
+/**
+ * Thrown by `TypedEventBus.publish()` when the EventsModule is configured
+ * with `multiTenant: true` and the caller did not supply
+ * `opts.metadata.tenantId`. Multi-tenant mode requires every outbox row to
+ * be attributable to a tenant — the `domain_events.tenant_id` column is
+ * populated from this value and the drain loop uses it for future
+ * tenant-scoped filtering (deferred — see ADR-024 §Multi-tenancy).
+ *
+ * Disable multi-tenancy at the module level (`multiTenant: false`, the
+ * default) to opt out of the requirement entirely.
+ */
+export class MissingTenantIdError extends Error {
+  readonly name = 'MissingTenantIdError';
+  constructor(public readonly eventType: string) {
+    super(
+      `Missing tenantId for event '${eventType}'. EventsModule is configured ` +
+        `with multiTenant: true — every publish must include ` +
+        `opts.metadata.tenantId. Either pass the tenantId or disable ` +
+        `multi-tenancy on the module.`,
+    );
+  }
+}

--- a/runtime/subsystems/events/events.module.ts
+++ b/runtime/subsystems/events/events.module.ts
@@ -25,14 +25,28 @@
  * Each process restricts its drain loop to the pools listed here. `pools`
  * is undefined by default → drain all pending rows (backwards-compatible).
  *
+ * Typed facade + multi-tenancy (EVT-6):
+ * - `TYPED_EVENT_BUS` resolves to the generated `TypedEventBus` wrapping
+ *   whichever backend is selected.
+ * - `multiTenant: true` makes `TypedEventBus.publish` throw
+ *   `MissingTenantIdError` when the caller forgets `metadata.tenantId`.
+ *
  * `global: true` means entity modules do not need to import EventsModule
- * individually — the EVENT_BUS token is available project-wide.
+ * individually — the EVENT_BUS and TYPED_EVENT_BUS tokens are available
+ * project-wide.
  */
-import { Module, type DynamicModule } from '@nestjs/common';
-import { EVENT_BUS, EVENTS_MODULE_OPTIONS, REDIS_URL } from './events.tokens';
+import { Module, type DynamicModule, type Provider } from '@nestjs/common';
+import {
+  EVENT_BUS,
+  EVENTS_MODULE_OPTIONS,
+  EVENTS_MULTI_TENANT,
+  REDIS_URL,
+  TYPED_EVENT_BUS,
+} from './events.tokens';
 import { DrizzleEventBus } from './event-bus.drizzle-backend';
 import { MemoryEventBus } from './event-bus.memory-backend';
 import { RedisEventBus } from './event-bus.redis-backend';
+import { TypedEventBus } from './generated/bus';
 
 export interface EventsModuleOptions {
   backend: 'drizzle' | 'memory' | 'redis';
@@ -53,10 +67,19 @@ export interface EventsModuleOptions {
    */
   pools?: string[];
   /**
-   * When true, the generated scaffold writes `tenant_id` into each
-   * outbox row and surfaces it on the typed facade. Placeholder here —
-   * EVT-6 wires the behaviour; EVT-4 ships the field so downstream work
-   * isn't blocked.
+   * Multi-tenancy opt-in (EVT-6).
+   *
+   * When `true`, every `TypedEventBus.publish()` call must supply
+   * `opts.metadata.tenantId` — otherwise it throws `MissingTenantIdError`.
+   * The tenantId is preserved on `event.metadata` and, for the Drizzle
+   * backend, written to `domain_events.tenant_id` (EVT-4).
+   *
+   * Drain-side tenant filtering is deferred — the tenant-context model
+   * (per-process vs. per-request vs. async-local-storage) is still
+   * unsettled; see ADR-024 §Multi-tenancy. Only the publish-side
+   * requirement ships here.
+   *
+   * Defaults to `false`.
    */
   multiTenant?: boolean;
 }
@@ -65,6 +88,19 @@ export interface EventsModuleAsyncOptions {
   useFactory: (...args: unknown[]) => Promise<EventsModuleOptions> | EventsModuleOptions;
   inject?: unknown[];
   imports?: unknown[];
+}
+
+/**
+ * Shared provider set: `TypedEventBus` itself, the `TYPED_EVENT_BUS` token
+ * binding, and the resolved `EVENTS_MULTI_TENANT` flag. Returned from one
+ * place so every `forRoot` branch and `forRootAsync` agree.
+ */
+function buildTypedBusProviders(multiTenant: boolean): Provider[] {
+  return [
+    TypedEventBus,
+    { provide: TYPED_EVENT_BUS, useExisting: TypedEventBus },
+    { provide: EVENTS_MULTI_TENANT, useValue: multiTenant },
+  ];
 }
 
 @Module({})
@@ -81,10 +117,20 @@ export class EventsModule {
           inject: (asyncOptions.inject ?? []) as (string | symbol | Function)[],
         },
         {
+          provide: EVENTS_MULTI_TENANT,
+          useFactory: (options: EventsModuleOptions) => options.multiTenant ?? false,
+          inject: [EVENTS_MODULE_OPTIONS],
+        },
+        {
+          provide: REDIS_URL,
+          useFactory: (options: EventsModuleOptions) =>
+            options.redisUrl ?? process.env['REDIS_URL'] ?? 'redis://localhost:6379',
+          inject: [EVENTS_MODULE_OPTIONS],
+        },
+        {
           provide: EVENT_BUS,
           useFactory: (options: EventsModuleOptions) => {
             const mod = EventsModule.forRoot(options);
-            // Return the provider instance by delegating to forRoot's logic
             const provider = mod.providers?.find(
               (p) => typeof p === 'object' && p !== null && 'provide' in p && p.provide === EVENT_BUS,
             );
@@ -95,14 +141,18 @@ export class EventsModule {
           },
           inject: [EVENTS_MODULE_OPTIONS],
         },
+        TypedEventBus,
+        { provide: TYPED_EVENT_BUS, useExisting: TypedEventBus },
       ],
-      exports: [EVENT_BUS],
+      exports: [EVENT_BUS, TYPED_EVENT_BUS, EVENTS_MULTI_TENANT],
     };
   }
 
   static forRoot(
     options: EventsModuleOptions = { backend: 'drizzle' },
   ): DynamicModule {
+    const multiTenant = options.multiTenant ?? false;
+
     if (options.backend === 'redis') {
       const resolvedUrl =
         options.redisUrl ?? process.env['REDIS_URL'] ?? 'redis://localhost:6379';
@@ -116,8 +166,9 @@ export class EventsModule {
           { provide: EVENT_BUS, useClass: RedisEventBus },
           // Register concrete class so NestJS can resolve lifecycle hooks
           RedisEventBus,
+          ...buildTypedBusProviders(multiTenant),
         ],
-        exports: [EVENT_BUS],
+        exports: [EVENT_BUS, TYPED_EVENT_BUS, EVENTS_MULTI_TENANT],
       };
     }
 
@@ -132,8 +183,9 @@ export class EventsModule {
       providers: [
         { provide: EVENTS_MODULE_OPTIONS, useValue: options },
         provider,
+        ...buildTypedBusProviders(multiTenant),
       ],
-      exports: [EVENT_BUS],
+      exports: [EVENT_BUS, TYPED_EVENT_BUS, EVENTS_MULTI_TENANT],
     };
   }
 }

--- a/runtime/subsystems/events/events.tokens.ts
+++ b/runtime/subsystems/events/events.tokens.ts
@@ -29,6 +29,20 @@ export const EVENT_BUS = 'EVENT_BUS' as const;
 export const TYPED_EVENT_BUS = 'TYPED_EVENT_BUS' as const;
 
 /**
+ * Injection token for the resolved multi-tenancy flag.
+ *
+ * Provided by `EventsModule.forRoot(...)` as `options.multiTenant ?? false`.
+ * Consumed by `TypedEventBus` to enforce the tenantId-is-required rule at
+ * publish time.
+ *
+ * String constant (not Symbol) so it matches by value across import
+ * boundaries — same convention as the other events tokens. (The jobs
+ * subsystem uses Symbols for the analogous token; events chose strings
+ * from the start and we keep the file internally consistent.)
+ */
+export const EVENTS_MULTI_TENANT = 'EVENTS_MULTI_TENANT' as const;
+
+/**
  * Injection token for the Redis connection URL used by RedisEventBus.
  * Provided automatically by EventsModule.forRoot({ backend: 'redis' }).
  */

--- a/runtime/subsystems/events/generated/bus.ts
+++ b/runtime/subsystems/events/generated/bus.ts
@@ -3,7 +3,8 @@
 
 import { Injectable, Inject } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import { EVENT_BUS } from '../events.tokens';
+import { EVENT_BUS, EVENTS_MULTI_TENANT } from '../events.tokens';
+import { MissingTenantIdError } from '../events-errors';
 import type { IEventBus, DrizzleTransaction } from '../event-bus.protocol';
 import { eventPayloadSchemas } from './schemas';
 import { getEventMetadata } from './registry';
@@ -20,10 +21,20 @@ import type { EventTypeName, EventOfType, PayloadOfType } from './types';
  * Validation gating (EVT-Q5): `CODEGEN_EVENT_VALIDATE` env flag, default on.
  * Uses `safeParse` + `console.warn` — never throws, so a bad publish does
  * not crash a hot path.
+ *
+ * Multi-tenancy (EVT-6): when the EventsModule is configured with
+ * `multiTenant: true`, every publish must supply `opts.metadata.tenantId`
+ * — otherwise `publish()` throws `MissingTenantIdError`. When `multiTenant`
+ * is `false` (default), no tenantId is required. If a tenantId IS supplied,
+ * it is preserved on `event.metadata` and the Drizzle backend writes it to
+ * `domain_events.tenant_id` (EVT-4).
  */
 @Injectable()
 export class TypedEventBus {
-	constructor(@Inject(EVENT_BUS) private readonly bus: IEventBus) {}
+	constructor(
+		@Inject(EVENT_BUS) private readonly bus: IEventBus,
+		@Inject(EVENTS_MULTI_TENANT) private readonly multiTenant: boolean,
+	) {}
 
 	async publish<T extends EventTypeName>(
 		type: T,
@@ -44,6 +55,11 @@ export class TypedEventBus {
 					check.error.issues,
 				);
 			}
+		}
+
+		const tenantId = opts?.metadata?.['tenantId'];
+		if (this.multiTenant && (tenantId === undefined || tenantId === null)) {
+			throw new MissingTenantIdError(type as string);
 		}
 
 		const aggregateType =

--- a/runtime/subsystems/events/index.ts
+++ b/runtime/subsystems/events/index.ts
@@ -4,8 +4,14 @@
  * Import the module in AppModule, inject the bus via EVENT_BUS token.
  */
 export type { DomainEvent, IEventBus, DrizzleTransaction } from './event-bus.protocol';
-export { EVENT_BUS, EVENTS_MODULE_OPTIONS, TYPED_EVENT_BUS } from './events.tokens';
+export {
+  EVENT_BUS,
+  EVENTS_MODULE_OPTIONS,
+  EVENTS_MULTI_TENANT,
+  TYPED_EVENT_BUS,
+} from './events.tokens';
 export { TypedEventBus } from './generated/bus';
+export { MissingTenantIdError } from './events-errors';
 export { EventsModule } from './events.module';
 export type { EventsModuleOptions } from './events.module';
 export { MemoryEventBus } from './event-bus.memory-backend';

--- a/src/__tests__/cli/event-codegen-generator.test.ts
+++ b/src/__tests__/cli/event-codegen-generator.test.ts
@@ -443,9 +443,14 @@ describe('buildBusContent', () => {
 		expect(empty).toBe(nonEmpty);
 	});
 
-	test('imports the EVENT_BUS token and IEventBus protocol', () => {
+	test('imports the EVENT_BUS / EVENTS_MULTI_TENANT tokens and IEventBus protocol', () => {
 		const content = buildBusContent([]);
-		expect(content).toContain("import { EVENT_BUS } from '../events.tokens';");
+		expect(content).toContain(
+			"import { EVENT_BUS, EVENTS_MULTI_TENANT } from '../events.tokens';",
+		);
+		expect(content).toContain(
+			"import { MissingTenantIdError } from '../events-errors';",
+		);
 		expect(content).toContain(
 			"import type { IEventBus, DrizzleTransaction } from '../event-bus.protocol';",
 		);
@@ -470,11 +475,21 @@ describe('buildBusContent', () => {
 		expect(content).toContain('...(opts?.metadata ?? {}),');
 	});
 
-	test('@Injectable() and @Inject(EVENT_BUS) are present', () => {
+	test('@Injectable() and @Inject(EVENT_BUS) / @Inject(EVENTS_MULTI_TENANT) are present', () => {
 		const content = buildBusContent([]);
 		expect(content).toContain('@Injectable()');
 		expect(content).toContain('@Inject(EVENT_BUS)');
+		expect(content).toContain('@Inject(EVENTS_MULTI_TENANT)');
 		expect(content).toContain('export class TypedEventBus {');
+	});
+
+	test('throws MissingTenantIdError when multiTenant is true and tenantId is absent', () => {
+		const content = buildBusContent([]);
+		// Publish-side tenant enforcement: module-level `multiTenant` flag +
+		// `opts.metadata.tenantId` absence → throw.
+		expect(content).toContain('this.multiTenant');
+		expect(content).toContain('MissingTenantIdError');
+		expect(content).toContain("opts?.metadata?.['tenantId']");
 	});
 });
 

--- a/src/__tests__/runtime/subsystems/events-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/events-module.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * EventsModule unit tests (EVT-6).
+ *
+ * Verifies the `forRoot({ backend })` factory wires:
+ *   - `EVENT_BUS` to the backend implementation
+ *   - `TYPED_EVENT_BUS` to the generated `TypedEventBus` facade
+ *   - `EVENTS_MULTI_TENANT` to the resolved boolean flag
+ * and that `TypedEventBus.publish()` enforces tenantId when multi-tenant
+ * mode is on.
+ *
+ * Memory backend only — Drizzle backend wiring is exercised in
+ * `just test-family` / `just test-integration` (real Postgres).
+ */
+import 'reflect-metadata';
+import { describe, expect, it } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import { Module } from '@nestjs/common';
+import { EventsModule } from '../../../../runtime/subsystems/events/events.module';
+import {
+  EVENT_BUS,
+  EVENTS_MULTI_TENANT,
+  TYPED_EVENT_BUS,
+} from '../../../../runtime/subsystems/events/events.tokens';
+import { TypedEventBus } from '../../../../runtime/subsystems/events/generated/bus';
+import { MemoryEventBus } from '../../../../runtime/subsystems/events/event-bus.memory-backend';
+import { MissingTenantIdError } from '../../../../runtime/subsystems/events/events-errors';
+import type { DomainEvent } from '../../../../runtime/subsystems/events/event-bus.protocol';
+
+// Any registered event type works; the registry currently ships with
+// `contact_created` — use it so payload validation (default on) is happy.
+// Keep payload-validation warnings quiet — `contact_created`'s Zod schema
+// wants UUIDs + a `createdBy`, and validation is on by default.
+const EVENT_TYPE = 'contact_created' as const;
+const PAYLOAD = {
+  contactId: '11111111-1111-1111-1111-111111111111',
+  accountId: '22222222-2222-2222-2222-222222222222',
+  createdBy: '33333333-3333-3333-3333-333333333333',
+} as const;
+
+describe('EventsModule.forRoot({ backend: "memory" })', () => {
+  it('resolves EVENT_BUS to MemoryEventBus and TYPED_EVENT_BUS to TypedEventBus', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    const bus = moduleRef.get(EVENT_BUS);
+    const typed = moduleRef.get(TYPED_EVENT_BUS);
+
+    expect(bus).toBeInstanceOf(MemoryEventBus);
+    expect(typed).toBeInstanceOf(TypedEventBus);
+
+    await moduleRef.close();
+  });
+
+  it('TYPED_EVENT_BUS and the TypedEventBus class resolve to the same instance', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    // Token and class both point at the same provider (useExisting aliasing).
+    const byToken = moduleRef.get(TYPED_EVENT_BUS);
+    const byClass = moduleRef.get(TypedEventBus);
+    expect(byToken).toBe(byClass);
+
+    await moduleRef.close();
+  });
+
+  it('defaults EVENTS_MULTI_TENANT to false when multiTenant is omitted', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(EVENTS_MULTI_TENANT)).toBe(false);
+
+    await moduleRef.close();
+  });
+
+  it('resolves EVENTS_MULTI_TENANT to false when multiTenant: false is explicit', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory', multiTenant: false })],
+    }).compile();
+
+    expect(moduleRef.get(EVENTS_MULTI_TENANT)).toBe(false);
+
+    await moduleRef.close();
+  });
+
+  it('resolves EVENTS_MULTI_TENANT to true when multiTenant: true', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory', multiTenant: true })],
+    }).compile();
+
+    expect(moduleRef.get(EVENTS_MULTI_TENANT)).toBe(true);
+
+    await moduleRef.close();
+  });
+
+  it('is global: true so consumer modules see the tokens transitively', async () => {
+    @Module({})
+    class ConsumerModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRoot({ backend: 'memory' }),
+        ConsumerModule,
+      ],
+    }).compile();
+
+    // Resolving the token from the root module proves global registration.
+    const typed = moduleRef.get(TYPED_EVENT_BUS);
+    expect(typed).toBeInstanceOf(TypedEventBus);
+
+    // The DynamicModule shape itself declares global: true.
+    const dyn = EventsModule.forRoot({ backend: 'memory' });
+    expect(dyn.global).toBe(true);
+
+    await moduleRef.close();
+  });
+
+  it('TypedEventBus.publish() dispatches through the memory bus to subscribers (multiTenant: false)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    const typed = moduleRef.get(TYPED_EVENT_BUS) as TypedEventBus;
+    const memoryBus = moduleRef.get(EVENT_BUS) as MemoryEventBus;
+
+    const received: DomainEvent[] = [];
+    memoryBus.subscribe(EVENT_TYPE, async (e) => { received.push(e); });
+
+    await typed.publish(EVENT_TYPE, 'c-1', PAYLOAD);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.type).toBe(EVENT_TYPE);
+    expect(received[0]?.aggregateId).toBe('c-1');
+    expect(received[0]?.payload).toEqual(PAYLOAD as unknown as Record<string, unknown>);
+    // tenantId is NOT required when multiTenant is off; metadata still
+    // gets the registry stamp but no tenantId is populated.
+    expect(received[0]?.metadata?.['tenantId']).toBeUndefined();
+    expect(received[0]?.metadata?.['pool']).toBe('events_change');
+
+    await moduleRef.close();
+  });
+
+  it('TypedEventBus.publish() throws MissingTenantIdError when multiTenant: true and tenantId is absent', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory', multiTenant: true })],
+    }).compile();
+
+    const typed = moduleRef.get(TYPED_EVENT_BUS) as TypedEventBus;
+
+    await expect(typed.publish(EVENT_TYPE, 'c-1', PAYLOAD)).rejects.toBeInstanceOf(
+      MissingTenantIdError,
+    );
+
+    // And when metadata exists but lacks tenantId:
+    await expect(
+      typed.publish(EVENT_TYPE, 'c-1', PAYLOAD, { metadata: { source: 'test' } }),
+    ).rejects.toBeInstanceOf(MissingTenantIdError);
+
+    await moduleRef.close();
+  });
+
+  it('TypedEventBus.publish() succeeds and preserves tenantId when multiTenant: true and tenantId is supplied', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory', multiTenant: true })],
+    }).compile();
+
+    const typed = moduleRef.get(TYPED_EVENT_BUS) as TypedEventBus;
+    const memoryBus = moduleRef.get(EVENT_BUS) as MemoryEventBus;
+
+    const received: DomainEvent[] = [];
+    memoryBus.subscribe(EVENT_TYPE, async (e) => { received.push(e); });
+
+    await typed.publish(EVENT_TYPE, 'c-1', PAYLOAD, {
+      metadata: { tenantId: 't1' },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.metadata?.['tenantId']).toBe('t1');
+    // Registry-stamped fields are still there alongside the tenantId.
+    expect(received[0]?.metadata?.['pool']).toBe('events_change');
+    expect(received[0]?.metadata?.['direction']).toBe('change');
+
+    await moduleRef.close();
+  });
+});
+
+describe('EventsModule.forRoot({ backend: "drizzle" })', () => {
+  it('exposes TYPED_EVENT_BUS and EVENTS_MULTI_TENANT alongside EVENT_BUS', () => {
+    // Construct the DynamicModule without compiling it (Drizzle backend
+    // would require a DrizzleClient provider). We just assert the
+    // providers array and the exports list.
+    const dyn = EventsModule.forRoot({ backend: 'drizzle', multiTenant: true });
+    expect(dyn.global).toBe(true);
+    expect(dyn.exports).toContain(EVENT_BUS);
+    expect(dyn.exports).toContain(TYPED_EVENT_BUS);
+    expect(dyn.exports).toContain(EVENTS_MULTI_TENANT);
+
+    const hasProvide = (token: unknown) =>
+      dyn.providers?.some(
+        (p) =>
+          typeof p === 'object' && p !== null && 'provide' in p && p.provide === token,
+      );
+    expect(hasProvide(TYPED_EVENT_BUS)).toBe(true);
+    expect(hasProvide(EVENTS_MULTI_TENANT)).toBe(true);
+  });
+});
+
+describe('EventsModule.forRoot({ backend: "redis" })', () => {
+  it('exposes TYPED_EVENT_BUS and EVENTS_MULTI_TENANT alongside EVENT_BUS', () => {
+    const dyn = EventsModule.forRoot({
+      backend: 'redis',
+      redisUrl: 'redis://localhost:6379',
+      multiTenant: true,
+    });
+    expect(dyn.global).toBe(true);
+    expect(dyn.exports).toContain(EVENT_BUS);
+    expect(dyn.exports).toContain(TYPED_EVENT_BUS);
+    expect(dyn.exports).toContain(EVENTS_MULTI_TENANT);
+  });
+});
+
+describe('EventsModule.forRootAsync', () => {
+  it('wires EVENT_BUS, TYPED_EVENT_BUS, and EVENTS_MULTI_TENANT from an async factory', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRootAsync({
+          useFactory: () => ({ backend: 'memory', multiTenant: true }),
+        }),
+      ],
+    }).compile();
+
+    const bus = moduleRef.get(EVENT_BUS);
+    const typed = moduleRef.get(TYPED_EVENT_BUS);
+    const multiTenant = moduleRef.get(EVENTS_MULTI_TENANT);
+
+    expect(bus).toBeInstanceOf(MemoryEventBus);
+    expect(typed).toBeInstanceOf(TypedEventBus);
+    expect(multiTenant).toBe(true);
+
+    // Behaviour matches forRoot: missing tenantId throws.
+    await expect(
+      (typed as TypedEventBus).publish(EVENT_TYPE, 'c-1', PAYLOAD),
+    ).rejects.toBeInstanceOf(MissingTenantIdError);
+
+    await moduleRef.close();
+  });
+});

--- a/src/cli/shared/event-codegen-generator.ts
+++ b/src/cli/shared/event-codegen-generator.ts
@@ -455,7 +455,8 @@ export function buildRegistryContent(events: EventDefinition[]): string {
  */
 const BUS_BODY = `import { Injectable, Inject } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import { EVENT_BUS } from '../events.tokens';
+import { EVENT_BUS, EVENTS_MULTI_TENANT } from '../events.tokens';
+import { MissingTenantIdError } from '../events-errors';
 import type { IEventBus, DrizzleTransaction } from '../event-bus.protocol';
 import { eventPayloadSchemas } from './schemas';
 import { getEventMetadata } from './registry';
@@ -472,10 +473,20 @@ import type { EventTypeName, EventOfType, PayloadOfType } from './types';
  * Validation gating (EVT-Q5): \`CODEGEN_EVENT_VALIDATE\` env flag, default on.
  * Uses \`safeParse\` + \`console.warn\` — never throws, so a bad publish does
  * not crash a hot path.
+ *
+ * Multi-tenancy (EVT-6): when the EventsModule is configured with
+ * \`multiTenant: true\`, every publish must supply \`opts.metadata.tenantId\`
+ * — otherwise \`publish()\` throws \`MissingTenantIdError\`. When \`multiTenant\`
+ * is \`false\` (default), no tenantId is required. If a tenantId IS supplied,
+ * it is preserved on \`event.metadata\` and the Drizzle backend writes it to
+ * \`domain_events.tenant_id\` (EVT-4).
  */
 @Injectable()
 export class TypedEventBus {
-\tconstructor(@Inject(EVENT_BUS) private readonly bus: IEventBus) {}
+\tconstructor(
+\t\t@Inject(EVENT_BUS) private readonly bus: IEventBus,
+\t\t@Inject(EVENTS_MULTI_TENANT) private readonly multiTenant: boolean,
+\t) {}
 
 \tasync publish<T extends EventTypeName>(
 \t\ttype: T,
@@ -496,6 +507,11 @@ export class TypedEventBus {
 \t\t\t\t\tcheck.error.issues,
 \t\t\t\t);
 \t\t\t}
+\t\t}
+
+\t\tconst tenantId = opts?.metadata?.['tenantId'];
+\t\tif (this.multiTenant && (tenantId === undefined || tenantId === null)) {
+\t\t\tthrow new MissingTenantIdError(type as string);
 \t\t}
 
 \t\tconst aggregateType =

--- a/test/baseline/runtime/subsystems/events/generated/bus.ts
+++ b/test/baseline/runtime/subsystems/events/generated/bus.ts
@@ -3,7 +3,8 @@
 
 import { Injectable, Inject } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import { EVENT_BUS } from '../events.tokens';
+import { EVENT_BUS, EVENTS_MULTI_TENANT } from '../events.tokens';
+import { MissingTenantIdError } from '../events-errors';
 import type { IEventBus, DrizzleTransaction } from '../event-bus.protocol';
 import { eventPayloadSchemas } from './schemas';
 import { getEventMetadata } from './registry';
@@ -20,10 +21,20 @@ import type { EventTypeName, EventOfType, PayloadOfType } from './types';
  * Validation gating (EVT-Q5): `CODEGEN_EVENT_VALIDATE` env flag, default on.
  * Uses `safeParse` + `console.warn` — never throws, so a bad publish does
  * not crash a hot path.
+ *
+ * Multi-tenancy (EVT-6): when the EventsModule is configured with
+ * `multiTenant: true`, every publish must supply `opts.metadata.tenantId`
+ * — otherwise `publish()` throws `MissingTenantIdError`. When `multiTenant`
+ * is `false` (default), no tenantId is required. If a tenantId IS supplied,
+ * it is preserved on `event.metadata` and the Drizzle backend writes it to
+ * `domain_events.tenant_id` (EVT-4).
  */
 @Injectable()
 export class TypedEventBus {
-	constructor(@Inject(EVENT_BUS) private readonly bus: IEventBus) {}
+	constructor(
+		@Inject(EVENT_BUS) private readonly bus: IEventBus,
+		@Inject(EVENTS_MULTI_TENANT) private readonly multiTenant: boolean,
+	) {}
 
 	async publish<T extends EventTypeName>(
 		type: T,
@@ -44,6 +55,11 @@ export class TypedEventBus {
 					check.error.issues,
 				);
 			}
+		}
+
+		const tenantId = opts?.metadata?.['tenantId'];
+		if (this.multiTenant && (tenantId === undefined || tenantId === null)) {
+			throw new MissingTenantIdError(type as string);
 		}
 
 		const aggregateType =


### PR DESCRIPTION
## Summary

Wires `TypedEventBus` into `EventsModule` under the `TYPED_EVENT_BUS` token across every `forRoot` branch (drizzle, memory, redis) and `forRootAsync`. Adds `EVENTS_MULTI_TENANT` boolean token and `MissingTenantIdError` so generated code can inject the typed facade with tenant enforcement at publish time.

Closes #97

## Design decisions

- **`useExisting` aliasing** — `TYPED_EVENT_BUS` binds to the `TypedEventBus` class via `useExisting`, so `moduleRef.get(TYPED_EVENT_BUS) === moduleRef.get(TypedEventBus)`. Generated code injects via the token, framework code via the class, single instance.
- **String constant, not Symbol** — `EVENTS_MULTI_TENANT = 'EVENTS_MULTI_TENANT' as const` matches the rest of `events.tokens.ts` (EVT-Q6 convention). Diverges from `JOBS_MULTI_TENANT` (Symbol); rationale captured in the token JSDoc.
- **Drain-side tenant filter deferred** — ADR-024 §Multi-tenancy mentions a drain filter but the tenant-context model (per-process? per-request? async-local?) is unsettled. This PR ships only publish-side enforcement; the drain filter can land once the tenant-context model is settled. Spec AC updated to defer.
- **Generator / runtime / baseline lockstep** — `src/cli/shared/event-codegen-generator.ts`, `runtime/subsystems/events/generated/bus.ts`, and `test/baseline/runtime/subsystems/events/generated/bus.ts` are byte-identical after this change.

## Drift fixes (living-docs)

- Spec wanted `multi_tenant` snake_case — TypeScript is `multiTenant` camelCase (EVT-4 placeholder). Corrected in EVT-6.md.
- Spec showed `EVENT_BUS` / `TYPED_EVENT_BUS` as `Symbol(...)` — they are string constants since EVT-3. Corrected.
- Spec had `TYPED_EVENT_BUS` as "new" — EVT-3 already declared it; only the provider wiring is new here. Corrected.
- `.claude/skills/events/SKILL.md` runtime snapshot bullets updated to list all four tokens, `MissingTenantIdError`, and the new `TypedEventBus` constructor shape.

## Test plan

- [x] `bun test` — 855 pass / 0 fail (was 842)
- [x] +12 tests in `src/__tests__/runtime/subsystems/events-module.spec.ts` using `@nestjs/testing`: token resolution, `useExisting` aliasing, `global: true`, `multiTenant` true/false/undefined, publish success + failure, `forRootAsync` parity
- [x] Baseline snapshot regenerated and verified byte-identical to runtime + generator output
- [x] `just test-unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)