### PR TITLE
feat(patterns): PATTERN-3 — delete family:, add pattern:/patterns:/config:

### DIFF
--- a/examples/eav/field_definition.yaml
+++ b/examples/eav/field_definition.yaml
@@ -10,7 +10,7 @@ entity:
   name: field_definition
   plural: field_definitions
   table: field_definitions
-  family: metadata
+  pattern: Metadata
   folder_structure: nested
 
 fields:

--- a/examples/eav/field_value.yaml
+++ b/examples/eav/field_value.yaml
@@ -11,7 +11,7 @@ entity:
   name: field_value
   plural: field_values
   table: field_values
-  family: metadata
+  pattern: Metadata
   folder_structure: nested
 
 fields:

--- a/src/__tests__/clean-lite-ps/controller-hardening.test.ts
+++ b/src/__tests__/clean-lite-ps/controller-hardening.test.ts
@@ -51,7 +51,7 @@ const baseEntity = {
     name: 'contact',
     plural: 'contacts',
     table: 'contacts',
-    family: 'synced',
+    pattern: 'Synced',
   },
   fields: {
     email: { type: 'string', required: true },

--- a/src/__tests__/clean-lite-ps/dto-template.test.ts
+++ b/src/__tests__/clean-lite-ps/dto-template.test.ts
@@ -53,7 +53,7 @@ function render(template: string, locals: Record<string, unknown>): string {
 
 // Fixture with a decimal field and a json field — covers both bugs.
 const agentDefinition = {
-  entity: { name: 'agent', plural: 'agents', table: 'agents', family: 'synced' },
+  entity: { name: 'agent', plural: 'agents', table: 'agents', pattern: 'Synced' },
   fields: {
     name: { type: 'string', required: true },
     temperature: { type: 'decimal', required: true },

--- a/src/__tests__/clean-lite-ps/eav-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-templates.test.ts
@@ -58,7 +58,7 @@ const baseEntity = {
     name: 'opportunity',
     plural: 'opportunities',
     table: 'opportunities',
-    family: 'synced',
+    pattern: 'Synced',
   },
   fields: {
     name: { type: 'string', required: true },

--- a/src/__tests__/clean-lite-ps/eav-value-table-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/eav-value-table-templates.test.ts
@@ -63,7 +63,7 @@ const valueEntity = {
     name: 'field_value',
     plural: 'field_values',
     table: 'field_values',
-    family: 'metadata',
+    pattern: 'Metadata',
   },
   eav_value_table: true,
   eav_definition_table: 'field_definition',
@@ -219,7 +219,7 @@ describe('clean-lite-ps eav_value_table — composition with eav on owning entit
     // opportunity is an eav-enabled owner.
     const valueLocals = buildCleanLitePsLocals(valueEntity, {});
     const opportunityEntity = {
-      entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', family: 'synced' },
+      entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', pattern: 'Synced' },
       eav: true,
       fields: { name: { type: 'string', required: true }, user_id: { type: 'uuid', required: true } },
       relationships: {},

--- a/src/__tests__/clean-lite-ps/entity-fk-template.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-fk-template.test.ts
@@ -50,7 +50,7 @@ const EMPTY_BASE_LOCALS = {};
 // ============================================================================
 
 const messageDefinitionCascade = {
-  entity: { name: 'message', plural: 'messages', table: 'messages', family: 'base' },
+  entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
   fields: {
     body: { type: 'string', required: true },
   },
@@ -80,7 +80,7 @@ const messageDefinitionSoftDeleteCascade = {
 // ============================================================================
 
 const messageDefinitionRestrict = {
-  entity: { name: 'message', plural: 'messages', table: 'messages', family: 'base' },
+  entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
   fields: {
     body: { type: 'string', required: true },
   },
@@ -101,7 +101,7 @@ const messageDefinitionRestrict = {
 // ============================================================================
 
 const childDefinitionSetNull = {
-  entity: { name: 'comment', plural: 'comments', table: 'comments', family: 'base' },
+  entity: { name: 'comment', plural: 'comments', table: 'comments', pattern: 'Base' },
   fields: {
     body: { type: 'string', required: true },
   },
@@ -122,7 +122,7 @@ const childDefinitionSetNull = {
 // ============================================================================
 
 const messageDefinitionNoOnDelete = {
-  entity: { name: 'message', plural: 'messages', table: 'messages', family: 'base' },
+  entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
   fields: {
     body: { type: 'string', required: true },
   },

--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -18,7 +18,7 @@ const contactDefinition = {
     name: 'contact',
     plural: 'contacts',
     table: 'contacts',
-    family: 'synced',
+    pattern: 'Synced',
   },
   fields: {
     user_id: { type: 'uuid', required: true },
@@ -37,7 +37,7 @@ const contactDefinition = {
   behaviors: ['timestamps', 'soft_delete'],
 };
 
-// Entity without family key
+// Entity without pattern key
 const noFamilyDefinition = {
   entity: { name: 'task', plural: 'tasks', table: 'tasks' },
   fields: { title: { type: 'string', required: true } },
@@ -45,9 +45,9 @@ const noFamilyDefinition = {
   behaviors: [],
 };
 
-// Activity family entity
+// Activity pattern entity
 const activityDefinition = {
-  entity: { name: 'note', plural: 'notes', table: 'notes', family: 'activity' },
+  entity: { name: 'note', plural: 'notes', table: 'notes', pattern: 'Activity' },
   fields: { body: { type: 'string', required: true } },
   relationships: {},
   behaviors: ['timestamps'],
@@ -81,7 +81,7 @@ describe('buildCleanLitePsLocals', () => {
     expect(locals.classNames.outputSchema).toBe('ContactOutputSchema');
   });
 
-  it('maps synced family to SyncedEntityRepository and SyncedEntityService', () => {
+  it('maps Synced pattern to SyncedEntityRepository and SyncedEntityService', () => {
     const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
 
     expect(locals.family).toBe('synced');
@@ -91,7 +91,7 @@ describe('buildCleanLitePsLocals', () => {
     expect(locals.serviceBaseImport).toBe('@shared/base-classes/synced-entity-service');
   });
 
-  it('maps activity family to ActivityEntityRepository and ActivityEntityService', () => {
+  it('maps Activity pattern to ActivityEntityRepository and ActivityEntityService', () => {
     const locals = buildCleanLitePsLocals(activityDefinition, EMPTY_BASE_LOCALS);
 
     expect(locals.family).toBe('activity');
@@ -101,7 +101,7 @@ describe('buildCleanLitePsLocals', () => {
     expect(locals.serviceBaseImport).toBe('@shared/base-classes/activity-entity-service');
   });
 
-  it('defaults to base family when family key is absent', () => {
+  it('defaults to base when pattern key is absent', () => {
     const locals = buildCleanLitePsLocals(noFamilyDefinition, EMPTY_BASE_LOCALS);
 
     expect(locals.family).toBe('base');
@@ -299,14 +299,14 @@ describe('buildCleanLitePsLocals', () => {
 
   it('produces collision-free class names for different entities sharing a query', () => {
     const accountDef = {
-      entity: { name: 'account', plural: 'accounts', table: 'accounts', family: 'synced' },
+      entity: { name: 'account', plural: 'accounts', table: 'accounts', pattern: 'Synced' },
       fields: { domain: { type: 'string', required: true } },
       relationships: {},
       behaviors: [],
       queries: [{ by: ['domain'], unique: true }],
     };
     const opportunityDef = {
-      entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', family: 'synced' },
+      entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', pattern: 'Synced' },
       fields: { domain: { type: 'string', required: true } },
       relationships: {},
       behaviors: [],

--- a/src/__tests__/clean-lite-ps/repository-template.test.ts
+++ b/src/__tests__/clean-lite-ps/repository-template.test.ts
@@ -47,7 +47,7 @@ function renderRepository(locals: Record<string, unknown>): string {
 }
 
 const baseEntity = {
-  entity: { name: 'contact', plural: 'contacts', table: 'contacts', family: 'synced' },
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', pattern: 'Synced' },
   fields: {
     email: { type: 'string', required: true },
   },

--- a/src/__tests__/clean-lite-ps/search-query-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/search-query-templates.test.ts
@@ -45,7 +45,7 @@ function render(relPath: string, locals: Record<string, unknown>): string {
 }
 
 const baseEntity = {
-  entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', family: 'synced' },
+  entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', pattern: 'Synced' },
   fields: {
     name: { type: 'string', required: true },
     canonical_state: {

--- a/src/__tests__/clean-lite-ps/soft-delete-404-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/soft-delete-404-templates.test.ts
@@ -50,7 +50,7 @@ function render(relPath: string, locals: Record<string, unknown>): string {
 }
 
 const baseEntity = {
-  entity: { name: 'contact', plural: 'contacts', table: 'contacts', family: 'synced' },
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', pattern: 'Synced' },
   fields: { email: { type: 'string', required: true } },
   relationships: {},
   behaviors: ['timestamps', 'soft_delete'],

--- a/src/__tests__/clean-lite-ps/write-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/write-templates.test.ts
@@ -51,7 +51,7 @@ const baseEntity = {
     name: 'contact',
     plural: 'contacts',
     table: 'contacts',
-    family: 'synced',
+    pattern: 'Synced',
   },
   fields: {
     email: { type: 'string', required: true },

--- a/src/__tests__/clean-lite-ps/zod-pipe-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/zod-pipe-templates.test.ts
@@ -49,7 +49,7 @@ function render(relPath: string, locals: Record<string, unknown>): string {
 }
 
 const baseEntity = {
-  entity: { name: 'contact', plural: 'contacts', table: 'contacts', family: 'synced' },
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', pattern: 'Synced' },
   fields: {
     email: { type: 'string', required: true },
   },

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -1,7 +1,7 @@
 /**
  * Schema v2 validation tests
  *
- * Tests for SPEC-002: family, queries, sync, events blocks
+ * Tests for ADR-031 pattern, queries, sync, events blocks
  * and pipelines config schema.
  */
 
@@ -19,37 +19,69 @@ import { resolveBehaviors } from '../../behaviors/index';
 import { resolve } from 'path';
 
 // ============================================================================
-// Entity Family
+// Pattern surface (ADR-031 — supersedes family:)
 // ============================================================================
 
-describe('family enum', () => {
+describe('pattern / patterns / config', () => {
 	const base = {
 		entity: { name: 'test', plural: 'tests', table: 'tests' },
 		fields: { id: { type: 'uuid', required: true } },
 	};
 
-	it('accepts all four family values', () => {
-		for (const family of ['synced', 'activity', 'knowledge', 'metadata']) {
+	it('accepts a single `pattern:` string', () => {
+		// Names are validated against the registry at codegen time (PATTERN-4),
+		// not by the schema itself — so any string is shape-valid here.
+		for (const pattern of ['Synced', 'Activity', 'Knowledge', 'Metadata', 'CrmEntity']) {
 			const result = EntityDefinitionSchema.safeParse({
 				...base,
-				entity: { ...base.entity, family },
+				entity: { ...base.entity, pattern },
 			});
 			expect(result.success).toBe(true);
 		}
 	});
 
-	it('rejects invalid family', () => {
+	it('accepts a `patterns:` array for multi-pattern composition', () => {
 		const result = EntityDefinitionSchema.safeParse({
 			...base,
-			entity: { ...base.entity, family: 'invalid' },
+			entity: { ...base.entity, patterns: ['CrmEntity', 'Event'] },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects declaring both `pattern:` and `patterns:`', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, pattern: 'Synced', patterns: ['Event'] },
 		});
 		expect(result.success).toBe(false);
 	});
 
-	it('family is optional', () => {
+	it('rejects the legacy `family:` key (deleted in PATTERN-3 per ADR-031)', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, family: 'synced' },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts a `config:` block keyed by pattern name', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: {
+				...base.entity,
+				pattern: 'CrmEntity',
+				config: { CrmEntity: { entityType: 'opportunity' } },
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('pattern + patterns + config are optional', () => {
 		const result = EntityDefinitionSchema.safeParse(base);
 		expect(result.success).toBe(true);
-		expect(result.data!.entity.family).toBeUndefined();
+		expect(result.data!.entity.pattern).toBeUndefined();
+		expect(result.data!.entity.patterns).toBeUndefined();
+		expect(result.data!.entity.config).toBeUndefined();
 	});
 });
 
@@ -462,7 +494,7 @@ describe('contact-v2.yaml integration', () => {
 		const result = loadEntityFromYaml(resolve('test/fixtures/contact-v2.yaml'));
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.definition.entity.family).toBe('synced');
+			expect(result.definition.entity.pattern).toBe('Synced');
 			expect(result.definition.queries).toHaveLength(6);
 			expect(result.definition.sync?.electric).toBe(true);
 			expect(result.definition.events).toHaveLength(3);
@@ -473,7 +505,7 @@ describe('contact-v2.yaml integration', () => {
 		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
 		const contact = result.entities[0];
 
-		expect(contact.family).toBe('synced');
+		expect(contact.pattern).toBe('Synced');
 		expect(contact.behaviors).toContain('external_id_tracking');
 		expect(contact.queries).toHaveLength(6);
 		expect(contact.sync?.electric).toBe(true);

--- a/src/analyzer/serialize-graph.ts
+++ b/src/analyzer/serialize-graph.ts
@@ -22,7 +22,9 @@ export interface SerializedEntity {
   name: string;
   plural: string;
   table: string;
-  family?: string;
+  pattern?: string;
+  patterns?: string[];
+  patternConfig?: Record<string, unknown>;
   fields: Record<string, SerializedField>;
   relationships: Record<string, SerializedRelationship>;
   behaviors: string[];
@@ -124,7 +126,9 @@ export function serializeDomainGraph(graph: DomainGraph): SerializedDomainGraph 
       name: entity.name,
       plural: entity.plural,
       table: entity.table,
-      family: entity.family,
+      pattern: entity.pattern,
+      patterns: entity.patterns,
+      patternConfig: entity.patternConfig,
       fields: serializeFields(entity.fields),
       relationships: serializeRelationships(entity.relationships),
       behaviors: entity.behaviors,

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -53,8 +53,6 @@ export interface ParsedRelationship {
 	resolved: boolean;
 }
 
-export type EntityFamily = 'crm-synced' | 'activity' | 'knowledge' | 'metadata';
-
 export interface ParsedQuery {
 	by: string[];
 	unique?: boolean;
@@ -88,7 +86,21 @@ export interface ParsedEntity {
 	name: string;
 	plural: string;
 	table: string;
-	family?: EntityFamily;
+	/**
+	 * Single pattern name (ADR-031). Mutually exclusive with `patterns`.
+	 * Resolves against the pattern registry (`src/patterns/registry.ts`)
+	 * at codegen time.
+	 */
+	pattern?: string;
+	/** Multi-pattern composition. Mutually exclusive with `pattern`. */
+	patterns?: string[];
+	/**
+	 * Per-pattern config map — key is pattern name, value is the raw YAML
+	 * block. Composition validation (PATTERN-4) parses each value against
+	 * the pattern's `configSchema` before codegen emits it as the
+	 * generated class's `patternConfig` property.
+	 */
+	patternConfig?: Record<string, unknown>;
 	/** Whether this entity is a valid scope target for job scoping (JOB-7). */
 	scopeable?: boolean;
 	folderStructure: 'nested' | 'flat';

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -54,10 +54,29 @@ function listEntityYamls(dir: string): string[] {
 
 interface EntitySummaryRow {
 	name: string;
-	family: string;
+	pattern: string;
 	fields: number;
 	queries: number;
 	file: string;
+}
+
+/**
+ * Render an entity's pattern choice as a single display string for the
+ * summary/list tables. `pattern:` wins; `patterns:` joins with `+`; the
+ * library `Base` pattern is the fallback for entities that declare
+ * neither. Matches the user-facing labels the registry uses.
+ */
+function summarizePatternLabel(entity: {
+	pattern?: string;
+	patterns?: string[];
+}): string {
+	if (typeof entity.pattern === 'string' && entity.pattern.length > 0) {
+		return entity.pattern;
+	}
+	if (Array.isArray(entity.patterns) && entity.patterns.length > 0) {
+		return entity.patterns.join('+');
+	}
+	return 'Base';
 }
 
 function summarizeEntityFile(filePath: string): EntitySummaryRow | null {
@@ -66,7 +85,10 @@ function summarizeEntityFile(filePath: string): EntitySummaryRow | null {
 	const def = result.definition;
 	return {
 		name: def.entity.name,
-		family: (def.entity as { family?: string }).family ?? 'base',
+		pattern: summarizePatternLabel(def.entity as {
+			pattern?: string;
+			patterns?: string[];
+		}),
 		fields: Object.keys(def.fields ?? {}).length,
 		queries: Array.isArray(
 			(def as unknown as { queries?: unknown[] }).queries
@@ -100,24 +122,24 @@ async function summary(ctx: Context): Promise<PaneOutput> {
 	const files = listEntityYamls(ctx.entitiesDir);
 	const rows = files.map(summarizeEntityFile).filter((r): r is EntitySummaryRow => r !== null);
 
-	const families = new Set(rows.map((r) => r.family));
+	const patterns = new Set(rows.map((r) => r.pattern));
 	const queryCount = rows.reduce((sum, r) => sum + r.queries, 0);
 
 	const nameCol = Math.max(4, ...rows.map((r) => r.name.length));
-	const famCol = Math.max(6, ...rows.map((r) => r.family.length));
+	const patCol = Math.max(7, ...rows.map((r) => r.pattern.length));
 
 	const body = rows.map((r) => {
 		const fields = `${r.fields} fields`.padEnd(10);
 		const queries = `${r.queries} queries`.padEnd(10);
 		return `${theme.system(icons.bullet)} ${padRight(r.name, nameCol)}  ${theme.muted(
-			padRight(r.family, famCol)
+			padRight(r.pattern, patCol)
 		)}  ${theme.muted(fields)} ${theme.muted(queries)}`;
 	});
 
 	return {
 		title: 'entities',
 		body,
-		footer: `${rows.length} entities · ${families.size} families · ${queryCount} queries`,
+		footer: `${rows.length} entities · ${patterns.size} patterns · ${queryCount} queries`,
 	};
 }
 
@@ -552,7 +574,7 @@ export class EntityListCommand extends Command {
 		description: 'List defined entities as a table',
 	});
 
-	family = Option.String('--family', { required: false });
+	pattern = Option.String('--pattern', { required: false });
 	format = Option.String('--format', 'plain');
 	json = Option.Boolean('--json', false);
 	cwd = Option.String('--cwd', { required: false });
@@ -576,7 +598,7 @@ export class EntityListCommand extends Command {
 		const rows = files
 			.map(summarizeEntityFile)
 			.filter((r): r is EntitySummaryRow => r !== null)
-			.filter((r) => (this.family ? r.family === this.family : true));
+			.filter((r) => (this.pattern ? r.pattern === this.pattern : true));
 
 		if (isJsonMode()) {
 			printJson({
@@ -587,14 +609,14 @@ export class EntityListCommand extends Command {
 		}
 
 		if (this.format === 'tree') {
-			const byFamily = new Map<string, EntitySummaryRow[]>();
+			const byPattern = new Map<string, EntitySummaryRow[]>();
 			for (const r of rows) {
-				const list = byFamily.get(r.family) ?? [];
+				const list = byPattern.get(r.pattern) ?? [];
 				list.push(r);
-				byFamily.set(r.family, list);
+				byPattern.set(r.pattern, list);
 			}
-			for (const [fam, list] of byFamily) {
-				console.log(theme.system(fam));
+			for (const [pat, list] of byPattern) {
+				console.log(theme.system(pat));
 				for (const r of list) {
 					console.log(`  ${theme.muted(icons.bullet)} ${r.name}  ${theme.muted(`${r.fields} fields`)}`);
 				}
@@ -604,15 +626,15 @@ export class EntityListCommand extends Command {
 
 		// plain
 		const nameW = Math.max(4, ...rows.map((r) => r.name.length));
-		const famW = Math.max(6, ...rows.map((r) => r.family.length));
+		const patW = Math.max(7, ...rows.map((r) => r.pattern.length));
 		console.log(
 			theme.muted(
-				`${padRight('NAME', nameW)}  ${padRight('FAMILY', famW)}  ${padRight('FIELDS', 8)} ${padRight('QUERIES', 8)}`
+				`${padRight('NAME', nameW)}  ${padRight('PATTERN', patW)}  ${padRight('FIELDS', 8)} ${padRight('QUERIES', 8)}`
 			)
 		);
 		for (const r of rows) {
 			console.log(
-				`${padRight(r.name, nameW)}  ${padRight(r.family, famW)}  ${padRight(String(r.fields), 8)} ${padRight(String(r.queries), 8)}`
+				`${padRight(r.name, nameW)}  ${padRight(r.pattern, patW)}  ${padRight(String(r.fields), 8)} ${padRight(String(r.queries), 8)}`
 			);
 		}
 		return 0;

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -230,7 +230,7 @@ function exampleEntityYaml(): string {
 #
 # entity:
 #   name: account
-#   family: synced        # base | synced | activity | metadata | knowledge
+#   pattern: Synced       # Base | Synced | Activity | Metadata | Knowledge (or app-defined)
 #
 # fields:
 #   name:

--- a/src/parser/load-entities.ts
+++ b/src/parser/load-entities.ts
@@ -7,7 +7,6 @@
 
 import { readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import type { EntityFamily } from '../analyzer/types.js';
 import {
 	loadEntityFromYaml,
 	loadRelationshipFromYaml,
@@ -66,7 +65,9 @@ function transformToEntity(result: LoadResult): ParsedEntity {
 		name: definition.entity.name,
 		plural: definition.entity.plural,
 		table: definition.entity.table,
-		family: definition.entity.family as EntityFamily | undefined,
+		pattern: definition.entity.pattern,
+		patterns: definition.entity.patterns,
+		patternConfig: definition.entity.config,
 		scopeable: definition.entity.scopeable ?? false,
 		folderStructure: definition.entity.folder_structure ?? 'nested',
 		fields: new Map(),

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -481,18 +481,26 @@ const EntityConfigSchema = z
       .optional()
       .default(["repository", "rest", "trpc"]),
 
-    // v2: Entity family classification (ADR-005)
-    // Determines which base class hierarchy the entity inherits from
-    family: z
-      .enum(["base", "synced", "activity", "knowledge", "metadata"])
-      .optional(),
+    // App-defined patterns (ADR-031, supersedes ADR-005 family:).
+    // `pattern:` and `patterns:` are mutually exclusive — use `pattern:`
+    // for a single pattern and `patterns:` for multi-pattern composition.
+    // Pattern names resolve against the registry at codegen time.
+    pattern: z.string().optional(),
+    patterns: z.array(z.string()).optional(),
+    // Per-pattern config, keyed by pattern name. Each value is validated
+    // against the pattern's `configSchema` in composition validation
+    // (src/patterns/validate-composition.ts — PATTERN-4).
+    config: z.record(z.string(), z.unknown()).optional(),
 
     // JOB-7: marks this entity as a valid scope target for job scoping.
     // Drives the generated ScopeEntityType union in
     // runtime/subsystems/jobs/generated/scope-entity-type.ts.
     scopeable: z.boolean().optional(),
   })
-  .strict();
+  .strict()
+  .refine((d) => !(d.pattern && d.patterns), {
+    message: "'pattern' and 'patterns' are mutually exclusive",
+  });
 
 export type EntityConfig = z.infer<typeof EntityConfigSchema>;
 

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -658,8 +658,26 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     ? pascalCase(eavDefinitionEntityPlural)
     : null;
 
-  // Family resolution
-  const family = entity.family || 'base';
+  // Pattern resolution.
+  //
+  // PATTERN-3 bridge (temporary): we still drive the template off the
+  // legacy lowercased family key, but the YAML surface is now `pattern:`
+  // (single) or `patterns:` (multi). PATTERN-5 replaces this block with a
+  // registry lookup via `src/patterns/registry.ts` and retires FAMILY_MAP.
+  //
+  // Resolution order:
+  //   1. `entity.pattern` — single-pattern case, lowercase the value to
+  //      index into FAMILY_MAP (e.g. 'Synced' -> 'synced').
+  //   2. `entity.patterns[0]` — multi-pattern case: the *first* name wins
+  //      for base-class selection, subsequent patterns will contribute
+  //      columns/behaviors (PATTERN-4 composition) but do not change the
+  //      template's repository/service base class choice.
+  //   3. 'base' — no pattern declared.
+  const patternName =
+    (typeof entity.pattern === 'string' && entity.pattern) ||
+    (Array.isArray(entity.patterns) && entity.patterns[0]) ||
+    null;
+  const family = patternName ? String(patternName).toLowerCase() : 'base';
   const familyConfig = FAMILY_MAP[family] || FAMILY_MAP['base'];
 
   // Process entity fields

--- a/test/fixtures/contact-v2.yaml
+++ b/test/fixtures/contact-v2.yaml
@@ -6,7 +6,7 @@ entity:
   name: contact
   plural: contacts
   table: contacts
-  family: synced
+  pattern: Synced
   folder_structure: nested
 
 fields:

--- a/test/fixtures/demo-deal.yaml
+++ b/test/fixtures/demo-deal.yaml
@@ -3,7 +3,7 @@ entity:
   name: deal
   plural: deals
   table: deals
-  family: synced
+  pattern: Synced
   folder_structure: nested
 
 fields:

--- a/test/run-test.ts
+++ b/test/run-test.ts
@@ -191,7 +191,12 @@ function runCodegen() {
         `--configPath "${join(sandbox, 'codegen.config.yaml')}" ` +
         `--workerExists true ` +
         `--workerPath "${join(sandbox, 'worker.ts')}" ` +
-        `--schemaPath "${v.out}"`,
+        `--schemaPath "${v.out}" ` +
+        // Silence the `mainHookInjected is not defined` EJS error in
+        // `templates/subsystem/jobs/main-hook.ejs.t`. The baseline's
+        // throwaway sandbox has no main.ts to inject into, so the flag's
+        // value is irrelevant; we just need *some* string.
+        `--mainHookInjected true`,
       { cwd: ROOT, stdio: 'pipe' },
     );
   }

--- a/test/scaffold/contact-scaffold.yaml
+++ b/test/scaffold/contact-scaffold.yaml
@@ -2,7 +2,7 @@
 #
 # Stripped-down version of contact-v2.yaml for use by test/scaffold/validate.sh.
 # Differences from contact-v2.yaml:
-#   - family: base (instead of crm-synced) — CrmEntityRepository does not exist yet
+#   - pattern: Base (instead of CrmEntity) — CrmEntityRepository does not exist yet
 #   - No external_id_tracking behavior — not yet supported in templates
 #   - No FK relationships to other entities — avoids circular import issues in scaffold
 #   - No queries/sync/events blocks — those are v2-only schema additions
@@ -14,7 +14,7 @@ entity:
   name: contact
   plural: contacts
   table: contacts
-  family: base
+  pattern: Base
 
 fields:
   first_name:

--- a/test/smoke/fixtures/account.yaml
+++ b/test/smoke/fixtures/account.yaml
@@ -5,7 +5,7 @@ entity:
   name: account
   plural: accounts
   table: accounts
-  family: synced
+  pattern: Synced
   folder_structure: nested
 
 fields:

--- a/test/smoke/fixtures/contact.yaml
+++ b/test/smoke/fixtures/contact.yaml
@@ -6,7 +6,7 @@ entity:
   name: contact
   plural: contacts
   table: contacts
-  family: synced
+  pattern: Synced
   folder_structure: nested
 
 fields:

--- a/tools/schema-graph-viewer/src/adapters/schema-adapter.ts
+++ b/tools/schema-graph-viewer/src/adapters/schema-adapter.ts
@@ -49,7 +49,10 @@ export interface SerializedEntity {
   name: string;
   plural: string;
   table: string;
-  family?: string;
+  // ADR-031 — pattern:/patterns:/config: replace the legacy `family:` key.
+  pattern?: string;
+  patterns?: string[];
+  patternConfig?: Record<string, unknown>;
   fields: Record<string, SerializedField> | [string, SerializedField][];
   relationships: Record<string, SerializedRelationship> | [string, SerializedRelationship][];
   behaviors: string[];
@@ -139,7 +142,8 @@ export function entityToNode(entity: SerializedEntity): GraphNodeData<Serialized
     label: pascalCase(entity.name),
     subtitle: entity.table,
     kind: 'entity',
-    group: entity.family ?? 'base',
+    group:
+      entity.pattern ?? entity.patterns?.[0] ?? 'Base',
     fields: fieldEntries.map(([, f]) => ({
       name: f.name,
       type: f.type,

--- a/tools/schema-graph-viewer/src/adapters/serialize-domain-graph.ts
+++ b/tools/schema-graph-viewer/src/adapters/serialize-domain-graph.ts
@@ -20,7 +20,9 @@ interface EntityLike {
   name: string;
   plural: string;
   table: string;
-  family?: string;
+  pattern?: string;
+  patterns?: string[];
+  patternConfig?: Record<string, unknown>;
   fields: Map<string, FieldLike>;
   relationships: Map<string, RelLike>;
   behaviors: string[];
@@ -114,7 +116,9 @@ export function serializeDomainGraph(graph: DomainGraphLike): SerializedDomainGr
       name: entity.name,
       plural: entity.plural,
       table: entity.table,
-      family: entity.family,
+      pattern: entity.pattern,
+      patterns: entity.patterns,
+      patternConfig: entity.patternConfig,
       fields: serializeFields(entity.fields),
       relationships: rels,
       behaviors: entity.behaviors,


### PR DESCRIPTION
Closes #139. Part of Epic #75 (Patterns Phase 1). Stacks on #142.

## Summary

Per ADR-031 "no backwards compatibility until users" — the legacy `family:` enum is deleted outright. No alias, no `console.warn`, no deprecation window. Every fixture migrates in one sweep.

## Diff shape (29 files, +190/-80)

### Schema + parser + types + CLI (6 files)
- `src/schema/entity-definition.schema.ts` — DELETE `family:`; ADD `pattern:` / `patterns:` / `config:` with a `.refine` asserting `pattern`/`patterns` mutual exclusion.
- `src/analyzer/types.ts` — DELETE the bugged `EntityFamily` alias (`'crm-synced' | 'activity' | 'knowledge' | 'metadata'` — wrong literal, missing `'base'`, plan Risk 5) and `family?` field; add `pattern`, `patterns`, `patternConfig`.
- `src/parser/load-entities.ts` — drop the `EntityFamily` cast that papered over the bug; map the three new fields.
- `src/analyzer/serialize-graph.ts` — serialized shape matches new schema.
- `src/cli/commands/entity.ts` — summary FAMILY column → PATTERN; `--family` filter → `--pattern`; new `summarizePatternLabel()` helper renders multi-pattern entities as `A+B`.
- `src/cli/shared/init-scaffold.ts` — scaffold YAML comment updated.

### Tools (2 files)
- `tools/schema-graph-viewer/src/adapters/{schema-adapter,serialize-domain-graph}.ts` — `SerializedEntity` surface matches new schema; graph-node grouping uses `pattern ?? patterns[0] ?? 'Base'`.

### Template bridge (1 file)
- `templates/entity/new/clean-lite-ps/prompt-extension.js` — reads `entity.pattern` / `entity.patterns[0]`, lowercases to index FAMILY_MAP. Commented as temporary — PATTERN-5 replaces FAMILY_MAP with a registry lookup.

### Fixtures (8 YAMLs) — every `family: <lower>` → `pattern: <Pascal>`
- `test/fixtures/{contact-v2,demo-deal}.yaml`
- `test/smoke/fixtures/{account,contact}.yaml`
- `test/scaffold/contact-scaffold.yaml`
- `examples/eav/{field_value,field_definition}.yaml`

### Tests (13 files)
- `src/__tests__/schema/schema-v2.test.ts` — rewritten pattern-surface tests: accepts single/multi/config, rejects legacy `family:`, rejects `pattern`+`patterns` together. 6 new assertions.
- `src/__tests__/clean-lite-ps/*.test.ts` × 10 — fixture values migrated mechanically; assertions on `locals.family` preserved (they verify the bridge output).
- `src/__tests__/clean-lite-ps/prompt-extension.test.ts` — fixture values + test descriptions updated.

### Pre-existing baseline runner fix (1 file — bundled with approval)
- `test/run-test.ts` adds `--mainHookInjected true` to the Hygen jobs baseline invocation. Without this, `templates/subsystem/jobs/main-hook.ejs.t`'s `skip_if: "<%= mainHookInjected %>"` header fails with `ReferenceError: mainHookInjected is not defined` during baseline regen. Pre-existing bug on `origin/main` (from PR #123 — template added, runner not taught about the flag). Flagged in #142's PR body.

## Baseline

**No regeneration required** — `test/baseline/` unchanged. `just test-baseline` passes **byte-identically** against the existing snapshot. The template bridge preserves output for all library patterns (Synced/Activity/Metadata/Base) because it produces the same lowercased family string that FAMILY_MAP still indexes on.

This has a downstream implication: PATTERN-5's integration gate ("`pattern: Synced` emits byte-identical output to pre-change `family: synced`") is **already met** for library patterns. PATTERN-5 becomes a pure internal refactor — swap FAMILY_MAP for registry lookup, add `patternConfig` emission, no observable output change expected.

## Gates

- `just test-unit`: **1028 pass, 0 fail** (was 1025 on main — net +3 from the rewritten schema-v2 suite).
- `bun run typecheck`: clean.
- `just test-baseline`: byte-identical pass against existing snapshot.

## Plan Risk 5 — EntityFamily type bug

Confirmed and fixed. Both the bugged type alias (`src/analyzer/types.ts:56`) and the papering cast (`src/parser/load-entities.ts:69`) are deleted in this PR.

## Scope boundaries honoured

- `clean/` (full Clean Architecture) pipeline untouched. Verified no `family` refs leaked into `templates/entity/new/backend/`.
- `runtime/base-classes/**` and `src/__tests__/runtime/**` keep their "family-specific methods" comments — they describe runtime classes, not the codegen YAML surface, and PATTERN-5 will address the template side.

## References

- Epic #75
- ADR-031 (#101)
- `docs/specs/app-defined-patterns-implementation.md` §2
- `docs/specs/PATTERNS-PHASE-1-PLAN.md` Risk 5 (EntityFamily bug — fixed here)
- Stacks on #142 (PATTERN-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)