### PR TITLE
SYNC-4 — Drizzle backends: PostgresCursorStore + DrizzleSyncRunRecorder

### DIFF
--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -120,7 +120,7 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
   async execute(input: ExecuteSyncInput<T>): Promise<ExecuteSyncResult> {
     const source = input.sourceOverride ?? this.source;
     const startedAt = Date.now();
-    const cursorBefore = await this.cursors.get(input.subscription.id);
+    const cursorBefore = await this.cursors.get(input.subscription.id, input.tenantId);
 
     const { id: runId } = await this.recorder.startRun({
       subscriptionId: input.subscription.id,
@@ -193,7 +193,7 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     // overwrite a valid cursor with `null` on a no-change run.
     if (cursorAdvanced && latestCursor !== null && latestCursor !== undefined) {
       try {
-        await this.cursors.put(input.subscription.id, latestCursor);
+        await this.cursors.put(input.subscription.id, latestCursor, input.tenantId);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         this.logger.error(

--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -5,10 +5,11 @@
  *   - SYNC-2 — protocols + DI tokens (#134)
  *   - SYNC-1 — Drizzle audit-table schemas (#148)
  *   - SYNC-3 — MemoryCursorStore (#149)
- *   - SYNC-5 — ExecuteSyncUseCase + DeepEqualDiffer (this slice)
+ *   - SYNC-5 — ExecuteSyncUseCase + DeepEqualDiffer + recorder/loopback protocols (#150)
+ *   - SYNC-4 — Drizzle backends (PostgresCursorStore + DrizzleSyncRunRecorder) (this slice)
  *
- * Drizzle backend (SYNC-4), module (SYNC-6), scaffold templates (SYNC-7),
- * and docs/skills (SYNC-8) land in their own PRs. See epic #60.
+ * Module (SYNC-6), scaffold templates (SYNC-7), and docs/skills (SYNC-8)
+ * land in their own PRs. See epic #60.
  */
 
 // Protocols
@@ -50,6 +51,9 @@ export {
   SYNC_SINK,
 } from './sync.tokens';
 
+// Errors
+export { MissingTenantIdError } from './sync-errors';
+
 // Audit schemas (SYNC-1) — Drizzle pgTable declarations + row types + enums
 export {
   syncSubscriptions,
@@ -80,3 +84,7 @@ export {
   type ExecuteSyncInput,
   type ExecuteSyncResult,
 } from './execute-sync.use-case';
+
+// Drizzle backends (SYNC-4)
+export { PostgresCursorStore } from './sync-cursor-store.drizzle-backend';
+export { DrizzleSyncRunRecorder } from './sync-run-recorder.drizzle-backend';

--- a/runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts
@@ -1,0 +1,102 @@
+/**
+ * PostgresCursorStore — Drizzle-backed `ICursorStore` (SYNC-4).
+ *
+ * Reads/writes `sync_subscriptions.cursor` directly — no service
+ * composition. Consumers that want a service layer around subscriptions
+ * wire it themselves; the port's contract is just cursor persistence.
+ *
+ * ## What `put` stamps
+ *
+ * `put` writes three columns in one statement: `cursor`, `last_sync_at`,
+ * and `updated_at`. Rationale: SYNC-1's scheduling index
+ * `(enabled, last_sync_at)` is useless if `last_sync_at` doesn't advance
+ * with every cursor put. Every real consumer needs this stamped, so
+ * bundling it here avoids every consumer wrapping the port in a service
+ * layer just to stamp a timestamp.
+ *
+ * ## Multi-tenancy
+ *
+ * When `SYNC_MULTI_TENANT` is true (SYNC-6):
+ *   - every read/write is scoped by `AND tenant_id = $tenantId`
+ *   - a null/missing `tenantId` throws `MissingTenantIdError`
+ *   - explicit `null` also throws — the caller must opt in loudly, matching
+ *     JOB-8 / EVT-6 strict-enforcement semantics
+ *
+ * When the flag is off, `tenantId` is ignored. Cross-tenant isolation is
+ * the caller's problem in single-tenant deployments.
+ */
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { and, eq, type SQL } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import { DRIZZLE } from '../../constants/tokens';
+import type { ICursorStore } from './sync-cursor-store.protocol';
+import { syncSubscriptions } from './sync-audit.schema';
+import { SYNC_MULTI_TENANT } from './sync.tokens';
+import { MissingTenantIdError } from './sync-errors';
+
+@Injectable()
+export class PostgresCursorStore implements ICursorStore {
+  private readonly multiTenant: boolean;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    @Optional() @Inject(SYNC_MULTI_TENANT) multiTenant?: boolean,
+  ) {
+    this.multiTenant = multiTenant ?? false;
+  }
+
+  async get(
+    subscriptionId: string,
+    tenantId?: string | null,
+  ): Promise<unknown | null> {
+    const where = this.buildWhere(subscriptionId, tenantId, 'get');
+
+    const rows = await this.db
+      .select({ cursor: syncSubscriptions.cursor })
+      .from(syncSubscriptions)
+      .where(where)
+      .limit(1);
+
+    if (rows.length === 0) return null;
+    return rows[0]?.cursor ?? null;
+  }
+
+  async put(
+    subscriptionId: string,
+    cursor: unknown,
+    tenantId?: string | null,
+  ): Promise<void> {
+    const where = this.buildWhere(subscriptionId, tenantId, 'put');
+
+    await this.db
+      .update(syncSubscriptions)
+      .set({
+        cursor,
+        lastSyncAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(where);
+  }
+
+  /**
+   * Centralized WHERE clause — `get` and `put` share identical semantics.
+   * Drift here would let a caller read under one tenancy rule and write
+   * under another.
+   */
+  private buildWhere(
+    subscriptionId: string,
+    tenantId: string | null | undefined,
+    operation: 'get' | 'put',
+  ): SQL | undefined {
+    if (this.multiTenant) {
+      if (tenantId === undefined || tenantId === null) {
+        throw new MissingTenantIdError(`cursor.${operation}`);
+      }
+      return and(
+        eq(syncSubscriptions.id, subscriptionId),
+        eq(syncSubscriptions.tenantId, tenantId),
+      );
+    }
+    return eq(syncSubscriptions.id, subscriptionId);
+  }
+}

--- a/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
@@ -14,6 +14,13 @@
  * serialize/deserialize cycle — consumers who care should test against
  * Postgres.
  *
+ * ## Multi-tenancy
+ *
+ * `tenantId` is accepted but ignored. The memory backend's state is
+ * process-local — there's no durable storage where a cross-tenant leak
+ * could occur. Tests that want to assert per-tenant isolation should
+ * target the Drizzle backend.
+ *
  * Not shipped in dealbrain-v2; this is a subsystem-first addition for the
  * test surface. Consumed by:
  *   - SYNC-5 unit tests (`ExecuteSyncUseCase` against synthetic sources)
@@ -30,14 +37,21 @@ export class MemoryCursorStore implements ICursorStore {
    */
   readonly cursors: Map<string, unknown> = new Map();
 
-  async get(subscriptionId: string): Promise<unknown | null> {
+  async get(
+    subscriptionId: string,
+    _tenantId?: string | null,
+  ): Promise<unknown | null> {
     // `Map.get` returns `undefined` for missing keys; the port contract
     // returns `null`. Normalize here so callers can `=== null`-check.
     const value = this.cursors.get(subscriptionId);
     return value === undefined ? null : value;
   }
 
-  async put(subscriptionId: string, cursor: unknown): Promise<void> {
+  async put(
+    subscriptionId: string,
+    cursor: unknown,
+    _tenantId?: string | null,
+  ): Promise<void> {
     // Overwrite semantics — matches the port contract and the Drizzle
     // backend's `ON CONFLICT DO UPDATE` behavior.
     this.cursors.set(subscriptionId, cursor);

--- a/runtime/subsystems/sync/sync-cursor-store.protocol.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.protocol.ts
@@ -7,12 +7,47 @@
  *
  * Cursor shape is opaque at this seam; strategies type it internally
  * (polling: `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`).
- * The postgres backend stores this as `sync_subscriptions.cursor` jsonb.
+ * The Drizzle backend stores this as `sync_subscriptions.cursor` jsonb.
+ *
+ * ## Multi-tenancy (SYNC-4)
+ *
+ * Both methods accept an optional `tenantId`. When `SYNC_MULTI_TENANT` is
+ * enabled (SYNC-6), the Drizzle backend MUST scope every read/write by
+ * `tenant_id`, and a `null`/missing value throws `MissingTenantIdError` at
+ * the module boundary. When the flag is off, `tenantId` is ignored.
+ *
+ * The in-memory backend ignores `tenantId` unconditionally — its state is
+ * process-local; cross-tenant isolation there is not meaningful.
+ *
+ * Why a signature change instead of a tenant-proxy wrapper: multi-tenant
+ * correctness bugs are silent and dangerous (cross-tenant cursor tampering).
+ * An explicit signature catches omissions at the type boundary; proxies
+ * hide who's enforcing. Matches JOB-8 / EVT-6 precedent — tenant ids flow
+ * through input shapes, not through wrapper layers.
  */
 export interface ICursorStore {
-  /** Return the last persisted cursor for `subscriptionId`, or `null`. */
-  get(subscriptionId: string): Promise<unknown | null>;
+  /**
+   * Return the last persisted cursor for `subscriptionId`, or `null`.
+   *
+   * @param tenantId  required when `SYNC_MULTI_TENANT` is on (backend
+   *                  scopes the SELECT by tenant); ignored otherwise.
+   */
+  get(subscriptionId: string, tenantId?: string | null): Promise<unknown | null>;
 
-  /** Persist `cursor` for `subscriptionId`. Overwrites. */
-  put(subscriptionId: string, cursor: unknown): Promise<void>;
+  /**
+   * Persist `cursor` for `subscriptionId`. Overwrites.
+   *
+   * The Drizzle backend also stamps `last_sync_at` + `updated_at` on the
+   * same row so the scheduling index `(enabled, last_sync_at)` stays
+   * accurate without consumers wrapping the port. The memory backend
+   * ignores timestamps.
+   *
+   * @param tenantId  required when `SYNC_MULTI_TENANT` is on (backend
+   *                  scopes the UPDATE by tenant); ignored otherwise.
+   */
+  put(
+    subscriptionId: string,
+    cursor: unknown,
+    tenantId?: string | null,
+  ): Promise<void>;
 }

--- a/runtime/subsystems/sync/sync-errors.ts
+++ b/runtime/subsystems/sync/sync-errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Typed errors for the sync subsystem (SYNC-4).
+ *
+ * Classes (not bare Error) so consumers can `instanceof` them in catch
+ * blocks and exception filters can map them to HTTP codes.
+ *
+ * Mirrors the shape of `events-errors.ts` and `jobs-errors.ts`.
+ */
+
+/**
+ * Thrown by the Drizzle cursor-store / run-recorder backends when
+ * `SYNC_MULTI_TENANT` is enabled but the caller did not supply a
+ * non-null `tenantId`. Strict enforcement at the boundary — explicit
+ * `null` still throws.
+ *
+ * Disable multi-tenancy on the module (`multiTenant: false`, the default)
+ * to opt out of the requirement entirely.
+ */
+export class MissingTenantIdError extends Error {
+  override readonly name = 'MissingTenantIdError';
+  constructor(operation: string) {
+    super(
+      `Missing tenantId for sync operation '${operation}'. SyncModule is ` +
+        `configured with multiTenant: true — every call must include a ` +
+        `non-null tenantId. Either pass the tenantId or disable multi-` +
+        `tenancy on the module.`,
+    );
+  }
+}

--- a/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
@@ -1,0 +1,119 @@
+/**
+ * DrizzleSyncRunRecorder — Drizzle-backed `ISyncRunRecorder` (SYNC-4).
+ *
+ * Generic write path only — extracted from dealbrain-v2's
+ * `SyncRunRecorderService`, minus CRM-specific convenience methods. Those
+ * stay consumer-owned; the subsystem ships the substrate.
+ *
+ * ## Responsibilities
+ *
+ *   - `startRun`     — INSERT sync_runs row in status='running', returns id.
+ *   - `recordItem`   — validates `changedFields` via `FieldDiffSchema.parse`
+ *                      BEFORE the INSERT; a malformed shape throws before
+ *                      any DB call fires. Enforces the ADR-0003 contract at
+ *                      the write boundary.
+ *   - `completeRun`  — UPDATE sync_runs with terminal status, counts,
+ *                      cursor_after, duration_ms, completed_at.
+ *
+ * ## Multi-tenancy
+ *
+ * When `SYNC_MULTI_TENANT` is true (SYNC-6):
+ *   - `startRun` and `recordItem` require non-null `tenantId` on input
+ *     (inputs already carry the field; the recorder enforces non-null).
+ *   - `completeRun` does NOT re-check tenancy — the run id was returned
+ *     by `startRun` which already enforced it, and run ids are uuids that
+ *     aren't guessable cross-tenant. This matches JOB-3's pattern of
+ *     trusting the run-id for downstream mutations.
+ */
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import { DRIZZLE } from '../../constants/tokens';
+import type {
+  CompleteRunInput,
+  ISyncRunRecorder,
+  RecordItemInput,
+  StartRunInput,
+} from './sync-run-recorder.protocol';
+import { syncRuns, syncRunItems } from './sync-audit.schema';
+import { FieldDiffSchema } from './sync-field-diff.protocol';
+import { SYNC_MULTI_TENANT } from './sync.tokens';
+import { MissingTenantIdError } from './sync-errors';
+
+@Injectable()
+export class DrizzleSyncRunRecorder implements ISyncRunRecorder {
+  private readonly multiTenant: boolean;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    @Optional() @Inject(SYNC_MULTI_TENANT) multiTenant?: boolean,
+  ) {
+    this.multiTenant = multiTenant ?? false;
+  }
+
+  async startRun(input: StartRunInput): Promise<{ id: string }> {
+    if (this.multiTenant && (input.tenantId === undefined || input.tenantId === null)) {
+      throw new MissingTenantIdError('startRun');
+    }
+
+    const rows = await this.db
+      .insert(syncRuns)
+      .values({
+        subscriptionId: input.subscriptionId,
+        direction: input.direction,
+        action: input.action,
+        status: 'running',
+        cursorBefore: input.cursorBefore ?? null,
+        tenantId: input.tenantId ?? null,
+      })
+      .returning({ id: syncRuns.id });
+
+    const id = rows[0]?.id;
+    if (!id) {
+      // Drizzle's insert().returning() contract: at least one row is
+      // returned for every successful INSERT. A missing id would indicate
+      // a driver misbehavior; throw loudly rather than return bogus data.
+      throw new Error('DrizzleSyncRunRecorder: INSERT RETURNING produced no id');
+    }
+    return { id };
+  }
+
+  async recordItem(input: RecordItemInput): Promise<void> {
+    if (this.multiTenant && (input.tenantId === undefined || input.tenantId === null)) {
+      throw new MissingTenantIdError('recordItem');
+    }
+
+    // ADR-0003 contract enforcement — reject malformed changedFields
+    // before the DB call fires. `parse` throws a ZodError; callers see
+    // the validation failure, not a DB constraint error.
+    FieldDiffSchema.parse(input.changedFields);
+
+    await this.db.insert(syncRunItems).values({
+      syncRunId: input.syncRunId,
+      entityType: input.entityType,
+      externalId: input.externalId,
+      localId: input.localId ?? null,
+      operation: input.operation,
+      status: input.status,
+      changedFields: input.changedFields,
+      title: input.title ?? null,
+      error: input.error ?? null,
+      tenantId: input.tenantId ?? null,
+    });
+  }
+
+  async completeRun(runId: string, input: CompleteRunInput): Promise<void> {
+    await this.db
+      .update(syncRuns)
+      .set({
+        status: input.status,
+        recordsFound: input.recordsFound,
+        recordsProcessed: input.recordsProcessed,
+        cursorAfter: input.cursorAfter ?? null,
+        durationMs: input.durationMs,
+        error: input.error ?? null,
+        completedAt: new Date(),
+      })
+      .where(eq(syncRuns.id, runId));
+  }
+}

--- a/src/__tests__/runtime/subsystems/sync-cursor-store.drizzle-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-cursor-store.drizzle-backend.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for PostgresCursorStore (SYNC-4).
+ *
+ * Pure bun:test with `drizzle-orm/pg-proxy` — no Postgres, no Docker. The
+ * pg-proxy callback captures every SQL + params pair so we can assert both
+ * the operation shape (SELECT/UPDATE, WHERE clauses) and the values
+ * written.
+ *
+ * Note on param shapes: pg-proxy serializes params to strings before
+ * handing them to the callback (cursors → JSON strings, Dates → ISO
+ * strings). This is pg-proxy-specific; real node-postgres handles typed
+ * params directly. Our assertions target the stringified forms since
+ * that's what this test harness produces — the Drizzle query builder
+ * generates the same SQL shape regardless of driver.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { drizzle } from 'drizzle-orm/pg-proxy';
+import type { DrizzleClient } from '../../../../runtime/types/drizzle';
+import { PostgresCursorStore } from '../../../../runtime/subsystems/sync/sync-cursor-store.drizzle-backend';
+import { MissingTenantIdError } from '../../../../runtime/subsystems/sync/sync-errors';
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+  method: string;
+}
+
+function makeCapturingDb(response: { rows: unknown[][] } | { rows: unknown[] }) {
+  const captures: Captured[] = [];
+  const db = drizzle(async (sql, params, method) => {
+    captures.push({ sql, params, method });
+    return response;
+  }) as unknown as DrizzleClient;
+  return { db, captures };
+}
+
+/** ISO-8601 UTC timestamp in pg-proxy's stringified form. */
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/;
+
+describe('PostgresCursorStore — single-tenant', () => {
+  let store: PostgresCursorStore;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({ rows: [] }));
+    store = new PostgresCursorStore(db);
+  });
+
+  describe('get', () => {
+    it('SELECTs cursor scoped by id only', async () => {
+      ({ db, captures } = makeCapturingDb({
+        rows: [['{"systemModstamp":"2026-04-21"}']] as unknown as unknown[],
+      }));
+      store = new PostgresCursorStore(db);
+
+      const result = await store.get('sub-1');
+
+      expect(result).toEqual({ systemModstamp: '2026-04-21' });
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('select');
+      expect(sql).toContain('"sync_subscriptions"');
+      expect(sql).toContain('"cursor"');
+      expect(sql).toContain('"id"');
+      // Single-tenant WHERE does not reference tenant_id.
+      expect(sql.toLowerCase()).not.toContain('tenant_id');
+      expect(params).toContain('sub-1');
+    });
+
+    it('returns null when no row exists', async () => {
+      const result = await store.get('missing');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the row has a null cursor column', async () => {
+      ({ db, captures } = makeCapturingDb({ rows: [[null]] as unknown as unknown[] }));
+      store = new PostgresCursorStore(db);
+      const result = await store.get('sub-1');
+      expect(result).toBeNull();
+    });
+
+    it('ignores tenantId when multi-tenant mode is off', async () => {
+      await store.get('sub-1', 'tenant-a');
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).not.toContain('tenant_id');
+      // tenantId is not bound as a param either — single-tenant path
+      // drops the argument entirely.
+      expect(params).not.toContain('tenant-a');
+    });
+  });
+
+  describe('put', () => {
+    it('UPDATEs cursor, last_sync_at, and updated_at in one statement', async () => {
+      await store.put('sub-1', { systemModstamp: '2026-04-21T13:00:00Z' });
+
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('update');
+      expect(sql).toContain('"sync_subscriptions"');
+      // All three stamped columns referenced in the SET clause.
+      expect(sql).toContain('"cursor"');
+      expect(sql).toContain('"last_sync_at"');
+      expect(sql).toContain('"updated_at"');
+      // Single-tenant WHERE scopes by id only.
+      expect(sql.toLowerCase()).not.toContain('tenant_id');
+      // id param present.
+      expect(params).toContain('sub-1');
+      // Cursor serialized as a JSON string containing the key. pg-proxy
+      // passes jsonb params through as stringified JSON.
+      const cursorParam = params.find(
+        (p) => typeof p === 'string' && p.includes('systemModstamp'),
+      );
+      expect(cursorParam).toBeDefined();
+    });
+
+    it('stamps last_sync_at and updated_at with ISO timestamps around now', async () => {
+      const before = Date.now();
+      await store.put('sub-1', { v: 1 });
+      const after = Date.now();
+
+      const [{ params }] = captures;
+      // ISO-shaped timestamps (pg-proxy stringifies Date params).
+      const isoParams = params.filter(
+        (p): p is string => typeof p === 'string' && ISO_RE.test(p),
+      );
+      expect(isoParams.length).toBeGreaterThanOrEqual(2);
+      for (const iso of isoParams) {
+        const t = new Date(iso).getTime();
+        expect(t).toBeGreaterThanOrEqual(before);
+        expect(t).toBeLessThanOrEqual(after + 100);
+      }
+    });
+  });
+});
+
+describe('PostgresCursorStore — multi-tenant', () => {
+  let store: PostgresCursorStore;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({ rows: [] }));
+    store = new PostgresCursorStore(db, true);
+  });
+
+  describe('strict tenancy enforcement', () => {
+    it('throws MissingTenantIdError when get() has no tenantId', async () => {
+      await expect(store.get('sub-1')).rejects.toBeInstanceOf(
+        MissingTenantIdError,
+      );
+      // No DB call fired.
+      expect(captures).toHaveLength(0);
+    });
+
+    it('throws MissingTenantIdError when get() has explicit null', async () => {
+      await expect(store.get('sub-1', null)).rejects.toBeInstanceOf(
+        MissingTenantIdError,
+      );
+    });
+
+    it('throws MissingTenantIdError when put() has no tenantId', async () => {
+      await expect(
+        store.put('sub-1', { v: 1 }),
+      ).rejects.toBeInstanceOf(MissingTenantIdError);
+      expect(captures).toHaveLength(0);
+    });
+
+    it('throws MissingTenantIdError when put() has explicit null', async () => {
+      await expect(
+        store.put('sub-1', { v: 1 }, null),
+      ).rejects.toBeInstanceOf(MissingTenantIdError);
+    });
+  });
+
+  describe('queries scoped by tenant', () => {
+    it('get() WHERE includes tenant_id and both params bind', async () => {
+      await store.get('sub-1', 'tenant-a');
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('tenant_id');
+      expect(params).toContain('sub-1');
+      expect(params).toContain('tenant-a');
+    });
+
+    it('put() WHERE includes tenant_id and both params bind', async () => {
+      await store.put('sub-1', { v: 1 }, 'tenant-a');
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('tenant_id');
+      expect(params).toContain('sub-1');
+      expect(params).toContain('tenant-a');
+    });
+  });
+});
+
+describe('PostgresCursorStore — multiTenant constructor default', () => {
+  it('defaults multiTenant to false when the token is not provided', async () => {
+    // When the @Optional() inject yields undefined, the store falls back
+    // to single-tenant mode. Exercising via the omitted constructor arg
+    // mirrors what DI will produce when `SYNC_MULTI_TENANT` is unbound.
+    const { db, captures } = makeCapturingDb({ rows: [] });
+    const store = new PostgresCursorStore(db, undefined);
+    await store.get('sub-1');
+    const [{ sql }] = captures;
+    expect(sql.toLowerCase()).not.toContain('tenant_id');
+  });
+});

--- a/src/__tests__/runtime/subsystems/sync-run-recorder.drizzle-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-run-recorder.drizzle-backend.spec.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for DrizzleSyncRunRecorder (SYNC-4).
+ *
+ * Pure bun:test with `drizzle-orm/pg-proxy` — no Postgres, no Docker.
+ *
+ * Covers:
+ *   - `startRun` INSERTs sync_runs row and returns the generated id
+ *   - `recordItem` runs FieldDiffSchema.parse BEFORE the DB call — a
+ *     malformed changedFields throws before any INSERT fires (ADR-0003
+ *     contract enforcement)
+ *   - `completeRun` UPDATEs the run row with terminal status + counts
+ *   - multi-tenant strict enforcement on startRun + recordItem
+ *   - single-tenant mode ignores tenantId
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { drizzle } from 'drizzle-orm/pg-proxy';
+import { ZodError } from 'zod';
+import type { DrizzleClient } from '../../../../runtime/types/drizzle';
+import { DrizzleSyncRunRecorder } from '../../../../runtime/subsystems/sync/sync-run-recorder.drizzle-backend';
+import { MissingTenantIdError } from '../../../../runtime/subsystems/sync/sync-errors';
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+  method: string;
+}
+
+function makeCapturingDb(
+  response: { rows: unknown[][] } | { rows: unknown[] },
+) {
+  const captures: Captured[] = [];
+  const db = drizzle(async (sql, params, method) => {
+    captures.push({ sql, params, method });
+    return response as { rows: unknown[] };
+  }) as unknown as DrizzleClient;
+  return { db, captures };
+}
+
+const RUN_UUID = '11111111-1111-1111-1111-111111111111';
+
+describe('DrizzleSyncRunRecorder — single-tenant', () => {
+  let recorder: DrizzleSyncRunRecorder;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({
+      rows: [[RUN_UUID]] as unknown[][],
+    }));
+    recorder = new DrizzleSyncRunRecorder(db);
+  });
+
+  describe('startRun', () => {
+    it('INSERTs into sync_runs and returns the id', async () => {
+      const result = await recorder.startRun({
+        subscriptionId: 'sub-1',
+        direction: 'inbound',
+        action: 'poll',
+        cursorBefore: null,
+      });
+
+      expect(result.id).toBe(RUN_UUID);
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('insert');
+      expect(sql).toContain('"sync_runs"');
+      expect(sql.toLowerCase()).toContain('returning');
+      // Non-nullable column values bound.
+      expect(params).toContain('sub-1');
+      expect(params).toContain('inbound');
+      expect(params).toContain('poll');
+      expect(params).toContain('running');
+    });
+
+    it('passes cursor_before through when provided', async () => {
+      await recorder.startRun({
+        subscriptionId: 'sub-1',
+        direction: 'inbound',
+        action: 'poll',
+        cursorBefore: { systemModstamp: '2026-04-21' },
+      });
+      const [{ params }] = captures;
+      const cursorParam = params.find(
+        (p) => typeof p === 'string' && p.includes('systemModstamp'),
+      );
+      expect(cursorParam).toBeDefined();
+    });
+
+    it('throws when INSERT RETURNING produces no rows (driver misbehavior)', async () => {
+      ({ db, captures } = makeCapturingDb({ rows: [] }));
+      recorder = new DrizzleSyncRunRecorder(db);
+
+      await expect(
+        recorder.startRun({
+          subscriptionId: 'sub-1',
+          direction: 'inbound',
+          action: 'poll',
+          cursorBefore: null,
+        }),
+      ).rejects.toThrow(/RETURNING produced no id/);
+    });
+  });
+
+  describe('recordItem', () => {
+    beforeEach(() => {
+      ({ db, captures } = makeCapturingDb({ rows: [] }));
+      recorder = new DrizzleSyncRunRecorder(db);
+    });
+
+    it('INSERTs a row with valid changedFields', async () => {
+      await recorder.recordItem({
+        syncRunId: RUN_UUID,
+        entityType: 'opportunity',
+        externalId: 'ext-1',
+        operation: 'updated',
+        status: 'success',
+        changedFields: { amount: { from: 100, to: 120 } },
+      });
+
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('insert');
+      expect(sql).toContain('"sync_run_items"');
+      expect(params).toContain(RUN_UUID);
+      expect(params).toContain('opportunity');
+      expect(params).toContain('ext-1');
+      expect(params).toContain('updated');
+      expect(params).toContain('success');
+      // changedFields serialized as JSON string containing the key.
+      const diffParam = params.find(
+        (p) => typeof p === 'string' && p.includes('amount'),
+      );
+      expect(diffParam).toBeDefined();
+    });
+
+    it('rejects malformed changedFields BEFORE the DB call (ADR-0003)', async () => {
+      await expect(
+        recorder.recordItem({
+          syncRunId: RUN_UUID,
+          entityType: 'opportunity',
+          externalId: 'ext-1',
+          operation: 'updated',
+          status: 'success',
+          // Not the {from, to} shape.
+          changedFields: { amount: 'not-an-object' } as unknown as Record<
+            string,
+            { from: unknown; to: unknown }
+          >,
+        }),
+      ).rejects.toBeInstanceOf(ZodError);
+
+      // No INSERT fired — parse threw before the await reached the db.
+      expect(captures).toHaveLength(0);
+    });
+
+    it('accepts empty-object changedFields for noop/skipped items', async () => {
+      await recorder.recordItem({
+        syncRunId: RUN_UUID,
+        entityType: 'opportunity',
+        externalId: 'ext-1',
+        operation: 'noop',
+        status: 'success',
+        changedFields: {},
+      });
+      expect(captures).toHaveLength(1);
+      const [{ params }] = captures;
+      expect(params).toContain('noop');
+    });
+  });
+
+  describe('completeRun', () => {
+    beforeEach(() => {
+      ({ db, captures } = makeCapturingDb({ rows: [] }));
+      recorder = new DrizzleSyncRunRecorder(db);
+    });
+
+    it('UPDATEs sync_runs with terminal status + counts + duration', async () => {
+      await recorder.completeRun(RUN_UUID, {
+        status: 'success',
+        recordsFound: 10,
+        recordsProcessed: 9,
+        cursorAfter: { systemModstamp: '2026-04-21T13:00:00Z' },
+        durationMs: 1234,
+      });
+
+      expect(captures).toHaveLength(1);
+      const [{ sql, params }] = captures;
+      expect(sql.toLowerCase()).toContain('update');
+      expect(sql).toContain('"sync_runs"');
+      expect(sql).toContain('"status"');
+      expect(sql).toContain('"records_found"');
+      expect(sql).toContain('"records_processed"');
+      expect(sql).toContain('"cursor_after"');
+      expect(sql).toContain('"duration_ms"');
+      expect(sql).toContain('"completed_at"');
+
+      expect(params).toContain('success');
+      expect(params).toContain(10);
+      expect(params).toContain(9);
+      expect(params).toContain(1234);
+      expect(params).toContain(RUN_UUID);
+    });
+
+    it('passes error string through when provided', async () => {
+      await recorder.completeRun(RUN_UUID, {
+        status: 'failed',
+        recordsFound: 1,
+        recordsProcessed: 0,
+        cursorAfter: null,
+        durationMs: 50,
+        error: 'session expired',
+      });
+      const [{ params }] = captures;
+      expect(params).toContain('failed');
+      expect(params).toContain('session expired');
+    });
+  });
+});
+
+describe('DrizzleSyncRunRecorder — multi-tenant', () => {
+  let recorder: DrizzleSyncRunRecorder;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({
+      rows: [[RUN_UUID]] as unknown[][],
+    }));
+    recorder = new DrizzleSyncRunRecorder(db, true);
+  });
+
+  describe('startRun — strict tenancy', () => {
+    it('throws MissingTenantIdError when tenantId is omitted', async () => {
+      await expect(
+        recorder.startRun({
+          subscriptionId: 'sub-1',
+          direction: 'inbound',
+          action: 'poll',
+          cursorBefore: null,
+        }),
+      ).rejects.toBeInstanceOf(MissingTenantIdError);
+      expect(captures).toHaveLength(0);
+    });
+
+    it('throws MissingTenantIdError when tenantId is explicit null', async () => {
+      await expect(
+        recorder.startRun({
+          subscriptionId: 'sub-1',
+          direction: 'inbound',
+          action: 'poll',
+          cursorBefore: null,
+          tenantId: null,
+        }),
+      ).rejects.toBeInstanceOf(MissingTenantIdError);
+    });
+
+    it('accepts a valid tenantId and binds it as a param', async () => {
+      await recorder.startRun({
+        subscriptionId: 'sub-1',
+        direction: 'inbound',
+        action: 'poll',
+        cursorBefore: null,
+        tenantId: 'tenant-a',
+      });
+      expect(captures).toHaveLength(1);
+      const [{ params }] = captures;
+      expect(params).toContain('tenant-a');
+    });
+  });
+
+  describe('recordItem — strict tenancy', () => {
+    it('throws MissingTenantIdError when tenantId is omitted', async () => {
+      ({ db, captures } = makeCapturingDb({ rows: [] }));
+      recorder = new DrizzleSyncRunRecorder(db, true);
+
+      await expect(
+        recorder.recordItem({
+          syncRunId: RUN_UUID,
+          entityType: 'opportunity',
+          externalId: 'ext-1',
+          operation: 'updated',
+          status: 'success',
+          changedFields: {},
+        }),
+      ).rejects.toBeInstanceOf(MissingTenantIdError);
+      expect(captures).toHaveLength(0);
+    });
+
+    it('accepts a valid tenantId and binds it', async () => {
+      ({ db, captures } = makeCapturingDb({ rows: [] }));
+      recorder = new DrizzleSyncRunRecorder(db, true);
+
+      await recorder.recordItem({
+        syncRunId: RUN_UUID,
+        entityType: 'opportunity',
+        externalId: 'ext-1',
+        operation: 'updated',
+        status: 'success',
+        changedFields: {},
+        tenantId: 'tenant-a',
+      });
+      const [{ params }] = captures;
+      expect(params).toContain('tenant-a');
+    });
+  });
+
+  describe('completeRun — does NOT re-check tenancy', () => {
+    it('trusts the run id and fires the UPDATE without tenant guard', async () => {
+      // completeRun takes a run id from startRun (which already enforced
+      // tenancy); forcing another check here would require threading
+      // tenantId through every call path. The run id is a uuid and not
+      // guessable cross-tenant.
+      ({ db, captures } = makeCapturingDb({ rows: [] }));
+      recorder = new DrizzleSyncRunRecorder(db, true);
+
+      await recorder.completeRun(RUN_UUID, {
+        status: 'success',
+        recordsFound: 1,
+        recordsProcessed: 1,
+        cursorAfter: null,
+        durationMs: 10,
+      });
+
+      expect(captures).toHaveLength(1);
+    });
+  });
+});
+
+describe('DrizzleSyncRunRecorder — multiTenant constructor default', () => {
+  it('defaults multiTenant to false when the token is not provided', async () => {
+    const { db, captures } = makeCapturingDb({
+      rows: [[RUN_UUID]] as unknown[][],
+    });
+    const recorder = new DrizzleSyncRunRecorder(db, undefined);
+
+    // No tenantId in input, no throw — single-tenant is the default.
+    await recorder.startRun({
+      subscriptionId: 'sub-1',
+      direction: 'inbound',
+      action: 'poll',
+      cursorBefore: null,
+    });
+    expect(captures).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #129. Part of epic #60 (sync-engine subsystem stack).

## Summary

Fifth child PR. Lands the two Drizzle-backed implementations the Phase 1 sync subsystem needs. Both backends enforce multi-tenancy at the boundary per `SYNC_MULTI_TENANT` (signature change to `ICursorStore`; strict input-shape check on the recorder).

## Files added

- `runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts` — `@Injectable() PostgresCursorStore implements ICursorStore`. Reads/writes `sync_subscriptions.cursor` directly (no service composition). `put()` stamps `last_sync_at + updated_at` in the same UPDATE so the SYNC-1 scheduling index `(enabled, last_sync_at)` stays accurate without consumers wrapping the port.
- `runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts` — `@Injectable() DrizzleSyncRunRecorder implements ISyncRunRecorder`. Generic write path only — no CRM-specific convenience methods. `recordItem` validates `changedFields` via `FieldDiffSchema.parse` BEFORE the INSERT (ADR-0003 contract at the write boundary).
- `runtime/subsystems/sync/sync-errors.ts` — `MissingTenantIdError` class. Mirror of `events-errors.ts` / `jobs-errors.ts`.
- `src/__tests__/runtime/subsystems/sync-cursor-store.drizzle-backend.spec.ts` — 13 pg-proxy-based unit tests.
- `src/__tests__/runtime/subsystems/sync-run-recorder.drizzle-backend.spec.ts` — 15 pg-proxy-based unit tests.

## Files modified

- `runtime/subsystems/sync/sync-cursor-store.protocol.ts` — `ICursorStore` gains `tenantId?: string | null` on `get()` and `put()`. No backwards-compat shim; matches JOB-8 / EVT-6 precedent of threading `tenant_id` through input shapes rather than proxy-wrapping the port.
- `runtime/subsystems/sync/sync-cursor-store.memory-backend.ts` — `MemoryCursorStore` accepts (and ignores) `tenantId`. State is process-local; cross-tenant isolation there is not meaningful.
- `runtime/subsystems/sync/execute-sync.use-case.ts` — threads `input.tenantId` into `cursors.get()` / `cursors.put()` calls.
- `runtime/subsystems/sync/index.ts` — barrel re-exports the two new backends + `MissingTenantIdError`.

## Design calls resolved (from the SYNC-4 gate)

1. **`cursor-store.put()` stamps `lastSyncAt`** — kept. Every real consumer needs this for the scheduling index to work. Narrowing to cursor-only would force every consumer to wrap the port in a service layer just to stamp a timestamp.

2. **Tenancy via signature change, not proxy.** `ICursorStore` gains `tenantId` args; Memory ignores, Drizzle enforces with `MissingTenantIdError` on null/missing when `multiTenant` is on. Rationale: multi-tenancy bugs are silent and dangerous — explicit signatures catch omissions at the type boundary.

3. **Recorder extraction: generic write path only.** `startRun`/`recordItem`/`completeRun` map 1:1 to the protocol; no CRM convenience methods. Consumers compose their domain-specific service layer above.

4. **`completeRun` does NOT re-check tenancy.** The run id was returned by `startRun` which already enforced it; run ids are uuids not guessable cross-tenant. Matches JOB-3's pattern of trusting the run id for downstream mutations. Documented in the backend header.

## Atlas migration plan

Per the gate agreement: no migration file lands in this PR. Consumers run `atlas migrate diff --env local --name sync_audit_tables` against the live schema from SYNC-1. SYNC-8's consumer docs will reference the existing CONSUMER-SETUP.md Atlas section.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test .../sync-cursor-store.drizzle-backend.spec.ts` — 13/13 pass
- [x] `bun test .../sync-run-recorder.drizzle-backend.spec.ts` — 15/15 pass
- [x] `just test-all` — 1195/0 (unit + baseline + smoke)

## Scope

This PR touches the `ICursorStore` protocol file (tenantId arg addition). That's deliberate per the "no backwards compat" policy — the protocol file was already SYNC-2's, but a signature change was the right call per the SYNC-4 gate, and there are no external consumers to break.

## What this PR does NOT include

- No `DynamicModule` wiring / `SyncModule.forRoot({ backend, multiTenant })` — that's SYNC-6 #131. Without it, `SYNC_MULTI_TENANT` is unbound in DI; `@Optional()` ensures both Drizzle backends default to single-tenant behavior when constructed by the module resolver.
- No scaffold templates (SYNC-7 #132) or docs (SYNC-8 #133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)