### PR TITLE
SYNC-6 — SyncModule + MemoryRunRecorder + multi-tenancy opt-in

### DIFF
--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -48,11 +48,13 @@ import type { IFieldDiffer, FieldDiff } from './sync-field-diff.protocol';
 import type { ISyncSink } from './sync-sink.protocol';
 import type { ISyncRunRecorder } from './sync-run-recorder.protocol';
 import type { ILoopbackFingerprintStore } from './sync-loopback.protocol';
+import { assertTenantId } from './sync-errors';
 import {
   SYNC_CHANGE_SOURCE,
   SYNC_CURSOR_STORE,
   SYNC_FIELD_DIFFER,
   SYNC_LOOPBACK_FINGERPRINT_STORE,
+  SYNC_MULTI_TENANT,
   SYNC_RUN_RECORDER,
   SYNC_SINK,
 } from './sync.tokens';
@@ -115,9 +117,21 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     @Optional()
     @Inject(SYNC_LOOPBACK_FINGERPRINT_STORE)
     private readonly loopback?: ILoopbackFingerprintStore<T>,
+    @Optional()
+    @Inject(SYNC_MULTI_TENANT)
+    private readonly multiTenant: boolean = false,
   ) {}
 
   async execute(input: ExecuteSyncInput<T>): Promise<ExecuteSyncResult> {
+    // Defense-in-depth tenancy guard — fire BEFORE startRun so a rejected
+    // input never leaves a dangling `status=running` row. Backends also
+    // enforce (SYNC-4), but failing fast at the orchestrator boundary is
+    // cheaper for observability, metrics, and manual cleanup.
+    assertTenantId(input.tenantId, {
+      multiTenant: this.multiTenant,
+      operation: 'execute',
+    });
+
     const source = input.sourceOverride ?? this.source;
     const startedAt = Date.now();
     const cursorBefore = await this.cursors.get(input.subscription.id, input.tenantId);

--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -6,10 +6,11 @@
  *   - SYNC-1 — Drizzle audit-table schemas (#148)
  *   - SYNC-3 — MemoryCursorStore (#149)
  *   - SYNC-5 — ExecuteSyncUseCase + DeepEqualDiffer + recorder/loopback protocols (#150)
- *   - SYNC-4 — Drizzle backends (PostgresCursorStore + DrizzleSyncRunRecorder) (this slice)
+ *   - SYNC-4 — Drizzle backends (#151)
+ *   - SYNC-6 — SyncModule + MemoryRunRecorder + multi-tenancy opt-in (this slice)
  *
- * Module (SYNC-6), scaffold templates (SYNC-7), and docs/skills (SYNC-8)
- * land in their own PRs. See epic #60.
+ * Scaffold templates (SYNC-7) and docs/skills (SYNC-8) land in their own
+ * PRs. See epic #60.
  */
 
 // Protocols
@@ -51,8 +52,8 @@ export {
   SYNC_SINK,
 } from './sync.tokens';
 
-// Errors
-export { MissingTenantIdError } from './sync-errors';
+// Errors + shared guards
+export { MissingTenantIdError, assertTenantId } from './sync-errors';
 
 // Audit schemas (SYNC-1) — Drizzle pgTable declarations + row types + enums
 export {
@@ -71,8 +72,12 @@ export type {
   SyncRunItemRow,
 } from './sync-audit.schema';
 
-// Memory backends (SYNC-3) — test doubles
+// Memory backends (SYNC-3, SYNC-6) — test doubles
 export { MemoryCursorStore } from './sync-cursor-store.memory-backend';
+export {
+  MemoryRunRecorder,
+  type MemoryRunRecord,
+} from './sync-run-recorder.memory-backend';
 
 // Runtime (SYNC-5) — orchestrator + default differ
 export {
@@ -88,3 +93,6 @@ export {
 // Drizzle backends (SYNC-4)
 export { PostgresCursorStore } from './sync-cursor-store.drizzle-backend';
 export { DrizzleSyncRunRecorder } from './sync-run-recorder.drizzle-backend';
+
+// Module (SYNC-6)
+export { SyncModule, type SyncModuleOptions } from './sync.module';

--- a/runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts
@@ -18,9 +18,10 @@
  *
  * When `SYNC_MULTI_TENANT` is true (SYNC-6):
  *   - every read/write is scoped by `AND tenant_id = $tenantId`
- *   - a null/missing `tenantId` throws `MissingTenantIdError`
- *   - explicit `null` also throws — the caller must opt in loudly, matching
- *     JOB-8 / EVT-6 strict-enforcement semantics
+ *   - a null/missing `tenantId` throws `MissingTenantIdError` via the
+ *     shared `assertTenantId` helper (one message shape across the
+ *     orchestrator + both backends, SYNC-6)
+ *   - explicit `null` also throws — matches JOB-8 / EVT-6 strict-enforcement
  *
  * When the flag is off, `tenantId` is ignored. Cross-tenant isolation is
  * the caller's problem in single-tenant deployments.
@@ -32,7 +33,7 @@ import { DRIZZLE } from '../../constants/tokens';
 import type { ICursorStore } from './sync-cursor-store.protocol';
 import { syncSubscriptions } from './sync-audit.schema';
 import { SYNC_MULTI_TENANT } from './sync.tokens';
-import { MissingTenantIdError } from './sync-errors';
+import { assertTenantId } from './sync-errors';
 
 @Injectable()
 export class PostgresCursorStore implements ICursorStore {
@@ -49,7 +50,7 @@ export class PostgresCursorStore implements ICursorStore {
     subscriptionId: string,
     tenantId?: string | null,
   ): Promise<unknown | null> {
-    const where = this.buildWhere(subscriptionId, tenantId, 'get');
+    const where = this.buildWhere(subscriptionId, tenantId, 'cursor.get');
 
     const rows = await this.db
       .select({ cursor: syncSubscriptions.cursor })
@@ -66,7 +67,7 @@ export class PostgresCursorStore implements ICursorStore {
     cursor: unknown,
     tenantId?: string | null,
   ): Promise<void> {
-    const where = this.buildWhere(subscriptionId, tenantId, 'put');
+    const where = this.buildWhere(subscriptionId, tenantId, 'cursor.put');
 
     await this.db
       .update(syncSubscriptions)
@@ -86,15 +87,16 @@ export class PostgresCursorStore implements ICursorStore {
   private buildWhere(
     subscriptionId: string,
     tenantId: string | null | undefined,
-    operation: 'get' | 'put',
+    operation: string,
   ): SQL | undefined {
+    assertTenantId(tenantId, {
+      multiTenant: this.multiTenant,
+      operation,
+    });
     if (this.multiTenant) {
-      if (tenantId === undefined || tenantId === null) {
-        throw new MissingTenantIdError(`cursor.${operation}`);
-      }
       return and(
         eq(syncSubscriptions.id, subscriptionId),
-        eq(syncSubscriptions.tenantId, tenantId),
+        eq(syncSubscriptions.tenantId, tenantId as string),
       );
     }
     return eq(syncSubscriptions.id, subscriptionId);

--- a/runtime/subsystems/sync/sync-errors.ts
+++ b/runtime/subsystems/sync/sync-errors.ts
@@ -1,5 +1,5 @@
 /**
- * Typed errors for the sync subsystem (SYNC-4).
+ * Typed errors + shared boundary helpers for the sync subsystem.
  *
  * Classes (not bare Error) so consumers can `instanceof` them in catch
  * blocks and exception filters can map them to HTTP codes.
@@ -8,13 +8,17 @@
  */
 
 /**
- * Thrown by the Drizzle cursor-store / run-recorder backends when
- * `SYNC_MULTI_TENANT` is enabled but the caller did not supply a
- * non-null `tenantId`. Strict enforcement at the boundary — explicit
- * `null` still throws.
+ * Thrown by the Drizzle cursor-store / run-recorder backends AND by the
+ * orchestrator entry point when `SYNC_MULTI_TENANT` is enabled but the
+ * caller did not supply a non-null `tenantId`. Strict enforcement at the
+ * boundary — explicit `null` still throws.
  *
  * Disable multi-tenancy on the module (`multiTenant: false`, the default)
  * to opt out of the requirement entirely.
+ *
+ * `operation` identifies the call site (e.g. `'cursor.put'`,
+ * `'startRun'`, `'execute'`) so the stack-trace message points at the
+ * specific boundary that rejected the input.
  */
 export class MissingTenantIdError extends Error {
   override readonly name = 'MissingTenantIdError';
@@ -25,5 +29,26 @@ export class MissingTenantIdError extends Error {
         `non-null tenantId. Either pass the tenantId or disable multi-` +
         `tenancy on the module.`,
     );
+  }
+}
+
+/**
+ * Shared boundary guard — used at the orchestrator entry AND inside the
+ * Drizzle backends. Keeping the check in one function guarantees every
+ * `MissingTenantIdError` carries the same message shape regardless of the
+ * site that raised it, which makes it easier for consumers to pattern-
+ * match on the error in logs/metrics.
+ *
+ * When `multiTenant` is false, the function is a no-op — `tenantId` may
+ * be anything (including `undefined`). When true, `undefined` or `null`
+ * throws.
+ */
+export function assertTenantId(
+  tenantId: string | null | undefined,
+  options: { multiTenant: boolean; operation: string },
+): asserts tenantId is string {
+  if (!options.multiTenant) return;
+  if (tenantId === undefined || tenantId === null) {
+    throw new MissingTenantIdError(options.operation);
   }
 }

--- a/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
@@ -18,12 +18,14 @@
  * ## Multi-tenancy
  *
  * When `SYNC_MULTI_TENANT` is true (SYNC-6):
- *   - `startRun` and `recordItem` require non-null `tenantId` on input
- *     (inputs already carry the field; the recorder enforces non-null).
+ *   - `startRun` and `recordItem` require non-null `tenantId` on input.
+ *     Enforcement goes through the shared `assertTenantId` helper so the
+ *     error message shape matches the orchestrator entry point + the
+ *     cursor-store backends.
  *   - `completeRun` does NOT re-check tenancy — the run id was returned
  *     by `startRun` which already enforced it, and run ids are uuids that
- *     aren't guessable cross-tenant. This matches JOB-3's pattern of
- *     trusting the run-id for downstream mutations.
+ *     aren't guessable cross-tenant. Matches JOB-3's pattern of trusting
+ *     the run-id for downstream mutations.
  */
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
@@ -38,7 +40,7 @@ import type {
 import { syncRuns, syncRunItems } from './sync-audit.schema';
 import { FieldDiffSchema } from './sync-field-diff.protocol';
 import { SYNC_MULTI_TENANT } from './sync.tokens';
-import { MissingTenantIdError } from './sync-errors';
+import { assertTenantId } from './sync-errors';
 
 @Injectable()
 export class DrizzleSyncRunRecorder implements ISyncRunRecorder {
@@ -52,9 +54,10 @@ export class DrizzleSyncRunRecorder implements ISyncRunRecorder {
   }
 
   async startRun(input: StartRunInput): Promise<{ id: string }> {
-    if (this.multiTenant && (input.tenantId === undefined || input.tenantId === null)) {
-      throw new MissingTenantIdError('startRun');
-    }
+    assertTenantId(input.tenantId, {
+      multiTenant: this.multiTenant,
+      operation: 'startRun',
+    });
 
     const rows = await this.db
       .insert(syncRuns)
@@ -79,9 +82,10 @@ export class DrizzleSyncRunRecorder implements ISyncRunRecorder {
   }
 
   async recordItem(input: RecordItemInput): Promise<void> {
-    if (this.multiTenant && (input.tenantId === undefined || input.tenantId === null)) {
-      throw new MissingTenantIdError('recordItem');
-    }
+    assertTenantId(input.tenantId, {
+      multiTenant: this.multiTenant,
+      operation: 'recordItem',
+    });
 
     // ADR-0003 contract enforcement — reject malformed changedFields
     // before the DB call fires. `parse` throws a ZodError; callers see

--- a/runtime/subsystems/sync/sync-run-recorder.memory-backend.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.memory-backend.ts
@@ -1,0 +1,143 @@
+/**
+ * MemoryRunRecorder — in-memory backend for `ISyncRunRecorder` (SYNC-6).
+ *
+ * Test double so `SyncModule.forRoot({ backend: 'memory' })` is genuinely
+ * end-to-end runnable without Postgres. Mirrors the role of
+ * `MemoryCursorStore`: plain keyed state, `clear()` helper for
+ * `beforeEach` resets, public inspection surface so tests can assert on
+ * the recorded run + item timeline without scraping logs.
+ *
+ * Validates `changedFields` through `FieldDiffSchema.parse` on every
+ * `recordItem` call — same ADR-0003 contract as the Drizzle backend. An
+ * in-memory recorder that skipped the validation would be a silently
+ * weaker contract than production.
+ *
+ * `startRun` generates a uuid via `crypto.randomUUID()` (Node 19+ / Bun).
+ * We don't import `uuid` because the subsystem has no other use for it.
+ *
+ * ## Multi-tenancy
+ *
+ * `tenantId` is accepted (and recorded on the in-memory row so tests can
+ * assert it) but enforcement lives at the module boundary. The memory
+ * backend intentionally does not throw on missing `tenantId` — that's
+ * the orchestrator's job when `multiTenant=true` (SYNC-6). A permissive
+ * memory recorder lets tests exercise error paths where the orchestrator
+ * short-circuits before ever reaching the recorder.
+ */
+import { Injectable } from '@nestjs/common';
+import type {
+  CompleteRunInput,
+  ISyncRunRecorder,
+  RecordItemInput,
+  StartRunInput,
+} from './sync-run-recorder.protocol';
+import { FieldDiffSchema } from './sync-field-diff.protocol';
+
+/**
+ * Concrete run row as held in memory. Shape mirrors the interesting
+ * columns on `sync_runs` so assertions read like DB queries.
+ */
+export interface MemoryRunRecord {
+  id: string;
+  subscriptionId: string;
+  direction: 'inbound' | 'outbound';
+  action: 'poll' | 'cdc' | 'webhook' | 'manual' | 'writeback';
+  status: 'running' | 'success' | 'no_changes' | 'failed';
+  cursorBefore: unknown | null;
+  cursorAfter: unknown | null;
+  recordsFound: number;
+  recordsProcessed: number;
+  durationMs: number | null;
+  error: string | null;
+  tenantId: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+}
+
+@Injectable()
+export class MemoryRunRecorder implements ISyncRunRecorder {
+  /**
+   * All started runs keyed by id. Public so tests can inspect lifecycle
+   * transitions without poking through recording methods.
+   */
+  readonly runs: Map<string, MemoryRunRecord> = new Map();
+
+  /**
+   * Items keyed by `sync_run_id`, array order matches insertion order —
+   * mirrors the timeline the `(sync_run_id, created_at)` index produces
+   * in Postgres.
+   */
+  readonly items: Map<string, RecordItemInput[]> = new Map();
+
+  async startRun(input: StartRunInput): Promise<{ id: string }> {
+    const id = crypto.randomUUID();
+    this.runs.set(id, {
+      id,
+      subscriptionId: input.subscriptionId,
+      direction: input.direction,
+      action: input.action,
+      status: 'running',
+      cursorBefore: input.cursorBefore ?? null,
+      cursorAfter: null,
+      recordsFound: 0,
+      recordsProcessed: 0,
+      durationMs: null,
+      error: null,
+      tenantId: input.tenantId ?? null,
+      startedAt: new Date(),
+      completedAt: null,
+    });
+    this.items.set(id, []);
+    return { id };
+  }
+
+  async recordItem(input: RecordItemInput): Promise<void> {
+    // Same ADR-0003 contract as the Drizzle backend.
+    FieldDiffSchema.parse(input.changedFields);
+
+    const bucket = this.items.get(input.syncRunId);
+    if (!bucket) {
+      throw new Error(
+        `MemoryRunRecorder.recordItem: no run started for id '${input.syncRunId}'. ` +
+          `Call startRun(...) first.`,
+      );
+    }
+    bucket.push(input);
+  }
+
+  async completeRun(runId: string, input: CompleteRunInput): Promise<void> {
+    const run = this.runs.get(runId);
+    if (!run) {
+      throw new Error(
+        `MemoryRunRecorder.completeRun: no run started for id '${runId}'.`,
+      );
+    }
+    run.status = input.status;
+    run.recordsFound = input.recordsFound;
+    run.recordsProcessed = input.recordsProcessed;
+    run.cursorAfter = input.cursorAfter ?? null;
+    run.durationMs = input.durationMs;
+    run.error = input.error ?? null;
+    run.completedAt = new Date();
+  }
+
+  /** Reset state. Tests call this in `beforeEach`. */
+  clear(): void {
+    this.runs.clear();
+    this.items.clear();
+  }
+
+  // ─── test ergonomics ─────────────────────────────────────────────────
+
+  /** All runs for a subscription, newest first. Timeline reads. */
+  getRunsForSubscription(subscriptionId: string): MemoryRunRecord[] {
+    return Array.from(this.runs.values())
+      .filter((r) => r.subscriptionId === subscriptionId)
+      .sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime());
+  }
+
+  /** All item rows for a run, insertion-ordered. */
+  getItemsForRun(runId: string): RecordItemInput[] {
+    return this.items.get(runId) ?? [];
+  }
+}

--- a/runtime/subsystems/sync/sync.module.ts
+++ b/runtime/subsystems/sync/sync.module.ts
@@ -1,0 +1,156 @@
+/**
+ * SyncModule — `DynamicModule.forRoot({ backend, multiTenant? })` factory
+ * wiring the sync subsystem's substrate (SYNC-6, ADR-008 subsystem pattern).
+ *
+ * ## What this module provides
+ *
+ *   - `SYNC_CURSOR_STORE`    — Drizzle or Memory cursor store
+ *   - `SYNC_RUN_RECORDER`    — Drizzle or Memory run recorder
+ *   - `SYNC_FIELD_DIFFER`    — default `DeepEqualDiffer`
+ *   - `SYNC_MULTI_TENANT`    — resolved boolean flag (defaults to false)
+ *   - `SYNC_MODULE_OPTIONS`  — the options object itself, for backends
+ *     that need to inspect config at construction time
+ *
+ * ## What this module does NOT provide
+ *
+ *   - `SYNC_CHANGE_SOURCE` — per-provider per-entity; consumer binds in
+ *     their feature module (e.g. `OpportunitySyncModule` provides a
+ *     `SalesforceOpportunityChangeSource`).
+ *   - `SYNC_SINK` — per canonical entity; consumer binds in their feature
+ *     module.
+ *   - `SYNC_LOOPBACK_FINGERPRINT_STORE` — optional; consumer provides
+ *     only when they have outbound writeback paths. `@Optional()` at the
+ *     orchestrator seam means absence is fine.
+ *   - `ExecuteSyncUseCase` — registered by the feature module alongside
+ *     its source + sink bindings. Providing the orchestrator here would
+ *     force Nest to resolve SYNC_CHANGE_SOURCE + SYNC_SINK at module
+ *     compile time, which fails when the feature module hasn't been
+ *     imported yet. Consumers register `ExecuteSyncUseCase` in the same
+ *     `providers` array as their source + sink so resolution is local
+ *     to where all three are bound.
+ *
+ * Same shape as `EventsModule.forRoot` — the module wires the bus; you
+ * bring your own handlers. Here: the module wires the substrate; you
+ * bring your own source + sink.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * // AppModule — single source of truth for backend + multi-tenancy.
+ * @Module({
+ *   imports: [SyncModule.forRoot({ backend: 'drizzle' })],
+ * })
+ * export class AppModule {}
+ *
+ * // Per-entity feature module — binds source + sink, gets the
+ * // orchestrator for free.
+ * @Module({
+ *   providers: [
+ *     { provide: SYNC_CHANGE_SOURCE, useClass: SalesforceOpportunitySource },
+ *     { provide: SYNC_SINK,          useClass: OpportunitySyncSink },
+ *     ExecuteSyncUseCase,
+ *   ],
+ * })
+ * export class OpportunitySyncModule {
+ *   constructor(
+ *     private readonly execute: ExecuteSyncUseCase<CanonicalOpportunity>,
+ *   ) {}
+ * }
+ * ```
+ *
+ * `global: true` means feature modules do not need to re-import
+ * `SyncModule` — the substrate tokens are available project-wide.
+ */
+import { Module, type DynamicModule, type Provider } from '@nestjs/common';
+import {
+  SYNC_CURSOR_STORE,
+  SYNC_FIELD_DIFFER,
+  SYNC_MODULE_OPTIONS,
+  SYNC_MULTI_TENANT,
+  SYNC_RUN_RECORDER,
+} from './sync.tokens';
+import { MemoryCursorStore } from './sync-cursor-store.memory-backend';
+import { MemoryRunRecorder } from './sync-run-recorder.memory-backend';
+import { PostgresCursorStore } from './sync-cursor-store.drizzle-backend';
+import { DrizzleSyncRunRecorder } from './sync-run-recorder.drizzle-backend';
+import { DeepEqualDiffer } from './deep-equal.differ';
+
+export interface SyncModuleOptions {
+  /**
+   * Backend selection. `drizzle` wires the Postgres cursor store +
+   * run-log recorder; `memory` wires in-memory doubles suitable for
+   * tests + local dev.
+   */
+  backend: 'drizzle' | 'memory';
+
+  /**
+   * Multi-tenancy opt-in (SYNC-6).
+   *
+   * When `true`, every call to the orchestrator + both Drizzle backends
+   * must supply a non-null `tenantId`; missing values throw
+   * `MissingTenantIdError`. Defense-in-depth: the orchestrator rejects
+   * at entry (no dangling `status=running` rows) AND the Drizzle
+   * backends reject at their write boundary (belt-and-braces for any
+   * path that bypasses the orchestrator). Both sites use the shared
+   * `assertTenantId` helper so error messages match.
+   *
+   * Memory backends accept `tenantId` unconditionally — their state is
+   * process-local; cross-tenant isolation there is not meaningful.
+   *
+   * Defaults to `false`.
+   */
+  multiTenant?: boolean;
+}
+
+@Module({})
+export class SyncModule {
+  static forRoot(options: SyncModuleOptions): DynamicModule {
+    const multiTenant = options.multiTenant ?? false;
+
+    const sharedProviders: Provider[] = [
+      { provide: SYNC_MODULE_OPTIONS, useValue: options },
+      { provide: SYNC_MULTI_TENANT, useValue: multiTenant },
+      // Default differ — consumers can override by binding a different
+      // `IFieldDiffer<T>` to `SYNC_FIELD_DIFFER` in their feature module.
+      { provide: SYNC_FIELD_DIFFER, useValue: new DeepEqualDiffer() },
+    ];
+
+    const backendProviders: Provider[] =
+      options.backend === 'memory'
+        ? [
+            // Wired as singletons via `useValue` so tests can pull
+            // them out via `moduleRef.get(MemoryCursorStore)` for
+            // direct assertions. Matches JOB-4 / MemoryJobStore shape.
+            { provide: MemoryCursorStore, useValue: new MemoryCursorStore() },
+            {
+              provide: SYNC_CURSOR_STORE,
+              useExisting: MemoryCursorStore,
+            },
+            { provide: MemoryRunRecorder, useValue: new MemoryRunRecorder() },
+            {
+              provide: SYNC_RUN_RECORDER,
+              useExisting: MemoryRunRecorder,
+            },
+          ]
+        : [
+            // Drizzle backends — injected with DRIZZLE (provided by the
+            // consumer's DrizzleModule) + the SYNC_MULTI_TENANT flag
+            // we bound above.
+            { provide: SYNC_CURSOR_STORE, useClass: PostgresCursorStore },
+            { provide: SYNC_RUN_RECORDER, useClass: DrizzleSyncRunRecorder },
+          ];
+
+    return {
+      module: SyncModule,
+      global: true,
+      providers: [...sharedProviders, ...backendProviders],
+      exports: [
+        SYNC_MODULE_OPTIONS,
+        SYNC_MULTI_TENANT,
+        SYNC_FIELD_DIFFER,
+        SYNC_CURSOR_STORE,
+        SYNC_RUN_RECORDER,
+      ],
+    };
+  }
+}

--- a/src/__tests__/runtime/subsystems/sync.module.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync.module.spec.ts
@@ -1,0 +1,374 @@
+/**
+ * SyncModule unit tests (SYNC-6).
+ *
+ * Mirrors `events-module.spec.ts`: compile the module via
+ * `@nestjs/testing`, assert the tokens resolve to the expected backends,
+ * and exercise the multi-tenancy surface end-to-end.
+ *
+ * Memory-backend path is the primary test surface; the Drizzle path is
+ * exercised with a fake DRIZZLE binding so we can assert the providers
+ * bind correctly without Postgres. Real Drizzle wiring is validated by
+ * the backend specs (#151) and the eventual integration tests.
+ */
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import { Global, Module } from '@nestjs/common';
+import { drizzle } from 'drizzle-orm/pg-proxy';
+import { DRIZZLE } from '../../../../runtime/constants/tokens';
+import type { DrizzleClient } from '../../../../runtime/types/drizzle';
+import { SyncModule } from '../../../../runtime/subsystems/sync/sync.module';
+import {
+  SYNC_CHANGE_SOURCE,
+  SYNC_CURSOR_STORE,
+  SYNC_FIELD_DIFFER,
+  SYNC_MODULE_OPTIONS,
+  SYNC_MULTI_TENANT,
+  SYNC_RUN_RECORDER,
+  SYNC_SINK,
+} from '../../../../runtime/subsystems/sync/sync.tokens';
+import { MemoryCursorStore } from '../../../../runtime/subsystems/sync/sync-cursor-store.memory-backend';
+import { MemoryRunRecorder } from '../../../../runtime/subsystems/sync/sync-run-recorder.memory-backend';
+import { PostgresCursorStore } from '../../../../runtime/subsystems/sync/sync-cursor-store.drizzle-backend';
+import { DrizzleSyncRunRecorder } from '../../../../runtime/subsystems/sync/sync-run-recorder.drizzle-backend';
+import { DeepEqualDiffer } from '../../../../runtime/subsystems/sync/deep-equal.differ';
+import { ExecuteSyncUseCase } from '../../../../runtime/subsystems/sync/execute-sync.use-case';
+import { MissingTenantIdError } from '../../../../runtime/subsystems/sync/sync-errors';
+import type {
+  Change,
+  IChangeSource,
+  SyncSubscriptionView,
+} from '../../../../runtime/subsystems/sync/sync-change-source.protocol';
+import type { ISyncSink } from '../../../../runtime/subsystems/sync/sync-sink.protocol';
+
+// ─── Inline fakes for source + sink (feature-module-owned tokens) ───────────
+
+interface CanonicalOpp extends Record<string, unknown> {
+  external_id: string;
+  amount?: number;
+}
+
+class EmptySource implements IChangeSource<CanonicalOpp> {
+  readonly label = 'test';
+  // eslint-disable-next-line @typescript-eslint/require-yield
+  async *listChanges(_sub: SyncSubscriptionView): AsyncIterable<Change<CanonicalOpp>> {
+    // yields nothing
+    return;
+  }
+}
+
+class OneChangeSource implements IChangeSource<CanonicalOpp> {
+  readonly label = 'test';
+  async *listChanges(_sub: SyncSubscriptionView): AsyncIterable<Change<CanonicalOpp>> {
+    yield {
+      externalId: 'ext-1',
+      operation: 'created',
+      record: { external_id: 'ext-1', amount: 100 },
+      cursor: { v: 1 },
+      source: 'poll',
+    };
+  }
+}
+
+class NoopSink implements ISyncSink<CanonicalOpp> {
+  async findByExternalId(): Promise<CanonicalOpp | null> {
+    return null;
+  }
+  async upsertByExternalId(
+    _userId: string,
+    record: CanonicalOpp,
+  ): Promise<{ id: string; saved: CanonicalOpp }> {
+    return { id: `local-${record.external_id}`, saved: record };
+  }
+  async softDeleteByExternalId(): Promise<{ id: string } | null> {
+    return null;
+  }
+}
+
+/**
+ * Feature-module wrapper so tests can compose `SyncModule.forRoot(...)`
+ * with a consumer-provided source + sink in a single `Test.createTestingModule`
+ * call. This mirrors what a real consumer's `OpportunitySyncModule` looks like.
+ */
+@Module({
+  providers: [
+    { provide: SYNC_CHANGE_SOURCE, useClass: OneChangeSource },
+    { provide: SYNC_SINK, useClass: NoopSink },
+    ExecuteSyncUseCase,
+  ],
+})
+class TestFeatureModule {}
+
+@Module({
+  providers: [
+    { provide: SYNC_CHANGE_SOURCE, useClass: EmptySource },
+    { provide: SYNC_SINK, useClass: NoopSink },
+    ExecuteSyncUseCase,
+  ],
+})
+class EmptyFeatureModule {}
+
+// ─── Memory backend ─────────────────────────────────────────────────────────
+
+describe('SyncModule.forRoot({ backend: "memory" })', () => {
+  it('resolves SYNC_CURSOR_STORE to MemoryCursorStore', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_CURSOR_STORE)).toBeInstanceOf(MemoryCursorStore);
+    await moduleRef.close();
+  });
+
+  it('resolves SYNC_RUN_RECORDER to MemoryRunRecorder', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_RUN_RECORDER)).toBeInstanceOf(MemoryRunRecorder);
+    await moduleRef.close();
+  });
+
+  it('resolves SYNC_FIELD_DIFFER to DeepEqualDiffer', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_FIELD_DIFFER)).toBeInstanceOf(DeepEqualDiffer);
+    await moduleRef.close();
+  });
+
+  it('binds SYNC_MODULE_OPTIONS to the passed options', async () => {
+    const options = { backend: 'memory' as const, multiTenant: true };
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot(options)],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_MODULE_OPTIONS)).toEqual(options);
+    await moduleRef.close();
+  });
+
+  it('defaults SYNC_MULTI_TENANT to false when multiTenant is omitted', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_MULTI_TENANT)).toBe(false);
+    await moduleRef.close();
+  });
+
+  it('resolves ExecuteSyncUseCase when a feature module binds source + sink', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        SyncModule.forRoot({ backend: 'memory' }),
+        EmptyFeatureModule,
+      ],
+    }).compile();
+
+    const orch = moduleRef.get(ExecuteSyncUseCase);
+    expect(orch).toBeInstanceOf(ExecuteSyncUseCase);
+    await moduleRef.close();
+  });
+
+  it('MemoryCursorStore and MemoryRunRecorder are singletons (same instance via class + token)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_CURSOR_STORE)).toBe(moduleRef.get(MemoryCursorStore));
+    expect(moduleRef.get(SYNC_RUN_RECORDER)).toBe(moduleRef.get(MemoryRunRecorder));
+    await moduleRef.close();
+  });
+});
+
+// ─── End-to-end memory run ──────────────────────────────────────────────────
+
+describe('SyncModule end-to-end (memory backend)', () => {
+  it('executes a run through the composed module with no tenantId (single-tenant)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        SyncModule.forRoot({ backend: 'memory' }),
+        TestFeatureModule,
+      ],
+    }).compile();
+
+    const orch = moduleRef.get(ExecuteSyncUseCase);
+    const recorder = moduleRef.get(MemoryRunRecorder);
+
+    const result = await orch.execute({
+      subscription: { id: 'sub-1', domain: 'opportunity' },
+      userId: 'user-1',
+      provider: 'salesforce-crm',
+      direction: 'inbound',
+      action: 'poll',
+    });
+
+    expect(result.status).toBe('success');
+    expect(result.recordsProcessed).toBe(1);
+
+    // MemoryRunRecorder captured the lifecycle — test ergonomics helpers
+    // make this a one-liner.
+    const runs = recorder.getRunsForSubscription('sub-1');
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe('success');
+    expect(recorder.getItemsForRun(runs[0]!.id)).toHaveLength(1);
+
+    await moduleRef.close();
+  });
+});
+
+// ─── Multi-tenancy enforcement ──────────────────────────────────────────────
+
+describe('SyncModule.forRoot({ multiTenant: true }) — enforcement', () => {
+  it('binds SYNC_MULTI_TENANT to true', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [SyncModule.forRoot({ backend: 'memory', multiTenant: true })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_MULTI_TENANT)).toBe(true);
+    await moduleRef.close();
+  });
+
+  it('orchestrator rejects execute() with no tenantId', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        SyncModule.forRoot({ backend: 'memory', multiTenant: true }),
+        TestFeatureModule,
+      ],
+    }).compile();
+
+    const orch = moduleRef.get(ExecuteSyncUseCase);
+    const recorder = moduleRef.get(MemoryRunRecorder);
+
+    await expect(
+      orch.execute({
+        subscription: { id: 'sub-1', domain: 'opportunity' },
+        userId: 'user-1',
+        provider: 'salesforce-crm',
+        direction: 'inbound',
+        action: 'poll',
+      }),
+    ).rejects.toBeInstanceOf(MissingTenantIdError);
+
+    // Critical: no dangling `status=running` row. The orchestrator
+    // threw BEFORE startRun fired.
+    expect(recorder.runs.size).toBe(0);
+
+    await moduleRef.close();
+  });
+
+  it('orchestrator rejects execute() with explicit null tenantId', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        SyncModule.forRoot({ backend: 'memory', multiTenant: true }),
+        TestFeatureModule,
+      ],
+    }).compile();
+
+    const orch = moduleRef.get(ExecuteSyncUseCase);
+    const recorder = moduleRef.get(MemoryRunRecorder);
+
+    await expect(
+      orch.execute({
+        subscription: { id: 'sub-1', domain: 'opportunity' },
+        userId: 'user-1',
+        provider: 'salesforce-crm',
+        direction: 'inbound',
+        action: 'poll',
+        tenantId: null,
+      }),
+    ).rejects.toBeInstanceOf(MissingTenantIdError);
+    expect(recorder.runs.size).toBe(0);
+
+    await moduleRef.close();
+  });
+
+  it('accepts a tenantId and passes it through the full run', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        SyncModule.forRoot({ backend: 'memory', multiTenant: true }),
+        TestFeatureModule,
+      ],
+    }).compile();
+
+    const orch = moduleRef.get(ExecuteSyncUseCase);
+    const recorder = moduleRef.get(MemoryRunRecorder);
+
+    const result = await orch.execute({
+      subscription: { id: 'sub-1', domain: 'opportunity' },
+      userId: 'user-1',
+      provider: 'salesforce-crm',
+      direction: 'inbound',
+      action: 'poll',
+      tenantId: 'tenant-a',
+    });
+
+    expect(result.status).toBe('success');
+    const runs = recorder.getRunsForSubscription('sub-1');
+    expect(runs[0]?.tenantId).toBe('tenant-a');
+    const items = recorder.getItemsForRun(runs[0]!.id);
+    expect(items[0]?.tenantId).toBe('tenant-a');
+
+    await moduleRef.close();
+  });
+});
+
+// ─── Drizzle backend wiring ─────────────────────────────────────────────────
+
+describe('SyncModule.forRoot({ backend: "drizzle" })', () => {
+  /**
+   * Consumers normally import DrizzleModule which binds the DRIZZLE token;
+   * in tests we provide it directly via a fake pg-proxy client. This lets
+   * us assert SyncModule wires the Drizzle backend classes without
+   * needing Postgres.
+   */
+  @Global()
+  @Module({
+    providers: [
+      {
+        provide: DRIZZLE,
+        useValue: drizzle(async () => ({ rows: [] })) as unknown as DrizzleClient,
+      },
+    ],
+    exports: [DRIZZLE],
+  })
+  class FakeDrizzleModule {}
+
+  it('resolves SYNC_CURSOR_STORE to PostgresCursorStore', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [FakeDrizzleModule, SyncModule.forRoot({ backend: 'drizzle' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_CURSOR_STORE)).toBeInstanceOf(PostgresCursorStore);
+    await moduleRef.close();
+  });
+
+  it('resolves SYNC_RUN_RECORDER to DrizzleSyncRunRecorder', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [FakeDrizzleModule, SyncModule.forRoot({ backend: 'drizzle' })],
+    }).compile();
+
+    expect(moduleRef.get(SYNC_RUN_RECORDER)).toBeInstanceOf(DrizzleSyncRunRecorder);
+    await moduleRef.close();
+  });
+
+  it('threads SYNC_MULTI_TENANT=true into the Drizzle backends', async () => {
+    // Exercise the end-to-end path: module flag → backend behavior.
+    // The backend throws MissingTenantIdError when flagged on, with no
+    // tenantId in the call.
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FakeDrizzleModule,
+        SyncModule.forRoot({ backend: 'drizzle', multiTenant: true }),
+      ],
+    }).compile();
+
+    const cursors = moduleRef.get<PostgresCursorStore>(SYNC_CURSOR_STORE);
+
+    await expect(cursors.get('sub-1')).rejects.toBeInstanceOf(
+      MissingTenantIdError,
+    );
+
+    await moduleRef.close();
+  });
+});


### PR DESCRIPTION
Closes #131. Part of epic #60 (sync-engine subsystem stack).

## Summary

Sixth child PR. Lands the `DynamicModule` factory that wires the sync subsystem substrate, the in-memory run recorder that makes `backend: 'memory'` genuinely end-to-end, and defense-in-depth multi-tenancy enforcement at the orchestrator boundary.

## Files added

- `runtime/subsystems/sync/sync.module.ts` — `SyncModule.forRoot({ backend, multiTenant? })`. Wires `SYNC_CURSOR_STORE`, `SYNC_RUN_RECORDER`, `SYNC_FIELD_DIFFER`, `SYNC_MULTI_TENANT`, `SYNC_MODULE_OPTIONS`. `global: true` — feature modules don't need to re-import.
- `runtime/subsystems/sync/sync-run-recorder.memory-backend.ts` — `MemoryRunRecorder` with `startRun`/`recordItem`/`completeRun` + `FieldDiffSchema.parse` validation (same contract as Drizzle). Ergonomic helpers: `getRunsForSubscription`, `getItemsForRun`.
- `src/__tests__/runtime/subsystems/sync.module.spec.ts` — 15 module-level tests via `@nestjs/testing`.

## Files modified

- `runtime/subsystems/sync/sync-errors.ts` — adds shared `assertTenantId` helper called at three sites (orchestrator entry, Drizzle cursor store, Drizzle recorder) so every `MissingTenantIdError` has identical message shape.
- `runtime/subsystems/sync/execute-sync.use-case.ts` — injects `SYNC_MULTI_TENANT` (`@Optional`, default false); calls `assertTenantId` at `execute()` entry BEFORE `startRun` fires. No dangling `status=running` rows when a rejected input comes in.
- `runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts` + `sync-run-recorder.drizzle-backend.ts` — `buildWhere` / `startRun` / `recordItem` delegate to `assertTenantId`. Unified message shape.
- `runtime/subsystems/sync/index.ts` — re-exports `SyncModule`, `SyncModuleOptions`, `MemoryRunRecorder`, `MemoryRunRecord`, `assertTenantId`.

## Design calls (gate-approved)

1. **`ExecuteSyncUseCase` is NOT provided by SyncModule.** Providing it forces Nest to resolve `SYNC_CHANGE_SOURCE + SYNC_SINK` at module compile time, which fails before the feature module is imported. Consumers register `ExecuteSyncUseCase` in the same `providers` array as their source + sink bindings. Documented in the module header with a worked example showing `OpportunitySyncModule` providing all three together.

2. **`DeepEqualDiffer` is wired via `useValue: new DeepEqualDiffer()`** — the class constructor's optional options object is reflected as an `Object` dependency by `emit-decorator-metadata`. `useValue` sidesteps that. Consumers binding a custom differ in their feature module override the default.

3. **`MemoryRunRecorder` ships here.** Per gate — `backend: 'memory'` must be end-to-end functional.

4. **Shared `assertTenantId` helper across orchestrator + backends.** Per gate — identical message shape at every enforcement point makes errors easier to pattern-match in logs/metrics.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test .../sync.module.spec.ts` — 15/15 pass
- [x] Existing orchestrator + Drizzle-backend specs — 42/42 (verify `assertTenantId` refactor did not regress)
- [x] `just test-all` — 1210/0 (unit + baseline + smoke)

## What this PR does NOT include

- No scaffold templates for `codegen subsystem install sync` (SYNC-7 #132 — gated).
- No consumer docs / `.claude/skills/sync/` (SYNC-8 #133).
- No Atlas migration file; consumers still run `migrate diff` against the SYNC-1 schema per the SYNC-4 agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)