### PR TITLE
SYNC-8 — consumer docs + sync skill (closes epic #60)

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: sync
+description: Use when working on IChangeSource<T>, ExecuteSyncUseCase, the sync_runs / sync_run_items audit model, cursor persistence (PostgresCursorStore / MemoryCursorStore), the DeepEqualDiffer + FieldDiffSchema contract, SyncModule wiring, or anything in runtime/subsystems/sync/. Load this before authoring a new IChangeSource adapter or ISyncSink, before touching the orchestrator loop, and before changing the changed_fields jsonb shape (ADR-0003).
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+user-invocable: false
+---
+
+# Sync Domain Skill
+
+The sync subsystem is the generic external-system integration engine.
+One orchestrator (`ExecuteSyncUseCase<T>`) runs every integration in
+the codebase. Per-provider code implements a single port —
+`IChangeSource<T>` — and per-entity code implements a single write
+surface — `ISyncSink<T>`. Everything else (cursor persistence, diffing,
+per-record audit, run lifecycle) is provided by the subsystem.
+
+This skill covers the Phase 1 runtime (SYNC-1..SYNC-8, epic #60). Phase
+2 (the `syncable:` YAML flag + codegen-produced per-entity sync binding
+modules) is gated on the App-Defined Patterns RFC and not shipped.
+
+## Mental model
+
+**Sync vs. jobs vs. events — three domains, one codebase:**
+
+| System | Purpose | Unit |
+|---|---|---|
+| **Events** | Immutable facts about what happened | `domain_events` rows |
+| **Jobs** | Stateful retryable work | `job_run` rows with status/retry |
+| **Sync** | Detect upstream change → diff → apply → record | `sync_runs` + `sync_run_items` pairs |
+
+Sync can trigger events (on successful upsert) and can be triggered by
+jobs (scheduled polling) or webhooks — but the three are distinct
+subsystems with different lifecycles. Don't collapse them.
+
+**Five-step dance — the invariant every integration repeats:**
+
+1. detect upstream change
+2. diff against local state
+3. apply (upsert or soft-delete)
+4. record delta
+5. emit event (consumer-owned wiring)
+
+Steps 2–5 are machinery the subsystem owns. Step 1 is the `IChangeSource<T>`
+port — per-provider, per-entity, per-detection-mode. Three detection
+modes (poll / CDC / webhook) converge on the same port; per-mode
+differences live in `Change<T>` metadata (`source`, `dedupKey`,
+`providerChangedFields`), not in separate ports. That was a deliberate
+compromise rejecting an `IPollSource` / `ICdcSource` / `IWebhookSource`
+split — see epic #60's design notes.
+
+**Audit model — structured, not freeform:**
+
+`sync_run_items.changed_fields` is `{ fieldName: { from: unknown, to: unknown } }`
+jsonb. Enforced at write time by `FieldDiffSchema.parse` at the recorder
+boundary (ADR-0003). This lets drift-detection queries work as one-shot
+SQL filters instead of payload-JSON scrapes. Every write path —
+Drizzle + Memory — validates identically.
+
+**Two enforcement points for multi-tenancy:**
+
+When `SYNC_MULTI_TENANT=true`, the orchestrator throws
+`MissingTenantIdError` at `execute()` entry BEFORE opening a
+`sync_runs` row (no dangling `status=running` rows), AND the Drizzle
+backends independently re-validate at their write boundary. Both sites
+use the shared `assertTenantId` helper so error messages match. The
+memory backends accept `tenantId` and record it but do not throw —
+memory state is process-local; cross-tenant isolation there isn't
+meaningful.
+
+## Task → L1 routing
+
+| When the task involves… | Read |
+|---|---|
+| Designing a new `IChangeSource<T>` / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
+| The orchestrator's run lifecycle, cursor advance, per-item failure, loopback | `orchestrator-flow.md` |
+| `sync_runs` / `sync_run_items` / `sync_subscriptions` shape, `changed_fields` (ADR-0003), worked queries | `audit-model.md` |
+| Writing a feature module, migrating from bespoke sync, multi-tenancy wiring | `consumer-patterns.md` |
+
+## Non-obvious rules (read twice)
+
+1. **One port for three modes.** Poll, CDC, and webhook adapters ALL
+   implement `IChangeSource<T>`. Per-mode concerns (CDC replay_id,
+   webhook event_id, provider-hinted changed fields) live in `Change<T>`
+   metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
+   introduce mode-specific ports — we rejected that design explicitly.
+
+2. **Cursors are opaque at the port seam.** `ICursorStore.get/put`
+   takes `unknown`. Each strategy types its cursor internally (poll:
+   `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`). The
+   orchestrator doesn't interpret the shape; it just persists what the
+   iterator last yielded.
+
+3. **All-failed runs still advance the cursor.** If every record in a
+   run fails, `status='failed'` is recorded but the cursor still
+   persists as last-yielded. Rationale: the source kept yielding;
+   re-running would not re-deliver those records. Retry semantics
+   (dead-letter replay, `action: 'manual'`) are caller-owned. Document
+   this in consumer runbooks — it's the most common "wait, what?"
+   moment during first-run adoption.
+
+4. **Created-record diffs include every non-null user field.** The
+   default `DeepEqualDiffer` ignores only row metadata (`id`,
+   `createdAt`, `updatedAt`, `deletedAt`, `type`, `lastModifiedAt`,
+   `fields`, `providerMetadata`). Domain fields — including
+   identifiers like `external_id` — are legitimately part of the diff
+   for a newly-created record. If a consumer wants to trim extras,
+   augment via `new DeepEqualDiffer({ ignore: [...] })` in their
+   feature module's `SYNC_FIELD_DIFFER` binding.
+
+5. **`SyncModule` does NOT provide `ExecuteSyncUseCase`.** Providing it
+   there would force Nest to resolve `SYNC_CHANGE_SOURCE` +
+   `SYNC_SINK` at module compile time, which fails before the feature
+   module is imported. Consumers register `ExecuteSyncUseCase` in the
+   same `providers` array as their source + sink bindings. Documented
+   in the `sync.module.ts` header with a worked `OpportunitySyncModule`
+   example.
+
+6. **`DeepEqualDiffer` is wired via `useValue: new DeepEqualDiffer()`.**
+   The class constructor's optional options object is reflected as an
+   `Object` dependency by Nest's emit-decorator-metadata; `useValue`
+   sidesteps that. Consumers binding a custom differ override the
+   default via their own `SYNC_FIELD_DIFFER` provider.
+
+7. **`completeRun` does NOT re-check tenancy** when `multiTenant=true`.
+   The run id was returned by `startRun` which already enforced it;
+   run ids are uuids, not guessable cross-tenant. Matches JOB-3's
+   pattern of trusting the run id for downstream mutations. Don't add
+   a guard there without an ADR.
+
+8. **ADR-0003 `FieldDiffSchema` is enforced at the recorder boundary,
+   not the column.** The `changed_fields` jsonb column has `$type<FieldDiff>`
+   annotation but the runtime gate is `FieldDiffSchema.parse(input.changedFields)`
+   in `recordItem`. Both Drizzle + Memory backends call parse — a
+   memory recorder that skipped the validation would be a silently
+   weaker contract than production.
+
+9. **`sync_subscriptions` is subsystem-owned, not consumer-owned.**
+   `PostgresCursorStore` reads/writes it directly. Consumers can still
+   list/query it freely for admin UIs, but don't ship an entity YAML
+   for it — that would produce redundant repositories/services
+   shadowing the subsystem. Same stance as `job_run`.
+
+## Do not
+
+- Do not introduce `IPollSource`, `ICdcSource`, or `IWebhookSource`.
+  The `IChangeSource<T>` union is deliberate. See epic #60 compromise
+  analysis.
+- Do not treat `changed_fields` as freeform jsonb. The `{ from, to }`
+  per-field shape is load-bearing for drift-detection queries and
+  enforced at write. Adding arbitrary keys breaks consumers.
+- Do not provide `ExecuteSyncUseCase` in `SyncModule`. It forces
+  eager resolution of consumer-owned tokens. Feature modules register
+  the orchestrator alongside their source + sink bindings.
+- Do not bypass `assertTenantId` when adding a new write path in a
+  Drizzle backend. Every boundary that accepts `tenantId` must
+  delegate to the shared helper so error messages match.
+- Do not ship entity YAMLs for `sync_subscriptions` / `sync_runs` /
+  `sync_run_items` — the subsystem owns the tables directly. This
+  was explicitly resolved during SYNC-7 scaffold design (epic #60 §
+  Phase 2 scopes `examples/sync/` YAMLs for later, not now).
+- Do not create `*.deprecated.ts`, parallel shapes, or migration
+  shims. No backwards compat to preserve — replace cleanly.
+- Do not expand `IChangeSource` / `ISyncSink` protocols without an
+  ADR. The narrow ports are deliberate; mode-specific richness lives
+  in `Change<T>` metadata or in extension methods the consumer owns.
+
+## Current runtime snapshot
+
+Files that ship to the consumer app (not templates):
+
+- `runtime/subsystems/sync/sync-change-source.protocol.ts` —
+  `IChangeSource<T>`, `Change<T>`, `ChangeSource` type, `SyncSubscriptionView`
+- `runtime/subsystems/sync/sync-cursor-store.protocol.ts` —
+  `ICursorStore` with `tenantId?` signature (SYNC-4)
+- `runtime/subsystems/sync/sync-field-diff.protocol.ts` —
+  `IFieldDiffer<T>`, `DiffResult`, `FieldDiffSchema` (Zod — ADR-0003)
+- `runtime/subsystems/sync/sync-sink.protocol.ts` — `ISyncSink<T>`
+- `runtime/subsystems/sync/sync-run-recorder.protocol.ts` —
+  `ISyncRunRecorder` + `StartRunInput` / `RecordItemInput` /
+  `CompleteRunInput`
+- `runtime/subsystems/sync/sync-loopback.protocol.ts` — optional
+  `ILoopbackFingerprintStore<T>`
+- `runtime/subsystems/sync/sync-audit.schema.ts` — 3 pgTables + 5
+  pgEnums (scaffold-time `tenant_id` conditional owned by the Hygen
+  template, not by this runtime source — matches JOB-6 / EVT-8
+  pattern)
+- `runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts` —
+  `PostgresCursorStore`; `put()` stamps `cursor` + `last_sync_at` +
+  `updated_at` in one statement so the scheduling index stays accurate
+- `runtime/subsystems/sync/sync-cursor-store.memory-backend.ts` —
+  `MemoryCursorStore` test double (SYNC-3)
+- `runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts` —
+  `DrizzleSyncRunRecorder`; validates `changedFields` via
+  `FieldDiffSchema.parse` BEFORE insert
+- `runtime/subsystems/sync/sync-run-recorder.memory-backend.ts` —
+  `MemoryRunRecorder` with ergonomic helpers (`getRunsForSubscription`,
+  `getItemsForRun`) for tests (SYNC-6)
+- `runtime/subsystems/sync/deep-equal.differ.ts` — default
+  `DeepEqualDiffer<T>` with canonical ignore list; `providerChangedFields`
+  CDC hint; Date → ISO string + decimal-string ↔ number normalizations
+- `runtime/subsystems/sync/execute-sync.use-case.ts` — the generic
+  orchestrator. `@Optional() SYNC_LOOPBACK_FINGERPRINT_STORE` +
+  `@Optional() SYNC_MULTI_TENANT`. Entry-point `assertTenantId` guard
+- `runtime/subsystems/sync/sync.module.ts` —
+  `SyncModule.forRoot({ backend, multiTenant? })`; `global: true`
+- `runtime/subsystems/sync/sync.tokens.ts` — string-valued tokens
+- `runtime/subsystems/sync/sync-errors.ts` — `MissingTenantIdError`
+  class + `assertTenantId(tenantId, { multiTenant, operation })` shared
+  helper
+
+Generator pieces:
+
+- `templates/subsystem/sync/` — main scaffold (`prompt.js`,
+  `sync-audit.schema.ejs.t`) — emitted on `subsystem install sync`
+- `templates/subsystem/sync-config/` — config-block scaffold — emitted
+  on first install; `--force` alone preserves an existing block,
+  `--force-config` opts into regeneration (F13 pattern)
+- `src/cli/shared/sync-scaffold-locals.ts` — resolves Hygen locals
+  (appName, multiTenant, configPath, schemaPath — NO generatedKeepPath)
+
+## Cross-links
+
+- Events SKILL.md — sync can `TypedEventBus.publish(...)` after each
+  successful upsert (consumer wires this; the subsystem doesn't).
+- Jobs SKILL.md — sync is typically triggered by a scheduled job
+  (polling) or on-demand via `action: 'manual'` from a CLI / operator
+  action.
+- `docs/adrs/ADR-008-subsystem-architecture.md` — Protocol → Backend
+  → Factory pattern the sync subsystem follows.
+- `docs/CONSUMER-SETUP.md#sync-subsystem` — fresh-install walkthrough.
+- `docs/guides/sync-migration.md` — migrating from a bespoke sync
+  pipeline.
+- Epic #60 — authoritative decision record; `IChangeSource<T>`
+  compromise analysis, ADR-0003 audit model rationale, dealbrain-v2
+  extraction verdict.

--- a/.claude/skills/sync/audit-model.md
+++ b/.claude/skills/sync/audit-model.md
@@ -1,0 +1,221 @@
+# Audit model
+
+Three tables, one contract. This file describes the shape, the
+ADR-0003 `changed_fields` decision, and the queries consumers
+typically write against them.
+
+## Tables
+
+### `sync_subscriptions`
+
+Cursor owner per `(integration_id, adapter, domain, external_ref)`
+tuple. Addressable by id by `ICursorStore`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | `defaultRandom()` |
+| `integration_id` | text | Opaque id of the connected account/instance (SFDC org id, GH installation id, etc.) |
+| `adapter` | text | Short adapter label: `'salesforce'`, `'hubspot'` |
+| `domain` | text | Canonical entity: `'opportunity'`, `'contact'` |
+| `external_ref` | text NULL | Upstream scope (filter id, webhook subscription id); NULL = full domain |
+| `enabled` | bool, default true | Scheduling filter |
+| `config` | jsonb, default `{}` | Per-subscription config (`batchSize`, `highWatermark`, …) |
+| `cursor` | jsonb NULL | Opaque; written by `ICursorStore.put()`; NULL until first successful run |
+| `last_sync_at` | ts NULL | Stamped by `PostgresCursorStore.put()` alongside cursor |
+| `tenant_id` | text NULL | Scaffold-time conditional (`sync.multi_tenant: true`) |
+| `created_at` / `updated_at` | ts |  |
+
+**Indexes:**
+- `uq_sync_subscriptions_tuple` — unique on `(integration_id, adapter, domain, external_ref)`. Postgres treats NULL `external_ref` as distinct (intentional — NULL = "full domain" covers only one logical slot but the DB doesn't prevent duplicates there; that's a consumer modeling concern).
+- `idx_sync_subscriptions_enabled_last_sync` — the scheduling query: "list enabled subscriptions ordered by staleness."
+
+### `sync_runs`
+
+One row per invocation of `ExecuteSyncUseCase.execute()`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK |  |
+| `subscription_id` | uuid FK → `sync_subscriptions.id` (cascade) |  |
+| `direction` | enum `inbound \| outbound` | Almost always `inbound`; `outbound` reserved for writeback |
+| `action` | enum `poll \| cdc \| webhook \| manual \| writeback` | Provenance for self-identification |
+| `status` | enum `running \| success \| no_changes \| failed` | `running` is in-flight only |
+| `records_found` / `records_processed` | int, default 0 |  |
+| `cursor_before` / `cursor_after` | jsonb NULL | Opaque cursor snapshots |
+| `duration_ms` | int NULL | Stamped at `completeRun` |
+| `error` | text NULL | From `completeRun(input.error)` — run-level error only |
+| `started_at` | ts, default now |  |
+| `completed_at` | ts NULL | NULL when `status='running'` |
+| `tenant_id` | text NULL | Scaffold-time conditional |
+
+**Indexes:**
+- `idx_sync_runs_subscription_started_at` — timeline: "most recent runs for this subscription"
+- `idx_sync_runs_status_started_at` — stale-run sweeper: "runs that started > N minutes ago and are still running"
+
+### `sync_run_items`
+
+One row per upstream change the orchestrator processed within a run.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK |  |
+| `sync_run_id` | uuid FK → `sync_runs.id` (cascade) |  |
+| `entity_type` | text | Canonical domain (`'opportunity'`) |
+| `external_id` | text | Upstream id |
+| `local_id` | text NULL | Set on `operation in (created, updated, deleted)`; null on `noop` |
+| `operation` | enum `created \| updated \| deleted \| noop` |  |
+| `status` | enum `success \| failed \| skipped` | `skipped` = loopback echo |
+| `changed_fields` | jsonb NOT NULL, default `{}` | ADR-0003 shape; validated by `FieldDiffSchema.parse` at write |
+| `title` | text NULL | Optional human label (`"Pinnacle opportunity"`) |
+| `error` | text NULL | Item-level error on `status='failed'` |
+| `created_at` | ts, default now |  |
+| `tenant_id` | text NULL | Scaffold-time conditional |
+
+**Indexes:**
+- `idx_sync_run_items_run_created_at` — timeline within a run
+- `idx_sync_run_items_entity_external` — per-record history: "every sync that touched opportunity/$extId"
+
+## ADR-0003 `changed_fields` shape
+
+```jsonc
+{
+  "stage_name": { "from": "Prospecting", "to": "Closed Won" },
+  "amount":     { "from": 92364,          "to": 120000 }
+}
+```
+
+Enforced at write time by `FieldDiffSchema.parse` in the recorder
+backend (both Drizzle and Memory). Malformed shapes throw a
+`ZodError` BEFORE the INSERT fires — consumers see a validation
+error, not a DB constraint error.
+
+**Why structured, not freeform:**
+
+Dealbrain-v2's pre-subsystem audit log stored diffs as arbitrary
+payload objects. Drift-detection queries ("when did this opportunity
+first become Closed Won?") required scraping JSON with
+`jsonb_path_exists` + custom extraction per query. The structured
+shape makes every drift query a one-shot SQL filter:
+
+```sql
+-- When did opportunity X first become Closed Won?
+SELECT sri.created_at
+FROM sync_run_items sri
+WHERE sri.entity_type = 'opportunity'
+  AND sri.external_id = '006Ab00000ABC'
+  AND sri.changed_fields -> 'stage_name' ->> 'to' = 'Closed Won'
+ORDER BY sri.created_at ASC
+LIMIT 1;
+```
+
+Without the structure, that query is a custom function call. With it,
+it's an index-friendly filter that every developer on the team can
+write in two minutes.
+
+**Canonical shapes for each `operation`:**
+
+| Operation | `changed_fields` |
+|---|---|
+| `created` | `{ [field]: { from: null, to: <value> } }` for every non-null user field |
+| `updated` | `{ [field]: { from: <old>, to: <new> } }` for mutated fields only |
+| `deleted` | `{}` (empty — deletion itself is the change) |
+| `noop` | `{}` (no change detected) |
+
+**Created-row diffs include `external_id` and other domain fields.**
+The default `DeepEqualDiffer` ignore list covers row metadata
+(`id`, `createdAt`, `updatedAt`, ...) but not domain identifiers.
+If that's too wide for a consumer's audit preferences, augment via
+`new DeepEqualDiffer({ ignore: [...] })` in their feature module.
+
+## Common queries
+
+### "What changed in the last 24 hours across all sync?"
+
+```sql
+SELECT sr.action, sri.entity_type, sri.external_id, sri.operation, sri.changed_fields
+FROM sync_run_items sri
+JOIN sync_runs sr ON sri.sync_run_id = sr.id
+WHERE sri.created_at > now() - interval '1 day'
+  AND sri.status = 'success'
+  AND sri.operation != 'noop'
+ORDER BY sri.created_at DESC;
+```
+
+### "Which subscriptions are stale?"
+
+```sql
+SELECT id, adapter, domain, external_ref, last_sync_at
+FROM sync_subscriptions
+WHERE enabled = true
+  AND (last_sync_at IS NULL OR last_sync_at < now() - interval '1 hour')
+ORDER BY last_sync_at ASC NULLS FIRST;
+```
+
+Uses `idx_sync_subscriptions_enabled_last_sync`.
+
+### "Any runs stuck in-flight?"
+
+```sql
+SELECT sr.id, sr.subscription_id, sr.started_at, sr.action
+FROM sync_runs sr
+WHERE sr.status = 'running'
+  AND sr.started_at < now() - interval '10 minutes';
+```
+
+Uses `idx_sync_runs_status_started_at`. Should return zero rows under
+normal operation — `completeRun` runs in a finally block. Non-zero
+counts indicate the process died mid-run (SIGKILL, OOM) without
+reaching the finally clause.
+
+### "Per-record history: every sync that touched this opportunity"
+
+```sql
+SELECT sri.created_at, sri.operation, sri.status, sri.changed_fields, sr.action
+FROM sync_run_items sri
+JOIN sync_runs sr ON sri.sync_run_id = sr.id
+WHERE sri.entity_type = 'opportunity'
+  AND sri.external_id = '006Ab00000ABC'
+ORDER BY sri.created_at DESC;
+```
+
+Uses `idx_sync_run_items_entity_external`.
+
+### "Drift detection: opportunities whose `amount` changed in the last week"
+
+```sql
+SELECT sri.external_id,
+       sri.changed_fields -> 'amount' ->> 'from' AS old_amount,
+       sri.changed_fields -> 'amount' ->> 'to'   AS new_amount,
+       sri.created_at
+FROM sync_run_items sri
+WHERE sri.entity_type = 'opportunity'
+  AND sri.created_at > now() - interval '7 days'
+  AND sri.changed_fields ? 'amount'
+ORDER BY sri.created_at DESC;
+```
+
+The `?` operator hits the jsonb column directly; no JOIN, no JSONB
+function gymnastics.
+
+## Multi-tenant filter
+
+When `multi_tenant: true`, every query above gains an `AND tenant_id
+= $1` filter (or a `tenant_id = current_setting('app.tenant_id')::text`
+if you've plumbed a per-request tenant context). The column is
+scaffold-emitted only when the flag is on, so single-tenant
+deployments don't carry the overhead.
+
+## Ownership
+
+All three tables are **subsystem-owned**. `PostgresCursorStore` reads
+/ writes `sync_subscriptions.cursor`; `DrizzleSyncRunRecorder` reads /
+writes `sync_runs` + `sync_run_items`. Consumers query them freely
+(dashboards, admin UIs) but must not write to them directly —
+bypassing the recorder's `FieldDiffSchema.parse` gate will land
+malformed data that breaks drift-detection queries.
+
+**Do not ship entity YAMLs for these tables.** The SYNC-7 scaffold
+explicitly skips them — shipping entity YAMLs would produce
+redundant repositories/services that shadow the subsystem. Phase 2's
+`examples/sync/` is the correct placement for reference schemas if a
+future consumer wants CRUD scaffolding over sync audit data.

--- a/.claude/skills/sync/consumer-patterns.md
+++ b/.claude/skills/sync/consumer-patterns.md
@@ -1,0 +1,395 @@
+# Consumer patterns
+
+How a consumer wires the sync subsystem end-to-end: the feature-module
+pattern, worked examples for adapters and sinks, multi-tenancy
+plumbing, and the "where does the event come from?" integration
+question.
+
+## Feature module shape
+
+`SyncModule.forRoot(...)` in `AppModule` wires the substrate. Every
+canonical entity that syncs gets its own feature module that binds:
+
+- `SYNC_CHANGE_SOURCE` — one adapter per `(provider, detection-mode, entity)`
+- `SYNC_SINK` — one sink per canonical entity
+- `ExecuteSyncUseCase` — the orchestrator class itself (NOT provided by `SyncModule`)
+- optionally, `SYNC_LOOPBACK_FINGERPRINT_STORE` and/or a custom `SYNC_FIELD_DIFFER`
+
+```ts
+import { Module } from '@nestjs/common';
+import {
+  ExecuteSyncUseCase,
+  SYNC_CHANGE_SOURCE,
+  SYNC_SINK,
+  SYNC_FIELD_DIFFER,
+  DeepEqualDiffer,
+} from '@shared/subsystems/sync';
+
+@Module({
+  providers: [
+    { provide: SYNC_CHANGE_SOURCE, useClass: SalesforceOpportunityChangeSource },
+    { provide: SYNC_SINK,          useClass: OpportunitySyncSink },
+    // Override the differ per-entity when you need a different ignore list:
+    {
+      provide: SYNC_FIELD_DIFFER,
+      useValue: new DeepEqualDiffer({ ignore: ['sync_version', 'internal_notes'] }),
+    },
+    ExecuteSyncUseCase,
+  ],
+  exports: [ExecuteSyncUseCase],
+})
+export class OpportunitySyncModule {}
+```
+
+**Why `ExecuteSyncUseCase` is listed here and not in `SyncModule`:**
+the orchestrator depends on `SYNC_CHANGE_SOURCE + SYNC_SINK`, which
+are per-feature. Nest's DI resolves providers at module compile time;
+putting the orchestrator in `SyncModule` would require those tokens
+globally, which fails until the feature module is imported. The
+`SyncModule` header documents this with a worked example.
+
+## Writing an `IChangeSource<T>`
+
+```ts
+import { Injectable } from '@nestjs/common';
+import type { IChangeSource, Change, SyncSubscriptionView } from '@shared/subsystems/sync';
+
+@Injectable()
+export class SalesforceOpportunityChangeSource
+  implements IChangeSource<CanonicalOpportunity>
+{
+  readonly label = 'salesforce-poll-opportunity';
+
+  constructor(
+    private readonly sfdc: SalesforceClient,
+    private readonly auth: SalesforceAuthStrategy,
+  ) {}
+
+  async *listChanges(
+    sub: SyncSubscriptionView,
+  ): AsyncIterable<Change<CanonicalOpportunity>> {
+    const cursor = sub.cursor as { systemModstamp?: string } | null;
+    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+
+    // Session refresh happens before the query — withAuthRetry wraps
+    // the SFDC client to force a refresh on 401 and retry once.
+    const records = await this.auth.withAuthRetry(sub.id, () =>
+      this.sfdc.query(
+        `SELECT Id, Name, Amount, StageName, SystemModstamp, IsDeleted
+         FROM Opportunity
+         WHERE SystemModstamp > ${since}
+         ORDER BY SystemModstamp ASC`,
+      ),
+    );
+
+    for (const r of records) {
+      yield {
+        externalId: r.Id,
+        operation: r.IsDeleted ? 'deleted' : 'updated',
+        record: toCanonicalOpportunity(r),
+        cursor: { systemModstamp: r.SystemModstamp },
+        source: 'poll',
+      };
+    }
+  }
+}
+```
+
+**Three rules:**
+
+1. **Yield `operation: 'updated'` for existing-row changes; the
+   orchestrator computes `'created'` vs `'updated'` based on whether
+   `sink.findByExternalId` returns null.** Don't try to pre-compute
+   this in the adapter — the adapter doesn't have a cheap way to
+   check local state, and duplicating the check wastes DB round-trips.
+
+2. **The cursor must be strictly-increasing per yield.** If you yield
+   records out of cursor order, a source crash mid-run will persist
+   the cursor of the last-yielded (not the last-successful) record,
+   and the next run will skip the records between the crash point and
+   the last yield. Order by your cursor column ASC.
+
+3. **Auth refresh belongs here, not in the orchestrator.** The
+   orchestrator has no notion of session expiry. Wrap your upstream
+   client calls with a retry-on-auth-fail layer (the events-codegen /
+   auth subsystem's `withAuthRetry` helper is the canonical pattern).
+
+## Writing an `ISyncSink<T>`
+
+```ts
+import { Inject, Injectable } from '@nestjs/common';
+import type { ISyncSink } from '@shared/subsystems/sync';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
+
+@Injectable()
+export class OpportunitySyncSink implements ISyncSink<CanonicalOpportunity> {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    private readonly opportunities: OpportunityService,
+    private readonly fields: FieldValueService,  // for EAV dual-write
+    private readonly accounts: AccountRepository, // for FK resolution
+  ) {}
+
+  async findByExternalId(
+    userId: string,
+    externalId: string,
+  ): Promise<CanonicalOpportunity | null> {
+    const row = await this.opportunities.findByExternalId(userId, externalId);
+    if (!row) return null;
+    const eavBag = await this.fields.loadForEntity('opportunity', row.id);
+    return toCanonical(row, eavBag);
+  }
+
+  async upsertByExternalId(
+    userId: string,
+    record: CanonicalOpportunity,
+    provider: string,
+  ): Promise<{ id: string; saved: CanonicalOpportunity }> {
+    // Single transaction spanning FK resolve + row upsert + EAV dual-write.
+    return this.db.transaction(async (tx) => {
+      const accountId = record.accountExternalId
+        ? await this.accounts.findByExternalIdRequired(
+            userId,
+            record.accountExternalId,
+            tx,
+          ).then((a) => a.id)
+        : null;
+
+      const { id, saved } = await this.opportunities.upsert(
+        userId,
+        { ...record, accountId, provider },
+        { tx },
+      );
+
+      await this.fields.syncFromCanonical(
+        'opportunity',
+        id,
+        record.fields ?? {},
+        tx,
+      );
+
+      return { id, saved: toCanonical(saved, record.fields ?? {}) };
+    });
+  }
+
+  async softDeleteByExternalId(
+    userId: string,
+    externalId: string,
+  ): Promise<{ id: string } | null> {
+    const result = await this.opportunities.softDeleteByExternalId(
+      userId,
+      externalId,
+    );
+    return result ? { id: result.id } : null;
+  }
+}
+```
+
+**The sink is where provider-specific write policy lives:**
+
+- EAV dual-write (canonical columns + `field_values` rows for custom
+  fields) — a single transaction spanning both.
+- FK resolution — `accountExternalId` → local `account.id` via a
+  repository lookup.
+- `provider` stamping on the saved row so downstream consumers can
+  filter "show me all opportunities synced from Salesforce vs.
+  HubSpot."
+- Re-entry tolerance — `upsert` with `ON CONFLICT (external_id) DO
+  UPDATE ... WHERE <something changed>` so a webhook retry or polling
+  overlap doesn't bump `updated_at` unnecessarily.
+
+**`findByExternalId` must return canonical.** If the local row is
+shaped differently, project it before returning. Mixed shapes break
+the differ.
+
+## Triggering a run
+
+`ExecuteSyncUseCase` does not schedule itself. Common triggers:
+
+### Scheduled job (typical polling)
+
+```ts
+@JobHandler({ type: 'sync_opportunity_poll', pool: 'events_inbound' })
+export class SyncOpportunityPollHandler {
+  constructor(private readonly execute: ExecuteSyncUseCase<CanonicalOpportunity>) {}
+
+  async handle(input: { subscriptionId: string; tenantId?: string }) {
+    return this.execute.execute({
+      subscription: { id: input.subscriptionId, domain: 'opportunity' },
+      userId: 'system',
+      provider: 'salesforce-crm',
+      direction: 'inbound',
+      action: 'poll',
+      tenantId: input.tenantId ?? null,
+    });
+  }
+}
+```
+
+Schedule the job with a cron trigger (see jobs SKILL.md §scheduling).
+
+### Webhook handler
+
+```ts
+@Controller('webhooks/salesforce')
+export class SalesforceWebhookController {
+  constructor(private readonly execute: ExecuteSyncUseCase<CanonicalOpportunity>) {}
+
+  @Post('opportunity-changed')
+  async handle(@Body() body: SalesforceWebhookPayload) {
+    const sub = await this.subscriptions.findByFingerprint(body.orgId, 'opportunity');
+    return this.execute.execute({
+      subscription: { id: sub.id, domain: 'opportunity' },
+      userId: 'system',
+      provider: 'salesforce-crm',
+      direction: 'inbound',
+      action: 'webhook',
+      tenantId: sub.tenantId,
+      // sourceOverride: replace the DI-bound source with a webhook
+      // adapter that yields the records in the payload body.
+      sourceOverride: new SalesforceWebhookChangeSource(body.records),
+    });
+  }
+}
+```
+
+### Manual operator re-sync
+
+```ts
+// CLI / admin UI — `action: 'manual'` distinguishes operator-triggered
+// runs from scheduled ones in the audit log.
+await this.execute.execute({
+  subscription: { id: subscriptionId, domain: 'opportunity' },
+  userId: actor.id,
+  provider: 'salesforce-crm',
+  direction: 'inbound',
+  action: 'manual',
+  tenantId: actor.tenantId,
+});
+```
+
+## Emitting events on successful sync
+
+The orchestrator does not emit events — that's a consumer concern.
+Wire `TypedEventBus.publish(...)` inside your sink's `upsertByExternalId`
+transaction, after the row is saved:
+
+```ts
+async upsertByExternalId(userId, record, provider) {
+  return this.db.transaction(async (tx) => {
+    const { id, saved } = await this.opportunities.upsert(userId, record, { tx });
+
+    // Emit the change event in the same transaction as the write.
+    // If the transaction rolls back, the event is never persisted.
+    await this.events.publish('opportunity_updated', id, {
+      opportunityId: id,
+      amount: saved.amount,
+      stageName: saved.stageName,
+      actorUserId: userId,
+    }, { tx });
+
+    return { id, saved: toCanonical(saved) };
+  });
+}
+```
+
+The `change` direction event lands in `events_change` pool; downstream
+consumers (projections, side-effects, webhook forwarders) subscribe
+via their own handlers. See events SKILL.md §directions-and-pools.
+
+## Multi-tenancy in practice
+
+Three changes when `multiTenant: true`:
+
+1. **`SyncModule.forRoot({ backend: 'drizzle', multiTenant: true })`**
+   in `AppModule`. This binds `SYNC_MULTI_TENANT=true` which both
+   Drizzle backends + the orchestrator inject.
+
+2. **Every `execute()` call passes `tenantId`.** Missing / null
+   throws `MissingTenantIdError` at entry (defense in depth — backends
+   re-validate at write boundary). Extract from your tenant context:
+   ```ts
+   await this.execute.execute({ ..., tenantId: ctx.tenant.id });
+   ```
+
+3. **Schema has `tenant_id` columns on all three sync tables.** Atlas
+   diff picks this up automatically when you flip
+   `sync.multi_tenant: true` in `codegen.config.yaml` and re-run
+   `subsystem install sync --force --force-config`. Apply the
+   migration before flipping the module flag, or the Drizzle backends
+   will throw `column "tenant_id" does not exist` on every write.
+
+Memory backends (for tests) accept `tenantId` and record it on rows
+but don't throw. Tests asserting cross-tenant isolation target the
+Drizzle backends via real Postgres (`just test-family` /
+`just test-integration`).
+
+## Loopback suppression
+
+Optional; only needed if your system has an outbound writeback path
+(we write to Salesforce, which echoes the change back on next poll).
+
+```ts
+@Injectable()
+export class RedisLoopbackStore implements ILoopbackFingerprintStore<CanonicalOpportunity> {
+  constructor(@Inject(REDIS) private readonly redis: RedisClient) {}
+
+  async isEchoOfOwnWrite(entityType, externalId, record) {
+    const key = `loopback:${entityType}:${externalId}`;
+    const fingerprint = hash(canonicalize(record));
+    const stored = await this.redis.get(key);
+    return stored === fingerprint;
+  }
+
+  /** Call this from your writeback path BEFORE the upstream write. */
+  async recordOwnWrite(entityType, externalId, record, ttlSec = 60) {
+    const key = `loopback:${entityType}:${externalId}`;
+    await this.redis.setex(key, ttlSec, hash(canonicalize(record)));
+  }
+}
+```
+
+Bind it in the feature module:
+
+```ts
+{ provide: SYNC_LOOPBACK_FINGERPRINT_STORE, useClass: RedisLoopbackStore }
+```
+
+The orchestrator's `@Optional()` inject means consumers without a
+writeback path simply omit the binding — the check is skipped.
+
+TTL shorter than the poll interval — otherwise old fingerprints
+pile up and silently suppress legitimate upstream edits.
+
+## Testing
+
+`SyncModule.forRoot({ backend: 'memory' })` + memory feature-module
+fakes = end-to-end test with no Postgres:
+
+```ts
+import { Test } from '@nestjs/testing';
+import { SyncModule, MemoryRunRecorder } from '@shared/subsystems/sync';
+
+const moduleRef = await Test.createTestingModule({
+  imports: [
+    SyncModule.forRoot({ backend: 'memory' }),
+    OpportunitySyncTestModule,  // same shape as OpportunitySyncModule but with fakes
+  ],
+}).compile();
+
+const orch = moduleRef.get(ExecuteSyncUseCase);
+const recorder = moduleRef.get(MemoryRunRecorder);
+
+await orch.execute({ /* ... */ });
+
+// Ergonomic helpers on MemoryRunRecorder make assertions one-liners.
+const runs = recorder.getRunsForSubscription('sub-1');
+expect(runs[0].status).toBe('success');
+expect(recorder.getItemsForRun(runs[0].id)).toHaveLength(3);
+```
+
+Unit-test sinks directly against a real test database (or a
+transaction-wrapping mock). Unit-test adapters against an HTTP mock
+for the upstream API. Integration-test the full stack via
+`just test-family` when you need Postgres end-to-end.

--- a/.claude/skills/sync/orchestrator-flow.md
+++ b/.claude/skills/sync/orchestrator-flow.md
@@ -1,0 +1,170 @@
+# Orchestrator flow
+
+`ExecuteSyncUseCase<T>` is the one generic sync loop in the codebase.
+This file walks through its lifecycle, failure semantics, and the
+decisions that are non-obvious until you've debugged a run.
+
+## Happy-path lifecycle
+
+```
+execute(input)
+  ├─ assertTenantId(input.tenantId, …)        ← throws BEFORE startRun when multiTenant
+  ├─ cursorBefore = cursors.get(subId, tenantId)
+  ├─ runId = recorder.startRun({subId, direction, action, cursorBefore, tenantId})
+  │
+  ├─ for await (change of source.listChanges(sub)):
+  │    recordsFound++
+  │    latestCursor = change.cursor
+  │    cursorAdvanced = true
+  │
+  │    try:
+  │      if loopback.isEchoOfOwnWrite(…): recordItem({operation:'noop', status:'skipped'}); continue
+  │
+  │      if change.operation === 'deleted':
+  │        result = sink.softDeleteByExternalId(…)
+  │        recordItem({operation: result ? 'deleted' : 'noop', status:'success', localId: result?.id})
+  │      else:
+  │        existing = sink.findByExternalId(…)
+  │        diff = differ.diff(existing, change.record, change.providerChangedFields)
+  │        if diff === 'noop':
+  │          recordItem({operation:'noop', status:'success'})
+  │        else:
+  │          { id } = sink.upsertByExternalId(…)
+  │          recordItem({operation: existing===null ? 'created' : 'updated', status:'success', localId: id, changedFields: diff})
+  │      recordsProcessed++
+  │    catch:
+  │      recordsFailed++
+  │      recordItem({status:'failed', error})
+  │
+  ├─ if cursorAdvanced: cursors.put(subId, latestCursor, tenantId)
+  └─ recorder.completeRun(runId, { status, counts, cursorAfter, durationMs, error })
+```
+
+## Five design decisions worth memorizing
+
+### 1. `assertTenantId` fires BEFORE `startRun`
+
+When `multiTenant=true` and `input.tenantId` is null/missing, the
+orchestrator throws `MissingTenantIdError` at entry. Critically, this
+happens before the `sync_runs` row is opened — no dangling
+`status=running` rows for rejected inputs. The Drizzle backends
+independently re-validate at their write boundary (defense in depth);
+all three sites use the shared `assertTenantId` helper so error
+messages are identical.
+
+### 2. Cursor advance is per-successful-yield, not per-run
+
+`latestCursor = change.cursor` updates on every iterator yield. The
+cursor is persisted in `cursors.put()` once at the end — but the value
+is whatever the iterator last produced, regardless of whether that
+record succeeded, failed, or was skipped for loopback.
+
+Consequence: a source that yields 10 records and throws on record 11
+still persists the cursor of record 10. Re-running picks up at record
+11, not back at the beginning.
+
+### 3. All-failed runs still advance the cursor
+
+If every record in a run throws from the sink, the orchestrator:
+- records each failure as a `sync_run_items` row with `status='failed'`
+- marks the run `status='failed'` with `error: 'all N records failed'`
+- **still persists the new cursor** (last-yielded)
+
+Rationale: the source kept yielding. Re-running would not re-deliver
+those records. Retry semantics (dead-letter replay, `action: 'manual'`
+resync with a `sourceOverride`) are caller-owned.
+
+**This is the most common "wait, what?" moment for first-time
+consumers.** Document it in your runbooks. If you want different
+semantics (hold cursor on all-fail), wrap the orchestrator with a
+retry policy layer — don't change the subsystem default.
+
+### 4. Source-iterator throws persist last-good cursor
+
+If `source.listChanges(...)` throws mid-iteration (auth expiry,
+network error, upstream rate-limit), the orchestrator catches,
+marks the run `status='failed'`, persists `latestCursor`, and runs
+`completeRun` in the finally clause.
+
+Consequence: partial runs don't lose progress. Re-running resumes
+from the last successful yield.
+
+Source throws BEFORE any yield (e.g. connect timeout) → cursor is not
+advanced (`cursorAdvanced` stays false); `cursors.put()` is skipped;
+`completeRun` runs with `cursorAfter: cursorBefore`.
+
+### 5. `completeRun` is in a finally block
+
+A thrown `startRun` / sink call / whatever still reaches
+`completeRun`. The run always terminates — no in-flight rows stuck in
+`status='running'`. Operator cleanup queries work against `completed_at
+IS NULL` filters.
+
+## Per-item failure does not fail the run
+
+The orchestrator's try/catch is per-record. One bad record increments
+`recordsFailed` and logs it; the loop continues. A run with 9
+successes + 1 failure is `status='success'` with
+`recordsProcessed: 9, recordsFailed: 1`.
+
+Only when **every** record fails AND at least one was seen does the
+run get `status='failed'` (see design decision 3).
+
+## Loopback filter
+
+When `SYNC_LOOPBACK_FINGERPRINT_STORE` is bound, every change goes
+through `isEchoOfOwnWrite(entityType, externalId, record)` first. An
+echo is recorded as `operation='noop', status='skipped'` with empty
+`changed_fields` — the audit log shows the skip so you can verify the
+suppression is working, but the sink is never called.
+
+Absent binding (`@Optional()` yields undefined), the check is skipped
+and all changes proceed normally.
+
+## Deletion branch
+
+`change.operation === 'deleted'` short-circuits the diff path. The
+orchestrator calls `sink.softDeleteByExternalId(userId, externalId)`;
+if the sink returns null (no local row), the item is recorded as
+`operation='noop', status='success'` — deletion of a never-synced
+record is not an error. If the sink returns `{ id }`, the item is
+recorded as `operation='deleted'` with the local id.
+
+`changed_fields` is always `{}` for deletions. The deletion itself is
+the change; per-field before/after would be redundant.
+
+## Noop emission
+
+`differ.diff(existing, incoming, ...) === 'noop'` short-circuits
+before the sink write. The item is recorded with
+`operation='noop', status='success'` and no sink call. This is the
+common case on cursor-over-poll runs where the differ-ignore list
+covers every upstream-updated field (e.g. SFDC bumps `SystemModstamp`
+but no canonical column changed).
+
+## `cursors.put` failure handling
+
+If the cursor persist throws (DB down, tenancy check failed), the
+orchestrator logs the error; if the run was otherwise successful, it
+promotes the run to `status='failed'` with
+`error: 'cursor put failed: ...'` and completes normally.
+
+Rationale: a successful run-log but no cursor advance is a bigger
+operational footgun than a failed-run marker — the next run would
+re-process every record. Failing loudly surfaces the cursor problem.
+
+## What the orchestrator does NOT do
+
+- **Does not emit events.** That's a consumer concern. Wire
+  `TypedEventBus.publish(...)` inside your `ISyncSink.upsertByExternalId`
+  transaction — after the row is saved, before the transaction commits.
+- **Does not schedule itself.** Scheduling (a cron, a job, a webhook
+  handler) is the caller's concern. Consumers typically wire
+  `ExecuteSyncUseCase` to a scheduled job in the `events_inbound` pool.
+- **Does not retry.** Per-item failures are recorded and skipped;
+  run-level failures bubble up to the caller. Retry policies (dead-
+  letter queues, manual re-sync, backoff) are caller-owned.
+- **Does not resolve subscriptions.** `input.subscription` is passed in
+  by the caller. Subscription lookup / filtering / enabled-check is
+  the caller's concern (typically via a `SyncSubscriptionService` the
+  consumer owns).

--- a/.claude/skills/sync/protocols-and-ports.md
+++ b/.claude/skills/sync/protocols-and-ports.md
@@ -1,0 +1,210 @@
+# Protocols and ports
+
+The sync subsystem has five ports. Four of them are required for a
+working run; one is optional. This file describes each port, what
+authoring a custom implementation looks like, and where the design
+decisions were made.
+
+## `IChangeSource<T>` — the detection seam
+
+The one port every sync adapter implements. Three detection modes
+(poll / CDC / webhook) converge here; per-mode differences live in
+`Change<T>` metadata.
+
+```ts
+interface IChangeSource<T> {
+  readonly label: string;  // e.g. 'salesforce-poll-opportunity'
+  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
+}
+
+interface Change<T> {
+  externalId: string;
+  operation: 'created' | 'updated' | 'deleted';
+  record: T;                           // canonical shape — provider mapping happens in the adapter
+  cursor: unknown;                     // typed internally; opaque at the seam
+  source: 'poll' | 'cdc' | 'webhook';  // provenance for run-log audit
+  dedupKey?: string;                   // CDC replay_id / webhook event_id when available
+  providerChangedFields?: string[];    // CDC-only hint; skips deep-equal when set
+}
+```
+
+**One adapter per `(provider, detection-mode, canonical-entity)` tuple.**
+`SalesforcePollOpportunityChangeSource` is one class, 50-ish LOC over a
+shared `PollingStrategyBase` helper. Don't write a monolithic adapter
+that yields a discriminated union across entities — narrower scope
+means one `label` per run-log row and better isolation.
+
+**Cursor shape is opaque at the port.** The strategy types it
+internally:
+- Poll: `{ systemModstamp: string }` or `{ lastSyncedAt: string }`
+- CDC: `{ replayId: number }`
+- Webhook: `{ ts: number }` or `{ eventId: string }`
+
+The orchestrator persists `change.cursor` as the iterator advances; it
+does not interpret the shape.
+
+**`providerChangedFields` is advisory.** When set (CDC providers that
+tell you which columns changed), the differ can skip deep-equal over
+untouched fields. Still filters through the ignore list — provider
+hints don't override the ignore rules.
+
+**Do not add mode-specific methods to `IChangeSource`.** The narrow
+port is deliberate; the compromise analysis behind it is in epic #60.
+If a new detection mode emerges, add a value to the `ChangeSource`
+union and a metadata field if needed — not a new port.
+
+## `ISyncSink<T>` — the write surface
+
+One sink per canonical entity. Speaks canonical externally; internal
+mapping stays inside.
+
+```ts
+interface ISyncSink<TCanonical> {
+  findByExternalId(userId: string, externalId: string): Promise<TCanonical | null>;
+  upsertByExternalId(userId: string, record: TCanonical, provider: string): Promise<{ id: string; saved: TCanonical }>;
+  softDeleteByExternalId(userId: string, externalId: string): Promise<{ id: string } | null>;
+}
+```
+
+**`findByExternalId` must return a canonical-shaped view of local state.**
+The differ compares `existing` (from the sink) against
+`change.record` (from the adapter) — mixing canonical and local shapes
+makes every row look "changed." If the local row uses a different
+column name or shape, project it inside the sink.
+
+**`upsertByExternalId` owns the transactional envelope.** Canonical
+columns, FK resolution (`account_id` from `accountExternalId`), EAV
+dual-write (when the entity has `fields`), `user_id` + `provider`
+stamping — all happen inside the sink's transaction. The subsystem
+never reaches around the sink to write to local tables.
+
+**Return the local id from `upsert`.** The orchestrator records it on
+`sync_run_items.local_id` for later drill-down joins between the audit
+log and the actual local row.
+
+**Re-entry tolerance is the sink's job.** If the orchestrator sees the
+same record twice in a window (a webhook retry, a polling overlap),
+the sink's upsert must be idempotent — typically `ON CONFLICT
+(external_id) DO UPDATE` with no-op semantics when the incoming record
+equals the existing row.
+
+## `ICursorStore` — cursor persistence
+
+Subscription-addressed cursor storage.
+
+```ts
+interface ICursorStore {
+  get(subscriptionId: string, tenantId?: string | null): Promise<unknown | null>;
+  put(subscriptionId: string, cursor: unknown, tenantId?: string | null): Promise<void>;
+}
+```
+
+**`put()` stamps `last_sync_at` + `updated_at` along with `cursor`** in
+the Drizzle backend. The `(enabled, last_sync_at)` scheduling index
+from SYNC-1 would be useless otherwise. If a dry-run / time-travel
+use case ever emerges, the right move is a third argument, not
+wrapping the port.
+
+**`tenantId` is a signature arg, not a proxy layer.** SYNC-4 chose the
+signature approach explicitly: multi-tenancy bugs are silent and
+dangerous; explicit signatures catch omissions at the type boundary;
+proxies hide who's enforcing. Matches JOB-8 / EVT-6 precedent. Memory
+backend accepts + ignores; Drizzle enforces via `assertTenantId`.
+
+**Do not instantiate `ICursorStore` inside a sink or adapter.** Always
+inject via `SYNC_CURSOR_STORE`. The orchestrator owns the `get/put`
+lifecycle — call sites outside it invert the control flow.
+
+## `IFieldDiffer<T>` — the diff seam
+
+Pluggable differ; default ships as `DeepEqualDiffer<T>`.
+
+```ts
+interface IFieldDiffer<T> {
+  diff(existing: T | null, incoming: T, providerChangedFields?: string[]): DiffResult;
+}
+
+type DiffResult = FieldDiff | 'noop';
+type FieldDiff = { [fieldName: string]: { from: unknown; to: unknown } };
+```
+
+**Default `DeepEqualDiffer` ignore list** (row metadata sinks /
+services stamp):
+`id`, `createdAt`, `updatedAt`, `deletedAt`, `type`, `lastModifiedAt`,
+`fields`, `providerMetadata`. `fields` is the EAV bag — it's diffed by
+the sink's EAV dual-write path, not at the canonical-record layer.
+
+**Normalizations applied during comparison (NOT in diff output):**
+
+- `Date → toISOString()` — adapters deliver strings, sinks return
+  `Date` from the DB driver. Normalize for comparison so they match.
+- Decimal-string ↔ number — Postgres `numeric` returns as a string
+  through Drizzle; adapters deliver numbers. When one side is numeric
+  and the other is a finite-parseable string, they compare equal.
+  Empty-string guard prevents silent 0-equality.
+
+**Diff output preserves raw values.** When a field genuinely differs,
+`{ from: Date, to: Date }` holds the raw Dates (not normalized ISO
+strings). `JSON.stringify` round-trips through jsonb normalize on
+persist; the audit stays faithful to the input.
+
+**Augmenting the ignore list per entity:**
+
+```ts
+{ provide: SYNC_FIELD_DIFFER, useValue: new DeepEqualDiffer({ ignore: ['sync_version'] }) }
+```
+
+Values are merged with the default set; you can't remove defaults.
+
+**Writing a custom `IFieldDiffer<T>`** (e.g. a type-aware differ that
+normalizes enums, or a CDC differ that only inspects hinted fields):
+bind it to `SYNC_FIELD_DIFFER` in the feature module. The orchestrator
+calls `differ.diff(existing, incoming, change.providerChangedFields)`
+once per record.
+
+## `ISyncRunRecorder` — the audit write surface
+
+```ts
+interface ISyncRunRecorder {
+  startRun(input: StartRunInput): Promise<{ id: string }>;
+  recordItem(input: RecordItemInput): Promise<void>;
+  completeRun(runId: string, input: CompleteRunInput): Promise<void>;
+}
+```
+
+**`recordItem` validates `changedFields` via `FieldDiffSchema.parse`
+BEFORE the write.** Both Drizzle and Memory backends do this. A
+malformed shape throws a `ZodError` at the recorder boundary; the
+orchestrator sees the validation failure, not a DB constraint error.
+
+**`completeRun` does not re-check tenancy.** The run id was returned by
+`startRun` which already enforced it; run ids are uuids not guessable
+cross-tenant. Matches JOB-3's pattern. Do not add a tenancy guard in
+`completeRun` without an ADR.
+
+**Not shipping a per-entity recorder.** Dealbrain's bespoke recorder
+had CRM-specific convenience methods (label resolution, entity-type
+narrowing). The subsystem extracted the generic write path only; those
+conveniences stay consumer-owned in a service layer above the recorder.
+
+## `ILoopbackFingerprintStore<T>` — optional
+
+Suppresses echoes of the local system's own outbound writes from the
+next inbound poll/CDC/webhook.
+
+```ts
+interface ILoopbackFingerprintStore<T = unknown> {
+  isEchoOfOwnWrite(entityType: string, externalId: string, record: T): Promise<boolean>;
+}
+```
+
+**Not shipped by the subsystem in Phase 1.** Consumers with outbound
+writeback paths provide their own (Redis-hashed with TTL shorter than
+the poll interval, or in-memory for tests). `@Optional()` on the
+orchestrator's inject means absence is fine — the check is skipped and
+all changes are processed normally.
+
+**`entityType` is `string` — no CRM narrowing.** Dealbrain's original
+port leaked `'opportunity' | 'account' | 'contact'` into the seam;
+HS-9 findings forced the fix before upstreaming. Don't re-introduce
+the narrowing; consumers narrow internally if they want.

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -425,6 +425,206 @@ their YAML. Generated use cases then call `TypedEventBus.publish(type, ...)`
 inside the domain transaction. See ADR-024 and the events skill
 (`.claude/skills/events/event-codegen.md`) for the shape and constraints.
 
+## Sync subsystem
+
+The sync subsystem (epic #60) ships a generic external-system sync engine:
+the `IChangeSource<T>` port (one seam for poll / CDC / webhook detection
+modes), `ExecuteSyncUseCase<T>` (the one orchestrator the whole codebase
+runs on), a structured per-field `changed_fields` audit log (ADR-0003),
+Drizzle + Memory backends for the cursor store and run recorder, and a
+default `DeepEqualDiffer` with a canonical ignore list.
+
+### Install
+
+```bash
+codegen subsystem install sync
+# or: bun /path/to/codegen-patterns/src/cli/index.ts subsystem install sync
+```
+
+This copies the runtime files into `<paths.subsystems>/sync/` (defaulting
+to `shared/subsystems/sync/`) and additionally:
+
+- Injects a `sync:` block into `codegen.config.yaml`:
+  ```yaml
+  sync:
+    backend: drizzle
+    multi_tenant: false
+  ```
+- Writes `sync-audit.schema.ts` via a Hygen template (the runtime file is
+  skipped by `copyRuntime`). This template owns the scaffold-time
+  `tenant_id` conditional — columns on `sync_subscriptions`, `sync_runs`,
+  and `sync_run_items` are emitted only when `sync.multi_tenant: true`.
+
+Switch the backend with `--backend memory` (useful in tests); the default
+is `drizzle`. Unlike events, the sync scaffold has **no `generated/`
+directory** — sync ships no codegen-emitted artifacts. Typed sync
+bindings per entity will arrive with the epic's Phase 2 (`syncable:` YAML
+flag), gated on the App-Defined Patterns RFC.
+
+### Register `SyncModule` in `AppModule`
+
+```ts
+import { SyncModule } from '@shared/subsystems/sync/sync.module';
+
+@Module({
+  imports: [
+    DatabaseModule,
+    SyncModule.forRoot({ backend: 'drizzle' }),
+    // ... other subsystems, GENERATED_MODULES, etc.
+  ],
+})
+export class AppModule {}
+```
+
+`SyncModule` is `global: true` and wires four ports — `SYNC_CURSOR_STORE`,
+`SYNC_RUN_RECORDER`, `SYNC_FIELD_DIFFER`, plus the `SYNC_MULTI_TENANT`
+flag — and nothing else. It intentionally does NOT provide
+`ExecuteSyncUseCase`; the orchestrator depends on `SYNC_CHANGE_SOURCE`
+and `SYNC_SINK`, which are per-entity and consumer-owned. Providing the
+orchestrator in `SyncModule` would force Nest to resolve those tokens at
+module compile time, which fails before your feature module is imported.
+
+Options:
+
+- `backend: 'drizzle' | 'memory'` — matches `sync.backend` in your config;
+  tests typically override to `'memory'`.
+- `multiTenant: true` — opt-in multi-tenancy (see below).
+
+### Per-entity feature module
+
+For each canonical entity you sync, write a feature module that binds your
+adapter (`IChangeSource<T>`), your sink (`ISyncSink<T>`), and the
+orchestrator class itself:
+
+```ts
+import { Module } from '@nestjs/common';
+import {
+  ExecuteSyncUseCase,
+  SYNC_CHANGE_SOURCE,
+  SYNC_SINK,
+} from '@shared/subsystems/sync';
+
+@Module({
+  providers: [
+    { provide: SYNC_CHANGE_SOURCE, useClass: SalesforceOpportunityChangeSource },
+    { provide: SYNC_SINK,          useClass: OpportunitySyncSink },
+    ExecuteSyncUseCase,
+  ],
+  exports: [ExecuteSyncUseCase],
+})
+export class OpportunitySyncModule {}
+```
+
+Consumers inject `ExecuteSyncUseCase<CanonicalOpportunity>` wherever they
+want to trigger a run — a scheduled job, a CLI command, a webhook
+handler, an operator UI button.
+
+### `IChangeSource<T>` — one port, three modes
+
+Three detection modes converge on a single port (ADR rejecting separate
+`IPollSource` / `ICdcSource` / `IWebhookSource`, per epic #60). Per-mode
+concerns live in `Change<T>` metadata, not in separate ports:
+
+```ts
+import type { IChangeSource, Change, SyncSubscriptionView } from '@shared/subsystems/sync';
+
+export class SalesforceOpportunityChangeSource
+  implements IChangeSource<CanonicalOpportunity>
+{
+  readonly label = 'salesforce-poll-opportunity';
+
+  async *listChanges(
+    subscription: SyncSubscriptionView,
+  ): AsyncIterable<Change<CanonicalOpportunity>> {
+    const cursor = subscription.cursor as { systemModstamp?: string } | null;
+    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+
+    const records = await this.sfdc.query(
+      `SELECT ... FROM Opportunity WHERE SystemModstamp > ${since}`,
+    );
+
+    for (const r of records) {
+      yield {
+        externalId: r.Id,
+        operation: r.IsDeleted ? 'deleted' : 'updated',
+        record: toCanonicalOpportunity(r),
+        cursor: { systemModstamp: r.SystemModstamp },
+        source: 'poll',
+      };
+    }
+  }
+}
+```
+
+The orchestrator persists `change.cursor` as the iterator advances; on a
+successful run the last-yielded cursor becomes `sync_subscriptions.cursor`
+for the next run.
+
+### `ISyncSink<T>` — the write surface
+
+One sink per canonical entity. The sink speaks the *canonical* shape
+externally; internal mapping (canonical → local columns, EAV dual-write,
+FK resolution) stays inside the implementation.
+
+```ts
+import type { ISyncSink } from '@shared/subsystems/sync';
+
+@Injectable()
+export class OpportunitySyncSink implements ISyncSink<CanonicalOpportunity> {
+  async findByExternalId(userId: string, externalId: string) { /* ... */ }
+  async upsertByExternalId(userId: string, record: CanonicalOpportunity, provider: string) { /* ... */ }
+  async softDeleteByExternalId(userId: string, externalId: string) { /* ... */ }
+}
+```
+
+### Audit model
+
+Every run produces:
+
+- One `sync_runs` row with `direction` (`inbound|outbound`), `action`
+  (`poll|cdc|webhook|manual|writeback`), `status`, counts, cursor
+  before/after, and duration.
+- One `sync_run_items` row per record processed. `changed_fields` is a
+  structured `{ fieldName: { from, to } }` jsonb per ADR-0003 — rejected
+  at the recorder if it doesn't parse against `FieldDiffSchema`. This
+  means queries like *"when did this opportunity first become Closed
+  Won?"* are a one-shot SQL filter, not a payload-JSON scrape.
+
+See `.claude/skills/sync/audit-model.md` for worked query examples and
+ADR-0003 rationale.
+
+### Multi-tenancy opt-in
+
+Flip `sync.multi_tenant: true` in `codegen.config.yaml`, then re-run
+`subsystem install sync --force --force-config` to re-emit the schema
+with `tenant_id` columns on all three tables, and cut an Atlas migration
+(see [Atlas migration workflow](#atlas-migration-workflow)). Also pass
+`multiTenant: true` to `SyncModule.forRoot(...)` so the orchestrator and
+the Drizzle backends enforce the flag:
+
+```ts
+SyncModule.forRoot({ backend: 'drizzle', multiTenant: true });
+```
+
+With `multiTenant: true`, every `ExecuteSyncUseCase.execute(...)` call
+MUST pass `tenantId`. The orchestrator's `execute()` method throws
+`MissingTenantIdError` at entry BEFORE opening a `sync_runs` row — no
+dangling `status=running` rows for rejected inputs. The Drizzle backends
+independently re-validate at their write boundary (defense in depth). All
+three sites use a shared `assertTenantId` helper so error messages match.
+
+Memory backends (`MemoryCursorStore`, `MemoryRunRecorder`) accept
+`tenantId` and record it on their in-memory rows but do not throw —
+memory state is process-local; cross-tenant isolation there is not
+meaningful. Tests that need per-tenant isolation guarantees target the
+Drizzle backends.
+
+### Migration from a bespoke sync pipeline
+
+Consumers already running custom sync code (e.g. dealbrain-v2's CRM sync):
+see [docs/guides/sync-migration.md](guides/sync-migration.md) for the
+step-by-step path.
+
 ## Auth subsystem
 
 The auth subsystem (ADR-031) ships `IAuthStrategy`, the abstract

--- a/docs/guides/sync-migration.md
+++ b/docs/guides/sync-migration.md
@@ -1,0 +1,263 @@
+# Migrating from a bespoke sync pipeline to the sync subsystem
+
+Who this is for: consumers already running custom `CrmSyncService` /
+`ExecuteSync` / hand-rolled cursor-store code that predates the sync
+subsystem. The obvious reference case is dealbrain-v2's CRM sync —
+~800 LOC across three commits that this subsystem extracted and
+generalized. The steps below describe the exact migration path that
+validated the subsystem's shape.
+
+If you're starting a new project, you don't need this guide — read
+[Sync subsystem](../CONSUMER-SETUP.md#sync-subsystem) in CONSUMER-SETUP
+instead.
+
+## The decision you're making
+
+Before any code moves: confirm the subsystem fits your detection model.
+It's optimized for the five-step dance every external integration repeats:
+
+> detect upstream change → diff against local state → apply → record
+> delta → emit event
+
+Steps 2–5 are machinery shared across integrations. Step 1 varies per
+provider but has exactly three shapes — poll, CDC, webhook — which the
+port's `ChangeSource` enum covers. If your pipeline fundamentally does
+something else (streaming projections, hand-reconciled invariants, a
+Kafka topology where downstream systems own their cursors), the
+subsystem is not for you.
+
+## Step 0 — Install the subsystem
+
+```bash
+codegen subsystem install sync
+```
+
+This lands the protocols (`IChangeSource<T>`, `ISyncSink<T>`,
+`ICursorStore`, `IFieldDiffer<T>`, `ISyncRunRecorder`), the Drizzle +
+Memory backends, the orchestrator, the default differ, and injects the
+`sync:` block into your config. Atlas will now see the three audit
+tables (`sync_subscriptions`, `sync_runs`, `sync_run_items`) as pending
+diffs; generate a migration:
+
+```bash
+atlas migrate diff --env local --name add_sync_audit_tables
+atlas migrate apply --env local
+```
+
+At this point the subsystem is installed but nothing is using it. Your
+bespoke pipeline keeps running unchanged.
+
+## Step 1 — Introduce `IChangeSource<T>` adapters, provider by provider
+
+Wrap your existing upstream code as an `IChangeSource<T>` implementation.
+The implementation doesn't need to change its internal logic — it just
+needs to expose the yield-changes shape:
+
+### Before
+
+```ts
+// Old: bespoke SalesforceSyncService pulling Opportunity changes.
+class SalesforceSyncService {
+  async runOpportunitySync() {
+    const cursor = await this.cursorRepo.get('sfdc-opp');
+    const records = await this.sfdc.query(...);
+    for (const r of records) {
+      await this.diffAndWrite(r);
+      await this.cursorRepo.set('sfdc-opp', r.SystemModstamp);
+    }
+  }
+  // ...diffAndWrite, cursor advance, audit writes all inline...
+}
+```
+
+### After
+
+```ts
+// New: adapter implements IChangeSource<T>. The orchestrator owns the loop.
+import type { IChangeSource, Change, SyncSubscriptionView } from '@shared/subsystems/sync';
+
+@Injectable()
+export class SalesforceOpportunityChangeSource
+  implements IChangeSource<CanonicalOpportunity>
+{
+  readonly label = 'salesforce-poll-opportunity';
+
+  constructor(private readonly sfdc: SalesforceClient) {}
+
+  async *listChanges(
+    sub: SyncSubscriptionView,
+  ): AsyncIterable<Change<CanonicalOpportunity>> {
+    const cursor = sub.cursor as { systemModstamp?: string } | null;
+    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const records = await this.sfdc.query(
+      `SELECT ... FROM Opportunity WHERE SystemModstamp > ${since}`,
+    );
+    for (const r of records) {
+      yield {
+        externalId: r.Id,
+        operation: r.IsDeleted ? 'deleted' : 'updated',
+        record: toCanonicalOpportunity(r),
+        cursor: { systemModstamp: r.SystemModstamp },
+        source: 'poll',
+      };
+    }
+  }
+}
+```
+
+The cursor shape is opaque at the port seam — your strategy types it
+internally. For polling, `{ systemModstamp }`; for CDC, `{ replayId }`;
+for webhook, `{ ts }`.
+
+**Decide once per provider:** whether the adapter is one `IChangeSource`
+per canonical entity (recommended — narrower scope, one label per
+run-log row) or one `IChangeSource` that yields a discriminated union.
+The first shape composes better with the orchestrator.
+
+## Step 2 — Introduce `ISyncSink<T>` for each canonical entity
+
+Your existing services (`OpportunityService`, `AccountService`) know how
+to write local rows. The sink wraps them, speaking the canonical shape
+externally:
+
+```ts
+@Injectable()
+export class OpportunitySyncSink implements ISyncSink<CanonicalOpportunity> {
+  constructor(
+    private readonly svc: OpportunityService,
+    private readonly fields: FieldValueService,  // for EAV dual-write
+  ) {}
+
+  async findByExternalId(userId: string, externalId: string) {
+    const local = await this.svc.findByExternalId(userId, externalId);
+    return local ? toCanonical(local) : null;
+  }
+
+  async upsertByExternalId(
+    userId: string,
+    record: CanonicalOpportunity,
+    provider: string,
+  ) {
+    // Open a transaction spanning the row write + EAV field writes.
+    // Return the local id + canonical projection of the saved row.
+    return this.db.transaction(async (tx) => {
+      const { id, saved } = await this.svc.upsert(userId, record, { tx });
+      await this.fields.syncFromCanonical(id, record.fields ?? {}, tx);
+      return { id, saved: toCanonical(saved) };
+    });
+  }
+
+  async softDeleteByExternalId(userId: string, externalId: string) {
+    const deleted = await this.svc.softDeleteByExternalId(userId, externalId);
+    return deleted ? { id: deleted.id } : null;
+  }
+}
+```
+
+The sink is where all your provider-specific write policy lives (EAV
+dual-write, FK resolution, provider field stamping). The subsystem does
+not prescribe any of that — sinks are intentionally consumer-owned.
+
+## Step 3 — Swap your orchestrator call for `ExecuteSyncUseCase`
+
+Replace the bespoke sync-loop invocation with the generic orchestrator.
+The feature module binds source + sink + orchestrator:
+
+```ts
+@Module({
+  providers: [
+    { provide: SYNC_CHANGE_SOURCE, useClass: SalesforceOpportunityChangeSource },
+    { provide: SYNC_SINK,          useClass: OpportunitySyncSink },
+    ExecuteSyncUseCase,
+  ],
+  exports: [ExecuteSyncUseCase],
+})
+export class OpportunitySyncModule {}
+```
+
+Then wherever your old scheduler / CLI / trigger ran the bespoke service:
+
+```ts
+// Before:
+// await this.salesforceSyncService.runOpportunitySync();
+
+// After:
+const result = await this.executeSync.execute({
+  subscription: { id: subscriptionId, domain: 'opportunity' },
+  userId: actorId,
+  provider: 'salesforce-crm',
+  direction: 'inbound',
+  action: 'poll',
+});
+
+if (result.status === 'failed') {
+  // result.error is the cause; partial progress is in result.recordsProcessed
+}
+```
+
+## Step 4 — Delete the old code
+
+Once the new path is running in production for one full sync cycle (and
+you've spot-checked the audit log against your expected changes):
+
+- Delete the bespoke orchestrator class.
+- Delete the bespoke cursor repository — the subsystem owns
+  `sync_subscriptions.cursor` now.
+- Delete the bespoke audit writes — `ExecuteSyncUseCase` writes
+  `sync_runs` + `sync_run_items` on every run.
+- Delete any one-off "re-run since timestamp" scripts — use the
+  orchestrator's `action: 'manual'` mode with a temporary
+  `sourceOverride` instead.
+
+CLAUDE.md's "no backwards compatibility" principle applies: don't leave
+deprecated versions, don't ship parallel paths, don't keep the old
+schema tables around. Cut cleanly.
+
+## Step 5 — Backfill historical runs (optional)
+
+If your bespoke pipeline wrote its own audit log and you want a unified
+history in `sync_runs` / `sync_run_items`, that's a one-off ETL. The
+subsystem's recorder writes one row per run at the end of the loop, so
+backfilling is a matter of rewriting old audit rows into the new schema.
+Don't invest in this unless downstream consumers (dashboards,
+drift-detection queries) actually read the old log.
+
+## Things you will notice
+
+- **Cursor advance is per-successful-yield, not per-successful-batch.**
+  The orchestrator persists the last-yielded `change.cursor` when the
+  iterator completes. A source iterator that throws mid-run still
+  advances to the last-good cursor — re-running picks up from the
+  furthest delivered record, not the beginning of the batch.
+
+- **All-failed runs still advance the cursor.** If every record in a
+  run failed, the subsystem marks the run `status: 'failed'` but
+  persists the new cursor anyway. Rationale: the source kept yielding;
+  re-running would not re-deliver those records. Retry semantics
+  (dead-letter replay, manual re-sync with `action: 'manual'`) are the
+  caller's concern. If this isn't what you want, wrap the orchestrator
+  with your own retry policy layer.
+
+- **Created-record diffs include every non-null user field** — including
+  domain identifiers like `external_id`. The default `DeepEqualDiffer`
+  ignores only row metadata (`id`, `createdAt`, `updatedAt`, ...). If
+  you want to trim additional fields from the audit log, pass an
+  `options.ignore` when binding the differ:
+  ```ts
+  { provide: SYNC_FIELD_DIFFER, useValue: new DeepEqualDiffer({ ignore: ['sync_version', 'internal_meta'] }) }
+  ```
+
+- **Loopback-fingerprint suppression is opt-in.** If your pipeline has an
+  outbound writeback path that echoes back on the next inbound poll,
+  bind an `ILoopbackFingerprintStore` to `SYNC_LOOPBACK_FINGERPRINT_STORE`
+  in your feature module. The orchestrator's `@Optional()` inject means
+  absence is fine — if you don't need it, don't provide it.
+
+## Further reading
+
+- [Sync subsystem](../CONSUMER-SETUP.md#sync-subsystem) — fresh-install
+  guide.
+- `.claude/skills/sync/SKILL.md` + L1 files — agent-facing decision
+  map.
+- Epic #60 — design rationale, `IChangeSource<T>` compromise analysis,
+  ADR-0003 audit model shape, dealbrain-v2 extraction verdict.


### PR DESCRIPTION
Closes #133. **Closes epic #60** (sync-engine subsystem stack, Phase 1).

## Summary

Final slice of the epic. Documentation + agent-facing skill so consumers (human and agent) have a path from "just installed the subsystem" to "running a real integration" without re-deriving the design from the protocol source.

## Files added

- `docs/guides/sync-migration.md` — step-by-step migration from a bespoke sync pipeline. Grounded in the dealbrain-v2 extraction path. Calls out the three non-obvious behaviors first-time consumers trip over (cursor advance on all-failed, created-diff width, opt-in loopback).
- `.claude/skills/sync/SKILL.md` + four L1 files:
  - `protocols-and-ports.md` — `IChangeSource`, `ISyncSink`, `ICursorStore`, `IFieldDiffer`, `ISyncRunRecorder`, `ILoopbackFingerprintStore` — what authoring each looks like and why the narrow-port / signature-multi-tenancy / opaque-cursor decisions are load-bearing
  - `orchestrator-flow.md` — happy-path lifecycle, five design decisions worth memorizing, per-item failure semantics, loopback/deletion/noop branches
  - `audit-model.md` — three-table schemas, ADR-0003 `changed_fields` contract with worked before/after, canonical operation shapes, five common consumer queries (recent changes, stale subs, stuck runs, per-record history, drift detection)
  - `consumer-patterns.md` — feature-module wiring, adapter + sink templates, triggering via scheduled job / webhook / manual operator, emitting events inside the sink transaction, multi-tenancy plumbing, loopback pattern, testing via `SyncModule.forRoot({ backend: 'memory' })`

## Files modified

- `docs/CONSUMER-SETUP.md` — new `## Sync subsystem` section between Events and Auth. Mirrors the Events section shape: install workflow, `SyncModule` wiring (with the "does NOT provide `ExecuteSyncUseCase`" caveat + worked feature-module example), adapter/sink templates, audit-model overview, multi-tenancy flow, migration-guide reference.

## Design decisions consolidated

Eight decisions made across SYNC-1..7 are now documented in a single readable surface:

1. One port for three detection modes.
2. Opaque cursor at the seam.
3. Cursor advance on all-failed runs (caller-owned retry).
4. Created-diff width — domain ids included.
5. `SyncModule` does NOT provide `ExecuteSyncUseCase`.
6. `DeepEqualDiffer` wired via `useValue` (decorator-metadata sidestep).
7. `completeRun` does not re-check tenancy.
8. Three-table audit is subsystem-owned; no entity YAMLs for `sync_*`.

## Test plan

- [x] `bun run typecheck` — clean (docs-only PR)
- [x] `just test-all` — 1228/0 (unchanged from SYNC-7)
- [x] Anchor links resolve (all `#`-linked sections in CONSUMER-SETUP.md + migration guide point at real headings)

## Epic closure

Closes the final SYNC-* sub-issue. Epic #60 is done for Phase 1. Phase 2 (`syncable:` YAML flag + codegen-produced per-entity bindings) remains gated on the App-Defined Patterns RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)