### PR TITLE
fix(subsystems): forRootAsync must resolve backend DI args

### DIFF
--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -863,6 +863,8 @@ database:
   dialect: postgres
 ```
 
+`codegen project init` defaults `generate.architecture` to `clean-lite-ps` — the lighter consumer-facing layout used by the scaffold-demo app. To opt into the full Clean Architecture pipeline (separate `domain/`, `application/`, `infrastructure/` directories, separate command/query classes), edit `codegen.config.yaml` and set `generate.architecture: clean`. The two pipelines are mutually exclusive and the scanner only overrides the default when it finds existing domain/application directories (see `docs/specs/TEST-SESSION-1.md` §3).
+
 `paths.generated` must sit inside your `tsconfig.json` `"include"` globs — otherwise TS won't typecheck the barrel.
 
 ## App-defined patterns

--- a/runtime/subsystems/cache/cache.module.ts
+++ b/runtime/subsystems/cache/cache.module.ts
@@ -15,9 +15,18 @@
  * directly without importing CacheModule. Register once in AppModule.
  *
  * The drizzle backend requires DRIZZLE to be provided globally (e.g., via DatabaseModule).
+ *
+ * Async configuration (`forRootAsync`):
+ * The async factory returns `CacheModuleOptions`; the CACHE provider then
+ * receives DRIZZLE (for the drizzle backend) through Nest DI rather than
+ * hand-constructing with `null` — see issue #108 which flagged the same
+ * shape in `EventsModule.forRootAsync`. DRIZZLE is injected as optional
+ * so memory-backend consumers are not required to wire DatabaseModule.
  */
 import { Module, type DynamicModule } from '@nestjs/common';
 import { CACHE, CACHE_DEFAULT_TTL } from './cache.tokens';
+import { DRIZZLE } from '../../constants/tokens';
+import type { DrizzleClient } from '../../types/drizzle';
 import { DrizzleCacheService } from './cache.drizzle-backend';
 import { MemoryCacheService } from './cache.memory-backend';
 
@@ -33,6 +42,26 @@ export interface CacheModuleAsyncOptions {
   imports?: unknown[];
 }
 
+/** String token for the resolved CacheModuleOptions in the async path. */
+const CACHE_MODULE_OPTIONS = 'CACHE_MODULE_OPTIONS' as const;
+
+function buildCacheAsync(
+  options: CacheModuleOptions,
+  db: DrizzleClient | null,
+): DrizzleCacheService | MemoryCacheService {
+  const defaultTtl = options.defaultTtl ?? null;
+  if (options.backend === 'drizzle') {
+    if (!db) {
+      throw new Error(
+        "CacheModule.forRootAsync: backend: 'drizzle' selected but DRIZZLE provider is not available. " +
+          'Ensure DatabaseModule (or another provider exposing DRIZZLE) is imported before CacheModule.forRootAsync.',
+      );
+    }
+    return new DrizzleCacheService(db, defaultTtl);
+  }
+  return new MemoryCacheService(defaultTtl);
+}
+
 @Module({})
 export class CacheModule {
   static forRootAsync(asyncOptions: CacheModuleAsyncOptions): DynamicModule {
@@ -42,23 +71,17 @@ export class CacheModule {
       imports: (asyncOptions.imports ?? []) as Parameters<typeof Module>[0]['imports'],
       providers: [
         {
-          provide: 'CACHE_MODULE_OPTIONS',
+          provide: CACHE_MODULE_OPTIONS,
           useFactory: asyncOptions.useFactory,
           inject: (asyncOptions.inject ?? []) as (string | symbol | Function)[],
         },
         {
           provide: CACHE,
-          useFactory: (options: CacheModuleOptions) => {
-            if (options.backend === 'drizzle') {
-              return new DrizzleCacheService(
-                null as unknown as Parameters<typeof DrizzleCacheService.prototype.get>[0] extends never ? never : Parameters<typeof DrizzleCacheService['prototype']['get']>[0] extends never ? never : never,
-                options.defaultTtl ?? null,
-              );
-            }
-            return new MemoryCacheService(options.defaultTtl ?? null);
-          },
-          inject: ['CACHE_MODULE_OPTIONS'],
+          useFactory: (options: CacheModuleOptions, db: DrizzleClient | null) =>
+            buildCacheAsync(options, db),
+          inject: [CACHE_MODULE_OPTIONS, { token: DRIZZLE, optional: true }],
         },
+        // Alias the concrete classes to CACHE for typed injection.
         { provide: DrizzleCacheService, useExisting: CACHE },
         { provide: MemoryCacheService, useExisting: CACHE },
       ],

--- a/runtime/subsystems/events/events.module.ts
+++ b/runtime/subsystems/events/events.module.ts
@@ -34,6 +34,15 @@
  * `global: true` means entity modules do not need to import EventsModule
  * individually — the EVENT_BUS and TYPED_EVENT_BUS tokens are available
  * project-wide.
+ *
+ * Async configuration (`forRootAsync`):
+ * The async factory returns `EventsModuleOptions`; the EVENT_BUS provider
+ * then receives its backend dependencies — DRIZZLE for the drizzle
+ * backend, REDIS_URL for the redis backend, the resolved options for the
+ * memory backend — through a proper `useFactory` so Nest DI wires them
+ * correctly. Earlier revisions hand-constructed backends with
+ * `new Class()` which silently left `db` / `redisUrl` undefined
+ * (issue #108).
  */
 import { Module, type DynamicModule, type Provider } from '@nestjs/common';
 import {
@@ -43,6 +52,8 @@ import {
   REDIS_URL,
   TYPED_EVENT_BUS,
 } from './events.tokens';
+import { DRIZZLE } from '../../constants/tokens';
+import type { DrizzleClient } from '../../types/drizzle';
 import { DrizzleEventBus } from './event-bus.drizzle-backend';
 import { MemoryEventBus } from './event-bus.memory-backend';
 import { RedisEventBus } from './event-bus.redis-backend';
@@ -103,6 +114,35 @@ function buildTypedBusProviders(multiTenant: boolean): Provider[] {
   ];
 }
 
+/**
+ * Construct the backend instance for the async path, routing constructor
+ * arguments through Nest-resolved dependencies.
+ *
+ * DRIZZLE is declared optional at inject time so that memory-backend
+ * consumers aren't required to also import `DatabaseModule`. If the
+ * drizzle backend is selected but no DRIZZLE provider is registered, we
+ * throw a clear error instead of silently constructing a broken bus.
+ */
+function buildEventBusAsync(
+  options: EventsModuleOptions,
+  db: DrizzleClient | null,
+  redisUrl: string,
+): unknown {
+  if (options.backend === 'drizzle') {
+    if (!db) {
+      throw new Error(
+        "EventsModule.forRootAsync: backend: 'drizzle' selected but DRIZZLE provider is not available. " +
+          'Ensure DatabaseModule (or another provider exposing DRIZZLE) is imported before EventsModule.forRootAsync.',
+      );
+    }
+    return new DrizzleEventBus(db, options);
+  }
+  if (options.backend === 'redis') {
+    return new RedisEventBus(redisUrl);
+  }
+  return new MemoryEventBus(options);
+}
+
 @Module({})
 export class EventsModule {
   static forRootAsync(asyncOptions: EventsModuleAsyncOptions): DynamicModule {
@@ -129,17 +169,16 @@ export class EventsModule {
         },
         {
           provide: EVENT_BUS,
-          useFactory: (options: EventsModuleOptions) => {
-            const mod = EventsModule.forRoot(options);
-            const provider = mod.providers?.find(
-              (p) => typeof p === 'object' && p !== null && 'provide' in p && p.provide === EVENT_BUS,
-            );
-            if (provider && typeof provider === 'object' && 'useClass' in provider) {
-              return new (provider.useClass as new () => unknown)();
-            }
-            throw new Error('EventsModule.forRootAsync: failed to resolve provider');
-          },
-          inject: [EVENTS_MODULE_OPTIONS],
+          useFactory: (
+            options: EventsModuleOptions,
+            db: DrizzleClient | null,
+            redisUrl: string,
+          ) => buildEventBusAsync(options, db, redisUrl),
+          inject: [
+            EVENTS_MODULE_OPTIONS,
+            { token: DRIZZLE, optional: true },
+            REDIS_URL,
+          ],
         },
         TypedEventBus,
         { provide: TYPED_EVENT_BUS, useExisting: TypedEventBus },

--- a/src/__tests__/runtime/subsystems/cache-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/cache-module.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * CacheModule unit tests.
+ *
+ * Covers the `forRoot` + `forRootAsync` factories. Memory backend goes
+ * end-to-end against `MemoryCacheService`; the drizzle backend is
+ * asserted structurally with a mock DRIZZLE provider (no Postgres
+ * required).
+ *
+ * Regression test for issue #108 (surfaced during the fix for
+ * `EventsModule.forRootAsync`): the cache module's async factory used
+ * to hand-construct `DrizzleCacheService` with a literal `null` for the
+ * DRIZZLE client, which would NRE on the first call. The factory now
+ * routes DRIZZLE through Nest DI.
+ */
+import 'reflect-metadata';
+import { describe, expect, it, mock } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import { Global, Module } from '@nestjs/common';
+import { CacheModule } from '../../../../runtime/subsystems/cache/cache.module';
+import { CACHE } from '../../../../runtime/subsystems/cache/cache.tokens';
+import { DrizzleCacheService } from '../../../../runtime/subsystems/cache/cache.drizzle-backend';
+import { MemoryCacheService } from '../../../../runtime/subsystems/cache/cache.memory-backend';
+import { DRIZZLE } from '../../../../runtime/constants/tokens';
+
+describe('CacheModule.forRoot', () => {
+  it('resolves CACHE to MemoryCacheService for backend: memory', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [CacheModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(CACHE)).toBeInstanceOf(MemoryCacheService);
+
+    await moduleRef.close();
+  });
+
+  it('forRoot returns a global DynamicModule', () => {
+    const dyn = CacheModule.forRoot({ backend: 'memory' });
+    expect(dyn.global).toBe(true);
+    expect(dyn.exports).toContain(CACHE);
+  });
+});
+
+describe('CacheModule.forRootAsync — DI for backend constructor args (#108)', () => {
+  /**
+   * Minimal Drizzle-shaped mock. `DrizzleCacheService.get()` path is not
+   * exercised here; we only need `set()` to reach `db.insert(...)`.
+   */
+  function makeMockDb() {
+    const insertBuilder = {
+      values: mock(() => ({
+        onConflictDoUpdate: mock(async () => []),
+      })),
+    };
+    const db = {
+      insert: mock(() => insertBuilder),
+    };
+    return { db, insertBuilder };
+  }
+
+  it('resolves CACHE to MemoryCacheService from an async factory', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        CacheModule.forRootAsync({
+          useFactory: () => ({ backend: 'memory', defaultTtl: 60 }),
+        }),
+      ],
+    }).compile();
+
+    expect(moduleRef.get(CACHE)).toBeInstanceOf(MemoryCacheService);
+
+    await moduleRef.close();
+  });
+
+  it('resolves DRIZZLE through DI for the drizzle backend (regression: used to pass null)', async () => {
+    const { db, insertBuilder } = makeMockDb();
+
+    @Global()
+    @Module({
+      providers: [{ provide: DRIZZLE, useValue: db }],
+      exports: [DRIZZLE],
+    })
+    class FakeDrizzleModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FakeDrizzleModule,
+        CacheModule.forRootAsync({
+          useFactory: () => ({ backend: 'drizzle', defaultTtl: 60 }),
+        }),
+      ],
+    }).compile();
+
+    const cache = moduleRef.get(CACHE);
+    expect(cache).toBeInstanceOf(DrizzleCacheService);
+
+    // Prove set() reached the injected mock DB. Pre-fix the constructor
+    // was called with `null as unknown as ...` for the db argument, so
+    // this would throw "Cannot read properties of null (reading 'insert')".
+    await (cache as DrizzleCacheService).set('k', { hello: 'world' });
+
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(insertBuilder.values).toHaveBeenCalledTimes(1);
+
+    await moduleRef.close();
+  });
+
+  it('throws a clear error when the drizzle backend is selected but DRIZZLE is not provided', async () => {
+    await expect(
+      Test.createTestingModule({
+        imports: [
+          CacheModule.forRootAsync({
+            useFactory: () => ({ backend: 'drizzle' }),
+          }),
+        ],
+      }).compile(),
+    ).rejects.toThrow(/DRIZZLE provider is not available/);
+  });
+});

--- a/src/__tests__/runtime/subsystems/events-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/events-module.spec.ts
@@ -247,3 +247,120 @@ describe('EventsModule.forRootAsync', () => {
     await moduleRef.close();
   });
 });
+
+// ============================================================================
+// Regression — issue #108 — forRootAsync must resolve backend constructor
+// args through Nest DI, not hand-construct with zero args.
+// ============================================================================
+
+import { mock } from 'bun:test';
+import { Global } from '@nestjs/common';
+import { DrizzleEventBus } from '../../../../runtime/subsystems/events/event-bus.drizzle-backend';
+import { DRIZZLE } from '../../../../runtime/constants/tokens';
+
+describe('EventsModule.forRootAsync — DI for backend constructor args (#108)', () => {
+  /**
+   * Minimal Drizzle-shaped mock — captures insert().values(...) so the test
+   * can assert publish() actually reached the injected client rather than an
+   * undefined/bare-constructed one.
+   */
+  function makeMockDb() {
+    const insertBuilder = {
+      values: mock(async (_args: unknown) => []),
+    };
+    const db = {
+      insert: mock(() => insertBuilder),
+    };
+    return { db, insertBuilder };
+  }
+
+  it('resolves DRIZZLE through DI for the drizzle backend (regression: used to bare-construct with undefined db)', async () => {
+    const { db, insertBuilder } = makeMockDb();
+
+    // Real consumers expose DRIZZLE via a @Global() DatabaseModule. Mirror
+    // that here so EventsModule.forRootAsync can see the token.
+    @Global()
+    @Module({
+      providers: [{ provide: DRIZZLE, useValue: db }],
+      exports: [DRIZZLE],
+    })
+    class FakeDrizzleModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FakeDrizzleModule,
+        EventsModule.forRootAsync({
+          useFactory: () => ({ backend: 'drizzle' }),
+        }),
+      ],
+    }).compile();
+
+    const bus = moduleRef.get(EVENT_BUS);
+    expect(bus).toBeInstanceOf(DrizzleEventBus);
+
+    // Prove publish reached the injected mock DB. Pre-fix the backend was
+    // constructed via `new DrizzleEventBus()` with zero args, leaving `db`
+    // undefined — this call would throw "Cannot read properties of undefined
+    // (reading 'insert')" on the hand-constructed instance.
+    await (bus as DrizzleEventBus).publish({
+      id: 'id-1',
+      type: 'contact_created',
+      aggregateId: 'a-1',
+      aggregateType: 'contact',
+      payload: {},
+      occurredAt: new Date('2026-01-01T00:00:00Z'),
+      metadata: { pool: 'events_change', direction: 'change' },
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(insertBuilder.values).toHaveBeenCalledTimes(1);
+
+    await moduleRef.close();
+  });
+
+  it('throws a clear error when the drizzle backend is selected but DRIZZLE is not provided', async () => {
+    // No DRIZZLE provider in the module — the factory should surface a
+    // descriptive error rather than silently constructing a broken bus.
+    await expect(
+      Test.createTestingModule({
+        imports: [
+          EventsModule.forRootAsync({
+            useFactory: () => ({ backend: 'drizzle' }),
+          }),
+        ],
+      }).compile(),
+    ).rejects.toThrow(/DRIZZLE provider is not available/);
+  });
+
+  it('redis backend receives the resolved REDIS_URL via DI (no bare construction)', async () => {
+    // We don't want to actually connect to Redis; assert the instance was
+    // constructed with the expected injected URL. Constructor alone does
+    // not open a connection — that happens in onModuleInit, which
+    // compile() does not invoke.
+    const { RedisEventBus } = await import(
+      '../../../../runtime/subsystems/events/event-bus.redis-backend'
+    );
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRootAsync({
+          useFactory: () => ({
+            backend: 'redis',
+            redisUrl: 'redis://test-host:6379/0',
+          }),
+        }),
+      ],
+    }).compile();
+
+    const bus = moduleRef.get(EVENT_BUS);
+    expect(bus).toBeInstanceOf(RedisEventBus);
+    // The constructor stores the URL on a private field; cast to access
+    // for the assertion. The important property is that the URL arrived —
+    // pre-fix it would have been `undefined`.
+    expect((bus as unknown as { redisUrl: string }).redisUrl).toBe(
+      'redis://test-host:6379/0',
+    );
+
+    await moduleRef.close();
+  });
+});

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -502,8 +502,8 @@ describe('contact-v2.yaml integration', () => {
 	});
 
 	it('maps through parser with correct types', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
-		const contact = result.entities[0];
+		const result = loadEntities(resolve('test/fixtures'));
+		const contact = result.entities.find((e) => e.name === 'contact')!;
 
 		expect(contact.pattern).toBe('Synced');
 		expect(contact.behaviors).toContain('external_id_tracking');
@@ -515,7 +515,7 @@ describe('contact-v2.yaml integration', () => {
 	});
 
 	it('passes consistency checks', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
+		const result = loadEntities(resolve('test/fixtures'));
 		const graph = buildDomainGraph(result.entities);
 		const issues = checkConsistency(graph);
 
@@ -532,8 +532,8 @@ describe('contact-v2.yaml integration', () => {
 
 describe('cross-block validation', () => {
 	it('catches query referencing unknown field', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
-		const contact = result.entities[0];
+		const result = loadEntities(resolve('test/fixtures'));
+		const contact = result.entities.find((e) => e.name === 'contact')!;
 
 		// Inject a bad query
 		contact.queries = [...(contact.queries ?? []), { by: ['nonexistent_field'] }];
@@ -546,8 +546,8 @@ describe('cross-block validation', () => {
 	});
 
 	it('skips by-field validation for via queries', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
-		const contact = result.entities[0];
+		const result = loadEntities(resolve('test/fixtures'));
+		const contact = result.entities.find((e) => e.name === 'contact')!;
 
 		// Via query with cross-entity field should not error
 		contact.queries = [{ by: ['opportunity_id'], via: 'opportunity_contact_link' }];
@@ -561,8 +561,8 @@ describe('cross-block validation', () => {
 	// dogfood #9: belongs_to FK fields (not separately declared under `fields:`)
 	// must still count as available fields for query validation.
 	it('accepts query on belongs_to FK field even when not declared in fields', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
-		const contact = result.entities[0];
+		const result = loadEntities(resolve('test/fixtures'));
+		const contact = result.entities.find((e) => e.name === 'contact')!;
 
 		// Simulate the buggy scenario: author relies on the belongs_to relationship
 		// to imply the `account_id` column, without also declaring it under `fields:`.
@@ -576,8 +576,8 @@ describe('cross-block validation', () => {
 	});
 
 	it('still rejects query on truly nonexistent field when belongs_to is present', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
-		const contact = result.entities[0];
+		const result = loadEntities(resolve('test/fixtures'));
+		const contact = result.entities.find((e) => e.name === 'contact')!;
 
 		contact.fields.delete('account_id');
 		contact.queries = [{ by: ['nonexistent'] }];
@@ -590,8 +590,8 @@ describe('cross-block validation', () => {
 	});
 
 	it('accepts composite query mixing declared field and belongs_to FK', () => {
-		const result = loadEntities(resolve('test/fixtures'), ['contact-v2.yaml']);
-		const contact = result.entities[0];
+		const result = loadEntities(resolve('test/fixtures'));
+		const contact = result.entities.find((e) => e.name === 'contact')!;
 
 		// Drop the declared account_id so only the belongs_to relationship provides it.
 		contact.fields.delete('account_id');


### PR DESCRIPTION
## Summary

- **#108 (EventsModule.forRootAsync)** — hand-constructed backends via `new (provider.useClass)()` with zero args, silently leaving `DrizzleEventBus.db` and `RedisEventBus.redisUrl` undefined. Rewritten as a proper `useFactory` that receives backend dependencies through Nest DI. DRIZZLE injected with `optional: true` so memory-backend consumers are not forced to wire DatabaseModule; descriptive error when drizzle is selected without a DRIZZLE provider in scope.
- **CacheModule.forRootAsync (bundled)** — identical bug shape discovered during the events fix (passed literal `null` for DRIZZLE with an `as unknown as never` cast). Same factory-based fix applied. Flagged here rather than in a separate issue per the no-silent-scope-expansion rule — fix is mechanical and diff is small. JobsModule and SyncModule have no `forRootAsync`, so no similar bug.
- **#117 (project init default docs)** — `docs/CONSUMER-SETUP.md` gains a one-paragraph clarifier that `clean-lite-ps` is the `project init` default and consumers opt into the full Clean Architecture pipeline by editing `codegen.config.yaml` (no CLI `--architecture` flag exists). Keeps `docs/specs/TEST-SESSION-1.md` §3 and the consumer setup doc in agreement. Leaves the init default at `clean-lite-ps` (fix option 1 in the issue).
- **schema-v2 test FS-ordering fix (approved scope expansion)** — surfaced by this PR's CI run. `loadEntities(dir)` takes one arg, but 7 call sites in `schema-v2.test.ts` passed a silently-ignored second `['contact-v2.yaml']` filter, then used `result.entities[0]` which depended on `readdirSync` ordering. On macOS the alphabetic roll put `contact-v2.yaml` first; on Linux CI, `demo-deal.yaml` came first, failing the `external_id_tracking` assertion. Dropped the ignored arg at all 7 sites and swapped `[0]` → `.find(e => e.name === 'contact')!` at the 6 sites that want a specific entity. Follow-up #156 tracks the underlying API question.

## Regression tests

- `events-module.spec.ts` — asserts `DrizzleEventBus` receives the injected DRIZZLE client (publish() reaches the mock DB), `RedisEventBus` receives the injected URL, and the missing-DRIZZLE error is clear.
- `cache-module.spec.ts` (new file) — mirror coverage for `CacheModule.forRoot` and `forRootAsync` drizzle + memory paths.

Both tests would fail on current `main` (hand-constructed backend with `undefined` db throws NRE on first `.insert(...)` call) and pass with this PR.

## Public API

No changes to `forRootAsync(asyncOptions)` signature. Same `EventsModuleAsyncOptions` / `CacheModuleAsyncOptions` shape. Consumers passing only `useFactory` (no `imports`) continue to work for memory backend; drizzle backend now correctly requires DRIZZLE to be in scope — previously it was also required but silently wrong.

## Out of scope

- #104 closed separately as incidentally fixed by #147 (verified `just test-baseline` green on `2c48830`).
- #156 (follow-up) files the `loadEntities` signature question; not addressed here.

## Test plan

- [x] `bun test src/__tests__/runtime/subsystems/events-module.spec.ts` — 15/15 pass
- [x] `bun test src/__tests__/runtime/subsystems/cache-module.spec.ts` — 5/5 pass
- [x] `bun test src/__tests__/schema/schema-v2.test.ts` — 61/61 pass
- [x] `just test-unit` — 1236/1236 pass
- [x] `just test-all` (test-unit + test-baseline + test-smoke) — all green locally
- [ ] `just test-all` green on CI (Linux) — pending push

Closes #108
Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)