### PR TITLE
feat(patterns): PATTERN-5 — registry-driven templates + patternConfig emission

### DIFF
--- a/.claude/skills/codegen/SKILL.md
+++ b/.claude/skills/codegen/SKILL.md
@@ -88,7 +88,7 @@ codegen project graph --output graph.json   # export graph JSON
 ```
 
 `codegen init` scaffolds the consumer's shared layer (as of PR #55):
-- `src/shared/base-classes/*` — family bases with optional `tx?: DrizzleTx` on writes
+- `src/shared/base-classes/*` — pattern bases (Base / Synced / Activity / Knowledge / Metadata) with optional `tx?: DrizzleTx` on writes
 - `src/shared/constants/tokens.ts` — `DRIZZLE` DI symbol
 - `src/shared/types/drizzle.ts` — `DrizzleClient` + `DrizzleTx` type aliases
 - `src/shared/http/zod-validation.pipe.ts` — runtime Zod validation on `@Body()`
@@ -123,7 +123,7 @@ entity:
   name: contact                          # singular snake_case
   plural: contacts
   table: contacts
-  family: synced                         # synced | activity | metadata | knowledge | base
+  pattern: Synced                        # Synced | Activity | Metadata | Knowledge | Base (or app-defined)
 
 fields:
   email:
@@ -235,7 +235,7 @@ As of PR #54, generated controllers:
 
 Aligned with codegen-patterns ADR-003 + ADR-004:
 
-- **Repository** — single table. Extends a family base class. No business logic. Accepts optional `tx` on writes.
+- **Repository** — single table. Extends a pattern base class (library or app-defined, per ADR-031). No business logic. Accepts optional `tx` on writes.
 - **Service** — aggregate. Composes repositories. May read any repo cross-domain. May call same-domain services. **May NOT write cross-domain.** Mandatory API boundary.
 - **Use Case** — workflow. Composes multiple services (including cross-domain). Owns the transaction for cross-domain writes. Emits events, calls external ports.
 - **Controller** — thin adapter. Calls use cases only.

--- a/.claude/specs/a15-nestjs-scaffold.md
+++ b/.claude/specs/a15-nestjs-scaffold.md
@@ -332,7 +332,7 @@ Note: Exact versions should match what is already used in the repo root `package
 
 The implementer should confirm which approach avoids changing codegen source, and document the decision in a comment in `database.module.ts`.
 
-**contact-v2.yaml behaviors:** `contact-v2.yaml` includes `external_id_tracking` behavior and `family: crm-synced`. If the codegen does not yet handle these (they may be v2-only schema additions), the scaffold test should use a stripped-down entity YAML that exercises only what codegen currently supports. Document this in a comment at the top of `validate.sh`.
+**contact-v2.yaml behaviors:** `contact-v2.yaml` includes `external_id_tracking` behavior and `pattern: Synced` (previously `family: crm-synced` before ADR-031). If the codegen does not yet handle these (they may be v2-only schema additions), the scaffold test should use a stripped-down entity YAML that exercises only what codegen currently supports. Document this in a comment at the top of `validate.sh`.
 
 **No auth, no guards:** The scaffold controller must be reachable without authentication. Verify the generated controller does not apply `@UseGuards(AuthGuard)` — that pattern appears in Electric SQL controllers, not plain REST. If guards are present, they must be disabled or overridden in the scaffold AppModule.
 

--- a/.claude/specs/a6-clean-lite-ps-templates.md
+++ b/.claude/specs/a6-clean-lite-ps-templates.md
@@ -1,9 +1,21 @@
 # Spec A6 — Clean-Lite-PS Template Set
 
-**Status:** Approved for implementation
+**Status:** Shipped. Post-implementation note added 2026-04-21 below.
 **Issue:** A6
-**Related ADRs:** ADR-002, ADR-003, ADR-005
+**Related ADRs:** ADR-002, ADR-003, ~~ADR-005~~ → superseded by [ADR-031](../../docs/adrs/ADR-031-app-defined-patterns.md)
 **Reference output:** `docs/architecture/sketches/contact-module-sketch.md`
+
+> **Post-implementation revision (2026-04-21, PATTERN-5):** this spec was
+> written when the YAML surface was `family: synced | activity | ...` and
+> the base-class choice was driven by a hard-coded `FAMILY_MAP` in
+> `templates/entity/new/clean-lite-ps/prompt-extension.js`. That surface has
+> been replaced by the pattern registry per ADR-031. Read occurrences of
+> "family" below as "library pattern name (lowercase)" and occurrences of
+> `entity.family` as `entity.pattern` (single) or `entity.patterns[0]`
+> (multi). The five library patterns (Base / Synced / Activity / Knowledge
+> / Metadata) are pre-registered; consumer-defined patterns are discovered
+> via `codegen.config.yaml patterns:` globs. See the "App-defined patterns"
+> section of `docs/CONSUMER-SETUP.md` for authoring details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ entity:
   name: contact
   plural: contacts
   table: contacts
-  family: synced                    # synced | activity | metadata | knowledge
+  pattern: Synced                   # Synced | Activity | Metadata | Knowledge | Base (or app-defined)
 
 fields:
   email:
@@ -123,8 +123,8 @@ modules/                           NestJS module wiring
 ```
 modules/{plural}/
   {entity}.entity.ts               Drizzle table + types
-  {entity}.repository.ts           Extends family base class
-  {entity}.service.ts              Extends family base service
+  {entity}.repository.ts           Extends pattern base class
+  {entity}.service.ts              Extends pattern base service
   {entity}.controller.ts           REST endpoints
   {plural}.module.ts               NestJS module
   dto/                             Create, Update, Output DTOs
@@ -203,7 +203,7 @@ src/                        Generator source code
   formatters/               Console, JSON, markdown output
   __tests__/                Unit tests (mirrors src/ structure)
 runtime/                    Code shipped into consumer projects
-  base-classes/             BaseRepository, BaseService, family bases
+  base-classes/             BaseRepository, BaseService, pattern bases
   subsystems/               Events, Jobs, Cache, Storage
 templates/                  Hygen EJS templates
 test/                       Baseline snapshots, scaffold integration, smoke test

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -665,6 +665,118 @@ database:
 
 `paths.generated` must sit inside your `tsconfig.json` `"include"` globs — otherwise TS won't typecheck the barrel.
 
+## App-defined patterns
+
+`pattern:` in entity YAML selects a base-class bundle (repository + service + implied columns + implied behaviors + per-entity config schema) that the generated concrete class extends. See [ADR-031](./adrs/ADR-031-app-defined-patterns.md) for the binding decisions.
+
+### Library-shipped patterns
+
+The codegen package pre-registers five patterns. Consumers never list these in `codegen.config.yaml`:
+
+| Pattern | Repository class | Notes |
+|---------|-----------------|-------|
+| `Base` | `BaseRepository` | Identity pattern — base CRUD only |
+| `Synced` | `SyncedEntityRepository` | Adds `external_id` / `provider` / `provider_metadata` + syncUpsert |
+| `Activity` | `ActivityEntityRepository` | Time-bounded interaction entities (notes, calls, meetings) |
+| `Knowledge` | `KnowledgeEntityRepository` | Long-form content with workflow status + semantic search |
+| `Metadata` | `MetadataEntityRepository` | History-tracked auxiliary rows |
+
+Declare one in entity YAML:
+
+```yaml
+entity:
+  name: opportunity
+  pattern: Synced
+behaviors:
+  - timestamps
+  - soft_delete
+```
+
+### App-defined patterns
+
+Consumers who need a domain abstraction beyond the library set (e.g. a `CrmEntity` bundling EAV routing + canonical field mapping) write their own `*.pattern.ts` file:
+
+```ts
+// src/patterns/crm-entity.pattern.ts
+import { definePattern } from '@pattern-stack/codegen';
+import { z } from 'zod';
+
+export const CrmEntityPattern = definePattern({
+  name: 'CrmEntity',
+  extends: ['Synced'],
+  repositoryClass: 'CrmEntityRepository',
+  serviceClass: 'CrmEntityService',
+  repositoryImport: '@/patterns/crm-entity.pattern',
+  serviceImport: '@/patterns/crm-entity.pattern',
+  configSchema: z.object({ entityType: z.string() }),
+  description: 'CRM entity with EAV dual-write + canonical field routing',
+});
+```
+
+Discovery is via globs in `codegen.config.yaml`:
+
+```yaml
+# codegen.config.yaml
+patterns:
+  - src/patterns/*.pattern.ts          # default when `patterns:` is absent
+  - vendor/internal-patterns/*.pattern.ts
+```
+
+Use it in entity YAML:
+
+```yaml
+entity:
+  name: opportunity
+  pattern: CrmEntity
+  config:
+    CrmEntity:
+      entityType: opportunity
+```
+
+The generated concrete class emits `protected override readonly patternConfig = { entityType: 'opportunity' } as const;` for the pattern's base class to read. No reflection; identical shape to `behaviors: BehaviorConfig`.
+
+### tsconfig alias requirement
+
+App-defined patterns reference their hand-written base classes via path aliases (`@/patterns/crm-entity.pattern`). Codegen emits the string verbatim into the generated `import` — resolution is the consumer's `tsconfig.json` responsibility. Add your alias alongside the others:
+
+```jsonc
+{
+  "compilerOptions": {
+    "paths": {
+      "@shared/*": ["./shared/*"],
+      "@modules/*": ["./modules/*"],
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+If the alias is missing, TypeScript compile of the generated code fails at import resolution — the codegen step itself does not verify the path resolves on the consumer side.
+
+### Composition (multi-pattern)
+
+Two or more patterns combine via `patterns:`:
+
+```yaml
+entity:
+  name: deal
+  patterns: [CrmEntity, Event]
+  config:
+    CrmEntity: { entityType: opportunity }
+    Event:
+      states:
+        qualifying: [developing, closed_lost]
+      initial_state: qualifying
+```
+
+The **first** pattern in the list wins the base-class selection. Subsequent patterns contribute columns + implied behaviors. Column-name conflicts, unknown pattern names, and invalid `config:` blocks are caught at codegen time with a hard error; `config:` keys for undeclared patterns and `pattern:` declarations under `generate.architecture: clean` produce warnings.
+
+### Caveats (Phase 1)
+
+- **Single-depth `extends` chain only.** A pattern may `extends: ['Synced']` but transitive resolution of `CrmEntity extends Synced extends Base` is deferred.
+- **`clean` pipeline no-op.** The full Clean Architecture backend (`generate.architecture: clean`) does not yet consume `pattern:`. Use `generate.architecture: clean-lite-ps` for pattern-driven emission.
+- **Method-name conflicts are caught by TypeScript**, not codegen. Two patterns declaring methods with the same signature surface as a compile error at the consumer class, not a codegen validation error.
+
 ## EAV dual-write — opt-in per entity
 
 Two YAML flags light up the EAV (entity-attribute-value) surface. Both default to `false` — entities that don't declare them get the non-EAV shape unchanged.
@@ -677,7 +789,7 @@ Declare this on the entity that has a dynamic `fields` bag alongside its core co
 # entities/opportunity.yaml
 entity:
   name: opportunity
-  family: synced
+  pattern: Synced
 eav: true
 fields:
   name:
@@ -702,7 +814,7 @@ Declare this on the entity that IS the value table (e.g. `field_value`). Paired 
 # entities/field_value.yaml
 entity:
   name: field_value
-  family: metadata
+  pattern: Metadata
 eav_value_table: true
 eav_definition_table: field_definition
 fields:
@@ -805,5 +917,5 @@ It shouldn't — that's a bug. File an issue. The only files codegen writes are 
 
 - [ADR-017 — Barrel Files over Hygen Injects](./adrs/ADR-017-barrel-files-over-injects.md) — why `@shared/*` exists and why codegen never mutates your files
 - [ADR-015 — CLI Command Architecture](./adrs/ADR-015-cli-command-architecture.md) — install forms and the noun-verb interface
-- [ADR-005 — Entity Family Base Classes](./adrs/ADR-005-entity-family-base-classes.md) — which family shim you need per entity
+- [ADR-031 — App-Defined Patterns](./adrs/ADR-031-app-defined-patterns.md) — `pattern:` / `patterns:` / `config:` surface; supersedes the legacy ADR-005 `family:` enum
 - [GETTING-STARTED.md](./GETTING-STARTED.md) — entity YAML authoring and the generator lifecycle

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -233,7 +233,7 @@ This guide covers working inside the `codegen-patterns` repo. To use the generat
 
 ## Next Steps
 
-- **Entity families** — assign `family: synced` (or `activity`, `metadata`, `knowledge`) in your YAML to inherit domain-specific query patterns. See [ADR-005](architecture/adrs/ADR-005-entity-family-base-classes.md).
+- **Patterns** — assign `pattern: Synced` (or `Activity`, `Metadata`, `Knowledge`) in your YAML to inherit the matching library base class (repository + service + query shape). Consumers can also define their own patterns — see [ADR-031](adrs/ADR-031-app-defined-patterns.md) and the "App-defined patterns" section of [CONSUMER-SETUP.md](CONSUMER-SETUP.md#app-defined-patterns).
 - **Declarative queries** — the `queries:` block generates typed repository methods with compound filters and ordering. No hand-written SQL.
 - **Subsystem architecture** — events, jobs, cache, and storage follow the Protocol/Backend/Factory pattern. See [ADR-008](architecture/adrs/ADR-008-subsystem-architecture.md).
 - **Claude Code skill** — run `just install-skill /path/to/my-app` to teach Claude Code how to generate entities in your project.

--- a/docs/specs/JOB-7.md
+++ b/docs/specs/JOB-7.md
@@ -84,10 +84,12 @@ export interface ParsedEntity {
 ### Parser population (`src/parser/load-entities.ts`)
 
 ```typescript
-// inside transformToEntity, next to `family`:
+// inside transformToEntity, next to the pattern surface:
 const entity: ParsedEntity = {
   // ... existing ...
-  family: definition.entity.family,
+  pattern: definition.entity.pattern,
+  patterns: definition.entity.patterns,
+  patternConfig: definition.entity.config,
   scopeable: definition.entity.scopeable ?? false,   // ← ADD
   // ... rest ...
 };
@@ -167,7 +169,7 @@ import type { ScopeEntityType } from '../../../subsystems/jobs/generated/scope-e
 
 ## Implementation Steps
 
-1. **Extend `EntityConfigSchema`** — add `scopeable: z.boolean().optional()` after `family`. `.strict()` stays.
+1. **Extend `EntityConfigSchema`** — add `scopeable: z.boolean().optional()` after the `pattern:` surface (ADR-031). `.strict()` stays.
 2. **Extend `ParsedEntity`** — add `scopeable?: boolean`.
 3. **Populate in parser** — `scopeable: definition.entity.scopeable ?? false` in `transformToEntity`.
 4. **Create generator** — `scope-entity-type-generator.ts` with `collectScopeableNames`, `buildScopeEntityTypeContent`, `generateScopeEntityType`. Match `barrel-generator.ts` style (HEADER constant, `mkdirSync`, same dry-run semantics).

--- a/docs/specs/app-defined-patterns-implementation.md
+++ b/docs/specs/app-defined-patterns-implementation.md
@@ -7,6 +7,11 @@
 **Scope:** codegen-patterns library changes — Phase 1 only. First consumer integration (dealbrain-v2 `CrmEntityPattern`) is Phase 2.
 
 > **Living-document note (2026-04-19):** This spec was originally drafted before the understand phase examined the existing codebase. Three earlier proposals (a `family:` deprecation alias with `console.warn`, a `generate.patterns` opt-in feature flag, and a `static readonly patternConfig` runtime accessor) contradicted both CLAUDE.md ("no backwards compatibility until users") and the existing `behaviors: BehaviorConfig` instance-property convention in `templates/entity/new/clean-lite-ps/repository.ejs.t`. ADR-031 documents the resolution; this spec was rewritten in the same commit to reflect the final shape.
+>
+> **Post-implementation revision (2026-04-21, PATTERN-5):** every file listed in §7 shipped. Three details discovered during implementation and worth pinning here:
+> 1. **Baseline regen was not required.** PATTERN-3's template bridge (single-line change in `prompt-extension.js` that lowercased `entity.pattern` to index the legacy FAMILY_MAP) produces byte-identical output for all library patterns. PATTERN-5's registry swap preserved that property, so `just test-baseline` passes against the unmodified `test/baseline/` snapshot. The integration gate from `PATTERNS-PHASE-1-PLAN.md` ("byte-identical output for an unchanged fixture") is met transitively through PATTERN-3.
+> 2. **`renderPatternConfigLiteral()` helper added to prompt-extension.js.** The spec's §6 example shows `patternConfig = { entityType: 'opportunity' } as const;` with bare identifier keys and single-quoted strings. A naive `JSON.stringify(patternConfig, null, 2)` emits `{"entityType": "opportunity"}` — valid TS but not idiomatic and brittle under consumer linters. The helper emits the ADR's style directly; unit-tested in `src/__tests__/clean-lite-ps/prompt-extension.test.ts`.
+> 3. **`analyzeDomain()` signature widened non-breakingly.** To plumb `generate.architecture` into the PATTERN-4 project-level warning (clean-pipeline no-op), the second positional argument now accepts either a relationships-dir string (legacy) or an options object `{ relationshipsDir?, architecture? }`. Existing callers (CLI `entity validate`, `project graph`) keep working; pattern-aware callers opt in via the object form.
 
 ---
 

--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -84,7 +84,7 @@ describe('buildCleanLitePsLocals', () => {
   it('maps Synced pattern to SyncedEntityRepository and SyncedEntityService', () => {
     const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
 
-    expect(locals.family).toBe('synced');
+    expect(locals.patternName).toBe('Synced');
     expect(locals.repositoryBaseClass).toBe('SyncedEntityRepository');
     expect(locals.serviceBaseClass).toBe('SyncedEntityService');
     expect(locals.repositoryBaseImport).toBe('@shared/base-classes/synced-entity-repository');
@@ -94,7 +94,7 @@ describe('buildCleanLitePsLocals', () => {
   it('maps Activity pattern to ActivityEntityRepository and ActivityEntityService', () => {
     const locals = buildCleanLitePsLocals(activityDefinition, EMPTY_BASE_LOCALS);
 
-    expect(locals.family).toBe('activity');
+    expect(locals.patternName).toBe('Activity');
     expect(locals.repositoryBaseClass).toBe('ActivityEntityRepository');
     expect(locals.serviceBaseClass).toBe('ActivityEntityService');
     expect(locals.repositoryBaseImport).toBe('@shared/base-classes/activity-entity-repository');
@@ -104,7 +104,7 @@ describe('buildCleanLitePsLocals', () => {
   it('defaults to base when pattern key is absent', () => {
     const locals = buildCleanLitePsLocals(noFamilyDefinition, EMPTY_BASE_LOCALS);
 
-    expect(locals.family).toBe('base');
+    expect(locals.patternName).toBe('Base');
     expect(locals.repositoryBaseClass).toBe('BaseRepository');
     expect(locals.serviceBaseClass).toBe('BaseService');
     expect(locals.repositoryBaseImport).toBe('@shared/base-classes/base-repository');
@@ -372,4 +372,205 @@ describe('buildCleanLitePsLocals', () => {
 
     expect(locals.clpOutputPaths.entity).toStartWith('src/');
   });
+});
+
+
+// ============================================================================
+// PATTERN-5 — registry-driven resolution + patternConfig emission
+// ============================================================================
+
+import { registerLibraryPattern, _resetRegistryForTests } from '../../patterns/registry.ts';
+import { z } from 'zod';
+import {
+  ActivityPattern,
+  BasePattern,
+  KnowledgePattern,
+  MetadataPattern,
+  SyncedPattern,
+} from '../../patterns/library/index.ts';
+
+describe('buildCleanLitePsLocals — PATTERN-5 registry integration', () => {
+  it('exposes `patternName` verbatim from the pattern registry', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+    expect(locals.patternName).toBe('Synced');
+  });
+
+  it('first entry of `patterns:` wins the base-class resolution', () => {
+    const def = {
+      entity: {
+        name: 'deal',
+        plural: 'deals',
+        table: 'deals',
+        patterns: ['Synced', 'Activity'],
+      },
+      fields: {},
+      relationships: {},
+      behaviors: ['timestamps'],
+    };
+    const locals = buildCleanLitePsLocals(def, EMPTY_BASE_LOCALS);
+    expect(locals.patternName).toBe('Synced');
+    expect(locals.repositoryBaseClass).toBe('SyncedEntityRepository');
+  });
+
+  it('hasPatternConfig is false for patterns that declare no config', () => {
+    const locals = buildCleanLitePsLocals(contactDefinition, EMPTY_BASE_LOCALS);
+    expect(locals.hasPatternConfig).toBe(false);
+    expect(locals.patternConfig).toBeNull();
+  });
+
+  it('hasPatternConfig is true + patternConfig populated when YAML supplies a config block', () => {
+    // Register a synthetic pattern with a configSchema to drive the test.
+    registerLibraryPattern({
+      name: 'CrmEntityTest',
+      repositoryClass: 'CrmEntityRepository',
+      repositoryImport: '@/patterns/crm-entity.pattern',
+      serviceClass: 'CrmEntityService',
+      serviceImport: '@/patterns/crm-entity.pattern',
+      repositoryInheritedMethods: [],
+      serviceInheritedMethods: [],
+      configSchema: z.object({ entityType: z.string() }),
+    });
+
+    const def = {
+      entity: {
+        name: 'opportunity',
+        plural: 'opportunities',
+        table: 'opportunities',
+        pattern: 'CrmEntityTest',
+      },
+      fields: {},
+      relationships: {},
+      behaviors: [],
+      config: { CrmEntityTest: { entityType: 'opportunity' } },
+    };
+    const locals = buildCleanLitePsLocals(def, EMPTY_BASE_LOCALS);
+    expect(locals.hasPatternConfig).toBe(true);
+    expect(locals.patternConfig).toEqual({ entityType: 'opportunity' });
+    expect(locals.repositoryBaseClass).toBe('CrmEntityRepository');
+    expect(locals.repositoryBaseImport).toBe('@/patterns/crm-entity.pattern');
+    expect(locals.patternName).toBe('CrmEntityTest');
+  });
+
+  it('base-class output is byte-identical to the pre-PATTERN-5 FAMILY_MAP for library patterns', () => {
+    // This test nails down the PATTERN-5 integration gate: the values
+    // returned for library patterns must match what the old FAMILY_MAP
+    // produced. Any future library-pattern edit that drifts the strings
+    // will fail here, which is the desired alarm.
+    const want = {
+      synced: {
+        repositoryBaseClass: 'SyncedEntityRepository',
+        serviceBaseClass: 'SyncedEntityService',
+        repositoryBaseImport: '@shared/base-classes/synced-entity-repository',
+        serviceBaseImport: '@shared/base-classes/synced-entity-service',
+      },
+      activity: {
+        repositoryBaseClass: 'ActivityEntityRepository',
+        serviceBaseClass: 'ActivityEntityService',
+        repositoryBaseImport: '@shared/base-classes/activity-entity-repository',
+        serviceBaseImport: '@shared/base-classes/activity-entity-service',
+      },
+      metadata: {
+        repositoryBaseClass: 'MetadataEntityRepository',
+        serviceBaseClass: 'MetadataEntityService',
+        repositoryBaseImport: '@shared/base-classes/metadata-entity-repository',
+        serviceBaseImport: '@shared/base-classes/metadata-entity-service',
+      },
+      knowledge: {
+        repositoryBaseClass: 'KnowledgeEntityRepository',
+        serviceBaseClass: 'KnowledgeEntityService',
+        repositoryBaseImport: '@shared/base-classes/knowledge-entity-repository',
+        serviceBaseImport: '@shared/base-classes/knowledge-entity-service',
+      },
+      base: {
+        repositoryBaseClass: 'BaseRepository',
+        serviceBaseClass: 'BaseService',
+        repositoryBaseImport: '@shared/base-classes/base-repository',
+        serviceBaseImport: '@shared/base-classes/base-service',
+      },
+    } as const;
+
+    for (const [lowerName, expected] of Object.entries(want)) {
+      const pascal = lowerName.charAt(0).toUpperCase() + lowerName.slice(1);
+      const def = {
+        entity: { name: 't', plural: 'ts', table: 'ts', pattern: pascal },
+        fields: {},
+        relationships: {},
+        behaviors: [],
+      };
+      const locals = buildCleanLitePsLocals(def, EMPTY_BASE_LOCALS);
+      expect(locals.repositoryBaseClass).toBe(expected.repositoryBaseClass);
+      expect(locals.serviceBaseClass).toBe(expected.serviceBaseClass);
+      expect(locals.repositoryBaseImport).toBe(expected.repositoryBaseImport);
+      expect(locals.serviceBaseImport).toBe(expected.serviceBaseImport);
+      expect(locals.patternName).toBe(pascal);
+    }
+  });
+});
+
+describe('renderPatternConfigLiteral — idiomatic TS literal emission', () => {
+  // Import the helper through the same extension barrel the templates do.
+  const mod = require('../../../templates/entity/new/clean-lite-ps/prompt-extension.js') as {
+    buildCleanLitePsLocals: typeof buildCleanLitePsLocals;
+  };
+  // The helper is exposed via the locals object; grab it by rendering a
+  // throwaway entity.
+  const sampleLocals = mod.buildCleanLitePsLocals(
+    {
+      entity: { name: 'x', plural: 'xs', table: 'xs', pattern: 'Base' },
+      fields: {},
+      relationships: {},
+      behaviors: [],
+    },
+    {},
+  ) as { renderPatternConfigLiteral: (v: unknown) => string };
+  const render = sampleLocals.renderPatternConfigLiteral;
+
+  it('emits bare identifier keys + single-quoted strings', () => {
+    expect(render({ entityType: 'opportunity' })).toBe(
+      "{\n  entityType: 'opportunity',\n}",
+    );
+  });
+
+  it('quotes keys that are not valid identifiers', () => {
+    expect(render({ 'with-dash': 1 })).toBe("{\n  'with-dash': 1,\n}");
+  });
+
+  it('handles nested objects', () => {
+    expect(
+      render({
+        states: { qualifying: ['developing', 'closed_lost'] },
+        initial_state: 'qualifying',
+      }),
+    ).toBe(
+      "{\n  states: {\n    qualifying: [\n      'developing',\n      'closed_lost',\n    ],\n  },\n  initial_state: 'qualifying',\n}",
+    );
+  });
+
+  it('handles numbers, booleans, and nulls without quotes', () => {
+    expect(render({ count: 3, active: true, note: null })).toBe(
+      "{\n  count: 3,\n  active: true,\n  note: null,\n}",
+    );
+  });
+
+  it('emits empty objects and arrays compactly', () => {
+    expect(render({})).toBe('{}');
+    expect(render({ arr: [] })).toBe("{\n  arr: [],\n}");
+  });
+
+  it('escapes single quotes within string values', () => {
+    expect(render({ note: "it's" })).toBe("{\n  note: 'it\\'s',\n}");
+  });
+});
+
+// Restore the canonical library registry after this file runs — several
+// library patterns were registered above via `registerLibraryPattern` which
+// would otherwise leak into the next test file in the Bun process.
+import { afterAll as _afterAllForCleanup } from 'bun:test';
+_afterAllForCleanup(() => {
+  _resetRegistryForTests({ includeLibrary: true });
+  registerLibraryPattern(BasePattern);
+  registerLibraryPattern(SyncedPattern);
+  registerLibraryPattern(ActivityPattern);
+  registerLibraryPattern(KnowledgePattern);
+  registerLibraryPattern(MetadataPattern);
 });

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -11,8 +11,10 @@ import path from 'node:path';
 import yaml from 'yaml';
 import {
   GenerateConfigSchema,
+  PatternsConfigSchema,
   PipelinesConfigSchema,
   type GenerateConfig,
+  type PatternsConfig,
   type PipelinesConfig,
 } from '../schema/pipelines-config.schema.js';
 
@@ -27,6 +29,12 @@ import {
 export interface ProjectConfig {
   pipelines?: PipelinesConfig;
   generate?: GenerateConfig;
+  /**
+   * Array of globs (relative to project root) that `loadAppPatterns()`
+   * expands to discover app-defined patterns (ADR-031, PATTERN-5).
+   * Absent ⇒ defaults to `['src/patterns/*.pattern.ts']`.
+   */
+  patterns?: PatternsConfig;
   [key: string]: unknown;
 }
 
@@ -78,6 +86,22 @@ function loadProjectConfig(cwd = process.cwd()): ProjectConfig | null {
       console.warn(
         `Warning: codegen.config.yaml has an invalid "generate" block:\n` +
           generateResult.error.issues
+            .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+            .join('\n')
+      );
+    }
+
+    // Validate the patterns block (always — we want the default glob applied
+    // even when the key is absent).
+    const rawPatterns =
+      raw && typeof raw === 'object' && 'patterns' in raw ? raw.patterns : undefined;
+    const patternsResult = PatternsConfigSchema.safeParse(rawPatterns);
+    if (patternsResult.success) {
+      raw.patterns = patternsResult.data;
+    } else {
+      console.warn(
+        `Warning: codegen.config.yaml has an invalid "patterns" block:\n` +
+          patternsResult.error.issues
             .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
             .join('\n')
       );

--- a/src/schema/pipelines-config.schema.ts
+++ b/src/schema/pipelines-config.schema.ts
@@ -192,6 +192,33 @@ export const PipelinesConfigSchema = z.object({
 export type PipelinesConfig = z.infer<typeof PipelinesConfigSchema>;
 
 // ============================================================================
+// Patterns Config (ADR-031, PATTERN-5)
+// ============================================================================
+
+/**
+ * Patterns manifest — array of globs, relative to project root, that
+ * `loadAppPatterns()` expands and dynamic-imports to discover app-defined
+ * patterns. Library-shipped patterns (Base / Synced / Activity / Knowledge
+ * / Metadata) are pre-registered by the codegen package; consumers never
+ * list them.
+ *
+ * Default (when the key is absent): `['src/patterns/*.pattern.ts']`.
+ *
+ * Example:
+ * ```yaml
+ * patterns:
+ *   - src/patterns/*.pattern.ts
+ *   - vendor/internal-patterns/*.pattern.ts
+ * ```
+ */
+export const PatternsConfigSchema = z
+  .array(z.string())
+  .optional()
+  .default(['src/patterns/*.pattern.ts']);
+
+export type PatternsConfig = z.infer<typeof PatternsConfigSchema>;
+
+// ============================================================================
 // Validation Helpers
 // ============================================================================
 

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -6,81 +6,102 @@
  */
 
 import pluralizePkg from 'pluralize';
+// The patterns barrel has the side effect of pre-registering the five
+// library-shipped patterns (Base / Synced / Activity / Knowledge /
+// Metadata). App-defined patterns are loaded separately in the parent
+// prompt.js via loadAppPatterns() against `codegen.config.yaml patterns:`
+// globs before this helper runs — we only read the registry here.
+import { getPattern } from '../../../../src/patterns/registry.js';
+import '../../../../src/patterns/library/index.js';
 
 // ============================================================================
-// Family → Base Class Mapping
+// Pattern registry resolution
 // ============================================================================
 
-const FAMILY_MAP = {
-  'synced': {
-    repositoryBaseClass: 'SyncedEntityRepository',
-    serviceBaseClass: 'SyncedEntityService',
-    repositoryBaseImport: '@shared/base-classes/synced-entity-repository',
-    serviceBaseImport: '@shared/base-classes/synced-entity-service',
-    repositoryInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-      'findByExternalId, findAllByUserId, findVisibleByUserId, syncUpsert',
-    ],
-    serviceInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete',
-      'findByExternalId, findAllByUserId, findVisibleByUserId',
-    ],
-  },
-  activity: {
-    repositoryBaseClass: 'ActivityEntityRepository',
-    serviceBaseClass: 'ActivityEntityService',
-    repositoryBaseImport: '@shared/base-classes/activity-entity-repository',
-    serviceBaseImport: '@shared/base-classes/activity-entity-service',
-    repositoryInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-      'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
-    ],
-    serviceInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete',
-      'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
-    ],
-  },
-  knowledge: {
-    repositoryBaseClass: 'KnowledgeEntityRepository',
-    serviceBaseClass: 'KnowledgeEntityService',
-    repositoryBaseImport: '@shared/base-classes/knowledge-entity-repository',
-    serviceBaseImport: '@shared/base-classes/knowledge-entity-service',
-    repositoryInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-      'semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch',
-    ],
-    serviceInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete',
-      'semanticSearch, findPendingByOpportunityId, updateStatus, updateStatusBatch',
-    ],
-  },
-  metadata: {
-    repositoryBaseClass: 'MetadataEntityRepository',
-    serviceBaseClass: 'MetadataEntityService',
-    repositoryBaseImport: '@shared/base-classes/metadata-entity-repository',
-    serviceBaseImport: '@shared/base-classes/metadata-entity-service',
-    repositoryInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-      'findByEntityIdAndType, listByEntityId, listHistoryByEntityId',
-    ],
-    serviceInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete',
-      'findByEntityIdAndType, listByEntityId, listHistoryByEntityId',
-    ],
-  },
-  base: {
-    repositoryBaseClass: 'BaseRepository',
-    serviceBaseClass: 'BaseService',
-    repositoryBaseImport: '@shared/base-classes/base-repository',
-    serviceBaseImport: '@shared/base-classes/base-service',
-    repositoryInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-    ],
-    serviceInheritedMethods: [
-      'findById, findByIds, list, count, exists, create, update, delete',
-    ],
-  },
-};
+
+/**
+ * Serialize a plain object as an idiomatic TypeScript object literal.
+ * Unlike JSON.stringify, this emits bare identifier keys when legal
+ * (matching the ADR-031 §4 example) and single-quoted strings. Only
+ * the shapes that actually appear in validated pattern configs are
+ * supported — strings, numbers, booleans, nulls, nested objects, and
+ * arrays of the same. Anything else falls through to JSON.stringify
+ * to stay safe.
+ */
+function renderPatternConfigLiteral(value, indent = '  ', initialIndent = '') {
+  // `currentIndent` is the indent applied to the closing brace of the
+  // outermost value; nested lines add one more level of `indent`.
+  // Templates that emit this helper inside an already-indented block
+  // (e.g. a class body indented by 2 spaces) should pass the block's
+  // indent as `initialIndent` so the closing brace and child lines line
+  // up correctly with the surrounding code.
+  return _renderLiteral(value, indent, initialIndent);
+}
+
+function _renderLiteral(value, baseIndent, currentIndent) {
+  if (value === null) return 'null';
+  if (typeof value === 'string') {
+    // Single-quoted TS string with \\ + ' escapes. Matches ADR-031 example style.
+    return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]';
+    const next = currentIndent + baseIndent;
+    const items = value.map((v) => `${next}${_renderLiteral(v, baseIndent, next)}`);
+    return `[\n${items.join(',\n')},\n${currentIndent}]`;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value);
+    if (entries.length === 0) return '{}';
+    const next = currentIndent + baseIndent;
+    const lines = entries.map(([k, v]) => {
+      const key = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k) ? k : `'${k}'`;
+      return `${next}${key}: ${_renderLiteral(v, baseIndent, next)}`;
+    });
+    return `{\n${lines.join(',\n')},\n${currentIndent}}`;
+  }
+  // Anything else — fall back to a safe JSON serialization.
+  return JSON.stringify(value);
+}
+
+/**
+ * Resolve the base-class locals (repository + service class name + import
+ * path + inherited-method comment lines) for an entity by looking up its
+ * declared pattern in the shared registry.
+ *
+ * Resolution order:
+ *   1. `entity.pattern` — single-pattern case. Returns that pattern's record.
+ *   2. `entity.patterns[0]` — multi-pattern case: the first name drives the
+ *      base-class choice. Subsequent patterns contribute columns + implied
+ *      behaviors (PATTERN-4 composition check) but do not change the
+ *      template's repository/service base class.
+ *   3. `'Base'` fallback — library pattern that anchors the identity case.
+ *
+ * Exported for unit-testing; consumers import `buildCleanLitePsLocals`.
+ */
+export function resolvePatternBaseClasses(entity) {
+  const name =
+    (typeof entity.pattern === 'string' && entity.pattern) ||
+    (Array.isArray(entity.patterns) && entity.patterns[0]) ||
+    'Base';
+  const def = getPattern(name) || getPattern('Base');
+  if (!def) {
+    throw new Error(
+      `Pattern '${name}' is not registered, and the library 'Base' pattern ` +
+      `is also missing. Did the patterns barrel fail to load?`,
+    );
+  }
+  return {
+    patternName: def.name,
+    repositoryBaseClass: def.repositoryClass,
+    serviceBaseClass: def.serviceClass,
+    repositoryBaseImport: def.repositoryImport,
+    serviceBaseImport: def.serviceImport,
+    repositoryInheritedMethods: def.repositoryInheritedMethods ?? [],
+    serviceInheritedMethods: def.serviceInheritedMethods ?? [],
+  };
+}
 
 // ============================================================================
 // Helper utilities
@@ -658,27 +679,38 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     ? pascalCase(eavDefinitionEntityPlural)
     : null;
 
-  // Pattern resolution.
+  // Pattern resolution — registry-driven (ADR-031, PATTERN-5).
   //
-  // PATTERN-3 bridge (temporary): we still drive the template off the
-  // legacy lowercased family key, but the YAML surface is now `pattern:`
-  // (single) or `patterns:` (multi). PATTERN-5 replaces this block with a
-  // registry lookup via `src/patterns/registry.ts` and retires FAMILY_MAP.
-  //
-  // Resolution order:
-  //   1. `entity.pattern` — single-pattern case, lowercase the value to
-  //      index into FAMILY_MAP (e.g. 'Synced' -> 'synced').
-  //   2. `entity.patterns[0]` — multi-pattern case: the *first* name wins
-  //      for base-class selection, subsequent patterns will contribute
-  //      columns/behaviors (PATTERN-4 composition) but do not change the
-  //      template's repository/service base class choice.
-  //   3. 'base' — no pattern declared.
-  const patternName =
-    (typeof entity.pattern === 'string' && entity.pattern) ||
-    (Array.isArray(entity.patterns) && entity.patterns[0]) ||
+  // The prior PATTERN-3 bridge that lowercased the pattern name to index
+  // FAMILY_MAP is gone; the registry returns the canonical record. The
+  // shape returned by `resolvePatternBaseClasses` matches the legacy
+  // FAMILY_MAP entries verbatim for the five library patterns so the
+  // emitted output is byte-identical.
+  const patternBase = resolvePatternBaseClasses(entity);
+  const { patternName } = patternBase;
+  // FAMILY_MAP is gone (PATTERN-5); `patternConfigClasses` is the structural
+  // equivalent — repository + service class names + import paths + inherited
+  // method comment lists, sourced directly from the pattern registry.
+  const patternConfigClasses = {
+    repositoryBaseClass: patternBase.repositoryBaseClass,
+    serviceBaseClass: patternBase.serviceBaseClass,
+    repositoryBaseImport: patternBase.repositoryBaseImport,
+    serviceBaseImport: patternBase.serviceBaseImport,
+    repositoryInheritedMethods: patternBase.repositoryInheritedMethods,
+    serviceInheritedMethods: patternBase.serviceInheritedMethods,
+  };
+  // Per-entity pattern config: resolve the matching block from
+  // `config: { <PatternName>: {...} }`. When the pattern has no
+  // configSchema OR the entity doesn't provide one, this stays null and
+  // templates emit no `patternConfig` property.
+  const patternConfigBlock =
+    (definition.config && definition.config[patternName]) ||
+    (definition.entity && definition.entity.config && definition.entity.config[patternName]) ||
     null;
-  const family = patternName ? String(patternName).toLowerCase() : 'base';
-  const familyConfig = FAMILY_MAP[family] || FAMILY_MAP['base'];
+  const hasPatternConfig =
+    patternConfigBlock != null &&
+    typeof patternConfigBlock === 'object' &&
+    Object.keys(patternConfigBlock).length > 0;
 
   // Process entity fields
   const processedFields = processFields(fields);
@@ -888,9 +920,12 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     drizzleTokenImport,
     drizzleTypeImport,
 
-    // Family
-    family,
-    ...familyConfig,
+    // Pattern — registry-driven (ADR-031)
+    patternName,
+    hasPatternConfig,
+    patternConfig: patternConfigBlock,
+    renderPatternConfigLiteral,
+    ...patternConfigClasses,
 
     // Behavior flags (also exposed at top level for template use)
     hasTimestamps,

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -30,6 +30,14 @@ export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%=
     userTracking: <%= !!hasUserTracking %>,
   };
 <% } -%>
+<% if (hasPatternConfig) { -%>
+
+  // Per-entity `<%= patternName %>` pattern config (from YAML `config:` block).
+  // The pattern's base class declares `protected readonly patternConfig: TConfig`
+  // typed via its `configSchema`; this concrete record is read by the base at
+  // runtime (identical shape to `behaviors: BehaviorConfig`).
+  protected override readonly patternConfig = <%- renderPatternConfigLiteral(patternConfig, '  ', '  ') %> as const;
+<% } -%>
 
   constructor(@Inject(DRIZZLE) db: DrizzleClient) {
     super(db);

--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -23,6 +23,13 @@ export class <%= classNames.service %> extends WithAnalytics(
   <%= serviceBaseClass %><<%= classNames.repository %>, <%= classNames.entity %>>,
 ) {
   protected override readonly entityName = '<%= entityName %>';
+<% if (hasPatternConfig) { -%>
+
+  // Per-entity `<%= patternName %>` pattern config (from YAML `config:` block).
+  // Mirrors the repository-side emission; the pattern's base service reads
+  // `this.patternConfig` directly.
+  protected override readonly patternConfig = <%- renderPatternConfigLiteral(patternConfig, '  ', '  ') %> as const;
+<% } -%>
 
   /** Injected by NestJS when EventsModule is registered. */
   @Optional() @Inject(EVENT_BUS)

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -221,6 +221,56 @@ function resolveBehaviors(behaviorConfigs) {
   };
 }
 
+
+// ============================================================================
+// Patterns — subprocess-local registry load (PATTERN-5)
+// ============================================================================
+//
+// The Hygen subprocess has no shared memory with the CLI process, so the
+// pattern registry is rebuilt here from scratch. Library patterns register
+// themselves as a side effect of importing the barrel; app-defined patterns
+// are loaded from `codegen.config.yaml patterns:` globs (default
+// `src/patterns/*.pattern.ts`). Both loads are deterministic and
+// side-effect-free — the registry determinism test in
+// `src/__tests__/patterns/registry.test.ts` pins down that the CLI and the
+// subprocess produce identical sorted results for the same file set.
+
+let _patternsLoadPromise = null;
+
+async function ensurePatternsRegistryLoaded() {
+  if (!_patternsLoadPromise) {
+    _patternsLoadPromise = (async () => {
+      // Side-effect import: pre-registers the five library patterns.
+      await import('../../../src/patterns/library/index.js');
+      const { loadAppPatterns } = await import('../../../src/patterns/registry.js');
+
+      // Read the `patterns:` manifest from codegen.config.yaml. Defaults
+      // to a single sensible glob when the key is absent — matches the
+      // ADR-031 default discovery shape.
+      const configPath = path.resolve(process.cwd(), 'codegen.config.yaml');
+      let manifest = ['src/patterns/*.pattern.ts'];
+      if (fs.existsSync(configPath)) {
+        try {
+          const parsed = yaml.parse(fs.readFileSync(configPath, 'utf-8'));
+          if (Array.isArray(parsed?.patterns)) {
+            manifest = parsed.patterns;
+          }
+        } catch {
+          // fall through with the default manifest; a malformed
+          // codegen.config.yaml is already surfaced by the CLI's config
+          // loader elsewhere.
+        }
+      }
+      const result = await loadAppPatterns(manifest, process.cwd());
+      for (const err of result.errors) {
+        // eslint-disable-next-line no-console
+        console.warn(`[codegen] ${err}`);
+      }
+    })();
+  }
+  return _patternsLoadPromise;
+}
+
 export default {
   prompt: async ({ args }) => {
     const yamlPath = args.yaml;
@@ -962,29 +1012,6 @@ export default {
     const frontendEnabled = generateConfig.frontend === true;
 
     // ============================================================================
-    // v2: Family
-    // ============================================================================
-
-    const FAMILY_REPOSITORY_MAP = {
-      'synced': 'SyncedEntityRepository',
-      'activity': 'ActivityEntityRepository',
-      'knowledge': 'KnowledgeEntityRepository',
-      'metadata': 'MetadataEntityRepository',
-    };
-
-    const FAMILY_SERVICE_MAP = {
-      'synced': 'SyncedEntityService',
-      'activity': 'ActivityEntityService',
-      'knowledge': 'KnowledgeEntityService',
-      'metadata': 'MetadataEntityService',
-    };
-
-    const family = entity.family ?? null;
-    const hasFamily = family != null;
-    const familyBaseRepository = family ? (FAMILY_REPOSITORY_MAP[family] ?? null) : null;
-    const familyBaseService = family ? (FAMILY_SERVICE_MAP[family] ?? null) : null;
-
-    // ============================================================================
     // v2: Queries
     // ============================================================================
 
@@ -1533,12 +1560,6 @@ export default {
       isCleanLitePs,
       frontendEnabled,
 
-      // Family
-      family,
-      hasFamily,
-      familyBaseRepository,
-      familyBaseService,
-
       // Queries
       hasQueries,
       processedQueries,
@@ -1582,6 +1603,12 @@ export default {
     // read the same locals to render typed publish blocks in their use-cases.
 
     if (isCleanLitePs) {
+      // Load app-defined patterns (if any) into the registry before the
+      // clean-lite-ps extension reads it. `loadAppPatterns` is idempotent
+      // and deterministic — calling it every run is cheap (one dynamic
+      // import per pattern file) and matches the two-process load story
+      // the registry tests pin down.
+      await ensurePatternsRegistryLoaded();
       const { buildCleanLitePsLocals } = await import('./clean-lite-ps/prompt-extension.js');
       Object.assign(locals, buildCleanLitePsLocals(definition, locals));
     } else {
@@ -1621,6 +1648,14 @@ export default {
         hasSearchQuery: false,
         searchQuery: null,
         hasExternalIdTracking: false,
+        // PATTERN-5 stubs — defined even for non-CLP architectures so the
+        // CLP template bodies render without `ReferenceError`s. The
+        // to:/skip_if: guards prevent file writes, but EJS still walks the
+        // body on every template.
+        patternName: 'Base',
+        hasPatternConfig: false,
+        patternConfig: null,
+        renderPatternConfigLiteral: () => '{}',
       });
     }
 


### PR DESCRIPTION
Closes #141. Final PR of the Phase 1 stack (Epic #75). Stacks on #144.

## Integration gate — PASSED

`just test-baseline` is **byte-identical** against the existing `test/baseline/` snapshot (121 files, zero diffs). The locked gate from #141 is met:

> End-to-end check: `pattern: Synced` emits byte-identical output to pre-change `family: synced` for an unchanged fixture.

## Summary

FAMILY_MAP is gone. Every clean-lite-ps template now resolves its base-class choice through the pattern registry. Entities that declare a `config:` block for a pattern with a `configSchema` emit `protected override readonly patternConfig = {...} as const;` on the generated repository + service (ADR-031 §4).

## Diff (15 files, +610 / -142)

### Templates (4)
- `prompt-extension.js` — FAMILY_MAP deleted; `resolvePatternBaseClasses(entity)` calls `getPattern()`; `renderPatternConfigLiteral()` helper emits idiomatic TS literals (not JSON-style — matches ADR-031 §4). No `family` alias — templates/tests consume `patternName` directly.
- `prompt.js` — dead `FAMILY_*_MAP` removed; `ensurePatternsRegistryLoaded()` added (library self-register + `loadAppPatterns()` against `codegen.config.yaml patterns:` globs).
- `repository.ejs.t` + `service.ejs.t` — emit `patternConfig` when the entity's YAML supplies one.

### Schema + config (2)
- `PatternsConfigSchema` added (default `['src/patterns/*.pattern.ts']`).
- `ProjectConfig.patterns?: PatternsConfig` + loader validation.

### Tests (1 file, +11 cases)
- `src/__tests__/clean-lite-ps/prompt-extension.test.ts`:
  - 5 PATTERN-5 registry cases (patternName exposure, patterns[0] wins, hasPatternConfig toggles, CrmEntity end-to-end, **byte-identical regression** against pre-PATTERN-5 FAMILY_MAP values).
  - 6 `renderPatternConfigLiteral` cases (bare identifier keys, quoted non-identifier keys, nested objects, numbers/booleans/nulls, empty collections, single-quote escaping).
  - `afterAll` cleanup prevents cross-file registry contamination.

### Docs (7 — living documentation rule)
- `docs/CONSUMER-SETUP.md` — new "App-defined patterns" section: library table, `definePattern()` authoring, manifest globs, **tsconfig path-alias requirement (plan Risk 2)**, composition rules, Phase 1 caveats.
- `docs/GETTING-STARTED.md`, `README.md`, `.claude/skills/codegen/SKILL.md` — family → pattern swaps.
- `.claude/specs/a6-clean-lite-ps-templates.md` — prominent post-impl revision note at top with ADR-031 redirect.
- `.claude/specs/a15-nestjs-scaffold.md`, `docs/specs/JOB-7.md` — one-line updates.
- `docs/specs/app-defined-patterns-implementation.md` — post-implementation revision note (no baseline regen needed, `renderPatternConfigLiteral`, widened `analyzeDomain` signature).

## Amendment per coordinator feedback

Original draft left a `family` lowercased alias on `locals` as a "transitional" surface. Removed cleanly per CLAUDE.md "no backwards compatibility until users":
- Alias deleted from `prompt-extension.js` (both the local and the return-object entry).
- 5 test assertions migrated from `locals.family` → `locals.patternName` (with PascalCase expected values to match the registry's canonical form).
- One loop iterator variable renamed `family` → `lowerName` for clarity.
- Verified: zero EJS templates read `locals.family`; it was confined to prompt-extension.js internals + test assertions. Clean removal.

## Gates

- `just test-unit`: **1058 pass, 0 fail** (was 1047 on main — +11 from this PR).
- `bun run typecheck`: clean.
- `just test-baseline`: byte-identical to existing snapshot. Integration gate PASSED.

## Locked decisions honoured

- `patternConfig` is instance `protected override readonly` (ADR-031 §4).
- `clean-lite-ps` pipeline only. `templates/entity/new/backend/` untouched.
- Single-depth `extends` chain preserved.
- Library patterns pre-registered; consumers do not list them.
- Discovery via globs with `src/patterns/*.pattern.ts` default.

## Phase 1 complete after this merge

- #142 PATTERN-2 (primitive + registry + 5 library patterns)
- #143 PATTERN-3 (delete family, add pattern/patterns/config)
- #144 PATTERN-4 (composition validator + analyzeDomain wiring)
- #141 this PR — PATTERN-5 (templates + patternConfig + docs)

Epic #75 ready to close.

## References

- Epic #75
- ADR-031 (#101)
- `docs/specs/app-defined-patterns-implementation.md` §5+§6+§7
- `docs/specs/PATTERNS-PHASE-1-PLAN.md` (final PR of the 5-PR stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)