### PR TITLE
SYNC-7 — subsystem install sync: Hygen scaffold + CLI wiring

### DIFF
--- a/src/__tests__/cli/subsystem.test.ts
+++ b/src/__tests__/cli/subsystem.test.ts
@@ -88,9 +88,9 @@ function capture<T>(fn: () => Promise<T>): Promise<{ result: T; out: string }> {
 // ---------------------------------------------------------------------------
 
 describe('subsystem — descriptor', () => {
-	test('knows all four subsystems', () => {
+	test('knows all five subsystems', () => {
 		expect(SUBSYSTEMS.map((s) => s.name).sort()).toEqual(
-			['cache', 'events', 'jobs', 'storage'].sort()
+			['cache', 'events', 'jobs', 'storage', 'sync'].sort()
 		);
 	});
 });
@@ -115,7 +115,7 @@ describe('subsystem — summary + list', () => {
 		);
 		const parsed = JSON.parse(out);
 		expect(parsed.command).toBe('subsystem list');
-		expect(parsed.subsystems).toHaveLength(4);
+		expect(parsed.subsystems).toHaveLength(5);
 		for (const row of parsed.subsystems) {
 			expect(row.status).toBe('available');
 		}
@@ -378,6 +378,132 @@ describe('subsystem — install F13 (config-block preservation)', () => {
 		);
 		expect(after).toContain('events:');
 		expect(after).toContain('backend: drizzle');
+	});
+});
+
+describe('subsystem — install sync (SYNC-7)', () => {
+	test('copies runtime/subsystems/sync into target + follows deps', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run(['subsystem', 'install', 'sync', '--force', '--json', '--cwd', root])
+		);
+		expect(result).toBe(0);
+		const installDir = path.join(root, 'src/shared/subsystems/sync');
+		expect(fs.existsSync(installDir)).toBe(true);
+		// Core files present.
+		expect(fs.existsSync(path.join(installDir, 'sync.module.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'sync-change-source.protocol.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'execute-sync.use-case.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'deep-equal.differ.ts'))).toBe(true);
+		// Drizzle backends present (default backend).
+		expect(fs.existsSync(path.join(installDir, 'sync-cursor-store.drizzle-backend.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'sync-run-recorder.drizzle-backend.ts'))).toBe(true);
+		// Memory backends present too — always copied for tests.
+		expect(fs.existsSync(path.join(installDir, 'sync-cursor-store.memory-backend.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(installDir, 'sync-run-recorder.memory-backend.ts'))).toBe(true);
+		// Shared deps copied to parallel tree.
+		expect(fs.existsSync(path.join(root, 'src/shared/types/drizzle.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(root, 'src/shared/constants/tokens.ts'))).toBe(true);
+	});
+
+	test('schema is emitted via Hygen (not copyRuntime) — verified by multi_tenant gating', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run(['subsystem', 'install', 'sync', '--force', '--json', '--cwd', root])
+		);
+		expect(result).toBe(0);
+		const schemaPath = path.join(
+			root,
+			'src/shared/subsystems/sync/sync-audit.schema.ts',
+		);
+		expect(fs.existsSync(schemaPath)).toBe(true);
+		// Default install is multi_tenant: false → no tenant_id columns emitted.
+		const schema = fs.readFileSync(schemaPath, 'utf8');
+		expect(schema).not.toContain("text('tenant_id')");
+	});
+
+	test('config block appended to codegen.config.yaml', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run(['subsystem', 'install', 'sync', '--force', '--cwd', root]),
+		);
+		const after = fs.readFileSync(path.join(root, 'codegen.config.yaml'), 'utf8');
+		expect(after).toContain('sync:');
+		expect(after).toContain('backend: drizzle');
+		expect(after).toContain('multi_tenant: false');
+	});
+
+	test('memory backend skips .drizzle-backend.ts; schema still emitted via Hygen', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'sync',
+				'--backend',
+				'memory',
+				'--force',
+				'--json',
+				'--cwd',
+				root,
+			])
+		);
+		expect(result).toBe(0);
+		const installDir = path.join(root, 'src/shared/subsystems/sync');
+		expect(
+			fs.existsSync(path.join(installDir, 'sync-cursor-store.drizzle-backend.ts')),
+		).toBe(false);
+		expect(
+			fs.existsSync(path.join(installDir, 'sync-run-recorder.drizzle-backend.ts')),
+		).toBe(false);
+		// Memory backends are always present.
+		expect(
+			fs.existsSync(path.join(installDir, 'sync-cursor-store.memory-backend.ts')),
+		).toBe(true);
+		// Schema still emitted (Hygen-driven, backend-independent).
+		expect(
+			fs.existsSync(path.join(installDir, 'sync-audit.schema.ts')),
+		).toBe(true);
+	});
+
+	test('detectInstalledSubsystems finds sync after install', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run(['subsystem', 'install', 'sync', '--force', '--cwd', root]),
+		);
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+		const installed = await detectInstalledSubsystems(ctx);
+		expect(installed.map((i) => i.name)).toContain('sync');
+	});
+
+	test('multi_tenant: true in config emits tenant_id columns in schema', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		// Hand-write a config with sync.multi_tenant: true.
+		fs.writeFileSync(
+			path.join(root, 'codegen.config.yaml'),
+			'paths:\n  subsystems: src/shared/subsystems\nsync:\n  backend: drizzle\n  multi_tenant: true\n',
+		);
+		const cli = buildCli();
+		const { result } = await capture(() =>
+			cli.run(['subsystem', 'install', 'sync', '--force', '--cwd', root]),
+		);
+		expect(result).toBe(0);
+		const schema = fs.readFileSync(
+			path.join(root, 'src/shared/subsystems/sync/sync-audit.schema.ts'),
+			'utf8',
+		);
+		expect(schema).toContain("text('tenant_id')");
 	});
 });
 

--- a/src/__tests__/cli/sync-scaffold-locals.test.ts
+++ b/src/__tests__/cli/sync-scaffold-locals.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for the SYNC-7 sync-scaffold locals resolver.
+ *
+ * Mirrors events-scaffold-locals.test.ts. Covers:
+ *   - default locals on first install (no `sync:` block in config)
+ *   - multi_tenant: true honored
+ *   - multi_tenant non-boolean values do not leak through
+ *   - custom `paths.subsystems` flows into schemaPath
+ *   - localsToHygenArgs serialises all flags
+ *   - localsToHygenArgs emits absolute paths
+ *   - NO generatedKeepPath — sync ships no codegen artifacts
+ */
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+
+import {
+	localsToHygenArgs,
+	resolveSyncScaffoldLocals,
+	type SyncScaffoldLocals,
+} from '../../cli/shared/sync-scaffold-locals.js';
+
+const CWD = '/tmp/sync-fixture';
+
+describe('resolveSyncScaffoldLocals', () => {
+	test('fresh-install defaults (no sync block)', () => {
+		const locals = resolveSyncScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+		});
+
+		expect(locals.multiTenant).toBe(false);
+		expect(locals.appName).toBe('sync-fixture');
+		expect(locals.configPath).toBe(path.resolve(CWD, 'codegen.config.yaml'));
+		expect(locals.schemaPath).toBe(
+			path.resolve(CWD, 'src/shared/subsystems/sync/sync-audit.schema.ts'),
+		);
+	});
+
+	test('sync.multi_tenant: true flows into multiTenant local', () => {
+		const locals = resolveSyncScaffoldLocals({
+			cwd: CWD,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			config: { sync: { multi_tenant: true } } as any,
+			fileExists: () => false,
+		});
+		expect(locals.multiTenant).toBe(true);
+	});
+
+	test('sync.multi_tenant non-boolean values do not leak through', () => {
+		for (const raw of ['true', 'yes', 1, 'on']) {
+			const locals = resolveSyncScaffoldLocals({
+				cwd: CWD,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				config: { sync: { multi_tenant: raw } } as any,
+				fileExists: () => false,
+			});
+			expect(locals.multiTenant).toBe(false);
+		}
+	});
+
+	test('paths.backend_src derives default subsystems root when paths.subsystems is unset', () => {
+		const locals = resolveSyncScaffoldLocals({
+			cwd: CWD,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			config: { paths: { backend_src: 'packages/api/src' } } as any,
+			fileExists: () => false,
+		});
+		expect(locals.schemaPath).toBe(
+			path.resolve(
+				CWD,
+				'packages/api/src/shared/subsystems/sync/sync-audit.schema.ts',
+			),
+		);
+	});
+
+	test('paths.subsystems takes precedence over paths.backend_src', () => {
+		const locals = resolveSyncScaffoldLocals({
+			cwd: CWD,
+			config: {
+				paths: {
+					backend_src: 'packages/api/src',
+					subsystems: 'custom/subsystems',
+				},
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any,
+			fileExists: () => false,
+		});
+		expect(locals.schemaPath).toBe(
+			path.resolve(CWD, 'custom/subsystems/sync/sync-audit.schema.ts'),
+		);
+	});
+
+	test('custom paths.subsystems flows into schemaPath', () => {
+		const locals = resolveSyncScaffoldLocals({
+			cwd: CWD,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			config: { paths: { subsystems: 'packages/api/src/subsystems' } } as any,
+			fileExists: () => false,
+		});
+		expect(locals.schemaPath).toBe(
+			path.resolve(
+				CWD,
+				'packages/api/src/subsystems/sync/sync-audit.schema.ts',
+			),
+		);
+	});
+
+	test('fileExists probe is permitted to be unused', () => {
+		expect(() =>
+			resolveSyncScaffoldLocals({
+				cwd: CWD,
+				config: null,
+				fileExists: () => {
+					throw new Error('should not be called');
+				},
+			}),
+		).not.toThrow();
+	});
+
+	test('no generatedKeepPath on the locals shape', () => {
+		// SYNC-7 intentionally omits a generated/ dir. Any future agent who
+		// tries to add it should fail this test first.
+		const locals = resolveSyncScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+		});
+		expect('generatedKeepPath' in locals).toBe(false);
+	});
+});
+
+describe('localsToHygenArgs', () => {
+	const base: SyncScaffoldLocals = {
+		appName: 'demo',
+		multiTenant: false,
+		configPath: '/abs/codegen.config.yaml',
+		schemaPath: '/abs/shared/subsystems/sync/sync-audit.schema.ts',
+	};
+
+	test('multiTenant booleans serialise to the literal strings Hygen expects', () => {
+		const offArgs = localsToHygenArgs(base);
+		const offIdx = offArgs.indexOf('--multiTenant');
+		expect(offIdx).toBeGreaterThanOrEqual(0);
+		expect(offArgs[offIdx + 1]).toBe('false');
+
+		const onArgs = localsToHygenArgs({ ...base, multiTenant: true });
+		const onIdx = onArgs.indexOf('--multiTenant');
+		expect(onArgs[onIdx + 1]).toBe('true');
+	});
+
+	test('all required flags present', () => {
+		const args = localsToHygenArgs(base);
+		for (const flag of ['--appName', '--multiTenant', '--configPath', '--schemaPath']) {
+			expect(args).toContain(flag);
+		}
+	});
+
+	test('no --generatedKeepPath flag', () => {
+		const args = localsToHygenArgs(base);
+		expect(args).not.toContain('--generatedKeepPath');
+	});
+
+	test('paths pass through as absolute', () => {
+		const args = localsToHygenArgs(base);
+		expect(args).toContain('/abs/codegen.config.yaml');
+		expect(args).toContain('/abs/shared/subsystems/sync/sync-audit.schema.ts');
+	});
+});

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -30,6 +30,10 @@ import {
 	localsToHygenArgs,
 	resolveJobsScaffoldLocals,
 } from '../shared/jobs-scaffold-locals.js';
+import {
+	localsToHygenArgs as syncLocalsToHygenArgs,
+	resolveSyncScaffoldLocals,
+} from '../shared/sync-scaffold-locals.js';
 import { copyRuntime } from '../shared/runtime-copier.js';
 import {
 	SUBSYSTEMS,
@@ -184,6 +188,18 @@ function backendFileFilter(
 			return false;
 		}
 
+		// SYNC-7: same pattern for sync — the Hygen template
+		// `templates/subsystem/sync/sync-audit.schema.ejs.t` is the sole
+		// emitter for the sync audit schema, gating the `tenant_id`
+		// columns on `sync.multi_tenant`. Skip here so `copyRuntime`
+		// never writes the always-tenant runtime source file.
+		if (
+			subsystemName === 'sync' &&
+			file === 'sync-audit.schema.ts'
+		) {
+			return false;
+		}
+
 		if (backend === 'memory') {
 			if (file.endsWith('.drizzle-backend.ts')) return false;
 			if (file.endsWith('.schema.ts')) return false;
@@ -325,6 +341,18 @@ export class SubsystemInstallCommand extends Command {
 					})
 				: null;
 
+		// SYNC-7: sync subsystem — inject the `sync:` config block and emit
+		// the tenancy-aware audit schema. No generated/ dir (sync ships no
+		// codegen artifacts — see sync-scaffold-locals.ts docstring).
+		const syncScaffold =
+			desc.name === 'sync'
+				? runSyncScaffold(ctx.cwd, ctx.config, {
+						dryRun: this.dryRun,
+						json: isJsonMode(),
+						forceConfig: this.forceConfig,
+					})
+				: null;
+
 		// #121 (F13): a parse-error on codegen.config.yaml causes the scaffold
 		// to refuse re-injection rather than silently overwrite. Surface it as
 		// a non-zero exit with a clear message; runtime files were already
@@ -338,6 +366,12 @@ export class SubsystemInstallCommand extends Command {
 		if (eventsScaffold?.configBlockOutcome === 'parse-error') {
 			printError(
 				'codegen.config.yaml is not valid YAML: refusing to inject events config block. Fix the YAML and re-run.',
+			);
+			return 1;
+		}
+		if (syncScaffold?.configBlockOutcome === 'parse-error') {
+			printError(
+				'codegen.config.yaml is not valid YAML: refusing to inject sync config block. Fix the YAML and re-run.',
 			);
 			return 1;
 		}
@@ -358,6 +392,7 @@ export class SubsystemInstallCommand extends Command {
 				},
 				...(jobsScaffold ? { scaffold: jobsScaffold } : {}),
 				...(eventsScaffold ? { scaffold: eventsScaffold } : {}),
+				...(syncScaffold ? { scaffold: syncScaffold } : {}),
 			});
 			return 0;
 		}
@@ -380,6 +415,14 @@ export class SubsystemInstallCommand extends Command {
 					`Events scaffold — ${eventsScaffold.planned.length} template targets`,
 				);
 				for (const p of eventsScaffold.planned) {
+					console.log(`  ${theme.muted(icons.arrow)} ${path.relative(ctx.cwd, p) || p}`);
+				}
+			}
+			if (syncScaffold?.planned?.length) {
+				printInfo(
+					`Sync scaffold — ${syncScaffold.planned.length} template targets`,
+				);
+				for (const p of syncScaffold.planned) {
 					console.log(`  ${theme.muted(icons.arrow)} ${path.relative(ctx.cwd, p) || p}`);
 				}
 			}
@@ -415,10 +458,26 @@ export class SubsystemInstallCommand extends Command {
 				);
 			}
 		}
+		if (syncScaffold) {
+			if (syncScaffold.ok) {
+				printSuccess(
+					`sync scaffold applied (config block, schema)`,
+				);
+			} else {
+				printWarning(
+					`sync scaffold (Hygen) failed — runtime files were written; re-run after fixing: ${syncScaffold.error ?? 'unknown error'}`,
+				);
+			}
+		}
 		printSuccess(`${desc.name} subsystem installed with ${backend} backend.`);
 		printInfo(
 			`Register ${capitalize(desc.name)}Module.forRoot({ backend: '${backend}' }) in your app.module.ts`
 		);
+		if (desc.name === 'sync') {
+			printInfo(
+				`Per-entity: register ExecuteSyncUseCase + your IChangeSource/ISyncSink bindings in a feature module (see SyncModule docstring).`
+			);
+		}
 		return 0;
 	}
 }
@@ -471,7 +530,7 @@ function planConfigBlockAction(
 
 interface ConfigBlockActionInput {
 	cwd: string;
-	actionFolder: 'jobs-config' | 'events-config';
+	actionFolder: 'jobs-config' | 'events-config' | 'sync-config';
 	configPath: string;
 	subsystem: DetectorSubsystemName;
 	outcome: ConfigBlockOutcome;
@@ -722,6 +781,94 @@ function runEventsScaffold(
 		actionFolder: 'events-config',
 		configPath: locals.configPath,
 		subsystem: 'events',
+		outcome: configBlockOutcome,
+		json: opts.json,
+	});
+
+	if (!configResult.ok) {
+		return {
+			ok: false,
+			planned,
+			error: configResult.error,
+			configBlockOutcome,
+		};
+	}
+
+	return { ok: true, planned, configBlockOutcome };
+}
+
+// ---------------------------------------------------------------------------
+// SYNC-7 — sync subsystem Hygen scaffold wiring
+// ---------------------------------------------------------------------------
+
+interface SyncScaffoldOutcome {
+	ok: boolean;
+	planned: string[];
+	error?: string;
+	/** #121 (F13): see JobsScaffoldOutcome. */
+	configBlockOutcome?: ConfigBlockOutcome;
+}
+
+function runSyncScaffold(
+	cwd: string,
+	config: Context['config'],
+	opts: { dryRun: boolean; json: boolean; forceConfig: boolean },
+): SyncScaffoldOutcome {
+	const locals = resolveSyncScaffoldLocals({
+		cwd,
+		config,
+		fileExists: (p: string) => fs.existsSync(p),
+	});
+
+	// Files the sync templates will target (used by --dry-run output and
+	// JSON reporting). Ordering matches the template set. No generated/
+	// entry — sync ships no codegen artifacts (see
+	// sync-scaffold-locals.ts docstring).
+	const planned: string[] = [
+		locals.configPath,
+		locals.schemaPath,
+	];
+
+	// #121 (F13): inspect config BEFORE invoking the main scaffold. Main
+	// scaffold no longer emits the config block — `subsystem/sync-config`
+	// handles that under CLI control.
+	const configBlockOutcome = planConfigBlockAction(
+		locals.configPath,
+		'sync',
+		opts.forceConfig,
+	);
+
+	if (configBlockOutcome === 'parse-error') {
+		return { ok: false, planned, configBlockOutcome };
+	}
+
+	if (opts.dryRun) {
+		return { ok: true, planned, configBlockOutcome };
+	}
+
+	const result = invokeHygen({
+		generator: 'subsystem',
+		action: 'sync',
+		cwd,
+		args: syncLocalsToHygenArgs(locals),
+		// Suppress Hygen stdout in JSON mode so it doesn't corrupt the JSON output.
+		inherit: !opts.json,
+	});
+
+	if (!result.ok) {
+		return {
+			ok: false,
+			planned,
+			error: result.stderr?.trim() || 'hygen exited non-zero',
+			configBlockOutcome,
+		};
+	}
+
+	const configResult = runConfigBlockAction({
+		cwd,
+		actionFolder: 'sync-config',
+		configPath: locals.configPath,
+		subsystem: 'sync',
 		outcome: configBlockOutcome,
 		json: opts.json,
 	});

--- a/src/cli/shared/config-block-detect.ts
+++ b/src/cli/shared/config-block-detect.ts
@@ -16,7 +16,7 @@ import { parse as parseYaml, parseDocument } from 'yaml';
 
 export type ConfigBlockState = 'missing' | 'present' | 'parse-error';
 
-export type SubsystemName = 'jobs' | 'events' | 'cache' | 'storage';
+export type SubsystemName = 'jobs' | 'events' | 'cache' | 'storage' | 'sync';
 
 /**
  * Detect whether a subsystem's top-level config block is present in a

--- a/src/cli/shared/subsystem-detect.ts
+++ b/src/cli/shared/subsystem-detect.ts
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { Context } from './context.js';
 
-export type SubsystemName = 'events' | 'jobs' | 'cache' | 'storage';
+export type SubsystemName = 'events' | 'jobs' | 'cache' | 'storage' | 'sync';
 export type SubsystemBackend = 'drizzle' | 'memory' | 'local' | 'unknown';
 
 export interface InstalledSubsystem {
@@ -48,6 +48,12 @@ export const SUBSYSTEMS: SubsystemDescriptor[] = [
 		description: 'File/object storage',
 		backends: ['local', 'memory'],
 		defaultBackend: 'local',
+	},
+	{
+		name: 'sync',
+		description: 'External-system sync engine (IChangeSource<T> + orchestrator + audit log)',
+		backends: ['drizzle', 'memory'],
+		defaultBackend: 'drizzle',
 	},
 ];
 

--- a/src/cli/shared/sync-scaffold-locals.ts
+++ b/src/cli/shared/sync-scaffold-locals.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure resolver for the Hygen locals consumed by `templates/subsystem/sync/`.
+ *
+ * SYNC-7: `subsystem install sync` runs after `copyRuntime` and invokes the
+ * sync scaffold generator. The two templates this steers:
+ *   - `codegen-config-sync-block.ejs.t` — appends the `sync:` block.
+ *   - `sync-audit.schema.ejs.t` — writes the three-table audit schema,
+ *     gating the `tenant_id` columns on `sync.multi_tenant`.
+ *
+ * Sync intentionally has NO `generated/` directory — unlike events (which
+ * codegen-emits `TypedEventBus`), sync has no typed artifacts to stage.
+ * The orchestrator + differ are directly importable; consumers override
+ * the differ by binding a different `IFieldDiffer<T>` to `SYNC_FIELD_DIFFER`.
+ * A future Phase-2 `syncable:` YAML flag (see epic #60) may add a
+ * `generated/` dir then; skipping it now avoids shipping a phantom
+ * directory. Matches the "don't design for hypothetical future
+ * requirements" line in CLAUDE.md.
+ *
+ * This module is filesystem-unaware except via injected probes — callers
+ * pass `fileExists(p)` rather than us reaching for `node:fs` directly. That
+ * keeps the unit test suite pure (see cli/sync-scaffold-locals.test.ts).
+ */
+import path from 'node:path';
+
+import type { CodegenConfig } from './context.js';
+import { resolveSubsystemsRootFromConfig } from './subsystems-path.js';
+
+export interface SyncScaffoldLocals {
+	/** Fallback basename for logs; not rendered in templates today. */
+	appName: string;
+	/** Gates the `tenant_id` columns in the schema template. */
+	multiTenant: boolean;
+	/** Where `codegen-config-sync-block.ejs.t` appends the `sync:` block. */
+	configPath: string;
+	/** Where `sync-audit.schema.ejs.t` writes the scaffolded schema. */
+	schemaPath: string;
+}
+
+export interface SyncScaffoldLocalsInput {
+	/** Absolute working directory of the consumer project. */
+	cwd: string;
+	/** Parsed codegen.config.yaml (may be null on a brand-new init). */
+	config: CodegenConfig | null;
+	/** Injected fs probe. Implementations: `(p) => fs.existsSync(p)`. */
+	fileExists: (absolutePath: string) => boolean;
+}
+
+/**
+ * Resolve all Hygen locals for `subsystem install sync` from config + cwd.
+ *
+ * - `sync.multi_tenant` defaults to `false` when the block is absent (first
+ *   install case). Only the literal `true` flips the flag — defends against
+ *   YAML truthy surprises like `'yes'` / `1`.
+ * - `schemaPath` resolves from `paths.subsystems` (or
+ *   `<paths.backend_src>/shared/subsystems` when unset; see
+ *   `subsystems-path.ts`), then appends `sync/sync-audit.schema.ts` —
+ *   matching exactly the location `copyRuntime` would have emitted before
+ *   we skipped that file via `backendFileFilter`.
+ *
+ * The `fileExists` probe is a reserved capability — today's templates
+ * don't consume any existence checks (config and schema use `inject` +
+ * `force` respectively). The parameter is kept for parity with the
+ * events/jobs resolvers and for future probes without an API break.
+ */
+export function resolveSyncScaffoldLocals(
+	input: SyncScaffoldLocalsInput,
+): SyncScaffoldLocals {
+	const { cwd, config } = input;
+	// fileExists is intentionally unused — see JSDoc. Touch the reference
+	// so tree-shaking / lint doesn't complain.
+	void input.fileExists;
+
+	const syncBlock = (config?.sync ?? {}) as Record<string, unknown>;
+
+	const subsystemsRoot = resolveSubsystemsRootFromConfig(cwd, config);
+
+	const configPath = path.resolve(cwd, 'codegen.config.yaml');
+	const schemaPath = path.resolve(
+		subsystemsRoot,
+		'sync',
+		'sync-audit.schema.ts',
+	);
+
+	return {
+		appName: path.basename(cwd),
+		multiTenant: normaliseMultiTenant(syncBlock.multi_tenant),
+		configPath,
+		schemaPath,
+	};
+}
+
+function normaliseMultiTenant(raw: unknown): boolean {
+	return raw === true;
+}
+
+/**
+ * Serialise locals to the `--flag value` argv pairs Hygen consumes.
+ * Booleans become `'true'` / `'false'`; string values pass through. Paths
+ * are forwarded as absolute so Hygen's `to:` front-matter resolves
+ * relative to them, not to Hygen's `cwd`.
+ */
+export function localsToHygenArgs(locals: SyncScaffoldLocals): string[] {
+	return [
+		'--appName', locals.appName,
+		'--multiTenant', locals.multiTenant ? 'true' : 'false',
+		'--configPath', locals.configPath,
+		'--schemaPath', locals.schemaPath,
+	];
+}

--- a/templates/subsystem/sync-config/codegen-config-sync-block.ejs.t
+++ b/templates/subsystem/sync-config/codegen-config-sync-block.ejs.t
@@ -1,0 +1,29 @@
+---
+to: "<%= configPath %>"
+inject: true
+append: true
+skip_if: "sync:"
+---
+
+sync:
+  # ── Backend selection (core/extension model — see CLAUDE.md) ──
+  # 'drizzle' is the production backend (Postgres cursor store +
+  # sync_runs / sync_run_items audit log). 'memory' is the in-process
+  # test backend (MemoryCursorStore + MemoryRunRecorder).
+  backend: drizzle
+
+  # ── Multi-tenancy (SYNC-6 / ADR-008) ──
+  # When true:
+  #   - the generated schema gains `tenant_id` columns on all three
+  #     sync tables;
+  #   - `ExecuteSyncUseCase.execute(...)` throws `MissingTenantIdError`
+  #     when called with a null / missing `tenantId`;
+  #   - `PostgresCursorStore` + `DrizzleSyncRunRecorder` throw the same
+  #     error at their write boundary (defense in depth);
+  #   - `MemoryCursorStore` + `MemoryRunRecorder` accept `tenantId` and
+  #     record it on their in-memory rows but do not throw — memory
+  #     state is process-local; cross-tenant isolation there is not
+  #     meaningful.
+  # Enabling post-install requires a reinstall (`subsystem install sync
+  # --force --force-config`) plus an Atlas migration.
+  multi_tenant: false

--- a/templates/subsystem/sync-config/prompt.js
+++ b/templates/subsystem/sync-config/prompt.js
@@ -1,0 +1,22 @@
+/**
+ * Hygen prompt.js — SYNC-7 sync config-block scaffold.
+ *
+ * Split from `templates/subsystem/sync/` so the CLI can invoke the
+ * config-block inject step independently of the rest of the sync scaffold.
+ * This lets `subsystem install sync --force` preserve an existing `sync:`
+ * block by skipping this action entirely, while `--force-config` opts in
+ * to regenerating it.
+ *
+ * Mirrors `events-config` exactly.
+ *
+ * Invoked via:
+ *   bunx hygen subsystem sync-config --configPath <abs>
+ */
+
+export default {
+  prompt: async ({ args }) => {
+    return {
+      configPath: args.configPath ?? "codegen.config.yaml",
+    };
+  },
+};

--- a/templates/subsystem/sync/prompt.js
+++ b/templates/subsystem/sync/prompt.js
@@ -1,0 +1,43 @@
+/**
+ * Hygen prompt.js — SYNC-7 sync subsystem scaffold.
+ *
+ * All locals are resolved by the CLI (src/cli/shared/sync-scaffold-locals.ts)
+ * and forwarded as CLI args. This prompt.js coerces boolean-ish strings back
+ * into JS booleans so template `<% if (multiTenant) { %>` gates work — Hygen
+ * args arrive as strings, and `if ("false")` would render truthy in EJS.
+ *
+ * Invoked via:
+ *   bunx hygen subsystem sync \
+ *     --configPath <abs> --schemaPath <abs> \
+ *     --multiTenant <'true'|'false'> --appName <string>
+ *
+ * Unlike events, sync has NO codegen-emitted artifacts (no generated/ dir,
+ * no typed bus facade). So no `generatedKeepPath` local. Consumers that
+ * want a typed layer above the orchestrator build it themselves — the
+ * subsystem ships the substrate.
+ *
+ * Intentionally no starter entity YAMLs (sync_subscription, sync_run,
+ * sync_run_item). The subsystem owns those tables directly via SYNC-1's
+ * sync-audit.schema.ts; shipping entity YAMLs would generate redundant
+ * repositories/services that shadow the subsystem. Matches the epic's
+ * Phase 2 timing for `examples/sync/`.
+ */
+
+function coerceBool(raw) {
+  if (raw === true) return true;
+  if (raw === false) return false;
+  if (typeof raw === "string") return raw.toLowerCase() === "true";
+  return false;
+}
+
+export default {
+  prompt: async ({ args }) => {
+    return {
+      appName: args.appName ?? "",
+      multiTenant: coerceBool(args.multiTenant),
+      configPath: args.configPath ?? "codegen.config.yaml",
+      schemaPath:
+        args.schemaPath ?? "shared/subsystems/sync/sync-audit.schema.ts",
+    };
+  },
+};

--- a/templates/subsystem/sync/sync-audit.schema.ejs.t
+++ b/templates/subsystem/sync/sync-audit.schema.ejs.t
@@ -1,0 +1,195 @@
+---
+to: "<%= schemaPath %>"
+force: true
+---
+/**
+ * Drizzle schema for the sync subsystem audit/observability tables (SYNC-1).
+ *
+ * Three tables model end-to-end sync observability, keyed by the single
+ * port every sync adapter implements (`IChangeSource<T>` from SYNC-2):
+ *
+ *   - `sync_subscriptions` — owns the cursor per
+ *       `(integration_id, adapter, domain, external_ref)` tuple. Addressed
+ *       by id by `ICursorStore` (SYNC-3/SYNC-4).
+ *   - `sync_runs`          — per-run audit log: start/complete, status,
+ *       cursor before/after, counts, direction + action.
+ *   - `sync_run_items`     — per-record change log with structured
+ *       `changed_fields` jsonb (ADR-0003). The `FieldDiff` type alias
+ *       is owned by the sync subsystem's runtime protocol
+ *       (`sync-field-diff.protocol.ts` from SYNC-2).
+ *
+ * ## `tenant_id` columns — scaffold-time conditional
+ *
+ * When `sync.multi_tenant: true` in `codegen.config.yaml`, this schema
+ * emits `tenant_id` as a nullable text column on all three tables. The
+ * `SYNC_MULTI_TENANT` DI flag (SYNC-6) enforces non-null at runtime
+ * across the orchestrator + Drizzle backends. Enabling post-install
+ * requires reinstalling this subsystem (`subsystem install sync --force
+ * --force-config`) plus an Atlas migration.
+ *
+ * See SYNC-1 / SYNC-6 in epic #60 for the decision rationale.
+ */
+import {
+  pgEnum,
+  pgTable,
+  uuid,
+  text,
+  jsonb,
+  integer,
+  boolean,
+  timestamp,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import type { InferSelectModel } from 'drizzle-orm';
+
+// NOTE: the `FieldDiff` type alias is imported from the runtime protocol
+// shipped by `subsystem install sync`. If you moved that file, fix this
+// import to point at the new location.
+import type { FieldDiff } from './sync-field-diff.protocol';
+
+// ─── Enums ──────────────────────────────────────────────────────────────────
+
+export const syncRunDirectionEnum = pgEnum('sync_run_direction', [
+  'inbound',
+  'outbound',
+]);
+
+export const syncRunActionEnum = pgEnum('sync_run_action', [
+  'poll',
+  'cdc',
+  'webhook',
+  'manual',
+  'writeback',
+]);
+
+export const syncRunStatusEnum = pgEnum('sync_run_status', [
+  'running',
+  'success',
+  'no_changes',
+  'failed',
+]);
+
+export const syncRunItemOperationEnum = pgEnum('sync_run_item_operation', [
+  'created',
+  'updated',
+  'deleted',
+  'noop',
+]);
+
+export const syncRunItemStatusEnum = pgEnum('sync_run_item_status', [
+  'success',
+  'failed',
+  'skipped',
+]);
+
+// ─── sync_subscriptions ─────────────────────────────────────────────────────
+
+export const syncSubscriptions = pgTable(
+  'sync_subscriptions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    integrationId: text('integration_id').notNull(),
+    adapter: text('adapter').notNull(),
+    domain: text('domain').notNull(),
+    externalRef: text('external_ref'),
+    enabled: boolean('enabled').notNull().default(true),
+    config: jsonb('config').notNull().default({}).$type<Record<string, unknown>>(),
+    cursor: jsonb('cursor').$type<unknown>(),
+    lastSyncAt: timestamp('last_sync_at', { withTimezone: true }),
+<% if (multiTenant) { -%>
+    tenantId: text('tenant_id'),                // scaffold-time conditional — see sync.multi_tenant
+<% } -%>
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uqSyncSubscriptionTuple: uniqueIndex('uq_sync_subscriptions_tuple').on(
+      t.integrationId,
+      t.adapter,
+      t.domain,
+      t.externalRef,
+    ),
+    idxSyncSubscriptionsEnabledLastSync: index(
+      'idx_sync_subscriptions_enabled_last_sync',
+    ).on(t.enabled, t.lastSyncAt),
+  }),
+);
+
+export type SyncSubscriptionRow = InferSelectModel<typeof syncSubscriptions>;
+
+// ─── sync_runs ──────────────────────────────────────────────────────────────
+
+export const syncRuns = pgTable(
+  'sync_runs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    subscriptionId: uuid('subscription_id')
+      .notNull()
+      .references(() => syncSubscriptions.id, { onDelete: 'cascade' }),
+    direction: syncRunDirectionEnum('direction').notNull(),
+    action: syncRunActionEnum('action').notNull(),
+    status: syncRunStatusEnum('status').notNull().default('running'),
+    recordsFound: integer('records_found').notNull().default(0),
+    recordsProcessed: integer('records_processed').notNull().default(0),
+    cursorBefore: jsonb('cursor_before').$type<unknown>(),
+    cursorAfter: jsonb('cursor_after').$type<unknown>(),
+    durationMs: integer('duration_ms'),
+    error: text('error'),
+    startedAt: timestamp('started_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+<% if (multiTenant) { -%>
+    tenantId: text('tenant_id'),                // scaffold-time conditional — see sync.multi_tenant
+<% } -%>
+  },
+  (t) => ({
+    idxSyncRunsSubscriptionStartedAt: index(
+      'idx_sync_runs_subscription_started_at',
+    ).on(t.subscriptionId, t.startedAt),
+    idxSyncRunsStatusStartedAt: index('idx_sync_runs_status_started_at').on(
+      t.status,
+      t.startedAt,
+    ),
+  }),
+);
+
+export type SyncRunRow = InferSelectModel<typeof syncRuns>;
+
+// ─── sync_run_items ─────────────────────────────────────────────────────────
+
+export const syncRunItems = pgTable(
+  'sync_run_items',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    syncRunId: uuid('sync_run_id')
+      .notNull()
+      .references(() => syncRuns.id, { onDelete: 'cascade' }),
+    entityType: text('entity_type').notNull(),
+    externalId: text('external_id').notNull(),
+    localId: text('local_id'),
+    operation: syncRunItemOperationEnum('operation').notNull(),
+    status: syncRunItemStatusEnum('status').notNull(),
+    changedFields: jsonb('changed_fields').notNull().default({}).$type<FieldDiff>(),
+    title: text('title'),
+    error: text('error'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+<% if (multiTenant) { -%>
+    tenantId: text('tenant_id'),                // scaffold-time conditional — see sync.multi_tenant
+<% } -%>
+  },
+  (t) => ({
+    idxSyncRunItemsRunCreatedAt: index('idx_sync_run_items_run_created_at').on(
+      t.syncRunId,
+      t.createdAt,
+    ),
+    idxSyncRunItemsEntityExternal: index(
+      'idx_sync_run_items_entity_external',
+    ).on(t.entityType, t.externalId),
+  }),
+);
+
+export type SyncRunItemRow = InferSelectModel<typeof syncRunItems>;


### PR DESCRIPTION
Closes #132. Part of epic #60 (sync-engine subsystem stack).

## Summary

Seventh child PR. Lands `bun codegen subsystem install sync` end-to-end: subsystem registration, scaffold-locals resolver, two Hygen template sets, and CLI wiring that mirrors the events/jobs path.

## Files added

- `src/cli/shared/sync-scaffold-locals.ts` — pure locals resolver (appName, multiTenant, configPath, schemaPath). Mirrors `events-scaffold-locals.ts` minus `generatedKeepPath` — sync ships no codegen artifacts.
- `templates/subsystem/sync/prompt.js` + `sync-audit.schema.ejs.t` — Hygen scaffold for the three-table audit schema. `tenant_id` columns gated on `sync.multi_tenant` (same scaffold-time conditional as events).
- `templates/subsystem/sync-config/prompt.js` + `codegen-config-sync-block.ejs.t` — inject-only template appending the `sync:` block (backend + multi_tenant only per gate).
- `src/__tests__/cli/sync-scaffold-locals.test.ts` — 12 tests covering defaults, multi_tenant honoring + non-bool rejection, paths precedence, serialization, plus a canary test asserting no `generatedKeepPath` in the locals shape.
- 6 new tests appended to `src/__tests__/cli/subsystem.test.ts` — real-filesystem sync install: drizzle copies, Hygen schema emission, config-block append, memory-backend filter, `detectInstalledSubsystems`, and `multi_tenant: true` end-to-end emitting `tenant_id` columns.

## Files modified

- `src/cli/shared/subsystem-detect.ts` — adds `'sync'` to `SubsystemName` union + `SUBSYSTEMS` descriptor list (drizzle default, memory for tests).
- `src/cli/shared/config-block-detect.ts` — adds `'sync'` to the `SubsystemName` union so `detectConfigBlock` / `stripConfigBlock` work on the `sync:` block.
- `src/cli/commands/subsystem.ts` — wires `runSyncScaffold` alongside events/jobs: filter rule, dispatch, JSON + dry-run + success hooks, union widening for `actionFolder`, and a sync-specific install hint pointing at the feature-module registration pattern (`ExecuteSyncUseCase` + source/sink bindings — see `SyncModule` docstring).

## Design calls (gate-approved)

1. **No starter entity YAMLs.** Subsystem-owned tables should not be shadowed by codegen; events/jobs don't ship entity YAMLs for their internal tables either. Phase 2 `examples/sync/` is the correct placement per the epic timing. Documented in `prompt.js` so a future agent doesn't re-add them out of reflex.

2. **No `generated/` dir.** No codegen artifacts. Canary test in `sync-scaffold-locals.test.ts` asserts the shape doesn't sprout one silently.

3. **Minimal `sync:` block — `backend` + `multi_tenant` only.** No placeholders per CLAUDE.md.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test .../sync-scaffold-locals.test.ts` — 12/12
- [x] `bun test .../subsystem.test.ts` — 23/23 (including 6 new sync-install cases exercising real filesystem + Hygen)
- [x] `just test-all` — 1228/0 (unit + baseline + smoke)

## What this PR does NOT include

- No consumer docs / `.claude/skills/sync/` (SYNC-8 #133 — next PR closes the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)