### PR TITLE
SYNC-1 — Drizzle audit schema (sync_subscriptions, sync_runs, sync_run_items)

### DIFF
--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -1,8 +1,12 @@
 /**
  * Sync subsystem — public API
  *
- * SYNC-2 slice (protocols + tokens only). Backends, orchestrator, and module
- * land in SYNC-3..SYNC-6. See epic #60 for the full plan.
+ * Slices landed so far:
+ *   - SYNC-2 — protocols + DI tokens (#134)
+ *   - SYNC-1 — Drizzle audit-table schemas (this slice)
+ *
+ * Backends (SYNC-3/4), orchestrator (SYNC-5), and module (SYNC-6) land in
+ * their own PRs. See epic #60 for the full plan.
  */
 
 // Protocols
@@ -34,3 +38,20 @@ export {
   SYNC_MULTI_TENANT,
   SYNC_SINK,
 } from './sync.tokens';
+
+// Audit schemas (SYNC-1) — Drizzle pgTable declarations + row types + enums
+export {
+  syncSubscriptions,
+  syncRuns,
+  syncRunItems,
+  syncRunDirectionEnum,
+  syncRunActionEnum,
+  syncRunStatusEnum,
+  syncRunItemOperationEnum,
+  syncRunItemStatusEnum,
+} from './sync-audit.schema';
+export type {
+  SyncSubscriptionRow,
+  SyncRunRow,
+  SyncRunItemRow,
+} from './sync-audit.schema';

--- a/runtime/subsystems/sync/sync-audit.schema.ts
+++ b/runtime/subsystems/sync/sync-audit.schema.ts
@@ -1,0 +1,300 @@
+/**
+ * Drizzle schema for the sync subsystem audit/observability tables (SYNC-1).
+ *
+ * Three tables model end-to-end sync observability, keyed by the single port
+ * every sync adapter implements (`IChangeSource<T>` from SYNC-2):
+ *
+ *   - `sync_subscriptions` — owns the cursor per
+ *       `(integration_id, adapter, domain, external_ref)` tuple. Addressed
+ *       by id by `ICursorStore` (SYNC-3/SYNC-4).
+ *   - `sync_runs`          — per-run audit log: start/complete, status,
+ *       cursor before/after, counts, direction (inbound|outbound),
+ *       action (poll|cdc|webhook|manual|writeback).
+ *   - `sync_run_items`     — per-record change log with structured
+ *       `changed_fields` jsonb enforced by the Zod `FieldDiffSchema`
+ *       contract (ADR-0003; protocol lives in SYNC-2's
+ *       sync-field-diff.protocol.ts).
+ *
+ * Design calls (vs. issue #126 open questions):
+ *
+ *   - `sync_subscriptions` ships in the subsystem (not consumer-owned).
+ *     Rationale: SYNC-4's `PostgresCursorStore` needs to read/write this
+ *     table directly; making it consumer-owned would require consumers to
+ *     hand-wire a shape the backend already knows. The row is addressable
+ *     by id and scoped by the uniqueness tuple; consumers can still
+ *     query/list it freely. Same stance as `job_run` being subsystem-
+ *     owned while remaining consumer-queryable.
+ *
+ *   - `tenant_id` is always emitted on the three tables as nullable text.
+ *     The `SYNC_MULTI_TENANT` DI flag (SYNC-6) is what enforces the
+ *     non-null + cross-tenant-isolation contract at the service/orchestrator
+ *     boundary. This mirrors JOB-1/JOB-8's final shape — runtime guard, not
+ *     a scaffold-time conditional column. Keeps the schema file uniform
+ *     across single-tenant and multi-tenant deployments.
+ *
+ *   - `changed_fields` on `sync_run_items` is typed via the Zod-inferred
+ *     `FieldDiff` shape from SYNC-2 (`{ [fieldName]: { from, to } }`). The
+ *     recorder service (SYNC-5) validates every write against
+ *     `FieldDiffSchema.parse` so consumers can rely on the shape.
+ */
+import {
+  pgEnum,
+  pgTable,
+  uuid,
+  text,
+  jsonb,
+  integer,
+  boolean,
+  timestamp,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import type { InferSelectModel } from 'drizzle-orm';
+
+import type { FieldDiff } from './sync-field-diff.protocol';
+
+// ─── Enums ──────────────────────────────────────────────────────────────────
+
+/**
+ * Direction of a sync run relative to local state.
+ *
+ *   - `inbound`  — external → local (the common case: SFDC poll → local DB).
+ *   - `outbound` — local → external (writeback; deferred per epic but the
+ *     column shape is reserved so future writeback runs share the audit log).
+ */
+export const syncRunDirectionEnum = pgEnum('sync_run_direction', [
+  'inbound',
+  'outbound',
+]);
+
+/**
+ * How the run detected upstream changes. Maps 1:1 to the `Change.source`
+ * provenance on inbound runs; `manual` captures operator-triggered re-syncs
+ * and `writeback` captures outbound runs.
+ */
+export const syncRunActionEnum = pgEnum('sync_run_action', [
+  'poll',
+  'cdc',
+  'webhook',
+  'manual',
+  'writeback',
+]);
+
+/**
+ * Lifecycle status of a sync run.
+ *
+ *   - `running`     — in-flight; recorder has started but not completed.
+ *   - `success`     — completed with at least one change processed.
+ *   - `no_changes`  — completed cleanly, no upstream changes found.
+ *   - `failed`      — errored before completion; `error` column carries the
+ *     message. `records_processed` may be non-zero (partial progress).
+ */
+export const syncRunStatusEnum = pgEnum('sync_run_status', [
+  'running',
+  'success',
+  'no_changes',
+  'failed',
+]);
+
+/**
+ * Operation applied per record. Mirrors `Change<T>.operation` from SYNC-2,
+ * plus the recorder's own `'noop'` for changes that matched existing state.
+ */
+export const syncRunItemOperationEnum = pgEnum('sync_run_item_operation', [
+  'created',
+  'updated',
+  'deleted',
+  'noop',
+]);
+
+/**
+ * Per-record status within a run. `skipped` captures loopback-detected echoes
+ * of the local system's own writes (see `ILoopbackFingerprintStore` in the
+ * epic), which record the external_id but intentionally do not touch local
+ * state.
+ */
+export const syncRunItemStatusEnum = pgEnum('sync_run_item_status', [
+  'success',
+  'failed',
+  'skipped',
+]);
+
+// ─── sync_subscriptions ─────────────────────────────────────────────────────
+
+/**
+ * One cursor owner per (integration, adapter, domain, external_ref).
+ *
+ *   - `integration_id` — opaque id of the connected account/instance. E.g.
+ *     the SFDC org id for polling strategies, the GitHub installation id
+ *     for webhook strategies.
+ *   - `adapter`        — short adapter label, e.g. `'salesforce'`, `'hubspot'`.
+ *   - `domain`         — canonical entity domain this subscription tracks,
+ *     e.g. `'opportunity'`, `'contact'`.
+ *   - `external_ref`   — optional upstream scope (e.g. a filter id, a
+ *     webhook subscription id). NULL when the subscription covers the
+ *     entire domain.
+ *
+ * The cursor shape is opaque jsonb — strategies type it internally (poll:
+ * `{ systemModstamp }`, cdc: `{ replayId }`, webhook: `{ ts }`). Overwritten
+ * by `ICursorStore.put(id, cursor)`.
+ */
+export const syncSubscriptions = pgTable(
+  'sync_subscriptions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    integrationId: text('integration_id').notNull(),
+    adapter: text('adapter').notNull(),
+    domain: text('domain').notNull(),
+    externalRef: text('external_ref'),
+    enabled: boolean('enabled').notNull().default(true),
+    /**
+     * Per-subscription configuration bag. Strategies type it internally;
+     * e.g. polling strategies stash `{ batchSize, highWatermark }` here.
+     */
+    config: jsonb('config').notNull().default({}).$type<Record<string, unknown>>(),
+    /**
+     * Opaque cursor persisted by `ICursorStore.put()`. NULL until the first
+     * successful run advances it.
+     */
+    cursor: jsonb('cursor').$type<unknown>(),
+    lastSyncAt: timestamp('last_sync_at', { withTimezone: true }),
+    /** Runtime-enforced when `SYNC_MULTI_TENANT` is true; see SYNC-6. */
+    tenantId: text('tenant_id'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    /**
+     * Composite uniqueness per the epic shape. `external_ref` is nullable;
+     * Postgres treats NULLs as distinct in a UNIQUE constraint, which means
+     * two rows with the same `(integration_id, adapter, domain)` and NULL
+     * external_ref are allowed. That's intentional — a subscription with
+     * NULL external_ref covers the full domain, and duplicates there would
+     * be a consumer-layer modeling issue, not a schema concern.
+     */
+    uqSyncSubscriptionTuple: uniqueIndex('uq_sync_subscriptions_tuple').on(
+      t.integrationId,
+      t.adapter,
+      t.domain,
+      t.externalRef,
+    ),
+    /** Scheduling query: list enabled subscriptions ordered by staleness. */
+    idxSyncSubscriptionsEnabledLastSync: index(
+      'idx_sync_subscriptions_enabled_last_sync',
+    ).on(t.enabled, t.lastSyncAt),
+  }),
+);
+
+export type SyncSubscriptionRow = InferSelectModel<typeof syncSubscriptions>;
+
+// ─── sync_runs ──────────────────────────────────────────────────────────────
+
+/**
+ * One row per invocation of `ExecuteSyncUseCase`. `started_at` is set when
+ * the recorder opens the run; `completed_at`, `status`, `records_*`,
+ * `cursor_after`, and `duration_ms` are filled on completion.
+ *
+ * `cursor_before` / `cursor_after` carry the opaque cursor snapshots so the
+ * run log is fully self-describing — given a run id, an operator can reason
+ * about exactly what window was scanned without cross-referencing another
+ * table.
+ */
+export const syncRuns = pgTable(
+  'sync_runs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    subscriptionId: uuid('subscription_id')
+      .notNull()
+      .references(() => syncSubscriptions.id, { onDelete: 'cascade' }),
+    direction: syncRunDirectionEnum('direction').notNull(),
+    action: syncRunActionEnum('action').notNull(),
+    status: syncRunStatusEnum('status').notNull().default('running'),
+    recordsFound: integer('records_found').notNull().default(0),
+    recordsProcessed: integer('records_processed').notNull().default(0),
+    cursorBefore: jsonb('cursor_before').$type<unknown>(),
+    cursorAfter: jsonb('cursor_after').$type<unknown>(),
+    durationMs: integer('duration_ms'),
+    error: text('error'),
+    startedAt: timestamp('started_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    /** Runtime-enforced when `SYNC_MULTI_TENANT` is true; see SYNC-6. */
+    tenantId: text('tenant_id'),
+  },
+  (t) => ({
+    /** Timeline read: "most recent runs for this subscription". */
+    idxSyncRunsSubscriptionStartedAt: index(
+      'idx_sync_runs_subscription_started_at',
+    ).on(t.subscriptionId, t.startedAt),
+    /** Stale-run sweeper: "runs that started > N minutes ago and are still running". */
+    idxSyncRunsStatusStartedAt: index('idx_sync_runs_status_started_at').on(
+      t.status,
+      t.startedAt,
+    ),
+  }),
+);
+
+export type SyncRunRow = InferSelectModel<typeof syncRuns>;
+
+// ─── sync_run_items ─────────────────────────────────────────────────────────
+
+/**
+ * One row per upstream change processed within a run. Captures the canonical
+ * decision the orchestrator made (`operation` + `status`), the structured
+ * per-field diff (`changed_fields`, ADR-0003), and the local row id
+ * (`local_id`) for drill-down joins.
+ *
+ * `changed_fields` is validated at the recorder layer via `FieldDiffSchema`
+ * (SYNC-2) — the $type<FieldDiff> annotation here only documents the shape
+ * for Drizzle consumers. The runtime enforcement is non-negotiable: downstream
+ * drift-detection queries rely on the `{from, to}` shape per field.
+ *
+ * `title` is an optional human-readable label captured at write time (e.g.
+ * `"Pinnacle opportunity"`) so run-log UIs don't need to re-hydrate the
+ * canonical record.
+ */
+export const syncRunItems = pgTable(
+  'sync_run_items',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    syncRunId: uuid('sync_run_id')
+      .notNull()
+      .references(() => syncRuns.id, { onDelete: 'cascade' }),
+    entityType: text('entity_type').notNull(),
+    externalId: text('external_id').notNull(),
+    localId: text('local_id'),
+    operation: syncRunItemOperationEnum('operation').notNull(),
+    status: syncRunItemStatusEnum('status').notNull(),
+    /**
+     * Structured per-field diff — ADR-0003 shape enforced by
+     * `FieldDiffSchema.parse` at the recorder service layer.
+     *
+     * Shape: `{ [fieldName]: { from: unknown, to: unknown } }`.
+     * Empty `{}` for `noop` items; `{ [field]: { from: null, to: <value> } }`
+     * for created items; `{ [field]: { from: <value>, to: null } }` for
+     * deleted items.
+     */
+    changedFields: jsonb('changed_fields').notNull().default({}).$type<FieldDiff>(),
+    title: text('title'),
+    error: text('error'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    /** Runtime-enforced when `SYNC_MULTI_TENANT` is true; see SYNC-6. */
+    tenantId: text('tenant_id'),
+  },
+  (t) => ({
+    /** Ordered timeline within a run. */
+    idxSyncRunItemsRunCreatedAt: index('idx_sync_run_items_run_created_at').on(
+      t.syncRunId,
+      t.createdAt,
+    ),
+    /** Per-record history: "every sync that touched opportunity/$extId". */
+    idxSyncRunItemsEntityExternal: index(
+      'idx_sync_run_items_entity_external',
+    ).on(t.entityType, t.externalId),
+  }),
+);
+
+export type SyncRunItemRow = InferSelectModel<typeof syncRunItems>;

--- a/src/__tests__/runtime/subsystems/sync-audit.schema.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-audit.schema.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for the sync-audit Drizzle schema (SYNC-1).
+ *
+ * Pure structural/metadata checks — no Postgres, no Docker. Verifies:
+ *   1. the three pgTable declarations import cleanly,
+ *   2. the expected columns are present on each table,
+ *   3. enums carry the values the runtime/tests will depend on
+ *      (`sync_runs` direction/action/status, item operation/status),
+ *   4. `InferSelectModel` resolved concrete row types (no implicit `any`
+ *      widening),
+ *   5. the `changed_fields` column shape round-trips through
+ *      `FieldDiffSchema.parse` — the ADR-0003 contract asserted at the
+ *      recorder boundary (SYNC-5) is expressible against this column.
+ *
+ * Index assertions are intentionally omitted: Drizzle stores index metadata
+ * on a non-public table symbol and there is no stable, public introspection
+ * API. The presence of the indexes is enforced by the schema source itself
+ * (see the index callback in `sync-audit.schema.ts`).
+ */
+import { describe, it, expect } from 'bun:test';
+import { getTableColumns } from 'drizzle-orm';
+import {
+  syncSubscriptions,
+  syncRuns,
+  syncRunItems,
+  syncRunDirectionEnum,
+  syncRunActionEnum,
+  syncRunStatusEnum,
+  syncRunItemOperationEnum,
+  syncRunItemStatusEnum,
+  type SyncSubscriptionRow,
+  type SyncRunRow,
+  type SyncRunItemRow,
+} from '../../../../runtime/subsystems/sync/sync-audit.schema';
+import { FieldDiffSchema } from '../../../../runtime/subsystems/sync/sync-field-diff.protocol';
+
+describe('sync-audit.schema — import smoke', () => {
+  it('exports the three pgTable declarations as objects', () => {
+    expect(typeof syncSubscriptions).toBe('object');
+    expect(typeof syncRuns).toBe('object');
+    expect(typeof syncRunItems).toBe('object');
+    expect(syncSubscriptions).not.toBeNull();
+    expect(syncRuns).not.toBeNull();
+    expect(syncRunItems).not.toBeNull();
+  });
+});
+
+describe('sync_subscriptions — column presence', () => {
+  const cols = getTableColumns(syncSubscriptions) as Record<string, unknown>;
+
+  it.each([
+    'id',
+    'integrationId',
+    'adapter',
+    'domain',
+    'externalRef',
+    'enabled',
+    'config',
+    'cursor',
+    'lastSyncAt',
+    'tenantId',
+    'createdAt',
+    'updatedAt',
+  ])('includes column %s', (key) => {
+    expect(cols[key]).toBeDefined();
+  });
+});
+
+describe('sync_runs — column presence', () => {
+  const cols = getTableColumns(syncRuns) as Record<string, unknown>;
+
+  it.each([
+    'id',
+    'subscriptionId',
+    'direction',
+    'action',
+    'status',
+    'recordsFound',
+    'recordsProcessed',
+    'cursorBefore',
+    'cursorAfter',
+    'durationMs',
+    'error',
+    'startedAt',
+    'completedAt',
+    'tenantId',
+  ])('includes column %s', (key) => {
+    expect(cols[key]).toBeDefined();
+  });
+});
+
+describe('sync_run_items — column presence', () => {
+  const cols = getTableColumns(syncRunItems) as Record<string, unknown>;
+
+  it.each([
+    'id',
+    'syncRunId',
+    'entityType',
+    'externalId',
+    'localId',
+    'operation',
+    'status',
+    'changedFields',
+    'title',
+    'error',
+    'createdAt',
+    'tenantId',
+  ])('includes column %s', (key) => {
+    expect(cols[key]).toBeDefined();
+  });
+});
+
+describe('enums — expected values', () => {
+  it('syncRunDirectionEnum includes inbound and outbound', () => {
+    expect(syncRunDirectionEnum.enumValues).toContain('inbound');
+    expect(syncRunDirectionEnum.enumValues).toContain('outbound');
+  });
+
+  it('syncRunActionEnum includes the five provenance values', () => {
+    for (const v of ['poll', 'cdc', 'webhook', 'manual', 'writeback']) {
+      expect(syncRunActionEnum.enumValues).toContain(v);
+    }
+  });
+
+  it('syncRunStatusEnum includes running/success/no_changes/failed', () => {
+    for (const v of ['running', 'success', 'no_changes', 'failed']) {
+      expect(syncRunStatusEnum.enumValues).toContain(v);
+    }
+  });
+
+  it('syncRunItemOperationEnum includes created/updated/deleted/noop', () => {
+    for (const v of ['created', 'updated', 'deleted', 'noop']) {
+      expect(syncRunItemOperationEnum.enumValues).toContain(v);
+    }
+  });
+
+  it('syncRunItemStatusEnum includes success/failed/skipped', () => {
+    for (const v of ['success', 'failed', 'skipped']) {
+      expect(syncRunItemStatusEnum.enumValues).toContain(v);
+    }
+  });
+});
+
+describe('row types — type-level compile checks', () => {
+  it('SyncSubscriptionRow resolves to a concrete row type', () => {
+    const row: SyncSubscriptionRow = {
+      id: '00000000-0000-0000-0000-000000000000',
+      integrationId: 'sfdc-org-abc',
+      adapter: 'salesforce',
+      domain: 'opportunity',
+      externalRef: null,
+      enabled: true,
+      config: {},
+      cursor: null,
+      lastSyncAt: null,
+      tenantId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    expect(row.id).toBeDefined();
+    expect(row.enabled).toBe(true);
+  });
+
+  it('SyncRunRow resolves to a concrete row type', () => {
+    const row: SyncRunRow = {
+      id: '00000000-0000-0000-0000-000000000000',
+      subscriptionId: '00000000-0000-0000-0000-000000000000',
+      direction: 'inbound',
+      action: 'poll',
+      status: 'running',
+      recordsFound: 0,
+      recordsProcessed: 0,
+      cursorBefore: null,
+      cursorAfter: null,
+      durationMs: null,
+      error: null,
+      startedAt: new Date(),
+      completedAt: null,
+      tenantId: null,
+    };
+    expect(row.direction).toBe('inbound');
+    expect(row.action).toBe('poll');
+  });
+
+  it('SyncRunItemRow resolves to a concrete row type', () => {
+    const row: SyncRunItemRow = {
+      id: '00000000-0000-0000-0000-000000000000',
+      syncRunId: '00000000-0000-0000-0000-000000000000',
+      entityType: 'opportunity',
+      externalId: '006Ab00000ABC',
+      localId: 'local-1',
+      operation: 'updated',
+      status: 'success',
+      changedFields: {
+        amount: { from: 92364, to: 120000 },
+        stage_name: { from: 'Prospecting', to: 'Closed Won' },
+      },
+      title: 'Pinnacle opportunity',
+      error: null,
+      createdAt: new Date(),
+      tenantId: null,
+    };
+    expect(row.operation).toBe('updated');
+    expect(row.changedFields.amount).toEqual({ from: 92364, to: 120000 });
+  });
+});
+
+describe('changed_fields — ADR-0003 shape round-trips through FieldDiffSchema', () => {
+  // Acceptance criterion in the issue body:
+  //   "Unit test asserting changed_fields JSON passes the schema"
+  //
+  // The column is $type<FieldDiff>-annotated; the Zod schema is what
+  // enforces the contract at write time. These cases exercise the three
+  // canonical shapes the recorder will produce (SYNC-5).
+
+  it('accepts a structured per-field diff (updated record)', () => {
+    const row: SyncRunItemRow['changedFields'] = {
+      amount: { from: 92364, to: 120000 },
+      stage_name: { from: 'Prospecting', to: 'Closed Won' },
+    };
+    expect(() => FieldDiffSchema.parse(row)).not.toThrow();
+  });
+
+  it('accepts an empty object (noop record)', () => {
+    const row: SyncRunItemRow['changedFields'] = {};
+    expect(() => FieldDiffSchema.parse(row)).not.toThrow();
+  });
+
+  it('accepts created-shape diffs (from: null, to: <value>)', () => {
+    const row: SyncRunItemRow['changedFields'] = {
+      amount: { from: null, to: 50_000 },
+      stage_name: { from: null, to: 'Prospecting' },
+    };
+    expect(() => FieldDiffSchema.parse(row)).not.toThrow();
+  });
+
+  it('accepts deleted-shape diffs (from: <value>, to: null)', () => {
+    const row: SyncRunItemRow['changedFields'] = {
+      amount: { from: 50_000, to: null },
+    };
+    expect(() => FieldDiffSchema.parse(row)).not.toThrow();
+  });
+
+  it('rejects malformed values that are not the {from, to} shape', () => {
+    // A plain scalar in a field slot is not the ADR-0003 shape.
+    const malformed = { amount: 'not-an-object' } as unknown;
+    expect(() => FieldDiffSchema.parse(malformed)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #126. Part of epic #60 (sync-engine subsystem stack).

## Summary

Second child PR of the sync-engine subsystem epic (SYNC-2 protocols + tokens landed as #134). Lands the three audit/observability tables the subsystem writes and reads against.

- `sync_subscriptions` — cursor owner per `(integration_id, adapter, domain, external_ref)` tuple; addressable by id by `ICursorStore` (SYNC-3/4).
- `sync_runs` — per-run audit log: direction (`inbound`|`outbound`), action (`poll`|`cdc`|`webhook`|`manual`|`writeback`), status, records found/processed, cursor before/after, duration, error.
- `sync_run_items` — per-record change log with structured `changed_fields` jsonb enforced by the ADR-0003 `FieldDiffSchema` contract from SYNC-2.

Unblocks SYNC-4 (`PostgresCursorStore` + run-log writers) and SYNC-5 (`ExecuteSyncUseCase` + recorder service).

## Files added

- `runtime/subsystems/sync/sync-audit.schema.ts` — pgTable declarations + 5 pgEnums + `InferSelectModel` row types. Mirrors the shape of `job-orchestration.schema.ts` (multi-table audit with enums) and `domain-events.schema.ts` (always-emit nullable `tenant_id`).
- `src/__tests__/runtime/subsystems/sync-audit.schema.spec.ts` — 52 pure unit tests covering column presence (all three tables), enum values, `InferSelectModel` shape, and `FieldDiffSchema` round-trip for `changed_fields` (the ADR-0003 acceptance criterion).

Barrel updated: `runtime/subsystems/sync/index.ts` now re-exports the tables, enums, and row types.

## Design calls resolved (issue #126 open questions)

- **`sync_subscriptions` ships in the subsystem, not consumer-owned.** SYNC-4's `PostgresCursorStore` must read/write this table directly. Making it consumer-owned would force consumers to hand-wire a shape the backend already knows. Same stance as `job_run` being subsystem-owned while remaining consumer-queryable.

- **`tenant_id` always emitted, nullable, on all three tables.** The `SYNC_MULTI_TENANT` DI flag (SYNC-6) enforces non-null + cross-tenant-isolation at the service/orchestrator boundary. Matches JOB-1/JOB-8's final shape — runtime guard, not a scaffold-time conditional column. Keeps the schema uniform across single- and multi-tenant deployments.

- **`changed_fields` typed via `FieldDiff`** (imported from SYNC-2). The recorder service (SYNC-5) validates every write against `FieldDiffSchema.parse`; the column's `NOT NULL DEFAULT '{}'` gives the schema layer a sensible floor for noop rows.

- **Composite uniqueness on `(integration_id, adapter, domain, external_ref)`** on `sync_subscriptions`. Postgres treats NULLs as distinct in UNIQUE constraints; two rows with the same triple and NULL `external_ref` are intentionally allowed (a subscription with NULL `external_ref` covers the full domain; duplicates there are a consumer modeling concern, not a schema concern).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/__tests__/runtime/subsystems/sync-audit.schema.spec.ts` — 52/52 pass
- [x] `just test-all` — 1118/0 (unit + baseline + smoke)

## What this PR does NOT include

- No backend implementations (`MemoryCursorStore` — SYNC-3 #128; `PostgresCursorStore` + run-log writers — SYNC-4 #129)
- No orchestrator / recorder service (`ExecuteSyncUseCase`, `DeepEqualDiffer`, `SyncRunRecorderService` — SYNC-5 #130)
- No `DynamicModule` wiring (SYNC-6 #131)
- No scaffold templates or `.claude/skills/sync/` docs (SYNC-7 #132, SYNC-8 #133)
- No Atlas migration — will be generated from this schema in SYNC-4's backend PR, same pattern as JOB-8's workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)