### PR TITLE
fix(cli): F11 — idempotent main.ts hook injection

### DIFF
--- a/.claude/specs/issue-119-init-scaffold-idempotent-main-hook.md
+++ b/.claude/specs/issue-119-init-scaffold-idempotent-main-hook.md
@@ -1,0 +1,30 @@
+# Issue #119 (F11) — Idempotent main.ts hook injection
+
+## Problem
+
+`codegen subsystem install jobs` injects a comment block into `src/main.ts` via `templates/subsystem/jobs/main-hook.ejs.t`. The template's `skip_if: "JobWorkerModule"` regex is unreliable — running the command again produces a duplicate comment block (repro'd in TEST-SESSION-1 Phase A).
+
+Note: the original GitHub issue body attributed this to `init-scaffold.ts` / `project init --force`. That attribution is incorrect; the code path is the jobs subsystem scaffold.
+
+## Files to change
+
+1. `templates/subsystem/jobs/main-hook.ejs.t` — swap `skip_if` regex for a `<%= mainHookInjected %>` Hygen local.
+2. `src/cli/shared/jobs-scaffold-locals.ts` — add `readFile` probe to input, compute `mainHookInjected` via a sentinel substring check, serialize it through the existing empty-string-is-falsy arg helper.
+3. `src/cli/commands/subsystem.ts` — plumb a `readFile` implementation through to `resolveJobsScaffoldLocals` in `runJobsScaffold`.
+4. `src/__tests__/cli/jobs-scaffold-locals.test.ts` — supply `readFile` in existing tests, add 3 new tests covering the true/false/serialize paths.
+
+## Approach
+
+Mirror the existing `workerExists` pattern — it already handles the "was this scaffolded before?" question for worker.ts with deterministic unit tests and no Hygen integration harness. `mainHookInjected` follows the same shape: a pure function of injected `readFile` + `fileExists` probes; empty-string maps to falsy in Hygen front-matter.
+
+Sentinel constant: `'JOBS — Embedded worker mode (optional)'` (the literal first line of the injected comment). Unique enough that user-authored `main.ts` content cannot false-positive.
+
+## Why not merge / why this approach
+
+- A regex `skip_if` is what failed; upgrading the regex doesn't address the root problem (Hygen's regex matching isn't guaranteed here).
+- Computing the skip flag in TypeScript gives us exact-string control and lets the fix be unit-tested without invoking Hygen.
+- Consistent with `workerExists` — one mental model for "was this scaffolded before?"
+
+## Test strategy
+
+Pure unit tests in `src/__tests__/cli/jobs-scaffold-locals.test.ts`. No integration harness needed. Runs under `just test-unit` (~200ms).

--- a/src/__tests__/cli/jobs-scaffold-locals.test.ts
+++ b/src/__tests__/cli/jobs-scaffold-locals.test.ts
@@ -30,6 +30,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			cwd: CWD,
 			config: null,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 
 		expect(locals.multiTenant).toBe(false);
@@ -51,6 +52,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			cwd: CWD,
 			config: { paths: { backend_src: 'packages/api/src' } } as any,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 		expect(locals.schemaPath).toBe(
 			path.resolve(
@@ -70,6 +72,7 @@ describe('resolveJobsScaffoldLocals', () => {
 				},
 			} as any,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 		expect(locals.schemaPath).toBe(
 			path.resolve(CWD, 'custom/subsystems/jobs/job-orchestration.schema.ts'),
@@ -81,6 +84,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			cwd: CWD,
 			config: { jobs: { multi_tenant: true } } as any,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 		expect(locals.multiTenant).toBe(true);
 	});
@@ -93,6 +97,7 @@ describe('resolveJobsScaffoldLocals', () => {
 				cwd: CWD,
 				config: { jobs: { multi_tenant: raw } } as any,
 				fileExists: () => false,
+				readFile: () => null,
 			});
 			expect(locals.multiTenant).toBe(false);
 		}
@@ -103,6 +108,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			cwd: CWD,
 			config: { jobs: { worker_mode: 'standalone' } } as any,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 		expect(standalone.workerMode).toBe('standalone');
 
@@ -110,6 +116,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			cwd: CWD,
 			config: { jobs: { worker_mode: 'wobbly' } } as any,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 		expect(bogus.workerMode).toBe('embedded');
 	});
@@ -119,6 +126,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			cwd: CWD,
 			config: { paths: { subsystems: 'packages/api/src/subsystems' } } as any,
 			fileExists: () => false,
+			readFile: () => null,
 		});
 		expect(locals.schemaPath).toBe(
 			path.resolve(
@@ -137,6 +145,7 @@ describe('resolveJobsScaffoldLocals', () => {
 				probed.push(p);
 				return p.endsWith('worker.ts');
 			},
+			readFile: () => null,
 		});
 		expect(probed).toEqual([path.resolve(CWD, 'worker.ts')]);
 		expect(locals.workerExists).toBe(true);
@@ -152,8 +161,37 @@ describe('resolveJobsScaffoldLocals', () => {
 					if (!p.endsWith('worker.ts')) never();
 					return false;
 				},
+				readFile: () => null,
 			}),
 		).not.toThrow();
+	});
+
+	test('mainHookInjected: true when main.ts already contains the sentinel', () => {
+		const locals = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+			readFile: () => '// JOBS — Embedded worker mode (optional)\n',
+		});
+		expect(locals.mainHookInjected).toBe(true);
+	});
+
+	test('mainHookInjected: false when main.ts missing or lacks sentinel', () => {
+		const missing = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(missing.mainHookInjected).toBe(false);
+
+		const present = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+			readFile: () => 'async function bootstrap() {}',
+		});
+		expect(present.mainHookInjected).toBe(false);
 	});
 });
 
@@ -167,6 +205,7 @@ describe('localsToHygenArgs', () => {
 		workerExists: false,
 		workerPath: '/abs/worker.ts',
 		schemaPath: '/abs/shared/subsystems/jobs/job-orchestration.schema.ts',
+		mainHookInjected: false,
 	};
 
 	test('multiTenant booleans serialise to the literal strings Hygen expects', () => {
@@ -200,9 +239,21 @@ describe('localsToHygenArgs', () => {
 			'--workerExists',
 			'--workerPath',
 			'--schemaPath',
+			'--mainHookInjected',
 		]) {
 			expect(args).toContain(flag);
 		}
+	});
+
+	test('localsToHygenArgs serialises mainHookInjected empty-string when false', () => {
+		const args = localsToHygenArgs(base);
+		const idx = args.indexOf('--mainHookInjected');
+		expect(idx).toBeGreaterThanOrEqual(0);
+		expect(args[idx + 1]).toBe('');
+
+		const present = localsToHygenArgs({ ...base, mainHookInjected: true });
+		const idx2 = present.indexOf('--mainHookInjected');
+		expect(present[idx2 + 1]).toBe('true');
 	});
 
 	test('paths pass through as absolute', () => {

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -413,6 +413,8 @@ function runJobsScaffold(
 		cwd,
 		config,
 		fileExists: (p: string) => fs.existsSync(p),
+		readFile: (p: string) =>
+			fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null,
 	});
 
 	// Files the four jobs templates will target (used by --dry-run output and

--- a/src/cli/shared/jobs-scaffold-locals.ts
+++ b/src/cli/shared/jobs-scaffold-locals.ts
@@ -33,6 +33,8 @@ export interface JobsScaffoldLocals {
 	workerPath: string;
 	/** Where `job-orchestration.schema.ejs.t` writes the scaffolded schema. */
 	schemaPath: string;
+	/** Sentinel-based idempotence flag for `main-hook.ejs.t`'s `skip_if`. */
+	mainHookInjected: boolean;
 }
 
 export interface JobsScaffoldLocalsInput {
@@ -42,7 +44,14 @@ export interface JobsScaffoldLocalsInput {
 	config: CodegenConfig | null;
 	/** Injected fs probe. Implementations: `(p) => fs.existsSync(p)`. */
 	fileExists: (absolutePath: string) => boolean;
+	/** Injected fs read probe; returns null when the file is absent. */
+	readFile: (absolutePath: string) => string | null;
 }
+
+/** Literal first line of the comment block emitted by `main-hook.ejs.t`. Must
+ * match the template content exactly (including the em-dash) so re-running the
+ * install detects the prior injection and skips. */
+const MAIN_HOOK_SENTINEL = 'JOBS — Embedded worker mode (optional)';
 
 /** Hygen front-matter treats any non-empty string as truthy for `skip_if`, so the
  * boolean-ish locals must render as the literal 'true' / empty string. EJS
@@ -68,7 +77,7 @@ function workerSkipValue(exists: boolean): string {
 export function resolveJobsScaffoldLocals(
 	input: JobsScaffoldLocalsInput,
 ): JobsScaffoldLocals {
-	const { cwd, config, fileExists } = input;
+	const { cwd, config, fileExists, readFile } = input;
 
 	const jobsBlock = (config?.jobs ?? {}) as Record<string, unknown>;
 
@@ -83,6 +92,10 @@ export function resolveJobsScaffoldLocals(
 		'job-orchestration.schema.ts',
 	);
 
+	const mainContent = readFile(mainTsPath);
+	const mainHookInjected =
+		mainContent !== null && mainContent.includes(MAIN_HOOK_SENTINEL);
+
 	return {
 		appName: path.basename(cwd),
 		workerMode: normaliseWorkerMode(jobsBlock.worker_mode),
@@ -92,6 +105,7 @@ export function resolveJobsScaffoldLocals(
 		workerExists: fileExists(workerPath),
 		workerPath,
 		schemaPath,
+		mainHookInjected,
 	};
 }
 
@@ -120,5 +134,6 @@ export function localsToHygenArgs(locals: JobsScaffoldLocals): string[] {
 		'--workerExists', workerSkipValue(locals.workerExists),
 		'--workerPath', locals.workerPath,
 		'--schemaPath', locals.schemaPath,
+		'--mainHookInjected', workerSkipValue(locals.mainHookInjected),
 	];
 }

--- a/templates/subsystem/jobs/main-hook.ejs.t
+++ b/templates/subsystem/jobs/main-hook.ejs.t
@@ -2,7 +2,7 @@
 to: "<%= mainTsPath %>"
 inject: true
 after: "NestFactory.create"
-skip_if: "JobWorkerModule"
+skip_if: "<%= mainHookInjected %>"
 ---
   // JOBS — Embedded worker mode (optional)
   // To run the job worker in-process (single-process deploy), add to AppModule imports:


### PR DESCRIPTION
## Summary

Fixes #119.

- The issue body attributes this to `init-scaffold.ts` / `project init --force`. **That attribution is incorrect.** The actual code path is `codegen subsystem install jobs`, which invokes `templates/subsystem/jobs/main-hook.ejs.t`. Its front-matter used `skip_if: "JobWorkerModule"` — a regex match that proved unreliable in TEST-SESSION-1 Phase A (re-running the command duplicated the embedded-mode comment block in `src/main.ts`).
- Replace the regex with a sentinel substring check computed in TypeScript: a new `readFile` probe on `JobsScaffoldLocalsInput` reads `src/main.ts`, looks for the literal `'JOBS — Embedded worker mode (optional)'`, and the result is serialised through the same empty-string-is-falsy helper already used for `workerExists`. Hygen's `skip_if: "<%= mainHookInjected %>"` then receives `'true'` or `''` — both safe for its truthiness contract.
- Consistent with the existing `workerExists` mental model: the CLI computes "was this scaffolded before?" flags in pure TypeScript, unit-tested without a Hygen harness.

## Files changed

- `templates/subsystem/jobs/main-hook.ejs.t` — `skip_if` now references the computed local.
- `src/cli/shared/jobs-scaffold-locals.ts` — `readFile` added to input; `mainHookInjected` added to output; `MAIN_HOOK_SENTINEL` declared at module scope; serialised via `workerSkipValue`.
- `src/cli/commands/subsystem.ts` — `runJobsScaffold` passes `readFile: (p) => fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null`.
- `src/__tests__/cli/jobs-scaffold-locals.test.ts` — `readFile: () => null` threaded through every existing call; three new tests (sentinel hit, sentinel miss across two shapes, args serialisation).
- `.claude/specs/issue-119-init-scaffold-idempotent-main-hook.md` — spec of record.

## Test plan

- [x] `just test-unit` green (923 tests, 0 fail, ~2s)
- [x] `bun run typecheck` green (strict TS build)
- [ ] Follow-up: exercise end-to-end in the next TEST-SESSION-1 dry-run — confirm a second `codegen subsystem install jobs --force` produces zero duplicate comment blocks in `src/main.ts`.

Generated with [Claude Code](https://claude.com/claude-code)