### PR TITLE
feat(patterns): PATTERN-4 — composition validator + analyzeDomain wiring

### DIFF
--- a/src/__tests__/patterns/validate-composition.test.ts
+++ b/src/__tests__/patterns/validate-composition.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Unit tests for `validatePatternComposition` + `validatePatternProject`.
+ * Every row of the ADR-031 composition rules table has a dedicated case.
+ */
+
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { z } from 'zod';
+
+import type {
+	AnalysisIssue,
+	ParsedEntity,
+	ParsedField,
+} from '../../analyzer/types.ts';
+import {
+	_resetRegistryForTests,
+	registerLibraryPattern,
+} from '../../patterns/registry.ts';
+import {
+	validatePatternComposition,
+	validatePatternProject,
+} from '../../patterns/validate-composition.ts';
+
+// Ensure library patterns are pre-registered (side-effect on barrel import).
+import '../../patterns/index.ts';
+
+// Several describe blocks below register synthetic library patterns
+// (Prioritized, Ranked, MethodA, CrmEntity, etc.) via the `beforeEach` +
+// `registerLibraryPattern` dance. Once this file finishes, re-register
+// the canonical five library patterns so any test file that runs after
+// us in the same Bun process sees the unchanged library registry.
+import {
+	ActivityPattern,
+	BasePattern,
+	KnowledgePattern,
+	MetadataPattern,
+	SyncedPattern,
+} from '../../patterns/library/index.ts';
+
+afterAll(() => {
+	_resetRegistryForTests({ includeLibrary: true });
+	registerLibraryPattern(BasePattern);
+	registerLibraryPattern(SyncedPattern);
+	registerLibraryPattern(ActivityPattern);
+	registerLibraryPattern(KnowledgePattern);
+	registerLibraryPattern(MetadataPattern);
+});
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeEntity(partial: Partial<ParsedEntity> & { name: string }): ParsedEntity {
+	return {
+		name: partial.name,
+		plural: partial.plural ?? `${partial.name}s`,
+		table: partial.table ?? `${partial.name}s`,
+		pattern: partial.pattern,
+		patterns: partial.patterns,
+		patternConfig: partial.patternConfig,
+		folderStructure: 'nested',
+		fields: partial.fields ?? new Map<string, ParsedField>(),
+		relationships: new Map(),
+		behaviors: partial.behaviors ?? [],
+		queries: undefined,
+		sourcePath: `/fake/${partial.name}.yaml`,
+	};
+}
+
+function fieldMap(names: string[]): Map<string, ParsedField> {
+	const m = new Map<string, ParsedField>();
+	for (const n of names) {
+		m.set(n, {
+			name: n,
+			type: 'string',
+			required: false,
+			nullable: true,
+			unique: false,
+			index: false,
+			constraints: {},
+			ui: {},
+		});
+	}
+	return m;
+}
+
+function errors(issues: AnalysisIssue[]): AnalysisIssue[] {
+	return issues.filter((i) => i.severity === 'error');
+}
+
+function warnings(issues: AnalysisIssue[]): AnalysisIssue[] {
+	return issues.filter((i) => i.severity === 'warning');
+}
+
+// ============================================================================
+// Base case
+// ============================================================================
+
+describe('validatePatternComposition — base cases', () => {
+	test('entity with no patterns returns no issues', () => {
+		const entity = makeEntity({ name: 'plain' });
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+
+	test('library pattern Synced with no config is valid', () => {
+		const entity = makeEntity({ name: 'contact', pattern: 'Synced' });
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Row: pattern referenced in YAML but not in the registry → error
+// ============================================================================
+
+describe('validatePatternComposition — unknown pattern', () => {
+	test('single unknown pattern surfaces one error', () => {
+		const entity = makeEntity({ name: 'ghost', pattern: 'DoesNotExist' });
+		const issues = validatePatternComposition(entity);
+		const errs = errors(issues);
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_unknown');
+		expect(errs[0]!.entity).toBe('ghost');
+		expect(errs[0]!.message).toMatch(/Unknown pattern 'DoesNotExist'/);
+	});
+
+	test('unknown pattern in patterns[] surfaces per-name', () => {
+		const entity = makeEntity({
+			name: 'ghost',
+			patterns: ['Synced', 'DoesNotExist', 'AlsoMissing'],
+		});
+		const errs = errors(validatePatternComposition(entity));
+		const unknownTypes = errs.filter((e) => e.type === 'pattern_unknown');
+		expect(unknownTypes.length).toBe(2);
+		expect(unknownTypes.map((e) => e.message)).toEqual([
+			expect.stringMatching(/DoesNotExist/) as unknown as string,
+			expect.stringMatching(/AlsoMissing/) as unknown as string,
+		]);
+	});
+});
+
+// ============================================================================
+// Row: column conflict between two patterns → error
+// ============================================================================
+
+describe('validatePatternComposition — column conflicts', () => {
+	beforeEach(() => {
+		_resetRegistryForTests();
+		// Register two synthetic patterns that both contribute `priority`.
+		registerLibraryPattern({
+			name: 'Prioritized',
+			columns: [{ name: 'priority', type: 'integer' }],
+		});
+		registerLibraryPattern({
+			name: 'Ranked',
+			columns: [
+				{ name: 'priority', type: 'integer' }, // same column name — should conflict
+				{ name: 'rank', type: 'integer' },
+			],
+		});
+		// Keep a conflict-free pattern too
+		registerLibraryPattern({
+			name: 'Flagged',
+			columns: [{ name: 'flag', type: 'boolean' }],
+		});
+	});
+
+	test('two patterns contributing the same column → error naming both', () => {
+		const entity = makeEntity({
+			name: 'item',
+			patterns: ['Prioritized', 'Ranked'],
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_column_conflict');
+		expect(errs[0]!.message).toMatch(/Pattern 'Ranked' contributes column 'priority'/);
+		expect(errs[0]!.message).toMatch(/pattern 'Prioritized'/);
+	});
+
+	test('pattern column conflicts with entity field → error', () => {
+		const entity = makeEntity({
+			name: 'item',
+			pattern: 'Prioritized',
+			fields: fieldMap(['priority']),
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_column_conflict');
+		expect(errs[0]!.message).toMatch(/conflicts with entity field 'priority'/);
+	});
+
+	test('pattern column conflicts with behavior field → error', () => {
+		// Register a pattern that collides with the `external_id_tracking`
+		// behavior's `external_id` field (which SyncedPattern implies).
+		registerLibraryPattern({
+			name: 'ExternalIdSquatter',
+			columns: [{ name: 'external_id', type: 'varchar(255)' }],
+		});
+		const entity = makeEntity({
+			name: 'item',
+			pattern: 'ExternalIdSquatter',
+			behaviors: ['external_id_tracking'],
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_column_conflict');
+		expect(errs[0]!.message).toMatch(/conflicts with behavior field 'external_id'/);
+	});
+
+	test('non-conflicting patterns compose cleanly', () => {
+		const entity = makeEntity({
+			name: 'item',
+			patterns: ['Prioritized', 'Flagged'],
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Row: same implied behavior across patterns → silent dedup (no error)
+// ============================================================================
+
+describe('validatePatternComposition — implied behavior dedup', () => {
+	beforeEach(() => {
+		_resetRegistryForTests();
+		registerLibraryPattern({
+			name: 'SyncedA',
+			repositoryClass: 'SyncedARepo',
+			impliedBehaviors: ['external_id_tracking'],
+		});
+		registerLibraryPattern({
+			name: 'SyncedB',
+			repositoryClass: 'SyncedBRepo',
+			impliedBehaviors: ['external_id_tracking'], // same implied behavior
+		});
+	});
+
+	test('two patterns implying the same behavior produce no issue', () => {
+		const entity = makeEntity({
+			name: 'x',
+			patterns: ['SyncedA', 'SyncedB'],
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Row: method-name conflict → NOT checked (ADR-031 delegates to TS)
+// ============================================================================
+
+describe('validatePatternComposition — method-name conflicts are NOT checked', () => {
+	beforeEach(() => {
+		_resetRegistryForTests();
+		registerLibraryPattern({
+			name: 'MethodA',
+			repositoryClass: 'AR',
+			repositoryInheritedMethods: ['findThing, countThing'],
+		});
+		registerLibraryPattern({
+			name: 'MethodB',
+			repositoryClass: 'BR',
+			repositoryInheritedMethods: ['findThing, save'], // overlapping method
+		});
+	});
+
+	test('overlapping method signatures produce no codegen error', () => {
+		const entity = makeEntity({
+			name: 'x',
+			patterns: ['MethodA', 'MethodB'],
+		});
+		// Per ADR-031 the TypeScript compiler catches this at the
+		// consumer. Codegen does not duplicate the check.
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Row: config: key for an unused pattern → warning
+// ============================================================================
+
+describe('validatePatternComposition — unused config keys', () => {
+	beforeEach(() => {
+		_resetRegistryForTests();
+		registerLibraryPattern({
+			name: 'Used',
+			repositoryClass: 'UsedRepo',
+		});
+	});
+
+	test('config block with a key for an undeclared pattern → warning', () => {
+		const entity = makeEntity({
+			name: 'x',
+			pattern: 'Used',
+			patternConfig: { Unused: { foo: 'bar' } },
+		});
+		const issues = validatePatternComposition(entity);
+		expect(errors(issues)).toEqual([]);
+		const warns = warnings(issues);
+		expect(warns.length).toBe(1);
+		expect(warns[0]!.type).toBe('pattern_config_unused');
+		expect(warns[0]!.message).toMatch(/'Unused'/);
+	});
+
+	test('config block keyed correctly for the declared pattern → no issues', () => {
+		const entity = makeEntity({
+			name: 'x',
+			pattern: 'Used',
+			patternConfig: { Used: { any: 'value' } },
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Row: pattern config fails its Zod schema → error
+// ============================================================================
+
+describe('validatePatternComposition — configSchema validation', () => {
+	beforeEach(() => {
+		_resetRegistryForTests();
+		registerLibraryPattern({
+			name: 'CrmEntity',
+			repositoryClass: 'CrmEntityRepository',
+			configSchema: z.object({ entityType: z.string() }),
+		});
+	});
+
+	test('valid config passes the configSchema', () => {
+		const entity = makeEntity({
+			name: 'opportunity',
+			pattern: 'CrmEntity',
+			patternConfig: { CrmEntity: { entityType: 'opportunity' } },
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+
+	test('missing required config field → error', () => {
+		const entity = makeEntity({
+			name: 'opportunity',
+			pattern: 'CrmEntity',
+			patternConfig: { CrmEntity: {} },
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_config_invalid');
+		expect(errs[0]!.message).toMatch(/entityType/);
+	});
+
+	test('wrong type in config → error', () => {
+		const entity = makeEntity({
+			name: 'opportunity',
+			pattern: 'CrmEntity',
+			patternConfig: { CrmEntity: { entityType: 42 as unknown as string } },
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_config_invalid');
+		expect(errs[0]!.message).toMatch(/entityType/);
+	});
+
+	test('patterns without configSchema accept any (or no) config', () => {
+		registerLibraryPattern({
+			name: 'NoConfig',
+			repositoryClass: 'NCR',
+		});
+		const entity = makeEntity({
+			name: 'x',
+			pattern: 'NoConfig',
+			patternConfig: { NoConfig: { anything: 'goes' } },
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Project-level — plan Risk 4
+// ============================================================================
+
+describe('validatePatternProject — clean-pipeline no-op warning', () => {
+	test('architecture: clean + entities with patterns → warning per entity', () => {
+		const entities = [
+			makeEntity({ name: 'a', pattern: 'Synced' }),
+			makeEntity({ name: 'b', patterns: ['Activity'] }),
+			makeEntity({ name: 'c' }), // no pattern — skipped
+		];
+		const issues = validatePatternProject({ entities, architecture: 'clean' });
+		expect(issues.length).toBe(2);
+		expect(issues.every((i) => i.severity === 'warning')).toBe(true);
+		expect(issues.every((i) => i.type === 'pattern_clean_pipeline_noop')).toBe(true);
+		expect(issues.map((i) => i.entity)).toEqual(['a', 'b']);
+	});
+
+	test('architecture: clean-lite-ps + entities with patterns → no warning', () => {
+		const entities = [makeEntity({ name: 'a', pattern: 'Synced' })];
+		const issues = validatePatternProject({
+			entities,
+			architecture: 'clean-lite-ps',
+		});
+		expect(issues).toEqual([]);
+	});
+
+	test('architecture omitted → no warning (analyzer-only mode)', () => {
+		const entities = [makeEntity({ name: 'a', pattern: 'Synced' })];
+		const issues = validatePatternProject({ entities });
+		expect(issues).toEqual([]);
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,15 +7,50 @@
 
 import { loadEntities, loadRelationships, resolveReferences, resolveRelationshipReferences } from './parser';
 import { buildDomainGraph, checkConsistency, computeStatistics } from './analyzer';
+import {
+	validatePatternComposition,
+	validatePatternProject,
+} from './patterns/validate-composition.js';
 import type { AnalysisResult, OutputFormat } from './analyzer/types';
 
 /**
- * Analyze a domain from entity and relationship YAML files
+ * Options for `analyzeDomain`. All fields are optional and additive — omitting
+ * them keeps the analyzer's behavior identical to pre-PATTERN-4 callers.
+ */
+export interface AnalyzeDomainOptions {
+	/**
+	 * Path to the relationships directory. Equivalent to the legacy second
+	 * positional argument — preserved for call-site compatibility.
+	 */
+	relationshipsDir?: string;
+	/**
+	 * Selected backend architecture from `codegen.config.yaml
+	 * generate.architecture`. When provided, enables the PATTERN-4 project-level
+	 * check (plan Risk 4) that warns when `pattern:` is declared but the
+	 * selected architecture does not yet consume patterns (e.g. `clean`).
+	 */
+	architecture?: string;
+}
+
+/**
+ * Analyze a domain from entity and relationship YAML files.
+ *
+ * The signature accepts either the legacy `(entitiesDir, relationshipsDir)`
+ * shape or the newer `(entitiesDir, options)` object form. Existing callers
+ * keep working unchanged; pattern-aware callers pass
+ * `{ architecture, relationshipsDir }` to opt into the Risk-4 project-level
+ * warning surface.
  */
 export async function analyzeDomain(
 	entitiesDir: string,
-	relationshipsDir?: string,
+	relationshipsOrOptions?: string | AnalyzeDomainOptions,
 ): Promise<AnalysisResult> {
+	const opts: AnalyzeDomainOptions =
+		typeof relationshipsOrOptions === 'string'
+			? { relationshipsDir: relationshipsOrOptions }
+			: relationshipsOrOptions ?? {};
+	const relationshipsDir = opts.relationshipsDir;
+
 	// Load and parse all entity files
 	const { entities, issues: loadIssues } = loadEntities(entitiesDir);
 
@@ -40,6 +75,18 @@ export async function analyzeDomain(
 	// Check consistency
 	const consistencyIssues = checkConsistency(graph);
 
+	// PATTERN-4 — pattern composition check. Runs AFTER resolveReferences()
+	// (per ADR-031 §3) so entity fields + behaviors are known; the
+	// per-entity validator detects column conflicts, unknown patterns, and
+	// config-schema failures, and the project-level validator covers plan
+	// Risk 4 (warn when `pattern:` is declared under an architecture that
+	// does not yet consume patterns).
+	const patternIssues = entities.flatMap((e) => validatePatternComposition(e));
+	const patternProjectIssues = validatePatternProject({
+		entities,
+		architecture: opts.architecture,
+	});
+
 	// Compute statistics
 	const statistics = computeStatistics(graph);
 
@@ -50,6 +97,8 @@ export async function analyzeDomain(
 		...resolveIssues,
 		...relResolveIssues,
 		...consistencyIssues,
+		...patternIssues,
+		...patternProjectIssues,
 	];
 
 	// Determine validity (only errors make it invalid)

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -27,6 +27,12 @@ export {
 	type LoadAppPatternsResult,
 } from './registry.js';
 
+export {
+	validatePatternComposition,
+	validatePatternProject,
+	type PatternProjectContext,
+} from './validate-composition.js';
+
 // Library pattern values — available for consumers that want to reference
 // them programmatically (rare, but cheap to export).
 export {

--- a/src/patterns/validate-composition.ts
+++ b/src/patterns/validate-composition.ts
@@ -1,0 +1,233 @@
+/**
+ * Pattern Composition Validator
+ *
+ * Enforces the ADR-031 composition rules against parsed entities:
+ *
+ *   | Case                                                       | Result                 |
+ *   |------------------------------------------------------------|------------------------|
+ *   | Column conflict between two patterns                       | error                  |
+ *   | Column conflict with entity field                          | error                  |
+ *   | Column conflict with a behavior field                      | error                  |
+ *   | Method-name conflict between patterns                      | (TS compile error)     |
+ *   | Same implied behavior across patterns                      | silent dedup           |
+ *   | Pattern referenced in YAML but not in the registry         | error                  |
+ *   | `config:` key for a pattern the entity is not using        | warning                |
+ *   | Pattern config fails its Zod schema                        | error                  |
+ *
+ * Method-name conflicts are explicitly **not** checked here — they surface as
+ * TypeScript compile errors at the consumer when the generated concrete
+ * class extends the base. Adding a codegen check would duplicate work
+ * the type system already does, so we stay silent on that row per ADR-031.
+ *
+ * Project-level validation (`validatePatternProject`) covers plan Risk 4:
+ * entities declaring `pattern:` while `generate.architecture: clean` is
+ * selected get a warning since the `clean` pipeline does not yet consume
+ * patterns. Additive Phase 3+ work per ADR.
+ *
+ * The shape mirrors `src/behaviors/index.ts:81–124` (`validateBehaviors`):
+ * a single pass that returns structured issues for `analyzeDomain()` to
+ * aggregate.
+ */
+
+import type { AnalysisIssue, ParsedEntity } from '../analyzer/types.js';
+import { resolveBehaviorFields } from '../behaviors/index.js';
+import { getPattern } from './registry.js';
+
+// ============================================================================
+// Per-entity validation
+// ============================================================================
+
+/**
+ * Validate pattern composition for a single entity. Returns an array of
+ * `AnalysisIssue` values suitable for concatenation into `analyzeDomain`'s
+ * aggregated issue list.
+ *
+ * Entities with no `pattern:` or `patterns:` declared return an empty
+ * array — pattern-free entities are a valid use case (plain `BaseRepository`
+ * fallback) and nothing below applies to them.
+ */
+export function validatePatternComposition(
+	entity: ParsedEntity,
+): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+
+	// Normalise `pattern:` (single) and `patterns:` (multi) into one list,
+	// preserving declaration order. `pattern` + `patterns` mutual exclusion
+	// is a schema-level check — by the time we get here, at most one shape
+	// is set.
+	const patternNames: string[] = entity.patterns ?? (entity.pattern ? [entity.pattern] : []);
+	if (patternNames.length === 0) return issues;
+
+	// Column-source tracker: maps column name → human-readable origin.
+	// Populated in priority order (entity fields > behavior fields >
+	// pattern contributions) so conflict messages name the *existing*
+	// contributor correctly.
+	const columnSources = new Map<string, string>();
+
+	for (const [name] of entity.fields) {
+		columnSources.set(name, `entity field '${name}'`);
+	}
+
+	// Behavior fields participate in conflict detection. Behaviors the
+	// entity has NOT already declared but that a pattern implies will be
+	// added below (silent dedup); conflicts against those show up when
+	// the pattern's columns are checked.
+	const behaviorFields = resolveBehaviorFields(entity.behaviors);
+	for (const bf of behaviorFields) {
+		const existing = columnSources.get(bf.name);
+		if (existing) {
+			// A behavior field colliding with an entity-declared field
+			// was already a codegen problem before patterns existed. We
+			// surface it here too so the composition check is the single
+			// authoritative pass for "column conflicts on this entity."
+			issues.push({
+				severity: 'error',
+				type: 'pattern_column_conflict',
+				entity: entity.name,
+				message:
+					`Behavior-contributed field '${bf.name}' conflicts with ${existing}.`,
+			});
+			continue;
+		}
+		columnSources.set(bf.name, `behavior field '${bf.name}'`);
+	}
+
+	// Track implied behaviors across all declared patterns so we can
+	// assert silent dedup rather than repeat issues — this also lets us
+	// return the deduped list for callers that want to thread it into
+	// template-locals later without re-walking.
+	const impliedBehaviors = new Set<string>(entity.behaviors);
+
+	for (const patternName of patternNames) {
+		const def = getPattern(patternName);
+
+		// Rule: pattern referenced in YAML but not in the registry
+		if (!def) {
+			issues.push({
+				severity: 'error',
+				type: 'pattern_unknown',
+				entity: entity.name,
+				message:
+					`Unknown pattern '${patternName}'. ` +
+					`Library patterns are pre-registered; app patterns are loaded from ` +
+					`globs in codegen.config.yaml 'patterns:' (default 'src/patterns/*.pattern.ts').`,
+			});
+			continue;
+		}
+
+		// Rule: pattern config must match the pattern's Zod schema
+		if (def.configSchema) {
+			const rawConfig = entity.patternConfig?.[patternName];
+			const result = def.configSchema.safeParse(rawConfig ?? {});
+			if (!result.success) {
+				const detail = result.error.issues
+					.map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+					.join(', ');
+				issues.push({
+					severity: 'error',
+					type: 'pattern_config_invalid',
+					entity: entity.name,
+					message:
+						`Pattern '${patternName}' config failed validation: ${detail}`,
+				});
+			}
+		}
+
+		// Rule: column contributions conflict with anything already in the
+		// column-sources table. The first column to claim a name wins; the
+		// second one reports the conflict naming both contributors.
+		for (const col of def.columns ?? []) {
+			const existing = columnSources.get(col.name);
+			if (existing) {
+				issues.push({
+					severity: 'error',
+					type: 'pattern_column_conflict',
+					entity: entity.name,
+					message:
+						`Pattern '${patternName}' contributes column '${col.name}' ` +
+						`which conflicts with ${existing}.`,
+				});
+				continue;
+			}
+			columnSources.set(col.name, `pattern '${patternName}'`);
+		}
+
+		// Silent dedup on implied behaviors — a pattern declaring a
+		// behavior the entity already has (or another pattern already
+		// contributed) is a no-op, not an error.
+		for (const b of def.impliedBehaviors ?? []) {
+			impliedBehaviors.add(b);
+		}
+	}
+
+	// Rule: `config:` key for a pattern not in the declared list → warning.
+	if (entity.patternConfig) {
+		const declared = new Set(patternNames);
+		for (const key of Object.keys(entity.patternConfig)) {
+			if (!declared.has(key)) {
+				issues.push({
+					severity: 'warning',
+					type: 'pattern_config_unused',
+					entity: entity.name,
+					message:
+						`Config block has key '${key}' but pattern '${key}' is not ` +
+						`declared in 'pattern:' or 'patterns:'. Remove the entry or ` +
+						`add the pattern.`,
+				});
+			}
+		}
+	}
+
+	return issues;
+}
+
+// ============================================================================
+// Project-level validation — plan Risk 4
+// ============================================================================
+
+export interface PatternProjectContext {
+	entities: ReadonlyArray<ParsedEntity>;
+	/**
+	 * Selected backend architecture from `codegen.config.yaml
+	 * generate.architecture`. `undefined` when the consumer is using the
+	 * library purely as an analyzer (no generation config loaded).
+	 */
+	architecture?: string;
+}
+
+/**
+ * Validate project-level invariants for patterns. Runs after
+ * `validatePatternComposition` has visited every entity, so we can
+ * assume per-entity errors have been surfaced.
+ *
+ * Today this only covers plan Risk 4: warn when patterns are declared
+ * but the selected architecture is `clean`, which does not yet consume
+ * them. A `clean` consumer with `pattern: Synced` is not broken — the
+ * `clean` pipeline ignores the key — but they see no effect, which is
+ * confusing without the warning.
+ */
+export function validatePatternProject(
+	ctx: PatternProjectContext,
+): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+
+	if (ctx.architecture === 'clean') {
+		const withPatterns = ctx.entities.filter(
+			(e) => (e.patterns && e.patterns.length > 0) || !!e.pattern,
+		);
+		for (const e of withPatterns) {
+			issues.push({
+				severity: 'warning',
+				type: 'pattern_clean_pipeline_noop',
+				entity: e.name,
+				message:
+					`'pattern:' is declared but 'generate.architecture: clean' does not ` +
+					`yet consume patterns. This declaration is a no-op. Patterns are ` +
+					`consumed by 'clean-lite-ps' today; 'clean' integration is Phase 3+ ` +
+					`additive work (ADR-031).`,
+			});
+		}
+	}
+
+	return issues;
+}


### PR DESCRIPTION
Closes #140. Part of Epic #75. Stacks on #143.

## Summary

Implements the ADR-031 composition validator and wires it into `analyzeDomain`. Also includes the project-level `clean` pipeline no-op warning (plan Risk 4).

## New

- `src/patterns/validate-composition.ts`
  - `validatePatternComposition(entity)` — per-entity check covering every row of the ADR-031 composition rules table.
  - `validatePatternProject({ entities, architecture })` — project-level check for the Risk 4 warning.

## Wired

- `src/index.ts` — `analyzeDomain` now accepts an options object `{ relationshipsDir?, architecture? }` while preserving the legacy `(entitiesDir, relationshipsDir)` positional form. The per-entity validator runs after `resolveReferences()` per ADR-031 §3; the project-level validator runs once. Issues flow through the standard `AnalysisResult.issues` pipeline.
- `src/patterns/index.ts` — barrel now exports `validatePatternComposition`, `validatePatternProject`, and the `PatternProjectContext` type.

## Rules enforced (ADR-031 table)

| Rule | Result | Tested |
|------|--------|--------|
| Column conflict between two patterns | error | yes |
| Pattern column conflicts with entity field | error | yes |
| Pattern column conflicts with behavior field | error | yes |
| Method-name conflict between patterns | TS compile error at consumer | yes (asserts NO codegen error) |
| Same implied behavior across patterns | silent dedup | yes |
| Pattern referenced but not in registry | error | yes (single + list) |
| `config:` key for unused pattern | warning | yes |
| Pattern config fails Zod schema | error | yes (missing field + wrong type) |

## Plan Risk 4

| Scenario | Result | Tested |
|----------|--------|--------|
| `architecture: clean` + entities with patterns | warning per entity | yes |
| `architecture: clean-lite-ps` + entities with patterns | no warning | yes |
| `architecture` omitted (analyzer-only mode) | no warning | yes |

## Tests

19 new unit tests in `src/__tests__/patterns/validate-composition.test.ts`. Synthetic library patterns registered inside the file are cleaned up via `afterAll` that clears the registry and re-registers the canonical five — prevents cross-file contamination in the Bun test runner.

## Gates

- `just test-unit`: **1047 pass, 0 fail** (was 1028 — +19 from this PR)
- `bun run typecheck`: clean
- `just test-baseline`: clean (byte-identical to existing snapshot)

## Scope

- 4 files, +695 / -2
- No template, schema, or parser changes (those are done or deferred to PATTERN-5).
- `clean` pipeline untouched except for the project-level warning surface.

## References

- Epic #75
- ADR-031 (#101) §3 — composition rules table
- `docs/specs/app-defined-patterns-implementation.md` §4
- `docs/specs/PATTERNS-PHASE-1-PLAN.md` Risk 4
- Stacks on #143 (PATTERN-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)