### PR TITLE
feat(patterns): PATTERN-2 — definePattern primitive + registry + 5 library patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chalk": "^5.6.2",
     "clipanion": "^4.0.0-rc.4",
     "drizzle-orm": "^0.45.2",
+    "glob": "^13.0.6",
     "ora": "^9.3.0",
     "pluralize": "^8.0.0",
     "yaml": "^2.8.3",

--- a/src/__tests__/patterns/pattern-definition.test.ts
+++ b/src/__tests__/patterns/pattern-definition.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for `definePattern` identity + `isPatternDefinition` shape guard.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { z } from 'zod';
+import {
+	definePattern,
+	isPatternDefinition,
+	type PatternDefinition,
+} from '../../patterns/pattern-definition.ts';
+
+describe('definePattern', () => {
+	test('returns its argument unchanged (identity)', () => {
+		const input: PatternDefinition = {
+			name: 'Test',
+			repositoryClass: 'TestRepository',
+		};
+		const output = definePattern(input);
+		expect(output).toBe(input);
+	});
+
+	test('preserves generic config-schema inference', () => {
+		const schema = z.object({ entityType: z.string() });
+		const pattern = definePattern({
+			name: 'Custom',
+			repositoryClass: 'CustomRepository',
+			configSchema: schema,
+		});
+		expect(pattern.configSchema).toBe(schema);
+	});
+});
+
+describe('isPatternDefinition', () => {
+	test('accepts a value with a string `name`', () => {
+		expect(isPatternDefinition({ name: 'Ok' })).toBe(true);
+	});
+
+	test('accepts a full PatternDefinition', () => {
+		expect(
+			isPatternDefinition({
+				name: 'Full',
+				repositoryClass: 'R',
+				serviceClass: 'S',
+				columns: [{ name: 'x', type: 'text' }],
+			}),
+		).toBe(true);
+	});
+
+	test('rejects null, undefined, and non-objects', () => {
+		expect(isPatternDefinition(null)).toBe(false);
+		expect(isPatternDefinition(undefined)).toBe(false);
+		expect(isPatternDefinition('name')).toBe(false);
+		expect(isPatternDefinition(42)).toBe(false);
+	});
+
+	test('rejects objects missing `name`', () => {
+		expect(isPatternDefinition({})).toBe(false);
+		expect(isPatternDefinition({ repositoryClass: 'X' })).toBe(false);
+	});
+
+	test('rejects objects where `name` is not a string', () => {
+		expect(isPatternDefinition({ name: 42 })).toBe(false);
+		expect(isPatternDefinition({ name: null })).toBe(false);
+	});
+});

--- a/src/__tests__/patterns/registry.test.ts
+++ b/src/__tests__/patterns/registry.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Unit tests for the pattern registry — library/app storage, lookup,
+ * `loadAppPatterns()` glob discovery, and two-process determinism.
+ */
+
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { definePattern } from '../../patterns/pattern-definition.ts';
+import {
+	_resetRegistryForTests,
+	getAllPatternNames,
+	getAppPatternNames,
+	getLibraryPatternNames,
+	getPattern,
+	loadAppPatterns,
+	registerLibraryPattern,
+} from '../../patterns/registry.ts';
+
+// Importing the barrel pre-registers the 5 library patterns as a side effect.
+// Tests that need library patterns present should `import '.../patterns/index.ts'`
+// at the top of their describe block.
+import '../../patterns/index.ts';
+
+// ============================================================================
+// Library pre-registration
+// ============================================================================
+
+describe('library pattern pre-registration', () => {
+	test('the 5 library patterns are present after importing the barrel', () => {
+		const libNames = getLibraryPatternNames();
+		expect(libNames).toContain('Base');
+		expect(libNames).toContain('Synced');
+		expect(libNames).toContain('Activity');
+		expect(libNames).toContain('Knowledge');
+		expect(libNames).toContain('Metadata');
+	});
+
+	test('library lookup returns the expected class/import metadata', () => {
+		const synced = getPattern('Synced');
+		expect(synced).toBeDefined();
+		expect(synced?.repositoryClass).toBe('SyncedEntityRepository');
+		expect(synced?.repositoryImport).toBe(
+			'@shared/base-classes/synced-entity-repository',
+		);
+		expect(synced?.impliedBehaviors).toEqual(['external_id_tracking']);
+	});
+
+	test('consumers do not need to list library patterns in a manifest', async () => {
+		// loadAppPatterns with an empty manifest must still leave library
+		// patterns resolvable — they live in a separate store.
+		_resetRegistryForTests(); // clears APP_PATTERNS, leaves LIBRARY_PATTERNS
+		const result = await loadAppPatterns([], process.cwd());
+		expect(result.loaded).toEqual([]);
+		expect(result.errors).toEqual([]);
+		expect(getPattern('Synced')).toBeDefined();
+	});
+});
+
+// ============================================================================
+// Registry insert/lookup semantics
+// ============================================================================
+
+describe('registry insert/lookup', () => {
+	beforeEach(() => {
+		_resetRegistryForTests(); // clear APP_PATTERNS only
+	});
+
+	test('registerLibraryPattern rejects a pattern with no contributions', () => {
+		expect(() =>
+			registerLibraryPattern(
+				definePattern({ name: 'Empty' }) as unknown as Parameters<
+					typeof registerLibraryPattern
+				>[0],
+			),
+		).toThrow(/contributes nothing/);
+	});
+
+	test('registerLibraryPattern accepts a columns-only pattern', () => {
+		registerLibraryPattern({
+			name: 'ColumnsOnly',
+			columns: [{ name: 'external_id', type: 'varchar(255)' }],
+		});
+		expect(getPattern('ColumnsOnly')?.name).toBe('ColumnsOnly');
+	});
+
+	test('getPattern returns undefined for unknown names', () => {
+		expect(getPattern('DefinitelyNotARealPatternName')).toBeUndefined();
+	});
+
+	test('getAllPatternNames dedupes + sorts library and app names', () => {
+		// library has Base/Synced/Activity/Knowledge/Metadata already;
+		// inject an app pattern and verify sort order.
+		_resetRegistryForTests();
+		const names = getAllPatternNames();
+		for (let i = 1; i < names.length; i++) {
+			expect(names[i - 1]!.localeCompare(names[i]!)).toBeLessThanOrEqual(0);
+		}
+	});
+});
+
+// ============================================================================
+// loadAppPatterns — glob + dynamic import
+// ============================================================================
+
+describe('loadAppPatterns', () => {
+	// Each test gets its own tmpdir so concurrent runs don't collide.
+	let tmpdir: string;
+
+	beforeEach(() => {
+		tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'pattern-registry-'));
+		fs.mkdirSync(path.join(tmpdir, 'src', 'patterns'), { recursive: true });
+		_resetRegistryForTests();
+	});
+
+	afterAll(() => {
+		// tmpdirs are small; leave the OS to clean them up if a test bailed
+		// out mid-way. Best-effort cleanup of anything we can see:
+		try {
+			for (const leftover of fs.readdirSync(os.tmpdir())) {
+				if (leftover.startsWith('pattern-registry-')) {
+					fs.rmSync(path.join(os.tmpdir(), leftover), {
+						recursive: true,
+						force: true,
+					});
+				}
+			}
+		} catch {
+			// ignore
+		}
+	});
+
+	function writePatternFile(relPath: string, source: string): string {
+		const abs = path.join(tmpdir, relPath);
+		fs.mkdirSync(path.dirname(abs), { recursive: true });
+		fs.writeFileSync(abs, source, 'utf8');
+		return abs;
+	}
+
+	test('discovers + registers a valid pattern via default glob shape', async () => {
+		// `definePattern` is re-exported from the barrel; app files import
+		// from the built package in real use, but for tests we point at the
+		// in-repo source via an absolute path so Bun resolves it.
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		writePatternFile(
+			'src/patterns/custom.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const CustomPattern = definePattern({
+	name: 'Custom',
+	repositoryClass: 'CustomRepository',
+	repositoryImport: '@/patterns/custom',
+});
+`,
+		);
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.loaded).toEqual(['Custom']);
+		expect(getPattern('Custom')?.repositoryClass).toBe('CustomRepository');
+		expect(getAppPatternNames()).toEqual(['Custom']);
+	});
+
+	test('ignores exports that are not pattern definitions', async () => {
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		writePatternFile(
+			'src/patterns/mixed.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const helper = () => 42;
+export const MY_CONST = 'not a pattern';
+export const danglingConst = { name: "Dangling" }; // export key does not end in "Pattern" — ignored
+export const RealPattern = definePattern({
+	name: 'Real',
+	serviceClass: 'RealService',
+});
+`,
+		);
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+
+		expect(result.errors).toEqual([]);
+		// Only the `RealPattern` export is registered: helper + MY_CONST
+		// fail `isPatternDefinition` (no string `name`), and
+		// `danglingConst` is skipped because its export key does
+		// not end in 'Pattern'.
+		expect(result.loaded).toEqual(['Real']);
+	});
+
+	test('reports pattern files that fail to import as errors, does not throw', async () => {
+		writePatternFile(
+			'src/patterns/broken.pattern.ts',
+			"this is not valid TypeScript ;; syntax error",
+		);
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+		expect(result.loaded).toEqual([]);
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.errors[0]).toMatch(/Failed to load pattern file/);
+	});
+
+	test('reports an invalid pattern (no contributions) as an error', async () => {
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		writePatternFile(
+			'src/patterns/empty.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const EmptyPattern = definePattern({ name: 'Empty' });
+`,
+		);
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+
+		expect(result.loaded).toEqual([]);
+		expect(result.errors.length).toBe(1);
+		expect(result.errors[0]).toMatch(/contributes nothing/);
+	});
+
+	test('dedupes a file matched by two overlapping globs', async () => {
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		writePatternFile(
+			'src/patterns/double.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const DoublePattern = definePattern({
+	name: 'Double',
+	repositoryClass: 'DoubleRepository',
+});
+`,
+		);
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts', 'src/**/*.pattern.ts'],
+			tmpdir,
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.loaded).toEqual(['Double']);
+	});
+
+	test('loaded list is sorted — determinism basis', async () => {
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		writePatternFile(
+			'src/patterns/z.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const ZetaPattern = definePattern({
+	name: 'Zeta',
+	repositoryClass: 'ZR',
+});
+`,
+		);
+		writePatternFile(
+			'src/patterns/a.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const AlphaPattern = definePattern({
+	name: 'Alpha',
+	repositoryClass: 'AR',
+});
+`,
+		);
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.loaded).toEqual(['Alpha', 'Zeta']);
+	});
+
+	test('idempotent: loading twice leaves the same state', async () => {
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		writePatternFile(
+			'src/patterns/same.pattern.ts',
+			`
+import { definePattern } from '${barrel}';
+export const SamePattern = definePattern({
+	name: 'Same',
+	repositoryClass: 'SameRepository',
+});
+`,
+		);
+
+		const first = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+		const second = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+		expect(second.loaded).toEqual(first.loaded);
+		expect(getAppPatternNames()).toEqual(['Same']);
+	});
+});
+
+// ============================================================================
+// Two-process determinism — ADR risk #1
+// ============================================================================
+
+describe('two-process determinism', () => {
+	// The Hygen subprocess builds a fresh registry per `entity new` run
+	// independently of the CLI. Both must resolve identically. Here we
+	// simulate the subprocess via a second bun invocation and compare
+	// its registry snapshot to ours.
+
+	test('same files produce the same sorted registry in a fresh process', async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pattern-deterministic-'));
+		fs.mkdirSync(path.join(tmp, 'src', 'patterns'), { recursive: true });
+
+		const barrel = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'patterns', 'one.pattern.ts'),
+			`
+import { definePattern } from '${barrel}';
+export const OnePattern = definePattern({
+	name: 'One',
+	repositoryClass: 'OneR',
+});
+`,
+		);
+		fs.writeFileSync(
+			path.join(tmp, 'src', 'patterns', 'two.pattern.ts'),
+			`
+import { definePattern } from '${barrel}';
+export const TwoPattern = definePattern({
+	name: 'Two',
+	repositoryClass: 'TwoR',
+});
+`,
+		);
+
+		// Process A — in-test
+		_resetRegistryForTests();
+		const a = await loadAppPatterns(['src/patterns/*.pattern.ts'], tmp);
+
+		// Process B — spawn bun with a one-liner that loads the registry and
+		// emits its own sorted view.
+		const registryPath = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/registry.ts',
+		);
+		const barrelPath = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/index.ts',
+		);
+		const child = spawnSync(
+			'bun',
+			[
+				'-e',
+				`
+await import('${barrelPath}');
+const { loadAppPatterns, getAppPatternNames } = await import('${registryPath}');
+const res = await loadAppPatterns(['src/patterns/*.pattern.ts'], '${tmp}');
+process.stdout.write(JSON.stringify({
+	loaded: res.loaded,
+	errors: res.errors,
+	appNames: getAppPatternNames(),
+}));
+`,
+			],
+			{ encoding: 'utf8' },
+		);
+
+		expect(child.status).toBe(0);
+		const b = JSON.parse(child.stdout) as {
+			loaded: string[];
+			errors: string[];
+			appNames: string[];
+		};
+
+		expect(b.errors).toEqual([]);
+		expect(a.errors).toEqual([]);
+		expect(a.loaded).toEqual(b.loaded);
+		expect(a.loaded).toEqual(['One', 'Two']); // alphabetical
+		expect(b.appNames).toEqual(['One', 'Two']);
+
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,3 +107,9 @@ export {
 	formatMarkdown,
 	formatMermaidGraph,
 } from './formatters';
+
+
+// Re-export patterns surface (definePattern + library patterns + registry).
+// Importing this barrel has the side effect of pre-registering the five
+// library-shipped patterns (Base / Synced / Activity / Knowledge / Metadata).
+export * from './patterns';

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Patterns public surface.
+ *
+ * Importing this barrel has the side effect of registering every
+ * library-shipped pattern with the registry. The CLI and the Hygen
+ * subprocess both import here to guarantee a populated registry before
+ * any codegen work begins.
+ */
+
+// Side-effect: register library patterns.
+import './library/index.js';
+
+export {
+	definePattern,
+	isPatternDefinition,
+	type PatternColumnContribution,
+	type PatternDefinition,
+} from './pattern-definition.js';
+
+export {
+	getAllPatternNames,
+	getAppPatternNames,
+	getLibraryPatternNames,
+	getPattern,
+	loadAppPatterns,
+	registerLibraryPattern,
+	type LoadAppPatternsResult,
+} from './registry.js';
+
+// Library pattern values — available for consumers that want to reference
+// them programmatically (rare, but cheap to export).
+export {
+	ActivityPattern,
+	BasePattern,
+	KnowledgePattern,
+	MetadataPattern,
+	SyncedPattern,
+} from './library/index.js';

--- a/src/patterns/library/activity.pattern.ts
+++ b/src/patterns/library/activity.pattern.ts
@@ -1,0 +1,32 @@
+/**
+ * ActivityPattern — replaces `family: activity`.
+ *
+ * Activity entities represent time-bounded interactions (calls, meetings,
+ * emails). The base repository/service expose date-range + opportunity +
+ * user-scoped lookups on top of the standard CRUD methods.
+ *
+ * Class names, import paths, and inherited-method strings match the
+ * legacy `FAMILY_MAP` entry verbatim so PATTERN-5's template swap produces
+ * byte-identical output.
+ */
+
+import { definePattern } from '../pattern-definition.js';
+
+export const ActivityPattern = definePattern({
+	name: 'Activity',
+	extends: ['Base'],
+	repositoryClass: 'ActivityEntityRepository',
+	serviceClass: 'ActivityEntityService',
+	repositoryImport: '@shared/base-classes/activity-entity-repository',
+	serviceImport: '@shared/base-classes/activity-entity-service',
+	repositoryInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+		'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
+	],
+	serviceInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete',
+		'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
+	],
+	description:
+		'Time-bounded interaction entities — date-range + opportunity scoped lookups',
+});

--- a/src/patterns/library/base.pattern.ts
+++ b/src/patterns/library/base.pattern.ts
@@ -1,0 +1,28 @@
+/**
+ * BasePattern — identity pattern for the `extends` chain.
+ *
+ * Contributes no columns, no implied behaviors, and no config. Its only
+ * purpose is to anchor the inheritance hierarchy so every other pattern
+ * can declare `extends: ['Base']` and codegen can resolve that to a
+ * concrete `BaseRepository` / `BaseService` reference.
+ *
+ * Matches the existing `family: base` entry in
+ * `templates/entity/new/clean-lite-ps/prompt-extension.js` verbatim.
+ */
+
+import { definePattern } from '../pattern-definition.js';
+
+export const BasePattern = definePattern({
+	name: 'Base',
+	repositoryClass: 'BaseRepository',
+	serviceClass: 'BaseService',
+	repositoryImport: '@shared/base-classes/base-repository',
+	serviceImport: '@shared/base-classes/base-service',
+	repositoryInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+	],
+	serviceInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete',
+	],
+	description: 'Identity pattern — base CRUD, no extra columns or methods',
+});

--- a/src/patterns/library/index.ts
+++ b/src/patterns/library/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Library pattern bootstrap — imports every shipped pattern and registers
+ * it with the shared library registry. Side-effect-only module: importing
+ * this barrel is what pre-registers `Base`, `Synced`, `Activity`,
+ * `Knowledge`, and `Metadata`.
+ *
+ * Adding a new library pattern is two edits: create the `*.pattern.ts`
+ * file and add the import+register pair below.
+ */
+
+import { registerLibraryPattern } from '../registry.js';
+import { ActivityPattern } from './activity.pattern.js';
+import { BasePattern } from './base.pattern.js';
+import { KnowledgePattern } from './knowledge.pattern.js';
+import { MetadataPattern } from './metadata.pattern.js';
+import { SyncedPattern } from './synced.pattern.js';
+
+registerLibraryPattern(BasePattern);
+registerLibraryPattern(SyncedPattern);
+registerLibraryPattern(ActivityPattern);
+registerLibraryPattern(KnowledgePattern);
+registerLibraryPattern(MetadataPattern);
+
+export {
+	ActivityPattern,
+	BasePattern,
+	KnowledgePattern,
+	MetadataPattern,
+	SyncedPattern,
+};

--- a/src/patterns/library/knowledge.pattern.ts
+++ b/src/patterns/library/knowledge.pattern.ts
@@ -1,0 +1,31 @@
+/**
+ * KnowledgePattern — replaces `family: knowledge`.
+ *
+ * Knowledge entities hold long-form content with a workflow status and
+ * semantic-search support (vectors, pending/approved states). The base
+ * classes expose `semanticSearch`, pending-by-opportunity lookups, and
+ * batch status updates.
+ *
+ * Class names, import paths, and inherited-method strings match the
+ * legacy `FAMILY_MAP` entry verbatim.
+ */
+
+import { definePattern } from '../pattern-definition.js';
+
+export const KnowledgePattern = definePattern({
+	name: 'Knowledge',
+	extends: ['Base'],
+	repositoryClass: 'KnowledgeEntityRepository',
+	serviceClass: 'KnowledgeEntityService',
+	repositoryImport: '@shared/base-classes/knowledge-entity-repository',
+	serviceImport: '@shared/base-classes/knowledge-entity-service',
+	repositoryInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+		'semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch',
+	],
+	serviceInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete',
+		'semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch',
+	],
+	description: 'Knowledge entities — semantic search + workflow status',
+});

--- a/src/patterns/library/metadata.pattern.ts
+++ b/src/patterns/library/metadata.pattern.ts
@@ -1,0 +1,31 @@
+/**
+ * MetadataPattern — replaces `family: metadata`.
+ *
+ * Metadata entities represent history-tracked auxiliary rows attached to a
+ * parent entity (audit trails, custom-field values, change logs). The base
+ * classes expose entity-id + type scoped lookups and history listing.
+ *
+ * Class names, import paths, and inherited-method strings match the
+ * legacy `FAMILY_MAP` entry verbatim.
+ */
+
+import { definePattern } from '../pattern-definition.js';
+
+export const MetadataPattern = definePattern({
+	name: 'Metadata',
+	extends: ['Base'],
+	repositoryClass: 'MetadataEntityRepository',
+	serviceClass: 'MetadataEntityService',
+	repositoryImport: '@shared/base-classes/metadata-entity-repository',
+	serviceImport: '@shared/base-classes/metadata-entity-service',
+	repositoryInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+		'findByEntityIdAndType, listByEntityId, listHistoryByEntityId',
+	],
+	serviceInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete',
+		'findByEntityIdAndType, listByEntityId, listHistoryByEntityId',
+	],
+	description:
+		'History-tracked metadata rows — entity-id + type scoped lookups',
+});

--- a/src/patterns/library/synced.pattern.ts
+++ b/src/patterns/library/synced.pattern.ts
@@ -1,0 +1,34 @@
+/**
+ * SyncedPattern — adds external-system sync columns and methods.
+ *
+ * Replaces the legacy `family: synced` entry in
+ * `templates/entity/new/clean-lite-ps/prompt-extension.js`. Class names,
+ * import paths, and inherited-method comment lines are preserved verbatim
+ * so PATTERN-5's template swap produces byte-identical output for
+ * pre-existing `family: synced` fixtures.
+ *
+ * Implies `external_id_tracking` — the behavior that contributes the
+ * `external_id`, `provider`, and `provider_metadata` columns to the table.
+ * An entity declaring `pattern: Synced` need not re-declare the behavior.
+ */
+
+import { definePattern } from '../pattern-definition.js';
+
+export const SyncedPattern = definePattern({
+	name: 'Synced',
+	extends: ['Base'],
+	repositoryClass: 'SyncedEntityRepository',
+	serviceClass: 'SyncedEntityService',
+	repositoryImport: '@shared/base-classes/synced-entity-repository',
+	serviceImport: '@shared/base-classes/synced-entity-service',
+	repositoryInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
+		'findByExternalId, findAllByUserId, findVisibleByUserId, syncUpsert',
+	],
+	serviceInheritedMethods: [
+		'findById, findByIds, list, count, exists, create, update, delete',
+		'findByExternalId, findAllByUserId, findVisibleByUserId',
+	],
+	impliedBehaviors: ['external_id_tracking'],
+	description: 'External CRM/system sync columns and syncUpsert methods',
+});

--- a/src/patterns/pattern-definition.ts
+++ b/src/patterns/pattern-definition.ts
@@ -1,0 +1,129 @@
+/**
+ * Pattern Definition — pure metadata record returned by an identity function.
+ *
+ * `definePattern()` is the registration artifact for both library-shipped and
+ * app-defined patterns. It carries only names + import paths for the classes
+ * a generated entity should extend — never the class constructors themselves.
+ * This keeps the codegen pipeline free of TS class-evaluation cost and avoids
+ * `reflect-metadata`, which lets the Hygen subprocess cheaply rebuild the
+ * registry (see `src/cli/shared/hygen.ts` — the registry loads twice per
+ * `entity new` invocation).
+ *
+ * See `docs/adrs/ADR-031-app-defined-patterns.md` §"Decision 1" for the
+ * binding surface and `docs/specs/app-defined-patterns-implementation.md` §1
+ * for the file-by-file rationale.
+ */
+
+import type { ZodSchema } from 'zod';
+
+/**
+ * A column a pattern contributes to every entity that declares it.
+ *
+ * Column-level conflicts between patterns, between a pattern and an
+ * entity-declared field, or between a pattern and a behavior-contributed
+ * field are codegen-time hard errors; see
+ * `src/patterns/validate-composition.ts`.
+ */
+export interface PatternColumnContribution {
+	/** snake_case column name — matches the database column */
+	name: string;
+	/** Drizzle column type string, e.g. "varchar(255)" or "text" */
+	type: string;
+}
+
+/**
+ * The full pattern metadata record. Every `definePattern({...})` call
+ * returns a value of this shape; the library and consumer registries
+ * store these and look them up by `name`.
+ */
+export interface PatternDefinition<TConfig = unknown> {
+	/** Unique name used in YAML — e.g. `pattern: Synced` */
+	name: string;
+
+	/**
+	 * Built-in patterns this extends, by name. Phase 1 supports single-depth
+	 * chains only — a pattern may `extends: ['Synced']` but the transitive
+	 * chain is not yet resolved. Multi-depth inheritance is deferred until
+	 * a real consumer asks.
+	 */
+	extends?: string[];
+
+	/** Constructor name codegen emits in the generated repo's `extends` clause */
+	repositoryClass?: string;
+	/** Constructor name codegen emits in the generated service's `extends` clause */
+	serviceClass?: string;
+
+	/**
+	 * Fully-qualified TypeScript path alias the consumer's tsconfig resolves.
+	 * Library patterns use the consumer-installed runtime base class path
+	 * (e.g. `@shared/base-classes/synced-entity-repository`); app patterns
+	 * use whatever alias the consumer has configured (e.g. `@/patterns/...`).
+	 */
+	repositoryImport?: string;
+	/** Same as `repositoryImport` but for the service base class */
+	serviceImport?: string;
+
+	/**
+	 * Documentation-only method-signature strings emitted as comments in the
+	 * generated repo. Exist purely so app authors reading the generated file
+	 * see what their concrete class inherits without jumping to the base.
+	 */
+	repositoryInheritedMethods?: string[];
+	/** Same as `repositoryInheritedMethods` but for the service base class */
+	serviceInheritedMethods?: string[];
+
+	/**
+	 * Columns this pattern adds to every entity that declares it. Used by
+	 * the composition validator to detect column-name collisions.
+	 */
+	columns?: PatternColumnContribution[];
+
+	/**
+	 * Behaviors this pattern implicitly enables. Entity YAML need not
+	 * re-declare them; duplicates across patterns are silent-deduped.
+	 */
+	impliedBehaviors?: string[];
+
+	/**
+	 * Zod schema that validates the per-entity `config:` block for this
+	 * pattern at parse time. When absent, entities may not supply a `config:`
+	 * entry for this pattern and codegen emits no `patternConfig` property.
+	 */
+	configSchema?: ZodSchema<TConfig>;
+
+	/** One-line description for codegen help output and error messages */
+	description?: string;
+}
+
+/**
+ * Identity function that returns its argument unchanged. The body is trivial
+ * on purpose — the whole point is to give TypeScript a hook for generic
+ * inference on `TConfig` while leaving the runtime value a plain object
+ * registered by the codegen loader.
+ */
+export function definePattern<TConfig = unknown>(
+	def: PatternDefinition<TConfig>,
+): PatternDefinition<TConfig> {
+	return def;
+}
+
+/**
+ * Shape check for values produced by `import()`ing an app pattern file.
+ * The registry loader runs this on every exported value it finds; only
+ * values that pass are registered.
+ *
+ * We keep this deliberately loose — a `name` string is the whole
+ * requirement — because a pattern that contributes neither columns nor
+ * class references is still a *valid* identity pattern (e.g. `BasePattern`
+ * exists to anchor the `extends` chain without contributing anything).
+ * Stricter shape rules belong in the registry's "at-least-one-contribution"
+ * check, not here.
+ */
+export function isPatternDefinition(val: unknown): val is PatternDefinition {
+	return (
+		typeof val === 'object' &&
+		val !== null &&
+		'name' in val &&
+		typeof (val as { name: unknown }).name === 'string'
+	);
+}

--- a/src/patterns/registry.ts
+++ b/src/patterns/registry.ts
@@ -1,0 +1,235 @@
+/**
+ * Pattern Registry — library + app pattern storage and discovery.
+ *
+ * Two stores keyed by pattern name:
+ *   - `LIBRARY_PATTERNS` — seeded by the codegen package itself when the
+ *     `src/patterns/library/*` barrel imports execute. Consumers never
+ *     list these in `codegen.config.yaml patterns:`.
+ *   - `APP_PATTERNS`     — populated by `loadAppPatterns()` from a
+ *     consumer-supplied glob set (default `src/patterns/*.pattern.ts`).
+ *
+ * `getPattern()` checks app patterns first so a consumer could, in
+ * principle, shadow a library pattern by using the same `name`. That's
+ * not a documented feature, but nothing in the API prevents it.
+ *
+ * The Hygen subprocess (`src/cli/shared/hygen.ts:64`) reloads this module
+ * independently — it has no shared memory with the CLI process. Both
+ * loads are deterministic, side-effect-free reads of the same files, so
+ * the registry contents are identical across processes. The registry
+ * test suite asserts this determinism explicitly.
+ *
+ * See `docs/adrs/ADR-031-app-defined-patterns.md` §"Decision 5" and
+ * `docs/specs/app-defined-patterns-implementation.md` §3.
+ */
+
+import { glob } from 'glob';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+	isPatternDefinition,
+	type PatternDefinition,
+} from './pattern-definition.js';
+
+// ============================================================================
+// Stores
+// ============================================================================
+
+const LIBRARY_PATTERNS: Map<string, PatternDefinition> = new Map();
+const APP_PATTERNS: Map<string, PatternDefinition> = new Map();
+
+/**
+ * Every pattern must contribute *something* — either at least one column
+ * or at least one of the two class references. A pattern that contributes
+ * nothing would generate no useful output and almost certainly indicates
+ * a typo or an unfinished definition.
+ */
+function assertHasContribution(def: PatternDefinition): void {
+	const hasColumns = Array.isArray(def.columns) && def.columns.length > 0;
+	const hasRepo =
+		typeof def.repositoryClass === 'string' && def.repositoryClass.length > 0;
+	const hasService =
+		typeof def.serviceClass === 'string' && def.serviceClass.length > 0;
+
+	if (!hasColumns && !hasRepo && !hasService) {
+		throw new Error(
+			`Pattern '${def.name}' contributes nothing — at least one of ` +
+				'`columns`, `repositoryClass`, or `serviceClass` is required.',
+		);
+	}
+}
+
+// ============================================================================
+// Library pattern registration
+// ============================================================================
+
+/**
+ * Insert a library pattern into the registry. Called once by each
+ * `src/patterns/library/*.pattern.ts` file via the barrel. Re-registering
+ * the same name overwrites the previous value silently; this is
+ * intentional for hot-reload scenarios but should not happen in normal
+ * use.
+ */
+export function registerLibraryPattern(def: PatternDefinition): void {
+	assertHasContribution(def);
+	LIBRARY_PATTERNS.set(def.name, def);
+}
+
+// ============================================================================
+// Lookup
+// ============================================================================
+
+/**
+ * Resolve a pattern by name. App patterns shadow library patterns with
+ * the same name — useful in principle but not a documented feature.
+ */
+export function getPattern(name: string): PatternDefinition | undefined {
+	return APP_PATTERNS.get(name) ?? LIBRARY_PATTERNS.get(name);
+}
+
+/**
+ * Return every registered pattern name (library + app), sorted for
+ * deterministic output. The two-process determinism test relies on this
+ * ordering being stable across processes.
+ */
+export function getAllPatternNames(): string[] {
+	const set = new Set<string>([
+		...LIBRARY_PATTERNS.keys(),
+		...APP_PATTERNS.keys(),
+	]);
+	return [...set].sort();
+}
+
+/** Library-only view — mainly for debugging and tests. */
+export function getLibraryPatternNames(): string[] {
+	return [...LIBRARY_PATTERNS.keys()].sort();
+}
+
+/** App-only view — mainly for debugging and tests. */
+export function getAppPatternNames(): string[] {
+	return [...APP_PATTERNS.keys()].sort();
+}
+
+// ============================================================================
+// App pattern discovery
+// ============================================================================
+
+export interface LoadAppPatternsResult {
+	/** Pattern names that were successfully registered, sorted */
+	loaded: string[];
+	/** One human-readable error per failed file import */
+	errors: string[];
+}
+
+/**
+ * Expand every glob in `manifestPaths` relative to `cwd`, dynamic-import
+ * each matching file, and register every exported value that passes
+ * `isPatternDefinition()`. Exports whose name ends in `Pattern` and
+ * pass the shape check are registered; other exports are ignored so
+ * that files can export helper values alongside their pattern.
+ *
+ * Import failures are non-fatal — the error is collected and returned
+ * so the CLI can surface it without breaking generation of unrelated
+ * entities. A pattern that fails the "at-least-one-contribution" check
+ * surfaces here as an error too.
+ *
+ * Idempotent: calling twice with the same arguments leaves `APP_PATTERNS`
+ * in the same state as calling once.
+ */
+export async function loadAppPatterns(
+	manifestPaths: string[],
+	cwd: string,
+): Promise<LoadAppPatternsResult> {
+	const loaded = new Set<string>();
+	const errors: string[] = [];
+
+	// Collect + dedupe absolute file paths across every glob pattern so
+	// a file matched by two globs is imported once.
+	const files = new Set<string>();
+	for (const raw of manifestPaths) {
+		try {
+			const expanded = await glob(raw, { cwd, absolute: true, nodir: true });
+			for (const filePath of expanded) {
+				files.add(filePath);
+			}
+		} catch (err) {
+			errors.push(
+				`Failed to expand pattern glob '${raw}': ${stringifyError(err)}`,
+			);
+		}
+	}
+
+	// Sort so dynamic-import order is deterministic across processes —
+	// the Hygen subprocess relies on this to produce the same registry
+	// as the CLI.
+	const sortedFiles = [...files].sort();
+
+	for (const filePath of sortedFiles) {
+		try {
+			// `pathToFileURL` is required for absolute-path dynamic imports on
+			// Windows and makes the behavior identical on macOS/Linux.
+			const mod = (await import(pathToFileURL(filePath).href)) as Record<
+				string,
+				unknown
+			>;
+			for (const [key, val] of Object.entries(mod)) {
+				if (!key.endsWith('Pattern')) continue;
+				if (!isPatternDefinition(val)) continue;
+				try {
+					assertHasContribution(val);
+					APP_PATTERNS.set(val.name, val);
+					loaded.add(val.name);
+				} catch (assertErr) {
+					errors.push(
+						`Pattern '${val.name}' in ${relPath(filePath, cwd)} is invalid: ${stringifyError(assertErr)}`,
+					);
+				}
+			}
+		} catch (err) {
+			errors.push(
+				`Failed to load pattern file '${relPath(filePath, cwd)}': ${stringifyError(err)}`,
+			);
+		}
+	}
+
+	return {
+		loaded: [...loaded].sort(),
+		errors,
+	};
+}
+
+// ============================================================================
+// Test-only reset
+// ============================================================================
+
+/**
+ * Clear every registered app pattern and, optionally, library patterns too.
+ *
+ * Intended for unit tests that build isolated scenarios on top of a clean
+ * registry. Not exported from the barrel — tests import it directly from
+ * `./registry.js`.
+ */
+export function _resetRegistryForTests(
+	opts: { includeLibrary?: boolean } = {},
+): void {
+	APP_PATTERNS.clear();
+	if (opts.includeLibrary) {
+		LIBRARY_PATTERNS.clear();
+	}
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function stringifyError(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+function relPath(abs: string, cwd: string): string {
+	try {
+		return path.relative(cwd, abs) || abs;
+	} catch {
+		return abs;
+	}
+}


### PR DESCRIPTION
Closes #138. Part of Epic #75 (Patterns Phase 1).

## Summary

Builds the library-side pattern primitive per [ADR-031](../blob/main/docs/adrs/ADR-031-app-defined-patterns.md). Additive only — no schema, parser, template, or `analyzeDomain` wiring (those land in PATTERN-3/4/5).

## What's new

- `src/patterns/pattern-definition.ts` — `PatternDefinition<TConfig>` type, `definePattern()` pure metadata identity function, `isPatternDefinition` shape guard.
- `src/patterns/registry.ts` — library + app stores, `getPattern`, `getAllPatternNames`, `loadAppPatterns()` (glob-based discovery via dynamic import; deterministic sorted output; non-fatal per-file errors; `assertHasContribution` rejects empty patterns).
- `src/patterns/library/{base,synced,activity,knowledge,metadata}.pattern.ts` — 5 library patterns. Class names, import paths, and inherited-method strings **match the legacy `FAMILY_MAP` entries in `templates/entity/new/clean-lite-ps/prompt-extension.js` verbatim** so PATTERN-5's template swap produces byte-identical output.
- `src/patterns/index.ts` + `src/patterns/library/index.ts` — public barrel + side-effect library registration.
- Re-exported from `src/index.ts` for the published surface.

## Tests

22 unit tests in `src/__tests__/patterns/*.test.ts`:

- `definePattern` identity + `isPatternDefinition` shape guard (6 tests)
- library pre-registration after barrel import (3 tests)
- registry insert/lookup semantics incl. `assertHasContribution` rejection (4 tests)
- `loadAppPatterns`: discovery, non-pattern-export filtering, bad-file handling, invalid-pattern reporting, cross-glob dedup, sorted determinism basis, idempotency (7 tests)
- **two-process determinism** (ADR/plan Risk 1): spawns a second `bun` process and asserts both resolve the same sorted app-pattern set (1 test)
- sorted determinism ordering across library + app names (1 test)

Full suite: **`just test-unit` green — 1025 pass, 0 fail**.

## Dependencies added

- `glob@^13.0.6` — production dep. Matches the impl spec's `import { glob } from "glob"` call. Zero-cost for consumers not using app patterns (library registry is side-effect-only on import).

## Locked decisions honoured

- `definePattern()` is a **pure metadata identity function** — never imports classes, only their names + import paths. No `reflect-metadata`.
- Library patterns (Base / Synced / Activity / Knowledge / Metadata) are **pre-registered by the codegen package**; consumers do not list them in `codegen.config.yaml patterns:`.
- Discovery uses **globs** (default `src/patterns/*.pattern.ts`), not per-file enumeration.
- `loadAppPatterns` emits **sorted** file and result lists so the CLI and Hygen subprocess produce identical registries (plan Risk 1).
- **Single-depth `extends`** — surface is present (string array) but no transitive resolution; multi-depth deferred.

## Gate

- `just test-unit` green (1025/1025).
- `bun run typecheck` clean.
- `bun run build` clean (patterns ship in `dist/src/index.js` + `dist/src/index.d.ts`).
- No schema/parser/template changes.

## Out of scope for this PR (by design — locked gates)

- YAML surface change (`family:` → `pattern:`): PATTERN-3 (#139).
- `validate-composition.ts` + `analyzeDomain` wiring: PATTERN-4 (#140).
- `FAMILY_MAP` template replacement + `patternConfig` emission + `PatternsConfigSchema`: PATTERN-5 (#141).

## Pre-existing baseline failure noted

`just test-baseline` fails on `origin/main` with an unrelated EJS template error referencing `mainHookInjected` in `templates/subsystem/jobs/main-hook.ejs.t`. Not caused by this PR — reproduced on clean `main`. Will need attention before PATTERN-3 can pass its baseline gate. Flagging to epic coordinator.

## References

- Epic #75
- ADR-031 (#101) — binding decisions
- `docs/specs/app-defined-patterns-implementation.md` §1–3 (pattern primitive + registry)
- `docs/specs/PATTERNS-PHASE-1-PLAN.md` (the 5-PR stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)