### PR TITLE
fix(cli): F12 — entity new --all tolerates bad YAMLs

### DIFF
--- a/.claude/specs/cli-02-entity-noun.md
+++ b/.claude/specs/cli-02-entity-noun.md
@@ -82,7 +82,7 @@ Generate a single entity from a YAML definition.
 - `--dry-run` — boolean. Plan what would be written, do not write.
 - `--force` — boolean. Skip git-safety check for uncommitted changes.
 - `--only <target>` — `backend | frontend | clean-lite-ps`. Generate a subset.
-- `--continue-on-error` — boolean. Used with `--all`. Report failures and continue.
+- `--continue-on-error` — boolean (default: `true`, since #120). Used with `--all`. Report failures and continue. Pass `--no-continue-on-error` (Clipanion auto-negation) to make the first failure fatal.
 
 **Behavior:**
 

--- a/.claude/specs/issue-120-entity-all-continue-on-error.md
+++ b/.claude/specs/issue-120-entity-all-continue-on-error.md
@@ -1,0 +1,30 @@
+# Issue #120 (F12) — entity new --all tolerates bad YAMLs
+
+## Problem
+
+`codegen entity new --all` short-circuits on the first invalid YAML, skipping all valid entities in the batch. Surfaced in TEST-SESSION-1 Phase A: the scaffold-generated `entities/example.yaml` (comments only, no `entity:` key) wedges subsequent generation even though every other file in `entities/` is valid.
+
+Three gates in `src/cli/commands/entity.ts` (pre-flight validation, cross-validation, Hygen loop break) all condition on `!this.continueOnError` with `continueOnError` defaulting to `false`.
+
+## Fix
+
+Two-commit, two-pronged:
+
+1. **Flip the default.** `Option.Boolean('--continue-on-error', true)`. The flag name stays; Clipanion's auto-generated `--no-continue-on-error` restores strict behavior for users who want it. Update the inline help/comment.
+2. **Stop seeding a broken placeholder.** `project init` in `src/cli/shared/init-scaffold.ts` skips creating `entities/example.yaml` when the `entities/` directory already contains another `*.yaml`. Defense in depth — even if a user passes `--no-continue-on-error`, a real project won't get the broken stub.
+
+## Why both
+
+The default flip alone fixes the reported bug, but leaves the latent issue that a fresh `project init --force` on a populated repo will re-drop the broken placeholder (see also #119's anti-pattern class). The init-side guard addresses the root cause. Either commit can be reverted independently.
+
+## Tests
+
+- `src/__tests__/cli/entity.test.ts` — two new cases on the existing `mkTempProject` harness:
+  - `--all` with one valid + one invalid YAML now exits `0` and reports both.
+  - `--all --no-continue-on-error` restores exit `1`.
+- `init-scaffold.ts` — no new test (existing harness doesn't cover that branch; not worth a new harness for 4 LOC of guard logic).
+
+## Docs updated
+
+- `docs/specs/TEST-SESSION-1.md` — F12 marked resolved (2026-04-20).
+- `.claude/specs/cli-02-entity-noun.md` if it mentions the flag.

--- a/docs/specs/EVT-7.md
+++ b/docs/specs/EVT-7.md
@@ -40,8 +40,9 @@ are drift captured during implementation — they reflect what actually shipped.
 6. **Warnings are stderr, errors gate generation.** The CLI pre-flight treats
    validation results as two buckets: `error` (`missing`, `wrong_direction`,
    `wrong_aggregate`) and `warning` (`no_emits`, `duplicate_emit`). Errors
-   abort the run unless `--continue-on-error` is passed; warnings always
-   print and never gate. A summary line reports counts.
+   are reported and skipped by default (`--continue-on-error` defaults to
+   `true` since #120); pass `--no-continue-on-error` to abort on the first
+   error. Warnings always print and never gate. A summary line reports counts.
 
 ## Overview
 

--- a/docs/specs/TEST-SESSION-1.md
+++ b/docs/specs/TEST-SESSION-1.md
@@ -13,7 +13,9 @@ Phase A + Phase B were executed at `~/Projects/dev/codegen-phase1-demo-v2/`. Thi
 - **F8** (`a8243a7`) — use-case payloadMap emits via `<%- ... %>` (raw) instead of `<%= ... %>` (HTML-escaped).
 - **F9 / F10** (`8c68a82`) — `tenant_id` emitted unconditionally on `job_run` (nullable); use-case template threads an optional `actor: { tenantId, userId }` param and controllers read the `x-tenant-id` / `x-user-id` headers. Decision reversal on JOB-Q1 documented in ADR-022 revision.
 
-Unresolved minor findings (F4, F6, F11, F12, F13) are filed as GH issues. Smoke-test gating (F7 umbrella) also filed.
+Unresolved minor findings (F4, F6, F11, F13) are filed as GH issues. Smoke-test gating (F7 umbrella) also filed.
+
+**F12 resolved (2026-04-20)** — #120: `entity new --all` now defaults to `--continue-on-error: true` (pass `--no-continue-on-error` to restore strict exit); `project init` skips seeding `entities/example.yaml` when other entity YAMLs already exist.
 
 **§3 YAML examples below are the corrected versions.** The pre-revision versions used flat-top-level shapes (`name:`, array-style `fields:/payload:`, `timestamp` field type, `string[]` payload type, outbound events with `aggregate:`) that do not match the Zod schemas in `src/schema/{entity,event}-definition.schema.ts`.
 

--- a/src/__tests__/cli/entity.test.ts
+++ b/src/__tests__/cli/entity.test.ts
@@ -248,6 +248,61 @@ describe('entity noun — new --dry-run', () => {
 		);
 		expect(result).toBe(2);
 	});
+
+	test('--all tolerates an invalid YAML alongside a valid one (default)', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		// Drop an invalid entity YAML (comments only, no `entity:` key) next to
+		// the valid contact fixture — mirrors the scaffold's example.yaml that
+		// originally triggered F12.
+		fs.writeFileSync(
+			path.join(root, 'entities', 'example.yaml'),
+			'# this is a placeholder\n',
+		);
+		const cli = buildCli();
+		const { result, out } = await captureStdoutWrite(() =>
+			cli.run([
+				'entity',
+				'new',
+				'--all',
+				'--dry-run',
+				'--force',
+				'--json',
+				'--cwd',
+				root,
+			]),
+		);
+		expect(result).toBe(0);
+		const parsed = JSON.parse(out);
+		expect(parsed.command).toBe('entity new');
+		expect(parsed.totals.planned).toBe(1);
+		expect(parsed.totals.invalid).toBe(1);
+		const names = (parsed.entities as Array<{ name: string }>).map((e) => e.name);
+		expect(names).toContain('contact');
+	});
+
+	test('--all --no-continue-on-error restores fatal exit for invalid YAML', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		fs.writeFileSync(
+			path.join(root, 'entities', 'example.yaml'),
+			'# this is a placeholder\n',
+		);
+		const cli = buildCli();
+		const { result } = await captureStdoutWrite(() =>
+			cli.run([
+				'entity',
+				'new',
+				'--all',
+				'--dry-run',
+				'--force',
+				'--no-continue-on-error',
+				'--cwd',
+				root,
+			]),
+		);
+		expect(result).toBe(1);
+	});
 });
 
 describe('entity noun — module shape', () => {

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -160,7 +160,7 @@ export class EntityNewCommand extends Command {
 	dryRun = Option.Boolean('--dry-run', false);
 	force = Option.Boolean('--force', false);
 	only = Option.String('--only', { required: false });
-	continueOnError = Option.Boolean('--continue-on-error', false);
+	continueOnError = Option.Boolean('--continue-on-error', true);
 	json = Option.Boolean('--json', false);
 	cwd = Option.String('--cwd', { required: false });
 	configPath = Option.String('--config', { required: false });
@@ -217,8 +217,9 @@ export class EntityNewCommand extends Command {
 
 		// EVT-7: pre-flight cross-validate each target's `emits:` block against
 		// the merged event registry (top-level events/*.yaml + entity events:
-		// desugar). Errors are fatal (unless --continue-on-error); warnings are
-		// surfaced via printWarning + JSON payload and never gate.
+		// desugar). Invalid emits are reported and skipped by default; pass
+		// --no-continue-on-error to make the first failure fatal. Warnings are
+		// always surfaced via printWarning + JSON payload and never gate.
 		const entitiesDirForEmits =
 			ctx.entitiesDir ?? path.resolve(ctx.cwd, 'entities');
 		const eventsDirForEmits = path.resolve(ctx.cwd, 'events');

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -659,20 +659,37 @@ export async function buildInitPlan(
 	// 10. entities/ + entities/example.yaml
 	entries.push(dirEntry(cwd, path.join(cwd, 'entities')));
 	{
-		const examplePath = path.join(cwd, 'entities', 'example.yaml');
-		if (!fs.existsSync(examplePath)) {
-			entries.push({
-				path: examplePath,
-				relPath: relOf(cwd, examplePath),
-				action: 'create',
-				content: exampleEntityYaml(),
-			});
-		} else {
+		const entitiesDir = path.join(cwd, 'entities');
+		const examplePath = path.join(entitiesDir, 'example.yaml');
+		const hasOtherYamls =
+			fs.existsSync(entitiesDir) &&
+			fs
+				.readdirSync(entitiesDir)
+				.some(
+					(f) =>
+						(f.endsWith('.yaml') || f.endsWith('.yml')) &&
+						f !== 'example.yaml',
+				);
+		if (fs.existsSync(examplePath)) {
 			entries.push({
 				path: examplePath,
 				relPath: relOf(cwd, examplePath),
 				action: 'skip',
 				reason: 'already exists',
+			});
+		} else if (hasOtherYamls) {
+			entries.push({
+				path: examplePath,
+				relPath: relOf(cwd, examplePath),
+				action: 'skip',
+				reason: 'other entities present',
+			});
+		} else {
+			entries.push({
+				path: examplePath,
+				relPath: relOf(cwd, examplePath),
+				action: 'create',
+				content: exampleEntityYaml(),
 			});
 		}
 	}


### PR DESCRIPTION
Fixes #120.

## Summary

- **Flip default** — `entity new --all` now defaults to `--continue-on-error: true` so one invalid YAML (typically the scaffold's `entities/example.yaml` placeholder) no longer wedges the entire batch. Clipanion's auto-negation gives `--no-continue-on-error` for users who want the old strict behavior.
- **Defense in depth** — `project init` now skips seeding `entities/example.yaml` when the `entities/` directory already contains another `*.yaml`. Even a re-run of `project init --force` on a populated repo no longer drops the broken stub.

## Files changed

| File | Change |
|------|--------|
| `src/cli/commands/entity.ts` | Flip default; reword EVT-7 pre-flight comment |
| `src/__tests__/cli/entity.test.ts` | +2 tests (default tolerates invalid; `--no-continue-on-error` restores fatal) |
| `src/cli/shared/init-scaffold.ts` | Skip `example.yaml` when other entity YAMLs present |
| `.claude/specs/issue-120-entity-all-continue-on-error.md` | New spec |
| `.claude/specs/cli-02-entity-noun.md` | Note new default |
| `docs/specs/EVT-7.md` | Note new default in pre-flight behavior |
| `docs/specs/TEST-SESSION-1.md` | Mark F12 resolved |

## Test plan

- [x] `just test-unit` — **922 pass / 0 fail** (was 920, added 2 new cases)
- [x] `bun run typecheck` — clean
- [ ] Manual: drop a comments-only `example.yaml` in a consumer `entities/` dir and run `codegen entity new --all` — valid entities still process, invalid one reported
- [ ] Manual: same scenario with `--no-continue-on-error` — exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)