### PR TITLE
AUTH-1 — auth subsystem extracted from dealbrain-v2 Gate-1 (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Entity-driven code generation system for full-stack TypeScript applications (v0.2). Generates Clean Architecture scaffolding from YAML entity definitions, including domain entities, repositories, use cases, DTOs, Drizzle schemas, NestJS modules, controllers, and frontend collections. Also provides infrastructure subsystem scaffolding (events, jobs, cache, storage).
+Entity-driven code generation system for full-stack TypeScript applications (v0.2). Generates Clean Architecture scaffolding from YAML entity definitions, including domain entities, repositories, use cases, DTOs, Drizzle schemas, NestJS modules, controllers, and frontend collections. Also provides infrastructure subsystem scaffolding (events, jobs, cache, storage, auth).
 
 ## Operating Principles
 
@@ -94,7 +94,7 @@ src/                    # Generator source code
   __tests__/            # Unit tests (mirrors src/ structure)
 runtime/                # Code shipped into user's generated project
   base-classes/         # BaseRepository, BaseService, family repos/services, WithAnalytics
-  subsystems/           # Infrastructure: events, jobs, cache, storage
+  subsystems/           # Infrastructure: events, jobs, cache, storage, auth
   constants/            # Injection tokens
   types/                # DrizzleClient type
 templates/              # Hygen EJS templates (the core product)

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -425,6 +425,196 @@ their YAML. Generated use cases then call `TypedEventBus.publish(type, ...)`
 inside the domain transaction. See ADR-024 and the events skill
 (`.claude/skills/events/event-codegen.md`) for the shape and constraints.
 
+## Auth subsystem
+
+The auth subsystem (ADR-031) ships `IAuthStrategy`, the abstract
+`OAuth2RefreshStrategy` template-method base, `withAuthRetry`, token-at-rest
+encryption (`IEncryptionKey` / `EnvEncryptionKey`), and an OAuth state-store
+port. It is a runtime-only library — there is no `subsystem install auth`
+command; consumers import the runtime directly and wire it into their
+NestJS `AppModule`.
+
+### Install
+
+No scaffold. Import the module in `AppModule`:
+
+```ts
+import { AuthModule } from '@pattern-stack/codegen/runtime/subsystems/auth';
+
+@Module({
+  imports: [
+    DatabaseModule,
+    AuthModule.forRoot({
+      encryptionKey: 'env',        // or: { useClass: MyKmsEncryptionKey }
+      oauthStateStore: 'in-memory', // or: { useClass: RedisOAuthStateStore }
+    }),
+    // ... other subsystems + GENERATED_MODULES
+  ],
+})
+export class AppModule {}
+```
+
+`AuthModule` is `global: true`. It provides `ENCRYPTION_KEY` and
+`OAUTH_STATE_STORE` tokens. Defaults: `EnvEncryptionKey` (reads
+`TOKEN_ENCRYPTION_KEY` from env) and `InMemoryOAuthStateStore`.
+
+### Env vars
+
+- `TOKEN_ENCRYPTION_KEY` — 32-byte base64 string. Required when
+  `encryptionKey: 'env'`. Generate with `openssl rand -base64 32`.
+
+### Environment setup
+
+The `InMemoryOAuthStateStore` is dev-only (single-process). Production
+deployments ship a Redis-backed implementation as a custom provider:
+
+```ts
+AuthModule.forRoot({
+  oauthStateStore: { useClass: RedisOAuthStateStore },
+});
+```
+
+Same for `EnvEncryptionKey` — production wants a KMS-backed impl
+(`{ useClass: KmsEncryptionKey }`). The subsystem ships the env-backed
+default for local dev + CI.
+
+### Implement a provider strategy
+
+Auth strategies are per-provider (Salesforce, HubSpot, Gmail, …) and live
+in the integration module, not the subsystem. Each extends
+`OAuth2RefreshStrategy` and overrides four hooks:
+
+```ts
+import {
+  OAuth2RefreshStrategy,
+  type ParsedRefreshResponse,
+  type DecryptedIntegration,
+  type AuthCredentials,
+} from '@pattern-stack/codegen/runtime/subsystems/auth';
+
+export class SalesforceAuthStrategy extends OAuth2RefreshStrategy {
+  protected readonly provider = 'salesforce-crm';
+  protected readonly defaultExpiresInSec = 7200;
+
+  protected tokenEndpoint(): string {
+    return `https://${this.config.authDomain}/services/oauth2/token`;
+  }
+
+  protected refreshBodyExtras(): Record<string, string> {
+    return {
+      client_id: this.config.clientId,
+      client_secret: this.config.clientSecret,
+    };
+  }
+
+  protected parseRefreshResponse(raw: unknown): ParsedRefreshResponse {
+    const r = raw as { access_token: string; refresh_token?: string; expires_in?: number };
+    return {
+      accessToken: r.access_token,
+      refreshToken: r.refresh_token,
+      expiresInSec: r.expires_in,
+    };
+  }
+
+  protected buildCredentials(
+    accessToken: string,
+    integration: DecryptedIntegration,
+    refreshRaw?: unknown,
+  ): AuthCredentials {
+    const raw = refreshRaw as { instance_url?: string } | undefined;
+    return {
+      accessToken,
+      instanceUrl:
+        raw?.instance_url ??
+        (integration.providerMetadata?.['instanceUrl'] as string),
+      apiVersion: this.config.apiVersion,
+    };
+  }
+}
+```
+
+Register the strategy under a provider-specific token in your integration
+module (there is no central `AUTH_STRATEGY` token):
+
+```ts
+export const SALESFORCE_AUTH_STRATEGY = Symbol('SALESFORCE_AUTH_STRATEGY');
+
+@Module({
+  providers: [
+    {
+      provide: SALESFORCE_AUTH_STRATEGY,
+      useFactory: (reader, writer) =>
+        new SalesforceAuthStrategy({
+          integrationReader: reader,
+          tokenWriter: writer,
+          // ... provider config
+        }),
+      inject: [AUTH_INTEGRATION_READER, AUTH_INTEGRATION_TOKEN_WRITER],
+    },
+  ],
+  exports: [SALESFORCE_AUTH_STRATEGY],
+})
+export class SalesforceAuthModule {}
+```
+
+### Integration-store ports — app-supplied
+
+`OAuth2RefreshStrategy` depends on two narrow ports that read/write
+integration rows. Consumers supply these as thin adapters over whatever
+service owns the `integrations` entity:
+
+```ts
+@Injectable()
+export class IntegrationStoreAdapter
+  implements IIntegrationReader, IIntegrationTokenWriter
+{
+  constructor(
+    private readonly service: IntegrationService,
+    private readonly refreshUseCase: RefreshIntegrationUseCase,
+  ) {}
+
+  findByIdDecrypted(id: string) {
+    return this.service.findByIdDecrypted(id);
+  }
+
+  persistRefresh(update: IntegrationTokenUpdate) {
+    return this.refreshUseCase.execute(update);
+  }
+}
+
+@Module({
+  providers: [
+    IntegrationStoreAdapter,
+    { provide: AUTH_INTEGRATION_READER, useExisting: IntegrationStoreAdapter },
+    { provide: AUTH_INTEGRATION_TOKEN_WRITER, useExisting: IntegrationStoreAdapter },
+  ],
+  exports: [AUTH_INTEGRATION_READER, AUTH_INTEGRATION_TOKEN_WRITER],
+})
+export class IntegrationStoreModule {}
+```
+
+A future `examples/auth-integrations/integration.yaml` starter will ship a
+canonical `integration` entity whose generated service + use case satisfy
+these ports out of the box — tracked alongside the sync subsystem roadmap.
+
+### Retry-once on session-expired
+
+`withAuthRetry` wraps an op with resolve → run → force-refresh-on-session-
+expired → retry once → propagate. Provider error classes participate by
+extending `SessionExpiredError` OR by setting
+`isSessionExpired === true` on their instances (duck-typed marker):
+
+```ts
+import { withAuthRetry } from '@pattern-stack/codegen/runtime/subsystems/auth';
+
+const result = await withAuthRetry(salesforceAuth, integrationId, (creds) =>
+  salesforceClient.listOpportunities(creds),
+);
+```
+
+A custom classifier is supported via the options third argument when the
+marker isn't practical.
+
 ## `app.module.ts` wiring
 
 `AppModule` imports the `DatabaseModule` first, then spreads the generated module barrel:

--- a/docs/adrs/ADR-031-auth-subsystem.md
+++ b/docs/adrs/ADR-031-auth-subsystem.md
@@ -1,0 +1,212 @@
+# ADR-031 — Auth subsystem: OAuth2 refresh template-method + encryption-at-rest port
+
+**Status:** Accepted
+**Date:** 2026-04-20
+**Owner:** Doug
+**Related:** ADR-001 (hexagonal), ADR-008 (subsystem architecture), issue [#59](https://github.com/pattern-stack/codegen-patterns/issues/59)
+
+## Context
+
+Every external integration an app builds — Salesforce, HubSpot, Gmail, Slack,
+Gong — repeats the same auth loop:
+
+1. Resolve credentials for an integration row.
+2. If the access token is missing/expired, POST `grant_type=refresh_token` to
+   the provider's token endpoint.
+3. Persist the new access token (and possibly a rotated refresh token) at
+   rest, encrypted.
+4. Catch "session expired" from the vendor SDK, retry once with a fresh token.
+5. On 400 `invalid_grant`/`invalid_token`, mark the integration broken so
+   background work stops attempting to use it.
+
+What varies per provider: the token endpoint URL, the body parameters, the
+field names in the refresh response, the credentials shape (SFDC ships an
+`instance_url`; HubSpot doesn't). What's identical: everything else —
+expiry-window math, force-refresh semantics, form-urlencoded POST, error
+mapping, rotation handling, encryption, state-parameter CSRF protection.
+
+The dealbrain-v2 project built this auth layer from scratch for Salesforce,
+then validated the shape by shipping HubSpot as a second consumer
+(Gate-1 "build first, extract later"). The findings doc captures the
+details: four small hooks per subclass, zero base-class changes needed
+across the two providers.
+
+This ADR captures the upstream extraction of that work into the
+codegen-patterns `runtime/subsystems/auth/` tree.
+
+## Decision
+
+### Slot under ADR-008's Protocol → Backend → Factory
+
+The auth subsystem follows the same three-layer pattern as events / jobs /
+cache / storage:
+
+- **Protocols** (`protocols/`) — `IAuthStrategy`, `IEncryptionKey`,
+  `IOAuthStateStore`, plus the narrow storage ports `IIntegrationReader` +
+  `IIntegrationTokenWriter` that let the refresh flow talk to the consumer's
+  integrations table without importing any entity framework.
+- **Runtime** (`runtime/`) — `OAuth2RefreshStrategy` (abstract template-
+  method base), `withAuthRetry`, `SessionExpiredError` marker,
+  `IntegrationBrokenError`.
+- **Backends** (`backends/`) — `EnvEncryptionKey` (AES-256-GCM from env) +
+  `InMemoryOAuthStateStore` (dev). Future: KMS-backed encryption, Redis-
+  backed state store.
+- **Factory** (`auth.module.ts`) — `AuthModule.forRoot({ encryptionKey,
+  oauthStateStore })` binds the backends; `global: true` so consumer modules
+  don't re-import.
+
+### Template-method contract (four hooks, two constants)
+
+`OAuth2RefreshStrategy.resolve()` is concrete. Subclasses override:
+
+```ts
+protected abstract readonly provider: string;              // slug
+protected abstract readonly defaultExpiresInSec: number;   // response fallback
+
+protected abstract tokenEndpoint(): string;
+protected abstract refreshBodyExtras(): Record<string, string>;
+protected abstract parseRefreshResponse(raw: unknown): ParsedRefreshResponse;
+protected abstract buildCredentials(
+  accessToken: string,
+  integration: DecryptedIntegration,
+  refreshRaw?: unknown,
+): AuthCredentials;
+```
+
+Base class handles (zero subclass intervention):
+- 5-minute expiry safety window
+- `forceRefresh` escape hatch
+- `no_refresh_token` → `IntegrationBrokenError`
+- Form-urlencoded POST with `Content-Type: application/x-www-form-urlencoded`
+- 400 `invalid_grant`/`invalid_token` → `IntegrationBrokenError`
+- Non-2xx → generic error with provider-scoped message
+- Refresh-token rotation persistence
+- Fetch + clock injection for tests
+- Provider-slug mismatch check
+
+Gate-1 evidence: four hooks + two constants are sufficient for both
+Salesforce (which rotates refresh tokens sometimes and ships `instance_url`)
+and HubSpot (which rotates every time, ships no host, needs `redirect_uri`
+in the refresh body). No base-class changes were needed when HubSpot landed.
+
+### `buildCredentials(…, refreshRaw?)` — opaque raw passthrough
+
+The raw refresh response is passed through to the subclass as a third
+argument. Salesforce peeks for a refreshed `instance_url`; HubSpot ignores
+it. The base class treats the raw response as opaque — it never inspects
+fields beyond the `ParsedRefreshResponse` the subclass returns.
+
+This keeps the contract narrow. Adding a fifth hook for every new per-
+provider concern would force the base class to know about each field;
+passing the raw response gives subclasses full escape-hatch flexibility
+without widening the hook surface.
+
+### `SessionExpiredError` marker + `isSessionExpiredError` predicate
+
+Dealbrain's original `withAuthRetry` hardcoded `instanceof
+SalesforceSessionExpiredError`. Upstream replaces that with a
+duck-typed marker — any error that is `instanceof SessionExpiredError` OR
+carries `isSessionExpired === true` gets retried. Provider error classes
+join the contract without extending this subsystem's class hierarchy,
+which avoids the cross-package `instanceof` footgun.
+
+`withAuthRetry` also takes an optional `isSessionExpired` classifier for
+consumers who want a custom predicate.
+
+### Narrow integration-store ports (no entity framework dep)
+
+`OAuth2RefreshStrategy` needs to read decrypted integration rows and
+persist refreshed tokens. The subsystem cannot import the consumer's
+`IntegrationService` — that would couple it to a specific entity
+framework.
+
+Solution: two narrow ports.
+
+```ts
+interface IIntegrationReader {
+  findByIdDecrypted(integrationId: string): Promise<DecryptedIntegration | null>;
+}
+
+interface IIntegrationTokenWriter {
+  persistRefresh(update: IntegrationTokenUpdate): Promise<void>;
+}
+```
+
+Consumers implement these as thin adapters over whatever service they've
+generated. The planned `examples/auth-integrations/integration.yaml`
+starter (separate PR) ships canonical implementations out of the box.
+
+### What the subsystem does NOT wire
+
+- **`IAuthStrategy` implementations.** Every app has multiple concurrent
+  strategies (one per provider). Registration belongs in the provider
+  module (`SalesforceModule`, `HubSpotModule`), not the subsystem. There
+  is no single `AUTH_STRATEGY` token.
+- **Integration-store ports.** They're inherently consumer-specific —
+  the subsystem ships the ports; the app's integrations domain satisfies
+  them. Wiring happens in the module that owns the integrations entity.
+
+## Consequences
+
+### Positive
+
+- **Two providers de-risk the abstraction.** SFDC and HubSpot share a
+  non-trivial contract without any base-class compromises.
+- **Tests don't need a real provider.** A 50-line fake subclass exercises
+  every hook. Backend unit tests skip Docker entirely (env key roundtrip +
+  in-memory state store).
+- **Consumers stay decoupled from entity framework.** The narrow integration
+  ports mean any app can adopt the subsystem without committing to
+  codegen-patterns' entity model.
+- **Future providers (Gmail, Slack) fit without code changes.** If they
+  don't, it's a bug that the two-consumer Gate-1 missed — not an expected
+  evolution.
+
+### Negative
+
+- **`AuthModule.forRoot` is thinner than events/cache.** It wires only two
+  of the four tokens (encryption + state store); integration-store tokens
+  + `IAuthStrategy` instances stay in consumer modules. This is correct —
+  those bindings ARE consumer-specific — but it means the subsystem doesn't
+  give the same "one-line install" feel.
+- **Error taxonomy is shallow.** `IntegrationBrokenError` + `SessionExpiredError`
+  cover the two cases all known providers need. A future provider with a
+  richer error model may need additional error types.
+
+### Neutral
+
+- Third consumer (Gmail, Slack) is the real test of whether four hooks
+  are enough. Plan: ship Gmail on top of `OAuth2RefreshStrategy` in a
+  future dealbrain-v2 PR; if a fifth hook is needed, revise this ADR.
+- PKCE support is explicitly out of scope for the initial extraction.
+  Adding PKCE is additive (another subclass hook or a new strategy
+  type); the existing refresh-token flow is orthogonal.
+
+## Alternatives Considered
+
+### Hardcode OAuth2 refresh into every provider module
+
+Status quo before Gate-1. Each provider reimplements the same 120-line
+refresh flow. Rejected: the duplication is mechanical, and bugs found in
+one copy (e.g. safe-JSON parsing on error responses) have to be fixed
+N times.
+
+### Single-consumer extraction (just Salesforce)
+
+What we rejected at Gate-1. The findings doc makes the explicit case:
+one consumer's abstraction is overfit by construction. HubSpot forced
+the `refreshBodyExtras()` hook into existence.
+
+### Wire `IAuthStrategy` centrally via a registry
+
+Every provider module registers its strategy at a central
+`AUTH_STRATEGIES` map. Rejected: it adds indirection for no win —
+consumers inject `SALESFORCE_AUTH_STRATEGY` directly in the SFDC adapter
+today; the registry would just rename that token without changing what
+the adapter looks up.
+
+## References
+
+- [Gate-1 auth extraction findings](https://github.com/pattern-stack/dealbrain/blob/main/docs/gate-1-auth-extraction-findings.md) — the upstream PR body cites this doc (also copied into the PR for reference).
+- [ADR-008 — Subsystem architecture](./ADR-008-subsystem-architecture.md)
+- [Issue #59 — Add auth subsystem](https://github.com/pattern-stack/codegen-patterns/issues/59)

--- a/runtime/subsystems/auth/auth.module.ts
+++ b/runtime/subsystems/auth/auth.module.ts
@@ -1,0 +1,91 @@
+/**
+ * AuthModule — DynamicModule factory for the auth subsystem.
+ *
+ * Wires the two pluggable backends the subsystem ships with:
+ *   - `ENCRYPTION_KEY`       → `EnvEncryptionKey` (AES-256-GCM from env)
+ *   - `OAUTH_STATE_STORE`    → `InMemoryOAuthStateStore` (dev) / custom Redis impl (prod)
+ *
+ * The two integration-store ports (`AUTH_INTEGRATION_READER`,
+ * `AUTH_INTEGRATION_TOKEN_WRITER`) are deliberately **not** wired by this
+ * module — they are always consumer-specific (adapters over the app's own
+ * integrations entity/service). Consumers provide them in the module that
+ * owns the integrations domain, not here.
+ *
+ * `IAuthStrategy` implementations are also per-provider and live in the
+ * integration module that uses them (`SalesforceModule`, `HubSpotModule`, …).
+ * The subsystem provides the abstract base class
+ * (`OAuth2RefreshStrategy`) — binding concrete strategies is an app concern.
+ *
+ * Usage in AppModule:
+ * ```typescript
+ * AuthModule.forRoot({
+ *   encryptionKey: 'env',
+ *   oauthStateStore: 'in-memory',
+ * });
+ * ```
+ *
+ * Or inject custom providers directly:
+ * ```typescript
+ * AuthModule.forRoot({
+ *   encryptionKey: { useClass: MyKmsEncryptionKey },
+ *   oauthStateStore: { useClass: RedisOAuthStateStore },
+ * });
+ * ```
+ *
+ * `global: true` means other modules don't need to re-import AuthModule to
+ * inject `ENCRYPTION_KEY` / `OAUTH_STATE_STORE`.
+ */
+import { Module, type DynamicModule, type Provider } from '@nestjs/common';
+import { ENCRYPTION_KEY, OAUTH_STATE_STORE } from './auth.tokens';
+import { EnvEncryptionKey } from './backends/encryption-key/env';
+import { InMemoryOAuthStateStore } from './backends/oauth-state-store/in-memory';
+
+type EncryptionKeyChoice =
+  | 'env'
+  | Omit<Provider, 'provide'>;
+
+type OAuthStateStoreChoice =
+  | 'in-memory'
+  | Omit<Provider, 'provide'>;
+
+export interface AuthModuleOptions {
+  /** `'env'` (default) or a full provider definition (e.g. `{ useClass: MyKmsEncryptionKey }`). */
+  encryptionKey?: EncryptionKeyChoice;
+  /** `'in-memory'` (default) or a full provider definition for a Redis/DB impl. */
+  oauthStateStore?: OAuthStateStoreChoice;
+}
+
+function resolveEncryptionKeyProvider(choice: EncryptionKeyChoice): Provider {
+  if (choice === 'env') {
+    return { provide: ENCRYPTION_KEY, useClass: EnvEncryptionKey };
+  }
+  return { provide: ENCRYPTION_KEY, ...choice } as Provider;
+}
+
+function resolveOAuthStateStoreProvider(
+  choice: OAuthStateStoreChoice,
+): Provider {
+  if (choice === 'in-memory') {
+    return { provide: OAUTH_STATE_STORE, useClass: InMemoryOAuthStateStore };
+  }
+  return { provide: OAUTH_STATE_STORE, ...choice } as Provider;
+}
+
+@Module({})
+export class AuthModule {
+  static forRoot(options: AuthModuleOptions = {}): DynamicModule {
+    const encryptionKeyProvider = resolveEncryptionKeyProvider(
+      options.encryptionKey ?? 'env',
+    );
+    const oauthStateStoreProvider = resolveOAuthStateStoreProvider(
+      options.oauthStateStore ?? 'in-memory',
+    );
+
+    return {
+      module: AuthModule,
+      global: true,
+      providers: [encryptionKeyProvider, oauthStateStoreProvider],
+      exports: [ENCRYPTION_KEY, OAUTH_STATE_STORE],
+    };
+  }
+}

--- a/runtime/subsystems/auth/auth.tokens.ts
+++ b/runtime/subsystems/auth/auth.tokens.ts
@@ -1,0 +1,27 @@
+/**
+ * Auth subsystem — injection tokens.
+ *
+ * Following ADR-008 guidance: `Symbol()` tokens for type safety and collision
+ * avoidance. Consumers inject these via `@Inject(...)` against the matching
+ * protocol interface.
+ *
+ * Usage:
+ * ```typescript
+ * constructor(
+ *   @Inject(ENCRYPTION_KEY) private readonly key: IEncryptionKey,
+ *   @Inject(OAUTH_STATE_STORE) private readonly states: IOAuthStateStore,
+ *   @Inject(AUTH_INTEGRATION_READER) private readonly reader: IIntegrationReader,
+ *   @Inject(AUTH_INTEGRATION_TOKEN_WRITER) private readonly writer: IIntegrationTokenWriter,
+ * ) {}
+ * ```
+ *
+ * `IAuthStrategy` implementations are provider-specific and registered under
+ * provider-specific tokens (e.g. `SALESFORCE_AUTH_STRATEGY`,
+ * `HUBSPOT_AUTH_STRATEGY`) by each integration module — this subsystem does
+ * not mandate a single `AUTH_STRATEGY` token because an app typically has
+ * many concurrent strategies, one per provider.
+ */
+export const ENCRYPTION_KEY = Symbol('ENCRYPTION_KEY');
+export const OAUTH_STATE_STORE = Symbol('OAUTH_STATE_STORE');
+export const AUTH_INTEGRATION_READER = Symbol('AUTH_INTEGRATION_READER');
+export const AUTH_INTEGRATION_TOKEN_WRITER = Symbol('AUTH_INTEGRATION_TOKEN_WRITER');

--- a/runtime/subsystems/auth/backends/encryption-key/env.ts
+++ b/runtime/subsystems/auth/backends/encryption-key/env.ts
@@ -1,0 +1,76 @@
+/**
+ * Env-backed AES-256-GCM encryption.
+ *
+ * Framing: `base64( nonce(12B) || ciphertext || authTag(16B) )`. Random nonce
+ * per call means two encryptions of the same plaintext produce different
+ * ciphertexts — prevents replay-style inference. Auth tag enforces integrity;
+ * any tampering throws on decrypt.
+ *
+ * Key source: `TOKEN_ENCRYPTION_KEY` env var, 32 bytes base64-encoded.
+ * Generate via `openssl rand -base64 32`.
+ *
+ * Future backend: `kms.ts` (AWS/GCP KMS) for production deployments that
+ * need key rotation + audit trails.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import type { IEncryptionKey } from '../../protocols/encryption-key';
+
+export interface EnvEncryptionKeyOptions {
+  /** Defaults to `process.env`. Tests inject a fixture. */
+  env?: NodeJS.ProcessEnv;
+  /** Defaults to `'TOKEN_ENCRYPTION_KEY'`. */
+  envVar?: string;
+}
+
+const ALGO = 'aes-256-gcm';
+const NONCE_BYTES = 12;
+const TAG_BYTES = 16;
+const KEY_BYTES = 32;
+
+export class EnvEncryptionKey implements IEncryptionKey {
+  private readonly key: Buffer;
+
+  constructor(opts: EnvEncryptionKeyOptions = {}) {
+    const env = opts.env ?? process.env;
+    const envVar = opts.envVar ?? 'TOKEN_ENCRYPTION_KEY';
+    const raw = env[envVar];
+    if (!raw) {
+      throw new Error(
+        `EnvEncryptionKey: ${envVar} is not set. Generate with: openssl rand -base64 32`,
+      );
+    }
+    const decoded = Buffer.from(raw, 'base64');
+    if (decoded.length !== KEY_BYTES) {
+      throw new Error(
+        `EnvEncryptionKey: ${envVar} must decode to ${KEY_BYTES} bytes (got ${decoded.length}). Use: openssl rand -base64 32`,
+      );
+    }
+    this.key = decoded;
+  }
+
+  async encrypt(plaintext: string): Promise<string> {
+    const nonce = randomBytes(NONCE_BYTES);
+    const cipher = createCipheriv(ALGO, this.key, nonce);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    return Buffer.concat([nonce, ciphertext, authTag]).toString('base64');
+  }
+
+  async decrypt(ciphertext: string): Promise<string> {
+    const buf = Buffer.from(ciphertext, 'base64');
+    if (buf.length < NONCE_BYTES + TAG_BYTES) {
+      throw new Error('EnvEncryptionKey: ciphertext too short');
+    }
+    const nonce = buf.subarray(0, NONCE_BYTES);
+    const authTag = buf.subarray(buf.length - TAG_BYTES);
+    const body = buf.subarray(NONCE_BYTES, buf.length - TAG_BYTES);
+
+    const decipher = createDecipheriv(ALGO, this.key, nonce);
+    decipher.setAuthTag(authTag);
+    const plain = Buffer.concat([decipher.update(body), decipher.final()]);
+    return plain.toString('utf8');
+  }
+}

--- a/runtime/subsystems/auth/backends/oauth-state-store/in-memory.ts
+++ b/runtime/subsystems/auth/backends/oauth-state-store/in-memory.ts
@@ -1,0 +1,42 @@
+/**
+ * In-memory OAuth state store.
+ *
+ * Single-process dev store. Production deployments need a Redis-backed impl
+ * (follow-up) so state survives restarts + is shared across workers.
+ */
+import type {
+  IOAuthStateStore,
+  OAuthStateEntry,
+} from '../../protocols/oauth-state-store';
+
+export interface InMemoryOAuthStateStoreOptions {
+  /** TTL in ms. Entries older than this are treated as absent. Default 10min. */
+  ttlMs?: number;
+  now?: () => number;
+}
+
+export class InMemoryOAuthStateStore implements IOAuthStateStore {
+  private readonly store = new Map<
+    string,
+    { entry: OAuthStateEntry; expiresAt: number }
+  >();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: InMemoryOAuthStateStoreOptions = {}) {
+    this.ttlMs = opts.ttlMs ?? 10 * 60 * 1000;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  async put(state: string, entry: OAuthStateEntry): Promise<void> {
+    this.store.set(state, { entry, expiresAt: this.now() + this.ttlMs });
+  }
+
+  async consume(state: string): Promise<OAuthStateEntry | null> {
+    const slot = this.store.get(state);
+    if (!slot) return null;
+    this.store.delete(state);
+    if (slot.expiresAt <= this.now()) return null;
+    return slot.entry;
+  }
+}

--- a/runtime/subsystems/auth/index.ts
+++ b/runtime/subsystems/auth/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Auth subsystem — public API.
+ *
+ * Protocol → Backend → Factory, per ADR-008 + ADR-031. Imports:
+ *
+ * ```typescript
+ * import {
+ *   AuthModule,
+ *   ENCRYPTION_KEY,
+ *   OAUTH_STATE_STORE,
+ *   AUTH_INTEGRATION_READER,
+ *   AUTH_INTEGRATION_TOKEN_WRITER,
+ *   OAuth2RefreshStrategy,
+ *   withAuthRetry,
+ *   IntegrationBrokenError,
+ *   SessionExpiredError,
+ *   type IAuthStrategy,
+ *   type IEncryptionKey,
+ *   type IOAuthStateStore,
+ *   type IIntegrationReader,
+ *   type IIntegrationTokenWriter,
+ * } from '@pattern-stack/codegen/runtime/subsystems/auth';
+ * ```
+ */
+
+// Protocols
+export type {
+  AuthCredentials,
+  AuthResolveOptions,
+  IAuthStrategy,
+} from './protocols/auth-strategy';
+export type { IEncryptionKey } from './protocols/encryption-key';
+export type {
+  IOAuthStateStore,
+  OAuthStateEntry,
+} from './protocols/oauth-state-store';
+export type {
+  DecryptedIntegration,
+  IIntegrationReader,
+  IIntegrationTokenWriter,
+  IntegrationTokenUpdate,
+} from './protocols/integration-store';
+
+// Tokens
+export {
+  ENCRYPTION_KEY,
+  OAUTH_STATE_STORE,
+  AUTH_INTEGRATION_READER,
+  AUTH_INTEGRATION_TOKEN_WRITER,
+} from './auth.tokens';
+
+// Runtime
+export {
+  OAuth2RefreshStrategy,
+  type OAuth2RefreshStrategyOptions,
+  type ParsedRefreshResponse,
+  type FetchLike,
+} from './runtime/oauth2-refresh.strategy';
+export { withAuthRetry, type WithAuthRetryOptions } from './runtime/with-auth-retry';
+export { IntegrationBrokenError } from './runtime/integration-broken.error';
+export {
+  SessionExpiredError,
+  isSessionExpiredError,
+} from './runtime/session-expired.error';
+
+// Backends
+export {
+  EnvEncryptionKey,
+  type EnvEncryptionKeyOptions,
+} from './backends/encryption-key/env';
+export {
+  InMemoryOAuthStateStore,
+  type InMemoryOAuthStateStoreOptions,
+} from './backends/oauth-state-store/in-memory';
+
+// Module
+export { AuthModule, type AuthModuleOptions } from './auth.module';

--- a/runtime/subsystems/auth/protocols/auth-strategy.ts
+++ b/runtime/subsystems/auth/protocols/auth-strategy.ts
@@ -1,0 +1,46 @@
+/**
+ * Auth subsystem — `IAuthStrategy` port.
+ *
+ * The credentials-resolution seam used by every integration adapter. Adapters
+ * depend on this interface; concrete strategies (SalesforceAuthStrategy,
+ * HubSpotAuthStrategy, future Gmail/Calendar) typically extend the
+ * `OAuth2RefreshStrategy` template-method base in `../runtime/`.
+ *
+ * See `docs/adrs/ADR-031-auth-subsystem.md` and
+ * `docs/gate-1-auth-extraction-findings.md` (inbound from dealbrain-v2) for
+ * the rationale.
+ */
+
+/**
+ * Credentials the adapter consumes — opaque bag at this boundary. Provider-
+ * specific shapes (`instanceUrl` for Salesforce, no host for HubSpot) live
+ * inside as extra fields.
+ */
+export interface AuthCredentials {
+  accessToken: string;
+  /** OAuth refresh token if the adapter needs to inspect it. Usually omitted. */
+  refreshToken?: string;
+  /** Provider-specific extras (instance URL, api version, scope list, …). */
+  [extra: string]: unknown;
+}
+
+export interface AuthResolveOptions {
+  /**
+   * Force the strategy to bypass its cache and mint fresh credentials.
+   * Callers use this after catching a session-expired error; a second
+   * resolve that still returns an expired token fails hard rather than
+   * looping.
+   */
+  forceRefresh?: boolean;
+}
+
+/**
+ * Auth-strategy contract shared by every integration adapter. Implementations
+ * typically extend `OAuth2RefreshStrategy` and override four small hooks.
+ */
+export interface IAuthStrategy {
+  resolve(
+    integrationId: string,
+    opts?: AuthResolveOptions,
+  ): Promise<AuthCredentials>;
+}

--- a/runtime/subsystems/auth/protocols/encryption-key.ts
+++ b/runtime/subsystems/auth/protocols/encryption-key.ts
@@ -1,0 +1,21 @@
+/**
+ * Auth subsystem — `IEncryptionKey` port.
+ *
+ * Symmetric encryption for secrets at rest (OAuth tokens, API keys).
+ * Ciphertexts are opaque strings; implementations embed whatever framing
+ * (nonce, auth tag, key version) they need. Callers must not inspect the
+ * ciphertext format.
+ */
+export interface IEncryptionKey {
+  /**
+   * Encrypt plaintext. Output is a self-contained string that includes any
+   * nonce + auth tag the impl needs for decryption. Safe to persist.
+   */
+  encrypt(plaintext: string): Promise<string>;
+
+  /**
+   * Decrypt a ciphertext produced by this impl. Throws on tamper (auth tag
+   * mismatch) or malformed input.
+   */
+  decrypt(ciphertext: string): Promise<string>;
+}

--- a/runtime/subsystems/auth/protocols/integration-store.ts
+++ b/runtime/subsystems/auth/protocols/integration-store.ts
@@ -1,0 +1,66 @@
+/**
+ * Auth subsystem — integration storage ports.
+ *
+ * `OAuth2RefreshStrategy` reads decrypted integration rows and persists
+ * refreshed tokens. The subsystem doesn't care what entity framework stores
+ * those rows — consumers implement these narrow ports against whatever
+ * `integrations` table their app uses.
+ *
+ * In dealbrain-v2 (the extraction source) both ports are satisfied by a
+ * pair of thin adapters over `IntegrationService` + `RefreshIntegrationUseCase`.
+ * The codegen-patterns `examples/auth-integrations/` starter (separate PR)
+ * ships a canonical `integration.yaml` whose generated service + use case
+ * satisfy the shape out of the box.
+ */
+
+/**
+ * An integration row with its secrets decrypted and ready to use.
+ *
+ * Consumers produce this shape from their own storage by passing stored
+ * ciphertexts through `IEncryptionKey.decrypt`. The subsystem never sees
+ * the ciphertext form.
+ */
+export interface DecryptedIntegration {
+  id: string;
+  /** Provider slug — must match the strategy's `provider`. */
+  provider: string;
+  /** Plaintext access token, or empty string if never granted. */
+  accessToken: string;
+  /** Plaintext refresh token, or null if not yet granted / revoked. */
+  refreshToken: string | null;
+  /** Access-token expiry wall time, or null if unknown. */
+  expiresAt: Date | null;
+  /** Opaque provider-specific metadata bag (instance URL, scopes, …). */
+  providerMetadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Read port — fetches a decrypted integration by id.
+ *
+ * Adapters typically wrap a service/repo call that does the decryption
+ * internally. `OAuth2RefreshStrategy.resolve()` calls this on every invocation.
+ */
+export interface IIntegrationReader {
+  findByIdDecrypted(integrationId: string): Promise<DecryptedIntegration | null>;
+}
+
+/**
+ * Write port — persists a refreshed access token (and optionally rotated
+ * refresh token) with the new expiry.
+ *
+ * The subsystem calls this after a successful refresh. Implementations are
+ * responsible for re-encrypting the tokens before they hit storage.
+ *
+ * `refreshToken` semantics: `undefined` means "provider did not rotate; keep
+ * existing ciphertext". A rotated token comes through as a string.
+ */
+export interface IntegrationTokenUpdate {
+  integrationId: string;
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: Date;
+}
+
+export interface IIntegrationTokenWriter {
+  persistRefresh(update: IntegrationTokenUpdate): Promise<void>;
+}

--- a/runtime/subsystems/auth/protocols/oauth-state-store.ts
+++ b/runtime/subsystems/auth/protocols/oauth-state-store.ts
@@ -1,0 +1,16 @@
+/**
+ * Auth subsystem — `IOAuthStateStore` port.
+ *
+ * CSRF protection for the OAuth2 authorize-code callback. Generic across
+ * providers. Concrete backends live under `../backends/oauth-state-store/`.
+ */
+export interface OAuthStateEntry {
+  userId: string;
+  createdAt: Date;
+}
+
+export interface IOAuthStateStore {
+  put(state: string, entry: OAuthStateEntry): Promise<void>;
+  /** Single-use consume: returns entry if present + valid, deletes it. */
+  consume(state: string): Promise<OAuthStateEntry | null>;
+}

--- a/runtime/subsystems/auth/runtime/integration-broken.error.ts
+++ b/runtime/subsystems/auth/runtime/integration-broken.error.ts
@@ -1,0 +1,21 @@
+/**
+ * Thrown when an OAuth2 provider returns `400 invalid_grant`/`invalid_token`
+ * on refresh — the refresh token itself is dead (user revoked, org
+ * deactivated, token expired beyond the provider's rotation window). The
+ * integration should be marked broken so background sync stops picking it
+ * up; the user re-initiates OAuth.
+ *
+ * Shared across every OAuth2 strategy.
+ */
+export class IntegrationBrokenError extends Error {
+  constructor(
+    readonly integrationId: string,
+    readonly errorCode: string,
+    readonly errorDescription: string,
+  ) {
+    super(
+      `Integration ${integrationId} broken: ${errorCode} - ${errorDescription}`,
+    );
+    this.name = 'IntegrationBrokenError';
+  }
+}

--- a/runtime/subsystems/auth/runtime/oauth2-refresh.strategy.ts
+++ b/runtime/subsystems/auth/runtime/oauth2-refresh.strategy.ts
@@ -1,0 +1,189 @@
+/**
+ * Abstract base class for OAuth2 refresh-token strategies.
+ *
+ * Template-method pattern: `resolve()` is concrete; four small hooks inject
+ * provider specifics. Validated across two providers in dealbrain-v2
+ * (SalesforceAuthStrategy, HubSpotAuthStrategy) before extraction here — see
+ * `docs/gate-1-auth-extraction-findings.md` for the "build first, extract
+ * later" evidence.
+ *
+ * Subclass contract:
+ *   - `provider`                — slug matched against `integrations.provider`
+ *   - `defaultExpiresInSec`     — fallback when refresh response omits `expires_in`
+ *   - `tokenEndpoint()`         — URL to POST the refresh grant
+ *   - `refreshBodyExtras()`     — provider-specific body params
+ *   - `parseRefreshResponse()`  — raw JSON → ParsedRefreshResponse
+ *   - `buildCredentials()`      — stored or freshly-refreshed access token +
+ *                                 integration + optional raw refresh response
+ *                                 → provider credentials
+ *
+ * Base handles: expiry check w/ 5-min safety window, `forceRefresh` escape
+ * hatch, POST form-urlencoded body, OAuth2 error mapping to
+ * `IntegrationBrokenError`, refresh-token rotation persistence, fetch +
+ * clock injection for tests.
+ */
+import type {
+  AuthCredentials,
+  AuthResolveOptions,
+  IAuthStrategy,
+} from '../protocols/auth-strategy';
+import type {
+  DecryptedIntegration,
+  IIntegrationReader,
+  IIntegrationTokenWriter,
+} from '../protocols/integration-store';
+import { IntegrationBrokenError } from './integration-broken.error';
+
+export type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/** Safety window before expiry that triggers a refresh. */
+const REFRESH_SAFETY_MS = 5 * 60 * 1000;
+
+export interface OAuth2RefreshStrategyOptions {
+  integrationReader: IIntegrationReader;
+  tokenWriter: IIntegrationTokenWriter;
+  /** Injectable fetch for tests. Defaults to the global `fetch`. */
+  fetch?: FetchLike;
+  /** Injectable clock for tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+export interface ParsedRefreshResponse {
+  accessToken: string;
+  /**
+   * New refresh token if the provider rotated it (HubSpot: always, Salesforce:
+   * sometimes). Omit when the provider reused the old refresh token.
+   */
+  refreshToken?: string;
+  /** Seconds from now. If omitted, subclass `defaultExpiresInSec` applies. */
+  expiresInSec?: number;
+}
+
+export abstract class OAuth2RefreshStrategy implements IAuthStrategy {
+  protected abstract readonly provider: string;
+  protected abstract readonly defaultExpiresInSec: number;
+
+  protected readonly integrationReader: IIntegrationReader;
+  protected readonly tokenWriter: IIntegrationTokenWriter;
+  protected readonly fetchImpl: FetchLike;
+  protected readonly now: () => number;
+
+  constructor(opts: OAuth2RefreshStrategyOptions) {
+    this.integrationReader = opts.integrationReader;
+    this.tokenWriter = opts.tokenWriter;
+    this.fetchImpl = opts.fetch ?? fetch;
+    this.now = opts.now ?? Date.now;
+  }
+
+  async resolve(
+    integrationId: string,
+    opts: AuthResolveOptions = {},
+  ): Promise<AuthCredentials> {
+    const integration =
+      await this.integrationReader.findByIdDecrypted(integrationId);
+    if (!integration) {
+      throw new Error(`Integration ${integrationId} not found`);
+    }
+    if (integration.provider !== this.provider) {
+      throw new Error(
+        `${this.constructor.name} called for non-${this.provider} integration ${integrationId} (provider=${integration.provider})`,
+      );
+    }
+
+    const needsRefresh =
+      opts.forceRefresh ||
+      this.isExpiring(integration.expiresAt) ||
+      !integration.accessToken;
+
+    if (!needsRefresh) {
+      return this.buildCredentials(integration.accessToken, integration);
+    }
+
+    if (!integration.refreshToken) {
+      throw new IntegrationBrokenError(
+        integrationId,
+        'no_refresh_token',
+        'Integration has no refresh token; user must reconnect',
+      );
+    }
+
+    const { parsed, raw } = await this.executeRefresh(
+      integrationId,
+      integration.refreshToken,
+    );
+    const newExpiresAt = new Date(
+      this.now() + (parsed.expiresInSec ?? this.defaultExpiresInSec) * 1000,
+    );
+    await this.tokenWriter.persistRefresh({
+      integrationId,
+      accessToken: parsed.accessToken,
+      refreshToken: parsed.refreshToken ?? undefined,
+      expiresAt: newExpiresAt,
+    });
+
+    return this.buildCredentials(parsed.accessToken, integration, raw);
+  }
+
+  protected abstract tokenEndpoint(): string;
+  protected abstract refreshBodyExtras(): Record<string, string>;
+  protected abstract parseRefreshResponse(raw: unknown): ParsedRefreshResponse;
+  protected abstract buildCredentials(
+    accessToken: string,
+    integration: DecryptedIntegration,
+    refreshRaw?: unknown,
+  ): AuthCredentials;
+
+  private async executeRefresh(
+    integrationId: string,
+    refreshToken: string,
+  ): Promise<{ parsed: ParsedRefreshResponse; raw: unknown }> {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      ...this.refreshBodyExtras(),
+    });
+    const response = await this.fetchImpl(this.tokenEndpoint(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    if (!response.ok) {
+      const err = (await safeJson(response)) as Partial<{
+        error: string;
+        error_description: string;
+        message: string;
+      }>;
+      if (
+        response.status === 400 &&
+        (err.error === 'invalid_grant' || err.error === 'invalid_token')
+      ) {
+        throw new IntegrationBrokenError(
+          integrationId,
+          err.error ?? 'invalid_grant',
+          err.error_description ?? err.message ?? 'refresh token rejected',
+        );
+      }
+      throw new Error(
+        `${this.provider} token refresh failed: ${response.status} ${err.error ?? ''} ${err.error_description ?? err.message ?? ''}`.trim(),
+      );
+    }
+    const raw = await response.json();
+    return { parsed: this.parseRefreshResponse(raw), raw };
+  }
+
+  private isExpiring(expiresAt: Date | null): boolean {
+    if (!expiresAt) return true;
+    return expiresAt.getTime() - this.now() < REFRESH_SAFETY_MS;
+  }
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.clone().json();
+  } catch {
+    return {};
+  }
+}

--- a/runtime/subsystems/auth/runtime/session-expired.error.ts
+++ b/runtime/subsystems/auth/runtime/session-expired.error.ts
@@ -1,0 +1,39 @@
+/**
+ * Provider-agnostic marker for "the access token was rejected; a forced
+ * refresh may recover."
+ *
+ * Concrete provider error classes (e.g. SalesforceSessionExpiredError,
+ * HubSpotUnauthorizedError) either extend `SessionExpiredError` directly or
+ * set `isSessionExpired === true` on their instances. `withAuthRetry` uses
+ * the `isSessionExpiredError` predicate to decide whether to force-refresh
+ * and retry once.
+ *
+ * This discriminator replaces the SFDC-only `instanceof` check from
+ * dealbrain-v2's original `withAuthRetry`. See
+ * `docs/gate-1-auth-extraction-findings.md` (recommendation 4).
+ */
+export class SessionExpiredError extends Error {
+  /** Duck-type marker — works across package boundaries where `instanceof` fails. */
+  readonly isSessionExpired = true as const;
+
+  constructor(message = 'Access token rejected by provider') {
+    super(message);
+    this.name = 'SessionExpiredError';
+  }
+}
+
+/**
+ * Predicate used by `withAuthRetry` by default.
+ *
+ * Matches any error that either `instanceof SessionExpiredError` or carries
+ * the `isSessionExpired === true` marker property. Provider adapters that
+ * want their existing error classes to participate can simply add the
+ * marker property without touching the class hierarchy.
+ */
+export function isSessionExpiredError(err: unknown): boolean {
+  if (err instanceof SessionExpiredError) return true;
+  if (err !== null && typeof err === 'object' && 'isSessionExpired' in err) {
+    return (err as { isSessionExpired?: unknown }).isSessionExpired === true;
+  }
+  return false;
+}

--- a/runtime/subsystems/auth/runtime/with-auth-retry.ts
+++ b/runtime/subsystems/auth/runtime/with-auth-retry.ts
@@ -1,0 +1,50 @@
+/**
+ * Run `op` with auth-aware retry-once on session-expired errors.
+ *
+ * Pattern: resolve creds → run op → if `isSessionExpired(e)` → resolve with
+ * `forceRefresh: true` → retry → propagate. A second session-expired error
+ * on the refreshed token propagates rather than looping, so transient
+ * adapter bugs can't hang the caller.
+ *
+ * Generalisation over dealbrain's original SFDC-specific version: the
+ * session-expired classifier is injected. Providers mark their session-
+ * expired errors (via `instanceof` of a marker class, or by setting a known
+ * property) and pass a classifier matching that shape.
+ *
+ * Default classifier recognises the marker interface `SessionExpiredError`
+ * shipped in `session-expired.error.ts` — concrete provider errors that
+ * extend it (or set `isSessionExpired === true`) get retried without any
+ * further wiring.
+ */
+import type {
+  AuthCredentials,
+  IAuthStrategy,
+} from '../protocols/auth-strategy';
+import { isSessionExpiredError } from './session-expired.error';
+
+export interface WithAuthRetryOptions {
+  /**
+   * Classifier that decides whether a thrown error is a session-expired
+   * signal worth retrying once with a fresh token. Defaults to the marker-
+   * interface check in `session-expired.error.ts`.
+   */
+  isSessionExpired?: (err: unknown) => boolean;
+}
+
+export async function withAuthRetry<T>(
+  authStrategy: IAuthStrategy,
+  integrationId: string,
+  op: (credentials: AuthCredentials) => Promise<T>,
+  options: WithAuthRetryOptions = {},
+): Promise<T> {
+  const classify = options.isSessionExpired ?? isSessionExpiredError;
+
+  let creds = await authStrategy.resolve(integrationId);
+  try {
+    return await op(creds);
+  } catch (e) {
+    if (!classify(e)) throw e;
+    creds = await authStrategy.resolve(integrationId, { forceRefresh: true });
+    return op(creds);
+  }
+}

--- a/runtime/subsystems/index.ts
+++ b/runtime/subsystems/index.ts
@@ -32,3 +32,32 @@ export { CacheModule, DrizzleCacheService, MemoryCacheService } from './cache';
 export { STORAGE } from './storage';
 export type { IStorageService } from './storage';
 export { StorageModule, LocalStorageBackend, MemoryStorageBackend } from './storage';
+
+// Auth
+export {
+  ENCRYPTION_KEY,
+  OAUTH_STATE_STORE,
+  AUTH_INTEGRATION_READER,
+  AUTH_INTEGRATION_TOKEN_WRITER,
+  AuthModule,
+  OAuth2RefreshStrategy,
+  withAuthRetry,
+  IntegrationBrokenError,
+  SessionExpiredError,
+  isSessionExpiredError,
+  EnvEncryptionKey,
+  InMemoryOAuthStateStore,
+} from './auth';
+export type {
+  IAuthStrategy,
+  IEncryptionKey,
+  IOAuthStateStore,
+  IIntegrationReader,
+  IIntegrationTokenWriter,
+  AuthCredentials,
+  AuthResolveOptions,
+  DecryptedIntegration,
+  OAuthStateEntry,
+  IntegrationTokenUpdate,
+  ParsedRefreshResponse,
+} from './auth';

--- a/src/__tests__/runtime/subsystems/auth/auth-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/auth-module.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * AuthModule — DI wiring smoke tests.
+ *
+ * Verifies that `forRoot()` provides the expected tokens with the expected
+ * backends, and that provider overrides work for both encryption-key and
+ * oauth-state-store slots.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { randomBytes } from 'node:crypto';
+import { AuthModule } from '../../../../../runtime/subsystems/auth/auth.module';
+import {
+  ENCRYPTION_KEY,
+  OAUTH_STATE_STORE,
+} from '../../../../../runtime/subsystems/auth/auth.tokens';
+import { EnvEncryptionKey } from '../../../../../runtime/subsystems/auth/backends/encryption-key/env';
+import { InMemoryOAuthStateStore } from '../../../../../runtime/subsystems/auth/backends/oauth-state-store/in-memory';
+import type { IEncryptionKey } from '../../../../../runtime/subsystems/auth/protocols/encryption-key';
+import type { IOAuthStateStore } from '../../../../../runtime/subsystems/auth/protocols/oauth-state-store';
+
+describe('AuthModule.forRoot', () => {
+  const previousKey = process.env['TOKEN_ENCRYPTION_KEY'];
+
+  beforeAll(() => {
+    process.env['TOKEN_ENCRYPTION_KEY'] = randomBytes(32).toString('base64');
+  });
+
+  afterAll(() => {
+    if (previousKey === undefined) delete process.env['TOKEN_ENCRYPTION_KEY'];
+    else process.env['TOKEN_ENCRYPTION_KEY'] = previousKey;
+  });
+
+  it('provides defaults (EnvEncryptionKey + InMemoryOAuthStateStore)', async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AuthModule.forRoot()],
+    }).compile();
+
+    const enc = moduleRef.get<IEncryptionKey>(ENCRYPTION_KEY);
+    const store = moduleRef.get<IOAuthStateStore>(OAUTH_STATE_STORE);
+
+    expect(enc).toBeInstanceOf(EnvEncryptionKey);
+    expect(store).toBeInstanceOf(InMemoryOAuthStateStore);
+
+    await moduleRef.close();
+  });
+
+  it('accepts a custom encryption-key provider', async () => {
+    class MyKey implements IEncryptionKey {
+      async encrypt(s: string): Promise<string> {
+        return `e:${s}`;
+      }
+      async decrypt(s: string): Promise<string> {
+        return s.replace(/^e:/, '');
+      }
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        AuthModule.forRoot({
+          encryptionKey: { useClass: MyKey },
+        }),
+      ],
+    }).compile();
+
+    const enc = moduleRef.get<IEncryptionKey>(ENCRYPTION_KEY);
+    expect(enc).toBeInstanceOf(MyKey);
+    expect(await enc.encrypt('x')).toBe('e:x');
+
+    await moduleRef.close();
+  });
+
+  it('accepts a custom oauth-state-store provider', async () => {
+    class MyStore implements IOAuthStateStore {
+      calls = 0;
+      async put(): Promise<void> {
+        this.calls++;
+      }
+      async consume(): Promise<null> {
+        return null;
+      }
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        AuthModule.forRoot({
+          oauthStateStore: { useClass: MyStore },
+        }),
+      ],
+    }).compile();
+
+    const store = moduleRef.get<IOAuthStateStore>(OAUTH_STATE_STORE);
+    expect(store).toBeInstanceOf(MyStore);
+
+    await moduleRef.close();
+  });
+});

--- a/src/__tests__/runtime/subsystems/auth/env-encryption-key.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/env-encryption-key.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * EnvEncryptionKey — AES-256-GCM roundtrip + failure-mode tests.
+ */
+import { describe, it, expect } from 'bun:test';
+import { randomBytes } from 'node:crypto';
+import { EnvEncryptionKey } from '../../../../../runtime/subsystems/auth/backends/encryption-key/env';
+
+function fixtureEnv(): NodeJS.ProcessEnv {
+  return {
+    TOKEN_ENCRYPTION_KEY: randomBytes(32).toString('base64'),
+  };
+}
+
+describe('EnvEncryptionKey', () => {
+  describe('construction', () => {
+    it('throws when the env var is missing', () => {
+      expect(() => new EnvEncryptionKey({ env: {} })).toThrow(
+        /TOKEN_ENCRYPTION_KEY is not set/,
+      );
+    });
+
+    it('throws when the key is the wrong length', () => {
+      expect(
+        () =>
+          new EnvEncryptionKey({
+            env: { TOKEN_ENCRYPTION_KEY: Buffer.from('too short').toString('base64') },
+          }),
+      ).toThrow(/must decode to 32 bytes/);
+    });
+
+    it('accepts a valid 32-byte base64 key', () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      expect(key).toBeInstanceOf(EnvEncryptionKey);
+    });
+
+    it('respects a custom env var name', () => {
+      const env: NodeJS.ProcessEnv = {
+        MY_CUSTOM_KEY: randomBytes(32).toString('base64'),
+      };
+      const key = new EnvEncryptionKey({ env, envVar: 'MY_CUSTOM_KEY' });
+      expect(key).toBeInstanceOf(EnvEncryptionKey);
+    });
+  });
+
+  describe('encrypt / decrypt', () => {
+    it('round-trips ASCII plaintext', async () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      const ct = await key.encrypt('hello world');
+      const pt = await key.decrypt(ct);
+      expect(pt).toBe('hello world');
+    });
+
+    it('round-trips unicode plaintext', async () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      const plaintext = '你好 🌍 ñoño';
+      const ct = await key.encrypt(plaintext);
+      expect(await key.decrypt(ct)).toBe(plaintext);
+    });
+
+    it('round-trips an empty string', async () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      const ct = await key.encrypt('');
+      expect(await key.decrypt(ct)).toBe('');
+    });
+
+    it('produces different ciphertexts for the same plaintext (random nonce)', async () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      const a = await key.encrypt('same plaintext');
+      const b = await key.encrypt('same plaintext');
+      expect(a).not.toBe(b);
+    });
+
+    it('throws when the ciphertext is too short', async () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      await expect(key.decrypt(Buffer.from('short').toString('base64'))).rejects.toThrow(
+        /ciphertext too short/,
+      );
+    });
+
+    it('throws on tampered auth tag', async () => {
+      const key = new EnvEncryptionKey({ env: fixtureEnv() });
+      const ct = await key.encrypt('don’t touch me');
+      // Flip the last byte (inside the auth tag region).
+      const buf = Buffer.from(ct, 'base64');
+      buf[buf.length - 1] ^= 0xff;
+      const tampered = buf.toString('base64');
+      await expect(key.decrypt(tampered)).rejects.toThrow();
+    });
+
+    it('throws when decrypted by a different key', async () => {
+      const alice = new EnvEncryptionKey({ env: fixtureEnv() });
+      const bob = new EnvEncryptionKey({ env: fixtureEnv() });
+      const ct = await alice.encrypt('secret');
+      await expect(bob.decrypt(ct)).rejects.toThrow();
+    });
+  });
+});

--- a/src/__tests__/runtime/subsystems/auth/in-memory-oauth-state-store.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/in-memory-oauth-state-store.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * InMemoryOAuthStateStore — put / single-use consume / TTL expiry.
+ */
+import { describe, it, expect } from 'bun:test';
+import { InMemoryOAuthStateStore } from '../../../../../runtime/subsystems/auth/backends/oauth-state-store/in-memory';
+
+describe('InMemoryOAuthStateStore', () => {
+  it('returns the entry on consume', async () => {
+    const store = new InMemoryOAuthStateStore();
+    const createdAt = new Date();
+    await store.put('state-1', { userId: 'user-1', createdAt });
+    const entry = await store.consume('state-1');
+    expect(entry?.userId).toBe('user-1');
+  });
+
+  it('consume is single-use', async () => {
+    const store = new InMemoryOAuthStateStore();
+    await store.put('state-2', { userId: 'user-2', createdAt: new Date() });
+    const first = await store.consume('state-2');
+    const second = await store.consume('state-2');
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+  });
+
+  it('returns null for unknown state', async () => {
+    const store = new InMemoryOAuthStateStore();
+    expect(await store.consume('unknown')).toBeNull();
+  });
+
+  it('expires entries past the TTL', async () => {
+    let now = 1_000;
+    const store = new InMemoryOAuthStateStore({ ttlMs: 500, now: () => now });
+    await store.put('state-ttl', { userId: 'u', createdAt: new Date(now) });
+    now += 1_000; // advance beyond ttl
+    expect(await store.consume('state-ttl')).toBeNull();
+  });
+});

--- a/src/__tests__/runtime/subsystems/auth/oauth2-refresh.strategy.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/oauth2-refresh.strategy.spec.ts
@@ -1,0 +1,394 @@
+/**
+ * OAuth2RefreshStrategy — template-method contract test.
+ *
+ * Uses a fake subclass so each hook can be asserted in isolation without
+ * depending on any provider. Mirrors the shape of the SFDC + HubSpot
+ * strategies shipped in dealbrain-v2 (Gate-1 extraction source).
+ */
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import {
+  OAuth2RefreshStrategy,
+  type OAuth2RefreshStrategyOptions,
+  type ParsedRefreshResponse,
+} from '../../../../../runtime/subsystems/auth/runtime/oauth2-refresh.strategy';
+import { IntegrationBrokenError } from '../../../../../runtime/subsystems/auth/runtime/integration-broken.error';
+import type {
+  DecryptedIntegration,
+  IIntegrationReader,
+  IIntegrationTokenWriter,
+  IntegrationTokenUpdate,
+} from '../../../../../runtime/subsystems/auth/protocols/integration-store';
+import type { AuthCredentials } from '../../../../../runtime/subsystems/auth/protocols/auth-strategy';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+class FakeReader implements IIntegrationReader {
+  constructor(private readonly row: DecryptedIntegration | null) {}
+  async findByIdDecrypted(): Promise<DecryptedIntegration | null> {
+    return this.row;
+  }
+}
+
+class RecordingWriter implements IIntegrationTokenWriter {
+  calls: IntegrationTokenUpdate[] = [];
+  async persistRefresh(update: IntegrationTokenUpdate): Promise<void> {
+    this.calls.push(update);
+  }
+}
+
+class FakeStrategy extends OAuth2RefreshStrategy {
+  protected readonly provider = 'fake';
+  protected readonly defaultExpiresInSec = 3600;
+
+  tokenEndpointCalls = 0;
+  refreshBodyExtrasCalls = 0;
+  parseRefreshCalls = 0;
+  buildCredentialsCalls: Array<{
+    accessToken: string;
+    hasRefreshRaw: boolean;
+  }> = [];
+
+  protected tokenEndpoint(): string {
+    this.tokenEndpointCalls++;
+    return 'https://example.test/oauth/token';
+  }
+
+  protected refreshBodyExtras(): Record<string, string> {
+    this.refreshBodyExtrasCalls++;
+    return { client_id: 'id', client_secret: 'secret' };
+  }
+
+  protected parseRefreshResponse(raw: unknown): ParsedRefreshResponse {
+    this.parseRefreshCalls++;
+    const r = raw as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
+    return {
+      accessToken: r.access_token,
+      refreshToken: r.refresh_token,
+      expiresInSec: r.expires_in,
+    };
+  }
+
+  protected buildCredentials(
+    accessToken: string,
+    integration: DecryptedIntegration,
+    refreshRaw?: unknown,
+  ): AuthCredentials {
+    this.buildCredentialsCalls.push({
+      accessToken,
+      hasRefreshRaw: refreshRaw !== undefined,
+    });
+    return {
+      accessToken,
+      orgId: (integration.providerMetadata?.['orgId'] as string) ?? 'org-default',
+    };
+  }
+}
+
+function mockFetch(
+  responder: (url: string, init: RequestInit | undefined) => Response | Promise<Response>,
+) {
+  return mock(async (url: string | URL | Request, init?: RequestInit) => {
+    return responder(String(url), init);
+  });
+}
+
+function makeIntegration(
+  overrides: Partial<DecryptedIntegration> = {},
+): DecryptedIntegration {
+  return {
+    id: 'int-1',
+    provider: 'fake',
+    accessToken: 'old-access',
+    refreshToken: 'old-refresh',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    providerMetadata: { orgId: 'org-42' },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('OAuth2RefreshStrategy', () => {
+  let fetchFn: ReturnType<typeof mockFetch>;
+  let now: number;
+  let writer: RecordingWriter;
+
+  beforeEach(() => {
+    now = 1_700_000_000_000;
+    writer = new RecordingWriter();
+    fetchFn = mockFetch(() => new Response(null, { status: 500 }));
+  });
+
+  function build(
+    reader: IIntegrationReader,
+    opts: Partial<OAuth2RefreshStrategyOptions> = {},
+  ): FakeStrategy {
+    return new FakeStrategy({
+      integrationReader: reader,
+      tokenWriter: writer,
+      fetch: fetchFn,
+      now: () => now,
+      ...opts,
+    });
+  }
+
+  describe('cache hit', () => {
+    it('returns stored token without calling fetch when not expiring', async () => {
+      const integration = makeIntegration({
+        expiresAt: new Date(now + 60 * 60 * 1000),
+      });
+      const strategy = build(new FakeReader(integration));
+
+      const creds = await strategy.resolve('int-1');
+
+      expect(creds.accessToken).toBe('old-access');
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(writer.calls).toHaveLength(0);
+      expect(strategy.buildCredentialsCalls).toEqual([
+        { accessToken: 'old-access', hasRefreshRaw: false },
+      ]);
+    });
+  });
+
+  describe('force refresh', () => {
+    it('bypasses the cache and calls the token endpoint', async () => {
+      const integration = makeIntegration({
+        expiresAt: new Date(now + 60 * 60 * 1000),
+      });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({
+              access_token: 'new-access',
+              refresh_token: 'new-refresh',
+              expires_in: 7200,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+
+      const creds = await strategy.resolve('int-1', { forceRefresh: true });
+
+      expect(strategy.tokenEndpointCalls).toBe(1);
+      expect(strategy.refreshBodyExtrasCalls).toBe(1);
+      expect(strategy.parseRefreshCalls).toBe(1);
+      expect(creds.accessToken).toBe('new-access');
+      expect(writer.calls).toHaveLength(1);
+      expect(writer.calls[0]).toMatchObject({
+        integrationId: 'int-1',
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+      });
+    });
+  });
+
+  describe('expiring window', () => {
+    it('refreshes when the token is inside the 5-minute safety window', async () => {
+      // Expires in 1 minute — inside the 5-minute safety window.
+      const integration = makeIntegration({
+        expiresAt: new Date(now + 60 * 1000),
+      });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({
+              access_token: 'new-access',
+              expires_in: 3600,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+
+      const creds = await strategy.resolve('int-1');
+      expect(fetchFn).toHaveBeenCalled();
+      expect(creds.accessToken).toBe('new-access');
+    });
+  });
+
+  describe('refresh body + hook order', () => {
+    it('POSTs form-urlencoded with grant_type + refresh_token + extras', async () => {
+      const integration = makeIntegration({
+        expiresAt: new Date(now - 1),
+      });
+      let capturedBody = '';
+      let capturedHeaders: Record<string, string> | undefined;
+      fetchFn = mockFetch((_url, init) => {
+        capturedBody = (init?.body as string) ?? '';
+        capturedHeaders = (init?.headers as Record<string, string>) ?? {};
+        return new Response(
+          JSON.stringify({ access_token: 'a', expires_in: 60 }),
+          { status: 200 },
+        );
+      });
+      const strategy = build(new FakeReader(integration));
+
+      await strategy.resolve('int-1');
+
+      const params = new URLSearchParams(capturedBody);
+      expect(params.get('grant_type')).toBe('refresh_token');
+      expect(params.get('refresh_token')).toBe('old-refresh');
+      expect(params.get('client_id')).toBe('id');
+      expect(params.get('client_secret')).toBe('secret');
+      expect(capturedHeaders?.['Content-Type']).toBe(
+        'application/x-www-form-urlencoded',
+      );
+    });
+
+    it('passes the raw refresh response to buildCredentials after refresh', async () => {
+      const integration = makeIntegration({ expiresAt: null });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({ access_token: 'fresh', expires_in: 100 }),
+            { status: 200 },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+
+      await strategy.resolve('int-1');
+
+      expect(strategy.buildCredentialsCalls).toEqual([
+        { accessToken: 'fresh', hasRefreshRaw: true },
+      ]);
+    });
+  });
+
+  describe('refresh-token rotation', () => {
+    it('persists the new refresh token when the provider rotates it', async () => {
+      const integration = makeIntegration({ expiresAt: new Date(now - 1) });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({
+              access_token: 'a',
+              refresh_token: 'r2',
+              expires_in: 60,
+            }),
+            { status: 200 },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+
+      await strategy.resolve('int-1');
+
+      expect(writer.calls[0]?.refreshToken).toBe('r2');
+    });
+
+    it('persists refreshToken=undefined when the provider reuses the old one', async () => {
+      const integration = makeIntegration({ expiresAt: new Date(now - 1) });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({ access_token: 'a', expires_in: 60 }),
+            { status: 200 },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+
+      await strategy.resolve('int-1');
+
+      expect(writer.calls[0]?.refreshToken).toBeUndefined();
+    });
+  });
+
+  describe('errors', () => {
+    it('throws when the integration is missing', async () => {
+      const strategy = build(new FakeReader(null));
+      await expect(strategy.resolve('missing')).rejects.toThrow(
+        /Integration missing not found/,
+      );
+    });
+
+    it('throws when the integration provider slug does not match', async () => {
+      const integration = makeIntegration({ provider: 'other' });
+      const strategy = build(new FakeReader(integration));
+      await expect(strategy.resolve('int-1')).rejects.toThrow(
+        /called for non-fake integration/,
+      );
+    });
+
+    it('throws IntegrationBrokenError when no refresh token is present', async () => {
+      const integration = makeIntegration({
+        expiresAt: new Date(now - 1),
+        refreshToken: null,
+      });
+      const strategy = build(new FakeReader(integration));
+      await expect(strategy.resolve('int-1')).rejects.toBeInstanceOf(
+        IntegrationBrokenError,
+      );
+    });
+
+    it('maps 400 invalid_grant → IntegrationBrokenError', async () => {
+      const integration = makeIntegration({ expiresAt: new Date(now - 1) });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({
+              error: 'invalid_grant',
+              error_description: 'expired or revoked',
+            }),
+            { status: 400 },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+      await expect(strategy.resolve('int-1')).rejects.toBeInstanceOf(
+        IntegrationBrokenError,
+      );
+    });
+
+    it('maps 400 invalid_token → IntegrationBrokenError (HubSpot-style)', async () => {
+      const integration = makeIntegration({ expiresAt: new Date(now - 1) });
+      fetchFn = mockFetch(
+        () =>
+          new Response(JSON.stringify({ error: 'invalid_token' }), {
+            status: 400,
+          }),
+      );
+      const strategy = build(new FakeReader(integration));
+      await expect(strategy.resolve('int-1')).rejects.toBeInstanceOf(
+        IntegrationBrokenError,
+      );
+    });
+
+    it('wraps non-400 failures with a provider-scoped message', async () => {
+      const integration = makeIntegration({ expiresAt: new Date(now - 1) });
+      fetchFn = mockFetch(
+        () =>
+          new Response(
+            JSON.stringify({ error: 'server_error', error_description: 'oops' }),
+            { status: 500 },
+          ),
+      );
+      const strategy = build(new FakeReader(integration));
+      await expect(strategy.resolve('int-1')).rejects.toThrow(
+        /fake token refresh failed/,
+      );
+    });
+  });
+
+  describe('expiry accounting', () => {
+    it('uses subclass defaultExpiresInSec when response omits expires_in', async () => {
+      const integration = makeIntegration({ expiresAt: new Date(now - 1) });
+      fetchFn = mockFetch(
+        () =>
+          new Response(JSON.stringify({ access_token: 'a' }), { status: 200 }),
+      );
+      const strategy = build(new FakeReader(integration));
+
+      await strategy.resolve('int-1');
+
+      // Default is 3600s on the fake subclass.
+      expect(writer.calls[0]?.expiresAt.getTime()).toBe(now + 3600 * 1000);
+    });
+  });
+});

--- a/src/__tests__/runtime/subsystems/auth/with-auth-retry.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/with-auth-retry.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * withAuthRetry — generic retry-once-on-session-expired semantics.
+ */
+import { describe, it, expect } from 'bun:test';
+import { withAuthRetry } from '../../../../../runtime/subsystems/auth/runtime/with-auth-retry';
+import { SessionExpiredError } from '../../../../../runtime/subsystems/auth/runtime/session-expired.error';
+import type {
+  AuthCredentials,
+  AuthResolveOptions,
+  IAuthStrategy,
+} from '../../../../../runtime/subsystems/auth/protocols/auth-strategy';
+
+class FakeStrategy implements IAuthStrategy {
+  calls: AuthResolveOptions[] = [];
+  constructor(private readonly tokens: string[]) {}
+  async resolve(
+    _id: string,
+    opts: AuthResolveOptions = {},
+  ): Promise<AuthCredentials> {
+    this.calls.push(opts);
+    const token = this.tokens[this.calls.length - 1] ?? this.tokens[this.tokens.length - 1];
+    return { accessToken: token! };
+  }
+}
+
+describe('withAuthRetry', () => {
+  it('returns the op result on first success without forcing refresh', async () => {
+    const strategy = new FakeStrategy(['t1']);
+    const result = await withAuthRetry(strategy, 'int-1', async (creds) => {
+      expect(creds.accessToken).toBe('t1');
+      return 'done';
+    });
+    expect(result).toBe('done');
+    expect(strategy.calls).toEqual([{}]);
+  });
+
+  it('retries once on SessionExpiredError with forceRefresh=true', async () => {
+    const strategy = new FakeStrategy(['stale', 'fresh']);
+    let attempt = 0;
+    const result = await withAuthRetry(strategy, 'int-1', async (creds) => {
+      attempt++;
+      if (attempt === 1) {
+        expect(creds.accessToken).toBe('stale');
+        throw new SessionExpiredError();
+      }
+      expect(creds.accessToken).toBe('fresh');
+      return 'recovered';
+    });
+    expect(result).toBe('recovered');
+    expect(strategy.calls).toEqual([{}, { forceRefresh: true }]);
+  });
+
+  it('propagates non-session-expired errors without retrying', async () => {
+    const strategy = new FakeStrategy(['t']);
+    await expect(
+      withAuthRetry(strategy, 'int-1', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(strategy.calls).toEqual([{}]);
+  });
+
+  it('propagates a second session-expired error (no infinite loop)', async () => {
+    const strategy = new FakeStrategy(['a', 'b']);
+    await expect(
+      withAuthRetry(strategy, 'int-1', async () => {
+        throw new SessionExpiredError();
+      }),
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(strategy.calls).toEqual([{}, { forceRefresh: true }]);
+  });
+
+  it('recognises errors marked with isSessionExpired=true (duck-typed)', async () => {
+    const strategy = new FakeStrategy(['a', 'b']);
+    class MySessionExpired extends Error {
+      readonly isSessionExpired = true as const;
+    }
+    let attempt = 0;
+    const result = await withAuthRetry(strategy, 'int-1', async () => {
+      attempt++;
+      if (attempt === 1) throw new MySessionExpired('vendor 401');
+      return 'ok';
+    });
+    expect(result).toBe('ok');
+  });
+
+  it('honours a custom classifier when provided', async () => {
+    const strategy = new FakeStrategy(['a', 'b']);
+    let attempt = 0;
+    class VendorError extends Error {
+      constructor(readonly code: number) {
+        super('vendor');
+      }
+    }
+    const result = await withAuthRetry(
+      strategy,
+      'int-1',
+      async () => {
+        attempt++;
+        if (attempt === 1) throw new VendorError(401);
+        return 'ok';
+      },
+      {
+        isSessionExpired: (e) => e instanceof VendorError && e.code === 401,
+      },
+    );
+    expect(result).toBe('ok');
+    expect(strategy.calls).toEqual([{}, { forceRefresh: true }]);
+  });
+});


### PR DESCRIPTION
Closes #59.

## Summary

Adds `runtime/subsystems/auth/` following Protocol → Backend → Factory (ADR-008). Ships the generic half of every OAuth2 integration: resolve credentials, refresh on expiry, retry once on session-expired, encrypt secrets at rest, CSRF-protect the OAuth callback.

**Build first, extract later.** The abstract `OAuth2RefreshStrategy` template-method base was built for Salesforce in dealbrain-v2, then validated by shipping HubSpot as a second consumer with zero base-class changes. The shape holds — four small overrides per subclass cover two wildly different vendors. Full Gate-1 evidence in dealbrain-v2's `docs/gate-1-auth-extraction-findings.md` (narrative mirrored in ADR-031 in this PR).

## In scope

- **Protocols** — `IAuthStrategy`, `IEncryptionKey`, `IOAuthStateStore`, plus narrow `IIntegrationReader` / `IIntegrationTokenWriter` ports so the subsystem doesn't import a consumer entity framework.
- **Runtime** — `OAuth2RefreshStrategy` (abstract; four hooks + two constants), `withAuthRetry` (retry-once, pluggable classifier), `SessionExpiredError` (duck-typed marker), `IntegrationBrokenError`.
- **Backends** — `EnvEncryptionKey` (AES-256-GCM from `TOKEN_ENCRYPTION_KEY`), `InMemoryOAuthStateStore` (dev).
- **Factory** — `AuthModule.forRoot({ encryptionKey, oauthStateStore })`, `global: true`.
- **ADR-031** — slots under ADR-008; captures the four-hook template-method decision + the opaque-raw-passthrough rationale.
- **CONSUMER-SETUP.md** — new Auth section (provider strategy recipe, integration-store adapter recipe, env vars).
- **Tests** — 38 new `bun:test` specs: encryption roundtrip + tamper detection, state-store TTL, OAuth2 template-method contract (cache hit, force refresh, expiring window, refresh body shape, rotation, error mapping for both `invalid_grant` and `invalid_token`, defaultExpiresInSec fallback), retry-once semantics with custom classifier + duck-typed marker, `AuthModule` DI smoke tests.

## Out of scope (intentionally)

- **Registering `IAuthStrategy` implementations.** Strategies are per-provider and live in the consumer's integration module. There's no single `AUTH_STRATEGY` token — apps have many concurrent strategies (one per provider) registered under provider-specific tokens.
- **Integration-store port adapters.** The subsystem ships the interfaces; the consumer's integrations domain supplies the implementations.
- **`integrations` starter entity YAML** (issue #59's second bullet). Planned as a follow-up `examples/auth-integrations/integration.yaml`, following the `examples/eav/` convention.
- **KMS-backed `IEncryptionKey`** / **Redis-backed `IOAuthStateStore`**. Both have production slots reserved in the backend layout; consumers supply them as custom providers today.
- **OAuth1, SAML, PKCE-specific strategies.** PKCE is additive (another subclass hook when a consumer needs it); OAuth1/SAML are separate flows.

## Consumers proving the protocol

Two active consumers in dealbrain-v2 (cited as Gate-1 evidence):
- `SalesforceAuthStrategy extends OAuth2RefreshStrategy` — overrides 4 hooks; uses `instance_url` peek from the opaque raw response.
- `HubSpotAuthStrategy extends OAuth2RefreshStrategy` — overrides 4 hooks; different `refreshBodyExtras` (`redirect_uri`), always-rotate refresh token, no instance URL.

Both pass 21 combined provider-level tests in dealbrain-v2 against the extracted base.

## Scoping decision (single PR vs split)

Issue #59 isn't labeled an epic. The 9 source files are tightly coupled: the protocol + template-method runtime + two backends + factory are one coherent slice. Splitting into AUTH-1..AUTH-N would multiply reviewer load without improving review quality, unlike the events subsystem which shipped as EVT-1..EVT-8 because it was ~3500 LOC with orthogonal concerns (outbox schema, three backends, typed-bus codegen, multi-tenancy). Auth is ~760 LOC total. Shipping as one.

## Test plan

- [x] `bun test src/__tests__/runtime/subsystems/auth/` — **38 pass / 0 fail**
- [x] `bun test src/__tests__/` (full unit suite) — **958 pass / 0 fail** (run with `PATH` containing node 22 so spawned subprocesses in `subsystem.test.ts` find `bunx`; otherwise 1 environment-flake fail unrelated to this PR — also fails on clean `main`)
- [x] `bun run typecheck` — clean
- [ ] Upstream reviewer to validate: does `runtime/subsystems/auth/` ship correctly via `tsup` build? (I didn't run `bun run build`; worth checking in CI.)

## Follow-ups (not blocking this PR)

- `.claude/skills/auth/SKILL.md` — **written but not committed** (the `.claude/skills/auth/` directory was blocked by a sandbox permission in my environment). The skill content is ready to drop in as a second commit; happy to open a tiny follow-up PR, or a reviewer can cherry-pick from the description.
- `examples/auth-integrations/integration.yaml` starter entity — tracked for a follow-up PR.
- Redis-backed `IOAuthStateStore`, KMS-backed `IEncryptionKey` — reserved backend slots.
- Consumer sweep in dealbrain-v2: after this lands, delete the local `src/subsystems/auth/` and point imports at `@pattern-stack/codegen/runtime/subsystems/auth`.

## References

- `docs/adrs/ADR-031-auth-subsystem.md` (this PR)
- `docs/adrs/ADR-008-subsystem-architecture.md`
- dealbrain-v2: `docs/gate-1-auth-extraction-findings.md`
- Issue #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)