### PR TITLE
SYNC-2 — Sync subsystem protocols + DI tokens

### DIFF
--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Sync subsystem — public API
+ *
+ * SYNC-2 slice (protocols + tokens only). Backends, orchestrator, and module
+ * land in SYNC-3..SYNC-6. See epic #60 for the full plan.
+ */
+
+// Protocols
+export type {
+  Change,
+  ChangeSource,
+  IChangeSource,
+  SyncSubscriptionView,
+} from './sync-change-source.protocol';
+export type { ICursorStore } from './sync-cursor-store.protocol';
+export type {
+  DiffResult,
+  FieldDiff,
+  FieldDiffValue,
+  IFieldDiffer,
+} from './sync-field-diff.protocol';
+export {
+  FieldDiffSchema,
+  FieldDiffValueSchema,
+} from './sync-field-diff.protocol';
+export type { ISyncSink } from './sync-sink.protocol';
+
+// Tokens
+export {
+  SYNC_CHANGE_SOURCE,
+  SYNC_CURSOR_STORE,
+  SYNC_FIELD_DIFFER,
+  SYNC_MODULE_OPTIONS,
+  SYNC_MULTI_TENANT,
+  SYNC_SINK,
+} from './sync.tokens';

--- a/runtime/subsystems/sync/sync-change-source.protocol.ts
+++ b/runtime/subsystems/sync/sync-change-source.protocol.ts
@@ -1,0 +1,99 @@
+/**
+ * Sync subsystem — change-source protocol (port)
+ *
+ * `IChangeSource<T>` is the hexagonal port every sync adapter implements.
+ * Use cases inject this interface via `SYNC_CHANGE_SOURCE` token. They never
+ * depend on a specific backend implementation.
+ *
+ * Three detection modes (poll / cdc / webhook) converge on this single port
+ * per ADR-0002 (dealbrain-v2). Per-mode differences live in the
+ * `Change.source` / `dedupKey` / `providerChangedFields` metadata fields,
+ * not in separate ports.
+ *
+ * See epic #60 (parent) and upstream ADR-008 subsystem architecture.
+ */
+
+// ============================================================================
+// Change provenance + shape
+// ============================================================================
+
+/**
+ * Provenance of a change record. Maps 1:1 to `sync_runs.action` so run logs
+ * self-identify.
+ */
+export type ChangeSource = 'poll' | 'cdc' | 'webhook';
+
+/**
+ * One upstream change, normalized.
+ *
+ * The adapter has already translated provider-specific record shape into a
+ * canonical T. Custom fields flow through the `fields` bag on `record` when
+ * T supports it (adapters attach it; the sink splits and routes).
+ *
+ * `dedupKey` — set by CDC (replay_id) and webhook (event_id) paths; absent
+ * for polling. Orchestrator uses it for idempotent re-delivery when present,
+ * falls back to fingerprint-comparison otherwise.
+ *
+ * `providerChangedFields` — CDC-only. Lets the differ skip deep-equals when
+ * the provider already told us which fields moved; falls back to computed
+ * diff when absent.
+ *
+ * `cursor` — opaque at this seam. Each strategy types it internally (poll:
+ * `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`) and the
+ * orchestrator persists whatever the strategy last yielded.
+ */
+export interface Change<T> {
+  readonly externalId: string;
+  readonly operation: 'created' | 'updated' | 'deleted';
+  readonly record: T;
+  readonly cursor: unknown;
+  readonly source: ChangeSource;
+  readonly dedupKey?: string;
+  readonly providerChangedFields?: string[];
+}
+
+// ============================================================================
+// Subscription shape (structural — consumer owns the row)
+// ============================================================================
+
+/**
+ * Minimal structural view of a sync-subscription row the port needs.
+ *
+ * The consumer owns the concrete `sync_subscriptions` table (schema lands in
+ * SYNC-1). This interface captures only the fields the port itself reads, so
+ * adapters can be typed without depending on the consumer's ORM row type.
+ */
+export interface SyncSubscriptionView {
+  /** Primary key — addresses the cursor in `ICursorStore`. */
+  readonly id: string;
+  /** Canonical entity domain, e.g. `'opportunity'`, `'contact'`. */
+  readonly domain: string;
+  /** Optional external reference — the upstream "scope" for this subscription. */
+  readonly externalRef?: string | null;
+}
+
+// ============================================================================
+// IChangeSource
+// ============================================================================
+
+/**
+ * The one port every sync adapter implements. Mode-specific concerns
+ * (scheduling, rate-limiting, ack contracts, credential refresh) stay in the
+ * strategy class that implements this interface — this seam is deliberately
+ * minimal.
+ *
+ * Strategies are per-provider per-mode per-entity — one concrete class per
+ * `(provider, detection-mode, canonical-entity)` tuple.
+ */
+export interface IChangeSource<T> {
+  /** Human label for run logs — e.g. `'salesforce-poll-opportunity'`. */
+  readonly label: string;
+
+  /**
+   * Async-iterate upstream changes, newest cursor last. The orchestrator
+   * persists `change.cursor` as it advances; strategies MUST yield at least
+   * one change before the async iterable completes if anything changed
+   * upstream, otherwise cursor advance is a no-op.
+   */
+  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
+}

--- a/runtime/subsystems/sync/sync-cursor-store.protocol.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.protocol.ts
@@ -1,0 +1,18 @@
+/**
+ * Sync subsystem — cursor-store protocol (port)
+ *
+ * Subscription-addressed cursor persistence. The subscription row IS the
+ * cursor owner — addressable by id, scoped by
+ * `(integration, adapter, domain, external_ref)` at the subscription level.
+ *
+ * Cursor shape is opaque at this seam; strategies type it internally
+ * (polling: `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`).
+ * The postgres backend stores this as `sync_subscriptions.cursor` jsonb.
+ */
+export interface ICursorStore {
+  /** Return the last persisted cursor for `subscriptionId`, or `null`. */
+  get(subscriptionId: string): Promise<unknown | null>;
+
+  /** Persist `cursor` for `subscriptionId`. Overwrites. */
+  put(subscriptionId: string, cursor: unknown): Promise<void>;
+}

--- a/runtime/subsystems/sync/sync-field-diff.protocol.ts
+++ b/runtime/subsystems/sync/sync-field-diff.protocol.ts
@@ -1,0 +1,61 @@
+/**
+ * Sync subsystem — field-diff protocol (port)
+ *
+ * `IFieldDiffer<T>` is the pluggable differ seam. The default implementation
+ * (`DeepEqualDiffer`, ships in SYNC-5) walks every field except an ignore
+ * list; CDC-aware differs can skip comparison for fields the provider didn't
+ * flag as changed.
+ *
+ * `FieldDiffSchema` is the structural enforcement of the `changed_fields`
+ * column per ADR-0003 — enforced at write time by the recorder service so
+ * consumers can rely on the shape in downstream queries.
+ */
+import { z } from 'zod';
+
+// ============================================================================
+// FieldDiff shape — the ADR-0003 contract
+// ============================================================================
+
+/**
+ * Structured per-field change. Enforced shape for `sync_run_items.changed_fields`.
+ *
+ * `created` items set `from: null, to: <value>` for every non-null field.
+ * `deleted` items set `from: <value>, to: null`.
+ * `noop` items carry `{}`.
+ */
+export const FieldDiffValueSchema = z.object({
+  from: z.unknown(),
+  to: z.unknown(),
+});
+
+export const FieldDiffSchema = z.record(z.string(), FieldDiffValueSchema);
+
+export type FieldDiffValue = z.infer<typeof FieldDiffValueSchema>;
+export type FieldDiff = z.infer<typeof FieldDiffSchema>;
+
+/** Result of comparing a new record against its existing local state. */
+export type DiffResult = FieldDiff | 'noop';
+
+// ============================================================================
+// IFieldDiffer
+// ============================================================================
+
+/**
+ * Pluggable differ. Default ships in SYNC-5 as `DeepEqualDiffer<T>` —
+ * deep-equal over every field except an ignore list (`updated_at` and other
+ * row metadata). CDC-aware differs restrict comparison to
+ * `providerChangedFields` when supplied.
+ */
+export interface IFieldDiffer<T> {
+  /**
+   * @param existing — current local state, or `null` when the record is new
+   * @param incoming — the canonical record coming from the adapter
+   * @param providerChangedFields — optional hint from CDC-capable sources;
+   *   when present, differ may restrict the comparison to these fields
+   */
+  diff(
+    existing: T | null,
+    incoming: T,
+    providerChangedFields?: string[],
+  ): DiffResult;
+}

--- a/runtime/subsystems/sync/sync-sink.protocol.ts
+++ b/runtime/subsystems/sync/sync-sink.protocol.ts
@@ -1,0 +1,55 @@
+/**
+ * Sync subsystem — sync-sink protocol (port)
+ *
+ * Write surface for the generic orchestrator. One per canonical entity type.
+ *
+ * **Shape contract:** the sink speaks the *canonical* `TCanonical` externally
+ * — `findByExternalId` returns a canonical-shaped view of local state
+ * (columns projected to canonical field names) so the differ compares
+ * like-for-like against `Change.record` from the adapter. Internal DB
+ * mapping (canonical → local write, EAV dual-write, FK resolution) stays
+ * inside the sink implementation.
+ *
+ * Implementations compose the entity's service + (when the entity has EAV)
+ * `FieldValueService` inside a single transaction. ADR-13-revised.
+ */
+export interface ISyncSink<TCanonical> {
+  /**
+   * Canonical-shaped view of local state, or `null` when no local row exists.
+   * Called once per change to source the diff's "before" side.
+   */
+  findByExternalId(
+    userId: string,
+    externalId: string,
+  ): Promise<TCanonical | null>;
+
+  /**
+   * Insert-or-update by `external_id`. Must:
+   *   - run EAV dual-write in a single transaction when the entity has `fields`
+   *   - resolve FK references (e.g. `account_id` from `accountExternalId`)
+   *     via a repository lookup
+   *   - stamp `user_id` and `provider` from caller / context
+   *   - tolerate re-entry (same record twice in a window = no-op)
+   *
+   * Returns the local row id and the canonical projection of the saved row
+   * (so the orchestrator can record it on `sync_run_items.local_id`).
+   *
+   * `provider` is the adapter domain string (e.g. `'salesforce-crm'`,
+   * `'hubspot-crm'`) persisted on the DB row. Passed from
+   * `ExecuteSyncInput.provider`.
+   */
+  upsertByExternalId(
+    userId: string,
+    record: TCanonical,
+    provider: string,
+  ): Promise<{ id: string; saved: TCanonical }>;
+
+  /**
+   * Soft-delete by `external_id`. Called when `Change.operation === 'deleted'`.
+   * Returns `null` when no local row exists (orchestrator records a no-op).
+   */
+  softDeleteByExternalId(
+    userId: string,
+    externalId: string,
+  ): Promise<{ id: string } | null>;
+}

--- a/runtime/subsystems/sync/sync.tokens.ts
+++ b/runtime/subsystems/sync/sync.tokens.ts
@@ -1,0 +1,42 @@
+/**
+ * Sync subsystem — DI tokens
+ *
+ * String constants (not Symbols) so they match by value across import
+ * boundaries — same convention as the events subsystem (`EVENT_BUS`). The
+ * jobs subsystem uses Symbols for its analogous tokens; events and sync
+ * stay internally consistent with strings.
+ *
+ * Usage in use cases:
+ * ```ts
+ * constructor(
+ *   @Inject(SYNC_CHANGE_SOURCE) private readonly source: IChangeSource<CanonicalOpportunity>,
+ *   @Inject(SYNC_CURSOR_STORE)  private readonly cursors: ICursorStore,
+ *   @Inject(SYNC_FIELD_DIFFER)  private readonly differ: IFieldDiffer<CanonicalOpportunity>,
+ *   @Inject(SYNC_SINK)          private readonly sink: ISyncSink<CanonicalOpportunity>,
+ * ) {}
+ * ```
+ *
+ * Concrete bindings are registered by `SyncModule.forRoot(...)` (SYNC-6).
+ */
+
+export const SYNC_CHANGE_SOURCE = 'SYNC_CHANGE_SOURCE' as const;
+export const SYNC_CURSOR_STORE = 'SYNC_CURSOR_STORE' as const;
+export const SYNC_FIELD_DIFFER = 'SYNC_FIELD_DIFFER' as const;
+export const SYNC_SINK = 'SYNC_SINK' as const;
+
+/**
+ * Injection token for the resolved `SyncModuleOptions` object (SYNC-6).
+ *
+ * Backends that need to observe module configuration (e.g. `multiTenant`
+ * flag, pool filters) inject via this token. Provided automatically by
+ * `SyncModule.forRoot(...)` / `SyncModule.forRootAsync(...)`.
+ */
+export const SYNC_MODULE_OPTIONS = 'SYNC_MODULE_OPTIONS' as const;
+
+/**
+ * Injection token for the resolved multi-tenancy flag (SYNC-6).
+ *
+ * Provided by `SyncModule.forRoot(...)` as `options.multiTenant ?? false`.
+ * Consumed by `ExecuteSyncUseCase` to enforce the tenantId-is-required rule.
+ */
+export const SYNC_MULTI_TENANT = 'SYNC_MULTI_TENANT' as const;

--- a/src/__tests__/runtime/subsystems/sync-field-diff.schema.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-field-diff.schema.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * FieldDiffSchema unit tests (SYNC-2)
+ *
+ * The Zod schema is the structural enforcement of `sync_run_items.changed_fields`
+ * per ADR-0003 (dealbrain-v2). These tests document the shape the recorder
+ * service will enforce at write time.
+ */
+import { describe, expect, it } from 'bun:test';
+import {
+  FieldDiffSchema,
+  FieldDiffValueSchema,
+} from '../../../../runtime/subsystems/sync/sync-field-diff.protocol';
+
+describe('FieldDiffValueSchema', () => {
+  it('accepts a minimal { from, to } pair', () => {
+    const parsed = FieldDiffValueSchema.parse({ from: 'a', to: 'b' });
+    expect(parsed).toEqual({ from: 'a', to: 'b' });
+  });
+
+  it('accepts nulls on either side (created / deleted shapes)', () => {
+    expect(FieldDiffValueSchema.parse({ from: null, to: 42 })).toEqual({
+      from: null,
+      to: 42,
+    });
+    expect(FieldDiffValueSchema.parse({ from: 42, to: null })).toEqual({
+      from: 42,
+      to: null,
+    });
+  });
+
+  it('accepts heterogeneous unknowns (numbers, strings, nested objects)', () => {
+    expect(
+      FieldDiffValueSchema.parse({
+        from: { nested: { deep: true } },
+        to: ['array', 1, null],
+      }),
+    ).toBeDefined();
+  });
+
+  it('accepts `undefined` for `from` or `to` (z.unknown tolerates omitted keys)', () => {
+    // Documents the relaxation: since `from`/`to` are `z.unknown()`, an
+    // object with the key absent passes because `undefined` is a valid
+    // `unknown`. Writers in dealbrain-v2 always set both keys explicitly;
+    // the recorder relies on convention, not schema enforcement here.
+    expect(FieldDiffValueSchema.safeParse({ to: 'b' }).success).toBe(true);
+    expect(FieldDiffValueSchema.safeParse({ from: 'a' }).success).toBe(true);
+  });
+
+  it('rejects a non-object value', () => {
+    expect(FieldDiffValueSchema.safeParse('not-an-object').success).toBe(false);
+    expect(FieldDiffValueSchema.safeParse(42).success).toBe(false);
+    expect(FieldDiffValueSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe('FieldDiffSchema', () => {
+  it('accepts an empty diff (no-op shape)', () => {
+    expect(FieldDiffSchema.parse({})).toEqual({});
+  });
+
+  it('accepts the canonical ADR-0003 example (amount + stage_name)', () => {
+    const parsed = FieldDiffSchema.parse({
+      stage_name: { from: 'Prospecting', to: 'Closed Won' },
+      amount: { from: 92364, to: 120000 },
+    });
+    expect(parsed['stage_name']).toEqual({
+      from: 'Prospecting',
+      to: 'Closed Won',
+    });
+    expect(parsed['amount']).toEqual({ from: 92364, to: 120000 });
+  });
+
+  it('accepts the created shape (every field from=null)', () => {
+    const parsed = FieldDiffSchema.parse({
+      name: { from: null, to: 'Acme' },
+      amount: { from: null, to: 5000 },
+    });
+    expect(parsed).toBeDefined();
+  });
+
+  it('accepts the deleted shape (every field to=null)', () => {
+    const parsed = FieldDiffSchema.parse({
+      name: { from: 'Acme', to: null },
+      amount: { from: 5000, to: null },
+    });
+    expect(parsed).toBeDefined();
+  });
+
+  it('rejects a diff whose value is not a { from, to } pair', () => {
+    const result = FieldDiffSchema.safeParse({
+      stage_name: 'Prospecting → Closed Won',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a diff whose value is a primitive', () => {
+    const result = FieldDiffSchema.safeParse({ amount: 42 });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #127. Part of epic #60.

## Summary

First child PR of the sync-engine subsystem epic. Lands the four hexagonal-port interfaces + DI tokens — the minimal seam every sync adapter implements and every backend/runtime consumes. Backends (SYNC-3 #128, SYNC-4 #129), orchestrator (SYNC-5 #130), and module (SYNC-6 #131) follow in their own PRs.

**Build first, extract later** — these protocols were exercised end-to-end in dealbrain-v2 (live Salesforce + HubSpot sync, 22/20/46 deals/accounts/contacts per HS-8 smoke) before being upstreamed. Extraction verdict documented in [dealbrain-v2 docs/stack-3-hubspot-adapter-findings.md §HS-9](https://github.com/Tempo-Systems/dealbrain/) — marks the surface as provider-agnostic and upstream-ready.

## Files added

- `runtime/subsystems/sync/sync-change-source.protocol.ts` — `IChangeSource<T>`, `Change<T>`, `ChangeSource` type, `SyncSubscriptionView`
- `runtime/subsystems/sync/sync-cursor-store.protocol.ts` — `ICursorStore { get(subId), put(subId, cursor) }`
- `runtime/subsystems/sync/sync-field-diff.protocol.ts` — `IFieldDiffer<T>`, `DiffResult`, `FieldDiffSchema` (Zod — ADR-0003 contract)
- `runtime/subsystems/sync/sync-sink.protocol.ts` — `ISyncSink<T>` (findByExternalId, upsertByExternalId, softDeleteByExternalId)
- `runtime/subsystems/sync/sync.tokens.ts` — `SYNC_CHANGE_SOURCE`, `SYNC_CURSOR_STORE`, `SYNC_FIELD_DIFFER`, `SYNC_SINK`, `SYNC_MODULE_OPTIONS`, `SYNC_MULTI_TENANT`
- `runtime/subsystems/sync/index.ts` — public barrel
- `src/__tests__/runtime/subsystems/sync-field-diff.schema.spec.ts` — 11 tests covering ADR-0003 shape

## Naming + convention calls

- **Filename convention** — upstream uses `<subsystem>-<role>.protocol.ts` (e.g. `event-bus.protocol.ts`, `job-orchestrator.protocol.ts`). This PR follows that — renamed from dealbrain's unprefixed `change-source.ts`.
- **Tokens are strings, not Symbols** — matches events subsystem (jobs uses Symbols; sync chose strings for cross-import-boundary value equality).
- **`SyncSubscriptionView` replaces a direct import of the consumer's `SyncSubscription` entity.** Ports should not depend on consumer ORM types. The structural view captures the three fields the port reads (`id`, `domain`, `externalRef?`).
- **CrmEntityType narrowing dropped** — dealbrain's port had a `'opportunity' | 'account' | 'contact'` union leak in `isCrmEntityType`. The subsystem port holds `string`; consumer-side `ILoopbackFingerprintStore` (CRM-only) keeps the narrow type locally.
- **`FieldDiffValue.from/to` stay `z.unknown()`** — an object with `from` or `to` missing still passes (treated as `undefined`). Dealbrain's shipped schema has the same relaxation; tightening it to `required` would break the existing recorder writes. Documented in the test file.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/__tests__/runtime/subsystems/sync-field-diff.schema.spec.ts` — 11/11 pass
- [x] `bun test src/__tests__/` — 930/931 pass (1 pre-existing failure in `subsystem.test.ts` unrelated to this PR — same failure on `origin/main`)

## Scope — what this PR does NOT include

Explicitly deferred to follow-up PRs per the epic's decomposition:

- No backend implementations (`MemoryCursorStore` — SYNC-3 #128; `PostgresCursorStore` — SYNC-4 #129)
- No orchestrator / default differ (`ExecuteSyncUseCase`, `DeepEqualDiffer` — SYNC-5 #130)
- No DynamicModule wiring (SYNC-6 #131)
- No Drizzle audit-table schemas (SYNC-1 #126)
- No scaffold templates (SYNC-7 #132) or docs (SYNC-8 #133)

Because this is protocols-only, the root `runtime/subsystems/index.ts` barrel is not touched — it will gain a `sync` export block once the module lands in SYNC-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)