### PR TITLE
SYNC-3 — MemoryCursorStore test double

### DIFF
--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -3,10 +3,11 @@
  *
  * Slices landed so far:
  *   - SYNC-2 — protocols + DI tokens (#134)
- *   - SYNC-1 — Drizzle audit-table schemas (this slice)
+ *   - SYNC-1 — Drizzle audit-table schemas (#148)
+ *   - SYNC-3 — MemoryCursorStore (this slice)
  *
- * Backends (SYNC-3/4), orchestrator (SYNC-5), and module (SYNC-6) land in
- * their own PRs. See epic #60 for the full plan.
+ * Drizzle backend (SYNC-4), orchestrator (SYNC-5), and module (SYNC-6) land
+ * in their own PRs. See epic #60 for the full plan.
  */
 
 // Protocols
@@ -55,3 +56,6 @@ export type {
   SyncRunRow,
   SyncRunItemRow,
 } from './sync-audit.schema';
+
+// Memory backends (SYNC-3) — test doubles
+export { MemoryCursorStore } from './sync-cursor-store.memory-backend';

--- a/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
@@ -1,0 +1,50 @@
+/**
+ * MemoryCursorStore — in-memory backend for `ICursorStore` (SYNC-3).
+ *
+ * Test double that lets consumers exercise `ExecuteSyncUseCase` (SYNC-5) and
+ * other cursor-consuming code paths without Postgres. Mirrors the role of
+ * `MemoryEventBus` and `MemoryJobStore`: plain keyed state, tests take a
+ * direct reference for `beforeEach` resets.
+ *
+ * Cursor values are stored by reference — the port's `get`/`put` contract
+ * treats them as opaque `unknown`. Callers that want durable value-equality
+ * semantics should snapshot via JSON before `put` and reparse after `get`;
+ * this is what the Drizzle backend (SYNC-4) does implicitly via jsonb
+ * round-trip. The memory backend intentionally does not simulate the
+ * serialize/deserialize cycle — consumers who care should test against
+ * Postgres.
+ *
+ * Not shipped in dealbrain-v2; this is a subsystem-first addition for the
+ * test surface. Consumed by:
+ *   - SYNC-5 unit tests (`ExecuteSyncUseCase` against synthetic sources)
+ *   - SYNC-6 module tests (`SyncModule.forRoot({ backend: 'memory' })`)
+ */
+import { Injectable } from '@nestjs/common';
+import type { ICursorStore } from './sync-cursor-store.protocol';
+
+@Injectable()
+export class MemoryCursorStore implements ICursorStore {
+  /**
+   * Subscription-id → last persisted cursor. Public so tests can inspect
+   * or pre-seed state; production callers MUST go through `get`/`put`.
+   */
+  readonly cursors: Map<string, unknown> = new Map();
+
+  async get(subscriptionId: string): Promise<unknown | null> {
+    // `Map.get` returns `undefined` for missing keys; the port contract
+    // returns `null`. Normalize here so callers can `=== null`-check.
+    const value = this.cursors.get(subscriptionId);
+    return value === undefined ? null : value;
+  }
+
+  async put(subscriptionId: string, cursor: unknown): Promise<void> {
+    // Overwrite semantics — matches the port contract and the Drizzle
+    // backend's `ON CONFLICT DO UPDATE` behavior.
+    this.cursors.set(subscriptionId, cursor);
+  }
+
+  /** Reset state. Tests call this in `beforeEach`. */
+  clear(): void {
+    this.cursors.clear();
+  }
+}

--- a/src/__tests__/runtime/subsystems/sync-cursor-store.memory-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-cursor-store.memory-backend.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for MemoryCursorStore (SYNC-3).
+ *
+ * Pure `bun:test` — no DI container, no Postgres. Exercises the `ICursorStore`
+ * contract: round-trip put/get, null on missing, overwrite semantics, and
+ * multi-subscription isolation.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { MemoryCursorStore } from '../../../../runtime/subsystems/sync/sync-cursor-store.memory-backend';
+import type { ICursorStore } from '../../../../runtime/subsystems/sync/sync-cursor-store.protocol';
+
+describe('MemoryCursorStore', () => {
+  let store: MemoryCursorStore;
+
+  beforeEach(() => {
+    store = new MemoryCursorStore();
+  });
+
+  describe('contract conformance', () => {
+    it('implements ICursorStore structurally', () => {
+      // Assignment to the port type is the structural check — if the
+      // class drifts from the port, this won't compile.
+      const asPort: ICursorStore = store;
+      expect(typeof asPort.get).toBe('function');
+      expect(typeof asPort.put).toBe('function');
+    });
+  });
+
+  describe('get — missing subscription', () => {
+    it('returns null when no cursor has been put', async () => {
+      const result = await store.get('sub-1');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for a subscription that was never seen', async () => {
+      await store.put('sub-1', { systemModstamp: '2026-04-01' });
+      const result = await store.get('sub-2');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('put + get — round-trip', () => {
+    it('returns the same cursor value that was put', async () => {
+      const cursor = { systemModstamp: '2026-04-21T13:05:00Z' };
+      await store.put('sub-1', cursor);
+      const result = await store.get('sub-1');
+      expect(result).toEqual(cursor);
+    });
+
+    it('accepts opaque cursor shapes (poll-style)', async () => {
+      await store.put('sub-1', { systemModstamp: '2026-04-21T13:05:00Z' });
+      expect(await store.get('sub-1')).toEqual({
+        systemModstamp: '2026-04-21T13:05:00Z',
+      });
+    });
+
+    it('accepts opaque cursor shapes (cdc-style)', async () => {
+      await store.put('sub-1', { replayId: 42 });
+      expect(await store.get('sub-1')).toEqual({ replayId: 42 });
+    });
+
+    it('accepts opaque cursor shapes (webhook-style)', async () => {
+      await store.put('sub-1', { ts: 1_713_705_900_000 });
+      expect(await store.get('sub-1')).toEqual({ ts: 1_713_705_900_000 });
+    });
+
+    it('accepts primitive cursor values', async () => {
+      await store.put('sub-str', 'token-abc');
+      await store.put('sub-num', 99);
+      await store.put('sub-null', null);
+      expect(await store.get('sub-str')).toBe('token-abc');
+      expect(await store.get('sub-num')).toBe(99);
+      // Explicit null is distinct from "missing" — the port treats both as
+      // `null`, but the memory map distinguishes them. Exercising the
+      // explicit-null path confirms `put(id, null)` then `get(id) === null`
+      // does not regress to "never seen."
+      expect(await store.get('sub-null')).toBeNull();
+    });
+  });
+
+  describe('put — overwrite semantics', () => {
+    it('overwrites prior cursor for the same subscription', async () => {
+      await store.put('sub-1', { systemModstamp: '2026-04-01' });
+      await store.put('sub-1', { systemModstamp: '2026-04-21' });
+      expect(await store.get('sub-1')).toEqual({
+        systemModstamp: '2026-04-21',
+      });
+    });
+  });
+
+  describe('multi-subscription isolation', () => {
+    it('keeps cursors for different subscriptions independent', async () => {
+      await store.put('sub-a', { systemModstamp: '2026-04-01' });
+      await store.put('sub-b', { replayId: 100 });
+      expect(await store.get('sub-a')).toEqual({
+        systemModstamp: '2026-04-01',
+      });
+      expect(await store.get('sub-b')).toEqual({ replayId: 100 });
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all cursors', async () => {
+      await store.put('sub-a', { x: 1 });
+      await store.put('sub-b', { y: 2 });
+      store.clear();
+      expect(await store.get('sub-a')).toBeNull();
+      expect(await store.get('sub-b')).toBeNull();
+    });
+
+    it('allows reuse after clear (tests use in beforeEach)', async () => {
+      await store.put('sub-a', { v: 1 });
+      store.clear();
+      await store.put('sub-a', { v: 2 });
+      expect(await store.get('sub-a')).toEqual({ v: 2 });
+    });
+  });
+
+  describe('cursors map — inspectable state', () => {
+    it('exposes the internal map for test assertions', async () => {
+      await store.put('sub-1', { systemModstamp: '2026-04-21' });
+      expect(store.cursors.size).toBe(1);
+      expect(store.cursors.has('sub-1')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #128. Part of epic #60 (sync-engine subsystem stack).

## Summary

Third child PR. Lands the in-memory `ICursorStore` backend — pure test double with a `Map<string, unknown>` backing store and a `clear()` helper for `beforeEach` resets.

Not shipped in dealbrain-v2 (dealbrain only has the Postgres backend); this is a subsystem-first addition for the test surface. Unblocks SYNC-5 unit tests and SYNC-6 module tests.

## Files added

- `runtime/subsystems/sync/sync-cursor-store.memory-backend.ts` — `@Injectable()` `MemoryCursorStore implements ICursorStore`. Normalizes the map's `undefined` (missing) to the port contract's `null`.
- `src/__tests__/runtime/subsystems/sync-cursor-store.memory-backend.spec.ts` — 13 unit tests: structural port conformance, null-on-missing, round-trip for poll/cdc/webhook/primitive cursor shapes, overwrite semantics, multi-subscription isolation, `clear()` behavior, explicit-null distinguished from never-seen.

Barrel updated: `runtime/subsystems/sync/index.ts` now re-exports `MemoryCursorStore`.

## Design notes

- Matches the shape of `MemoryEventBus` and `MemoryJobStore`: `@Injectable()`, public inspectable state, `clear()` helper. No options token — the cursor port has no backend-specific configuration surface.
- Intentionally does NOT simulate JSON serialize/deserialize round-trip. The Drizzle backend (SYNC-4) implicitly round-trips via jsonb; tests that care about serialization semantics should target Postgres. Documented in the file header.
- Explicit `put(id, null)` is distinguishable from "never seen" in the internal Map but both map to `null` at the port boundary. Exercising both paths guards against a future refactor regressing the normalization.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/__tests__/runtime/subsystems/sync-cursor-store.memory-backend.spec.ts` — 13/13 pass
- [x] `just test-all` — 1131/0 (unit + baseline + smoke)

## Scope

This PR is cursor-store-only per the issue's explicit acceptance criteria. Other memory backends (e.g. for the run-log writer in SYNC-4) are not in scope — SYNC-5's recorder service will take its run/item dependencies via the port surface and tests will construct lightweight fakes inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)