### PR TITLE
ci: F7-meta — wire test-smoke into just test-all

### DIFF
--- a/docs/specs/PHASE-1-HANDOFF.md
+++ b/docs/specs/PHASE-1-HANDOFF.md
@@ -185,7 +185,7 @@ Session ran Phase A (setup) and Phase B (baseline smoke) at `~/Projects/dev/code
 
 - #116 (F4) — `paths.events_dir` not configurable
 - #117 (F6) — `project init` default vs spec disagreement
-- #118 (F7 umbrella) — smoke test not gating main (meta-bug: the reason F7a/b/c was missed)
+- ~~#118 (F7 umbrella) — smoke test not gating main (meta-bug: the reason F7a/b/c was missed)~~ (FIXED)
 - #119 (F11) — `project init --force` re-injects main.ts hook
 - #120 (F12) — `entity new --all` aborts aggregately on one bad YAML
 - #121 (F13) — `subsystem install --force` overwrites `multi_tenant` user setting

--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ validate:
     bash test/scaffold/validate.sh
 
 # Run all tests
-test-all: test-unit test-baseline
+test-all: test-unit test-baseline test-smoke
 
 # ─── Domain Analysis ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

One-line recipe change: `just test-all` now runs `test-unit + test-baseline + test-smoke` instead of just the first two. Closes #118.

```diff
-test-all: test-unit test-baseline
+test-all: test-unit test-baseline test-smoke
```

## Rationale

TEST-SESSION-1 surfaced #118 (the F7 meta-bug): `main` @ `c31115c` had 5 typecheck errors in emitted consumer code that `just test-smoke` caught but that `test-unit` + `test-baseline` by design cannot. The pipeline smoke is the only check that actually compiles emitted code against a strict tsconfig. Nobody saw the 5 errors because the canonical "run all tests" recipe excluded smoke.

See evidence quoted in #118.

## Hybrid split

The coordinator decided against folding a full CI bootstrap into this PR. The justfile hygiene fix is proportionate to what #118 scoped. The separate, bigger question — "this repo has no `.github/workflows/` at all; should it?" — is tracked in #136 with all the decisions that deserve standalone review (bun pinning, Postgres service container, per-PR cost of Docker-in-CI, required-vs-optional gates, etc.).

## Living-docs updates

- `docs/specs/PHASE-1-HANDOFF.md` — #118 marked `~~…~~ (FIXED)` per the convention established in PR #122 (F4 / #116).

## Test plan

- [x] `just test-unit` green on branch (920 pass, 0 fail).
- [x] `just --list` confirms the recipe parses.
- [ ] `just test-all` deliberately NOT run during builder pass (60-120s smoke cost); will run as part of normal validator / pre-merge discipline.

## References

- #118 — the meta-bug this closes
- #136 — companion issue for CI bootstrap (separate review)
- PR #122 — convention for marking issues closed in PHASE-1-HANDOFF
- `docs/specs/TEST-SESSION-1.md` — session that surfaced the F7 findings