### PR TITLE
docs(ADR-023): review-pass revision + BRIDGE Phase 2 orchestration plan

### DIFF
--- a/docs/adrs/ADR-023-event-to-job-bridge.md
+++ b/docs/adrs/ADR-023-event-to-job-bridge.md
@@ -1,11 +1,33 @@
 # ADR-023 — Event-to-Job Bridge
 
-**Status:** Draft
-**Date:** 2026-04-21
+**Status:** Revised (ready for spec cutting)
+**Date:** 2026-04-21 (original draft), revised 2026-04-21 (review pass)
 **Owner:** Doug
 **Related:** ADR-022 (Job Orchestration Domain Model), ADR-024 (Events Domain Formalization), ADR-008 (Subsystem Architecture)
 **Depends on:** ADR-024 Phase 1 (shipped via EVT-1..EVT-8) — typed event registry, `TypedEventBus`, direction-routed outbox
 **Unblocks:** ADR-026 (JobEvent Observability — selective job lifecycle → events broadcast)
+
+## 2026-04-21 Revision Notes
+
+This ADR was reviewed on 2026-04-21 against the draft shipped in PR #9cca553. Refinements below are **additions**, not rewrites — every original decision stands.
+
+Changes incorporated:
+
+1. **New Decision 7** — Developer-facing facade `IEventFlow` with two verbs (`publish`, `publishAndStart`). Closes the authoring-consistency gap: without it, Tier 2 code looks like uncoupled `publish()` + `orchestrator.start()` calls and Tier 3 code looks like decorator metadata. The facade makes the tiers grep-friendly and review-visible.
+2. **New section** — *Three tiers of event-driven work* (subscribe / direct invoke / bridge). Clarifies that the bridge is one of three sanctioned patterns, not the only answer. Includes decision tree.
+3. **Decision 2 update** — Concrete latency guardrails added: typed JSDoc on `triggers:` field, CONSUMER-SETUP "When NOT to use the bridge" section, hop-count table.
+4. **Decision 1 commitment** — Reverse-lookup CLI `codegen events consumers <type>` indexes all three tiers. Shipped in Phase 2.
+5. **New section** — *`publishAndStart` + existing `triggers:` collision*. The facade pre-writes a `bridge_delivery` row so the drain's later UNIQUE constraint dedups the bridge-side spawn. Exactly one execution per (event, trigger) pair.
+6. **Open Q1 + Q3 resolved** — Locked: new `runtime/subsystems/bridge/` subsystem with its own `BridgeModule.forRoot()`. Registry lives at `runtime/subsystems/bridge/generated/registry.ts`.
+7. **Open Q2 resolved** — Drain atomicity is one transaction per event, within per-event processing (not one tx per batch).
+8. **New section** — *Pool alignment guidance*. Two pool layers (reserved `events_*` wrapper pools + user job pools); pool-per-class-of-work, not per-event-type.
+9. **New section** — *Events are facts, jobs are work*. Short primer for new readers; resolves the common "I publish an event, what runs?" confusion.
+10. **Added to Consequences** — Trigger rename/removal, event payload schema evolution, multi-tenancy null-tenantId error path, ordering guarantees.
+11. **Moved out** — The `BridgeDeliveryHandler` pseudocode (decision 2) moved to the BRIDGE-5 spec; this ADR keeps the flow diagram only.
+
+Phase 2 PR stack is spelled out in `docs/specs/BRIDGE-PHASE-2-PLAN.md`.
+
+---
 
 ## Context
 
@@ -18,8 +40,73 @@ Today, that seam is hand-written: a consumer subscribes via `IEventBus.subscribe
 3. **There is no typed binding.** The subscriber writes `ev.payload as { accountId: string }` — the registry knows the payload shape but the subscriber doesn't consult it.
 4. **There is no control plane.** An operator who wants to pause event-driven fanout (during a migration, during an incident) has no single knob. They either stop the outbox (kills everything including in-process subscribers) or set flags in N services.
 5. **The reserved `events_inbound | events_change | events_outbound` pools exist but have no behavior.** ADR-022 reserved them against user handlers "for the bridge." Until the bridge lands, the reservation is a guard with no occupant.
+6. **There is no consistent authoring surface.** Different consumers express functionally identical flows in radically different shapes — some with imperative calls, some with ad-hoc subscribers, some with hand-rolled dedup tables. Review-time, nothing signals "this is a durable fanout" vs "this is a request-path call."
 
 The bridge closes that seam. It is the single, formalized, typed, observable path from "an event was published" to "a job was started in response." It is **owned by neither the events subsystem nor the jobs subsystem** — it's a narrow layer between them.
+
+## Primer: events are facts, jobs are work
+
+Before the decisions, name the distinction this ADR is built on.
+
+**An event is a fact.** Past tense. Immutable. Just data:
+
+```ts
+type UserSignedUp = {
+  type: 'user.signup'
+  payload: { userId: string, email: string }
+}
+```
+
+Publishing an event is like writing a diary entry. It has no behavior on its own.
+
+**A job is a unit of work.** A named handler class with an execute method:
+
+```ts
+@JobHandler({ type: 'send_welcome_email', pool: 'outbound_email' })
+class SendWelcomeEmailJob {
+  async handle(ctx: JobContext<{ userId: string }>) {
+    // actually sends the email
+  }
+}
+```
+
+When you "run a job" you instantiate its handler and call `handle(ctx)`.
+
+The bridge is the map: **when event X occurs, run jobs J₁..Jₙ.** You always start a specifically named job. You never "run an event."
+
+## Three tiers of event-driven work
+
+The bridge is not the only sanctioned way to react to events. There are three tiers, each with a different durability/latency profile. Authors pick by use case.
+
+| Tier | Mechanism | Durability | Latency | Use for |
+|---|---|---|---|---|
+| **1. Subscribe** | `IEventBus.subscribe()` in-process | None (at-most-once) | ~ms | metrics, cache busts, logs |
+| **2. Direct invoke** | `events.publishAndStart(...)` (facade, Decision 7) | Yes, via caller tx | 1 worker claim poll | request-path work needing durability |
+| **3. Bridge** | `@JobHandler({ triggers: [...] })` | Yes, via outbox+ledger | 2–3 poll cycles | durable async fanout |
+
+### Decision tree
+
+```
+You want work to happen when event X is published.
+
+Does the user/caller need to wait for it?
+├── YES → Tier 2: events.publishAndStart(X, jobType, input)
+│
+└── NO → Can you tolerate occasional loss (cheap/recoverable)?
+         ├── YES → Tier 1: IEventBus.subscribe('X', handler)
+         │
+         └── NO  → Tier 3: @JobHandler({ triggers: [{ event: 'X', ... }] })
+```
+
+### Visibility of all three tiers
+
+A single CLI command, `codegen events consumers <event_type>`, scans all three:
+
+- `bridgeRegistry` entries (Tier 3)
+- Grep for `publishAndStart(X, ...)` call sites (Tier 2 — AST scan of the facade method)
+- Declared `IEventBus.subscribe('X', ...)` handlers (Tier 1)
+
+Output is a single fanout report per event type. This is how reverse discoverability works — no need for an event-owned YAML surface. **Committed to Phase 2 scope.**
 
 ## Decision
 
@@ -29,14 +116,14 @@ Split the bridge into two layers with different change cost:
 
 | Layer | What lives here | Cost to change after ship |
 |---|---|---|
-| **Spine** (runtime contract) | `IJobBridge` protocol, `bridge_delivery` table, `bridgeRegistry` shape, wrapper-run execution model | High — schema migration or protocol bump |
-| **Authoring surface** | How users declare triggers: decorator form, optional YAML form, `map:` / `when:` / `scope:` fields | Low — pure codegen, no runtime impact |
+| **Spine** (runtime contract) | `IJobBridge` + `IEventFlow` protocols, `bridge_delivery` table, `bridgeRegistry` shape, wrapper-run execution model | High — schema migration or protocol bump |
+| **Authoring surface** | How users declare triggers: decorator form, optional YAML form, `map:` / `when:` fields; the facade method names | Low — pure codegen and service-layer naming, no runtime impact |
 
 The spine is opinionated and minimal. The authoring surface is free to grow; new authoring styles compile down to the same `bridgeRegistry` without touching the runtime.
 
 This matches the core-contract + extensions pattern from CLAUDE.md: the spine guarantees portability and observability; authoring styles layer on top additively.
 
-### Six locked decisions
+### Seven locked decisions
 
 #### 1. Triggers are job-owned, declared on the handler
 
@@ -52,6 +139,8 @@ class SendWelcomeEmailJob { /* ... */ }
 ```
 
 Rationale: the handler already owns pool, concurrency, replay, retry. Declaring "which events I care about" alongside is the locality that matches how authors think. The event subsystem stays zero-knowledge about jobs — the registry is built by codegen scanning handler decorators, not event YAML.
+
+**Reverse discoverability** — the concern that job-owned triggers make "what listens to event X?" require a grep — is resolved by the `codegen events consumers <type>` CLI (see *Three tiers* above).
 
 **Reversal cost:** low. A future YAML authoring style (`triggers/*.yaml`) can be added as a second codegen source producing into the same `bridgeRegistry`. Both styles can coexist.
 
@@ -99,6 +188,8 @@ Flow:
                         └──────────────────────────────┘
 ```
 
+(`BridgeDeliveryHandler` implementation lives in `docs/specs/BRIDGE-5.md`.)
+
 Rationale: reusing `job_run` machinery (pool concurrency, retry, cancellation cascade, memoization, observability) for bridge deliveries is strictly cheaper than building parallel versions of all those features for `bridge_delivery`. Every operational capability the jobs subsystem already has applies to bridge fanout for free:
 
 - **Pause fanout globally**: `jobs.pools.events_change.concurrency = 0` holds wrappers in `pending`. Flip back on, they drain.
@@ -108,7 +199,21 @@ Rationale: reusing `job_run` machinery (pool concurrency, retry, cancellation ca
 - **Delay / debounce**: wrapper has `run_at`; schedule it.
 - **Observability**: wrappers show up in the jobs dashboard like any other run. Every Airflow/Temporal-style view gets bridge activity for free.
 
-Cost: 2× `job_run` rows per fanout (wrapper + user job), and one extra claim-cycle of latency between event arrival and user job start (≈ poll interval). At realistic event rates (100s–1000s/sec), this is not a concern. At 10k+/sec, revisit.
+**Latency cost.** 2× `job_run` rows per fanout (wrapper + user job), and **2–3 poll cycles** of latency from publish to user-job execution:
+
+| Hop | Stage | Time (typical) |
+|---|---|---|
+| 1 | outbox drain poll | 100–1000ms |
+| 2 | wrapper claim poll | 100–1000ms |
+| 3 | user job claim poll | 100–1000ms |
+| — | **Total publish → user handle()** | **~300ms – 3s** |
+
+At realistic event rates (100s–1000s/sec), this is not a concern. At 10k+/sec with high fanout, revisit.
+
+**Latency guardrails** (new in revision):
+
+- JSDoc on `@JobHandler.triggers`: *"Adds ~{poll_interval × 2–3} of latency. For sub-second request-path work, use `events.publishAndStart()` instead."*
+- CONSUMER-SETUP section: **"When NOT to use the bridge"** — names the cutoff (>1s latency tolerable, durability required, observability in dashboard wanted). Points to `publishAndStart` for sub-second needs.
 
 The reserved `events_*` pools now have a real function: they are **the pools where bridge-delivery wrappers run**. The reservation rule (user `@JobHandler` cannot target them) stands unchanged — it exists because the framework's own bridge-delivery handlers live there.
 
@@ -136,7 +241,7 @@ State enum: `pending | delivered | skipped | failed`.
 
 - `pending` — wrapper run exists, hasn't successfully started user job yet.
 - `delivered` — user job started, `user_run_id` populated.
-- `skipped` — intentional no-op (e.g., `when:` predicate returned false, or dedupe collision returned incumbent run id).
+- `skipped` — intentional no-op (`when:` returned false, or pre-emptive facade-side delivery write dedup'd a bridge-side spawn).
 - `failed` — wrapper handler exhausted its retry policy. Ops-visible via dashboard; no automatic retry past the wrapper's own retry policy.
 
 Rationale: mirrors the events outbox stance (no sweeper in Phase 1). Infra blips are absorbed by the wrapper's normal retry policy. Persistent failure means a broken trigger, broken map, or unreachable orchestrator — all of which need human eyes, not more retries.
@@ -164,6 +269,138 @@ Rationale: `user.created` bursts with internal-test users, `contact.updated` eve
 
 **Reversal cost:** low. Pure codegen — omit the field and handlers filter internally.
 
+#### 7. Developer-facing facade: `IEventFlow` service with two verbs
+
+Two imperative call shapes — `publish` and `publishAndStart` — exposed via an injectable `IEventFlow` token. All request-path and fanout publishing goes through this facade, not through `IEventBus` directly. Subscribers (Tier 1) remain declarative (`@OnEvent` decorator) and bypass the facade.
+
+```ts
+export interface IEventFlow {
+  /**
+   * Tier 3 + Tier 1 — plain publish.
+   * Writes to outbox; bridge triggers fire async (via @JobHandler.triggers);
+   * in-process @OnEvent subscribers fire in-call.
+   * Returns when the outbox row is committed.
+   */
+  publish<T extends EventType>(
+    event: TypedEvent<T>
+  ): Promise<void>
+
+  /**
+   * Tier 2 + Tier 3 + Tier 1 — publish + eagerly start a specific named job.
+   * Writes to outbox; ALSO inserts a job_run for `jobType` synchronously
+   * via orchestrator.start(). Bridge triggers and @OnEvent subscribers
+   * fire as normal for the event. Returns the eagerly-started run's id.
+   *
+   * Use when the caller needs the job enqueued before returning to the
+   * user (request-path, within-transaction durability). If the same job
+   * has a declared trigger for this event, the facade pre-writes a
+   * bridge_delivery(status=delivered) row to dedup the later bridge spawn.
+   */
+  publishAndStart<T extends EventType, J extends JobType>(
+    event: TypedEvent<T>,
+    jobType: J,
+    input: JobInputOf<J>,
+    opts?: {
+      parentRunId?: string
+      tenantId?: string | null
+    }
+  ): Promise<{ runId: string }>
+}
+```
+
+Rationale: without the facade, Tier 2 code looks like uncoupled `eventBus.publish()` + `orchestrator.start()` calls — there's no grep that distinguishes "these are semantically coupled" from "these are independent operations." Two developers producing functionally identical flows write visibly different code. The facade forces consistency:
+
+- **Review-visible**: `grep publishAndStart` finds every Tier 2 call site; `grep publish` finds every Tier 3 call site.
+- **Consistent shape across teams**: same verb, same argument order, same error handling.
+- **Grep-friendly for the fanout CLI**: `codegen events consumers <type>` can AST-scan `publishAndStart` calls alongside bridge triggers and subscribers.
+- **Explicit about dedup**: `publishAndStart` handles the "job has both a declared trigger and an eager-start call site" case in one place (see below).
+- **Matches pattern-stack Python precedent**: `backend-patterns` exposes intent-named verbs over raw primitives; this mirrors that shape.
+
+Under the hood the facade is thin: `publish` delegates to `IEventBus.publish`; `publishAndStart` delegates to `IEventBus.publish` + `IJobOrchestrator.start` + (if relevant) an idempotent pre-write of `bridge_delivery`.
+
+**Reversal cost:** low. The facade is a pure service layer over existing primitives. Removing it just reverts authors to calling the underlying services directly.
+
+### `publishAndStart` + existing `triggers:` collision
+
+The intersection case needs explicit handling:
+
+- **Case A** — the job has NO `triggers:` entry for this event. `publishAndStart` is the only path that starts this job for this event. Bridge drain scans registry, finds no match, never spawns. **No double-run possible.** Common case.
+- **Case B** — the job HAS a `triggers:` entry AND a caller uses `publishAndStart` with the same (event, job) pair. Without intervention, both paths would spawn a `job_run`.
+
+For Case B, the facade **pre-writes a `bridge_delivery` row** before (or as part of) the eager `orchestrator.start()` call:
+
+```ts
+// Inside publishAndStart, for Case B:
+await tx.insert(bridge_delivery).values({
+  event_id,
+  trigger_id: `${jobType}#${triggerIndex}`,
+  wrapper_run_id: null,                // facade never writes a wrapper
+  user_run_id: eagerRunId,
+  status: 'delivered',                 // already done, bridge should skip
+  // ...
+})
+```
+
+When the outbox drain later processes the event and attempts to insert its own `bridge_delivery` row for the same `(event_id, trigger_id)`, the `UNIQUE` constraint fails → drain catches it → skips that trigger → other triggers for the same event still fire normally.
+
+**Result:** exactly one execution per (event, trigger) pair, regardless of invocation path. The ledger is the single source of truth.
+
+The `trigger_id` resolution requires the facade to consult `bridgeRegistry` at call time — adding a registry lookup per `publishAndStart` call. At facade-level this is a constant-time Map access against the in-memory registry; negligible cost.
+
+### Pool alignment guidance
+
+Pools are the unit of concurrency control. Jobs in the same pool compete for slots; head-of-line blocking between dissimilar work classes is the classic failure mode. Bridge-driven fanout spans **two pool layers**:
+
+```
+publish(user.signup)
+   │
+   ▼
+┌──────────────────────┐
+│ wrapper job_run      │ ← Pool A: events_change (reserved, framework-owned)
+│ @framework/bridge_   │   — one per event direction, cheap wrappers
+│  delivery handler    │
+└──────────┬───────────┘
+           │
+           │ wrapper calls orchestrator.start(userJob)
+           ▼
+┌──────────────────────┐
+│ user job_run         │ ← Pool B: declared by @JobHandler.pool
+│ SendWelcomeEmailJob  │   — contention happens HERE
+│   pool: outbound_email│
+└──────────────────────┘
+```
+
+**Pool A (reserved `events_*`):** bridge wrappers only. Cheap (~1ms per wrapper run: registry lookup, `when:` evaluation, `orchestrator.start`, ledger update). Run at high concurrency (e.g., 32). Not usually a bottleneck.
+
+**Pool B (user pools):** actual work, real contention. This is where author pool choice matters.
+
+**Rule of thumb.** Pool-per-class-of-work, not per-event-type. One event can fan out into many different user pools:
+
+```
+user.signup  (events_change wrapper pool)
+   ├─→ SendWelcomeEmailJob      → outbound_email
+   ├─→ ProvisionWorkspaceJob     → internal
+   ├─→ EmitAnalyticsJob          → outbound_analytics
+   └─→ SyncContactToHubspotJob   → external_crm
+```
+
+Each user pool answers one question: *what scarce resource am I protecting behind this queue?* Typical pool set:
+
+| Pool | Scarce resource |
+|---|---|
+| `outbound_email` | SMTP / Mailgun throughput |
+| `outbound_analytics` | Segment batch-send efficiency |
+| `external_crm` | HubSpot / SFDC API rate limits |
+| `external_payments` | Stripe rate limit, high-stakes retries |
+| `internal` | general-purpose, no external dependency |
+| `background_reports` | low-priority, slow, shouldn't starve user-facing work |
+
+**4–8 pools** for a medium app. Too few → head-of-line blocking. Too many → operational toil.
+
+The reserved `events_*` pools don't count toward that budget — they're fixed by the framework.
+
+**Ordering guarantee** (new in revision): reserved-pool concurrency > 1 means no implicit ordering between sequential events for the same user pool. If a consumer needs "A before B" ordering for events on the same aggregate, set `jobs.pools.events_<direction>.concurrency = 1` (serializes wrappers) or `jobs.pools.<user_pool>.concurrency = 1` (serializes user jobs). Default configuration gives parallelism, not ordering.
+
 ### Schema: `bridge_delivery`
 
 ```sql
@@ -171,7 +408,7 @@ CREATE TABLE bridge_delivery (
   id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   event_id          uuid NOT NULL REFERENCES domain_events(id),
   trigger_id        text NOT NULL,                 -- stable, codegen-emitted: "<job_type>#<index>"
-  wrapper_run_id    uuid NOT NULL REFERENCES job_run(id),
+  wrapper_run_id    uuid REFERENCES job_run(id),   -- nullable: null when facade pre-wrote as 'delivered'
   user_run_id       uuid REFERENCES job_run(id),   -- null until delivered or if skipped/failed
   status            bridge_delivery_status NOT NULL DEFAULT 'pending',
   skip_reason       text,                          -- populated when status=skipped
@@ -190,13 +427,13 @@ CREATE INDEX bridge_delivery_user_run_idx ON bridge_delivery (user_run_id) WHERE
 ```
 
 Notes:
-- `UNIQUE (event_id, trigger_id)` is the idempotency ledger — the outbox can safely replay an event, the drain will attempt to insert a duplicate delivery and fail the constraint, and skip.
-- `tenant_id` mirrors the `job_run` multi-tenancy convention (JOB-8 / ADR-022 2026-04-20 revision). Always emitted, always nullable. Multi-tenancy enforced at the `IJobBridge` DI boundary, not via DB constraint.
-- No FK from `user_run_id` to `job_run.id` for the case where the orchestrator never created the run (`skipped` due to `when:`).
+- `UNIQUE (event_id, trigger_id)` is the idempotency ledger — the outbox can safely replay an event, the drain will attempt to insert a duplicate delivery and fail the constraint, and skip. Also dedups facade-eager vs bridge-drain for the same (event, trigger) pair (see Decision 7 collision section).
+- `wrapper_run_id` is nullable to accommodate facade-eager delivery writes that have no wrapper (the facade started the user job directly, no wrapper needed). The bridge-drain path always populates it.
+- `tenant_id` mirrors the `job_run` multi-tenancy convention (JOB-8 / ADR-022 2026-04-20 revision). Always emitted, always nullable. Multi-tenancy enforced at the `IJobBridge` / `IEventFlow` DI boundary, not via DB constraint.
 
 ### The `bridgeRegistry` shape
 
-Generated into `runtime/subsystems/events/generated/bridge.ts` (or `runtime/subsystems/jobs/generated/bridge.ts` — pool-side concern; to be resolved in BRIDGE-3):
+Generated into **`runtime/subsystems/bridge/generated/registry.ts`** (resolves original Open Q3 — bridge subsystem owns it, not events and not jobs):
 
 ```ts
 export const bridgeRegistry: BridgeRegistry = {
@@ -221,51 +458,34 @@ export const bridgeRegistry: BridgeRegistry = {
 
 Keyed by event type, ordered array per type (preserves declaration order across handlers). `triggerId` is stable across codegens — `<jobType>#<triggerIndex>` — so replays resolve to the same `bridge_delivery` UNIQUE row.
 
-### The framework wrapper handler
+### `BridgeModule` and subsystem boundaries
 
-Registered automatically by `JobsDomainModule`, lives in `events_inbound | events_change | events_outbound` pools:
+New subsystem at `runtime/subsystems/bridge/`. Its `BridgeModule.forRoot({ multiTenant })` imports `JobsDomainModule` + `EventsModule`, registers the framework `BridgeDeliveryHandler` on all three reserved pools, wires the `IJobBridge` and `IEventFlow` tokens, and exposes them globally.
+
+This is the *combiner*: neither events nor jobs subsystems know about the bridge. The bridge imports from both.
+
+Consumer wiring:
 
 ```ts
-@JobHandler({
-  type: '@framework/bridge_delivery',
-  pool: 'events_change',        // one per direction; registered 3x
-  retryPolicy: { attempts: 3, backoff: 'exponential', base_ms: 1000 },
-  // no scope; the delivery is a framework concern
+@Module({
+  imports: [
+    EventsModule.forRoot({ backend: 'drizzle', multiTenant: false }),
+    JobsDomainModule.forRoot({ /* ... */ }),
+    BridgeModule.forRoot({ multiTenant: false }),   // ← add this line
+  ],
 })
-class BridgeDeliveryHandler {
-  async handle(ctx: JobContext<{ deliveryId: string }>) {
-    const delivery = await ctx.step('load_delivery', () =>
-      this.deliveryRepo.findById(ctx.input.deliveryId)
-    )
-    const event = await ctx.step('load_event', () =>
-      this.eventRepo.findById(delivery.eventId)
-    )
-    const registryEntry = bridgeRegistry[event.type]?.find(
-      (t) => t.triggerId === delivery.triggerId
-    )
-    if (!registryEntry) {
-      await this.deliveryRepo.markSkipped(delivery.id, 'trigger_unregistered')
-      return
-    }
-    if (registryEntry.when && !registryEntry.when(event)) {
-      await this.deliveryRepo.markSkipped(delivery.id, 'when_predicate_false')
-      return
-    }
-    const input = registryEntry.map(event)
-    const userRun = await ctx.step('spawn_user_run', () =>
-      this.orchestrator.start(registryEntry.jobType, input, {
-        parentRunId: ctx.run.id,
-        triggerSource: 'event',
-        triggerRef: event.id,
-        tenantId: event.metadata.tenantId ?? null,
-      })
-    )
-    await this.deliveryRepo.markDelivered(delivery.id, userRun.id)
-  }
-}
+class AppModule {}
 ```
 
-Step memoization ensures that a wrapper crashed mid-delivery can replay idempotently: if `spawn_user_run` completed but `markDelivered` didn't, replay skips the spawn and resumes at the mark. The `orchestrator.start()` call is itself idempotent via the user job's own dedupe window if configured.
+**`BridgeModule` must be imported after `EventsModule` and `JobsDomainModule`** — the framework handler registration consults both subsystems' DI tokens. Documented in CONSUMER-SETUP.
+
+### Outbox drain atomicity
+
+The outbox drain inserts one `bridge_delivery` row + one wrapper `job_run` row **per matched trigger, all inside a single per-event transaction**, along with marking the event `processed_at`. A crash inside this transaction leaves the event unprocessed for re-claim; the `UNIQUE(event_id, trigger_id)` constraint dedups the eventual retry.
+
+The drain processes events in batch (claim N rows at once via `FOR UPDATE SKIP LOCKED`) but each event's processing runs in its own transaction inside the batch loop. This prevents a single bad trigger from failing the whole batch.
+
+(Resolves original Open Q2.)
 
 ## Consequences
 
@@ -274,20 +494,26 @@ Step memoization ensures that a wrapper crashed mid-delivery can replay idempote
 - **Uniform observability.** Bridge fanout appears in the jobs dashboard as runs, using the same visualization primitives as every other run. No separate UI surface.
 - **Uniform control plane.** Pool concurrency, pause, throttle, cancel, schedule — all existing job-machinery knobs apply to bridge activity.
 - **Typed publish → typed trigger → typed job input.** One `eventRegistry` is the source of truth. `map:` callbacks are typechecked.
-- **Idempotency by construction.** `UNIQUE (event_id, trigger_id)` short-circuits replays without application logic.
+- **Idempotency by construction.** `UNIQUE (event_id, trigger_id)` short-circuits replays AND dedups facade-eager vs bridge-drain collision.
 - **Reserved pools now have purpose.** `events_*` reservation stops being a guard against a phantom future and becomes the operating location of the bridge.
 - **Cascade cancel for free.** `parent_run_id` links wrapper to user job; `parent_close_policy` gives per-trigger control.
+- **Three-tier consistency.** The facade + CLI make the authoring model explicit: Tier 1, 2, 3 each have a named call shape and appear in the same fanout report.
+- **Grep-reviewable fanout.** `publishAndStart` call sites are greppable; `@JobHandler.triggers` decorators are greppable; `@OnEvent` subscribers are greppable. Reviewers can audit fanout without reading every use case.
 
 ### Negative
 
 - **2× `job_run` row count per fanout.** Wrappers + user runs. At realistic rates, negligible. At 10k+ events/sec with high fanout, revisit.
-- **+1 poll cycle of latency** between event drain and user job start. For non-realtime work (all bridge use cases), negligible. For realtime, bypass the bridge — use an imperative `orchestrator.start()` from the use case.
-- **Mental model overhead.** New users see two runs per fanout and ask "what's the wrapper?" Mitigated by naming (`@framework/bridge_delivery`) and dashboard filtering-by-default.
+- **2–3 poll cycles of latency** between event publish and user job start via the bridge. For non-realtime work, negligible. For realtime, use `publishAndStart` (Tier 2).
+- **Mental model overhead.** New users see two runs per bridge fanout and ask "what's the wrapper?" Mitigated by naming (`@framework/bridge_delivery`) and dashboard filtering-by-default.
 - **Reserved pools carry running code.** Framework-owned code, not user code — but still code that can fail. Mitigation: wrapper handler is small, well-tested, and its failures surface as `bridge_delivery.status = 'failed'` which is ops-visible.
+- **Facade indirection.** Authors no longer call `IEventBus.publish` directly — they go through `IEventFlow.publish`. Small cognitive overhead; documented in CONSUMER-SETUP. The trade is enforced by convention, not compiler; a determined author can still reach for `IEventBus` and lose the consistency property.
 
-### Neutral
+### Neutral / edge cases (added in revision)
 
-- The outbox drain gains one responsibility: when draining a row, also insert `bridge_delivery` + wrapper `job_run` rows for each matched trigger. This replaces the current "deliver to in-process subscribers" pattern for handlers that do heavy work; in-process subscribers remain valid for cheap projections / cache busts.
+- **Trigger rename or removal.** Renaming `send_welcome_email` → `send_user_welcome` changes the `triggerId` (`send_welcome_email#0` → `send_user_welcome#0`). In-flight `bridge_delivery` rows for the old name become orphaned but benign — they're audit-only after the run completed; if still `pending`, the bridge-delivery handler no longer finds a registry entry and marks them `skipped` with `skip_reason='trigger_unregistered'`. No auto-migration. Documented in CONSUMER-SETUP.
+- **Event payload schema evolution.** If an event's payload shape changes in a non-backward-compat way, replayed `bridge_delivery` rows reference events with the old shape but `map:` code expects the new shape. Step memoization on the wrapper handler protects the already-completed `spawn_user_run` step; only the never-yet-run replays hit `map:`, and those will surface as typecheck errors (caught at codegen) or runtime errors (wrapper marked `failed`). **Rule**: breaking schema changes require a coordinated trigger-map migration in the same PR. Documented in `.claude/skills/bridge/`.
+- **Multi-tenancy null-tenantId.** When `BridgeModule` is configured with `multiTenant: true` and an event's `metadata.tenantId` is null, the wrapper handler throws `MissingTenantIdError` (same error shape as jobs / sync / events subsystems) and the delivery transitions to `failed`. The eager `publishAndStart` path enforces the same at its entry (before writing the `bridge_delivery` row) — mirrors JOB-8 / SYNC-6 precedent.
+- **Ordering guarantee.** Reserved-pool concurrency > 1 means sequential events for the same aggregate can have their user jobs run out of order. Consumers needing strict ordering must set pool concurrency to 1. Documented in CONSUMER-SETUP.
 
 ## Alternatives considered
 
@@ -313,19 +539,39 @@ Declare in `events/user.created.yaml`: `triggers: [send_welcome_email, ...]`.
 
 Outbox drain worker handles the registry match and calls `orchestrator.start()` directly, without wrapper runs. Similar to B, differs only in code location.
 
-**Rejected because:** same fundamental issue as B. Also: couples the events-subsystem drain poller to the jobs-subsystem orchestrator, adding cross-subsystem imports that should flow the other direction (jobs consumes events registry, not vice versa).
+**Rejected because:** same fundamental issue as B. Also: couples the events-subsystem drain poller to the jobs-subsystem orchestrator, adding cross-subsystem imports that should flow through the bridge subsystem instead.
+
+### F. Dual-mode triggers (`@JobHandler.triggers: [{ event, mode: 'bridge' | 'immediate' }]`)
+
+Considered during the 2026-04-21 review. The `triggers:` declaration would carry a `mode:` field selecting sync vs async execution at the same declaration site.
+
+**Rejected because:** "immediate" has ambiguous semantics (pre-commit sync? post-commit async? bypass or pre-write the ledger?), and the use case that would drive the decision (durable + <100ms) doesn't exist yet. Additionally, mixing execution modes on the same authoring surface hides meaningful behavioral differences from reviewers. Direct invoke (Tier 2 via `publishAndStart`) already handles the sub-second case; keeping the two paths at different call sites makes the intent visible. Revisit in Phase 3 if evidence materializes.
+
+### G. Direction-based auto-routing (events pick their own tier)
+
+Considered during the 2026-04-21 review. Map event direction (`inbound | change | outbound`) to execution mode automatically — e.g., `change` → direct invoke, `inbound/outbound` → bridge.
+
+**Rejected because:** direction describes *where an event comes from / where it's going*, not the durability/latency profile of downstream reactions. The same event (`order.placed`) has three triggers in this ADR's examples that each want different profiles. Auto-routing by direction would make execution semantics implicit and refactoring event direction would silently change every trigger's behavior.
 
 ## Phase roadmap
 
 **Phase 2 (this ADR) — ships as BRIDGE-1..N:**
-- `bridge_delivery` schema and Drizzle backend.
-- `IJobBridge` protocol + framework `BridgeDeliveryHandler`.
-- Codegen: `bridgeRegistry` from `@JobHandler.triggers` decorator metadata.
-- Build-time validation against `eventRegistry`.
-- `when:` predicates and typed `map:` callbacks.
-- Multi-tenancy threading (event `metadata.tenantId` → `job_run.tenant_id`).
-- Hygen scaffold templates.
-- CONSUMER-SETUP + skill documentation.
+
+See `docs/specs/BRIDGE-PHASE-2-PLAN.md` for the PR stack and dependency graph.
+
+Summary:
+- `bridge_delivery` schema + Drizzle backend
+- `IJobBridge` + `IEventFlow` protocols
+- New `runtime/subsystems/bridge/` subsystem + `BridgeModule.forRoot()`
+- Framework `BridgeDeliveryHandler` + outbox drain integration
+- Codegen: `bridgeRegistry` from `@JobHandler.triggers` decorator metadata
+- Build-time validation against `eventRegistry`
+- `when:` predicates and typed `map:` callbacks
+- `EventFlowService` facade implementation (both verbs)
+- Multi-tenancy threading (event `metadata.tenantId` → `job_run.tenant_id`)
+- Fanout CLI: `codegen events consumers <type>`
+- Hygen scaffold templates
+- CONSUMER-SETUP + `.claude/skills/bridge/` documentation
 
 **Phase 2.5 — deferred, cheap to add later:**
 - YAML authoring style (`triggers/*.yaml` or inline in `events/*.yaml`) as a second codegen source.
@@ -336,20 +582,20 @@ Outbox drain worker handles the registry match and calls `orchestrator.start()` 
 - Certain job lifecycle transitions (e.g., `job_run_completed` for specific handlers) publish as `domain_events`, which can in turn trigger other jobs via this same bridge.
 - Does not modify the bridge — only adds a new event-publish call site in `JobEventLogger`.
 
-## Open questions
+## Resolved questions
 
-1. **Wrapper handler registration mechanism.** The framework handler needs to register once per reserved pool (`events_inbound`, `events_change`, `events_outbound`) at module init. Concretely: does `JobsDomainModule.forRoot()` always register it, or does `BridgeModule.forRoot()` exist as a separate opt-in module? **Proposal:** separate `BridgeModule` that imports `JobsDomainModule` + `EventsModule` and wires the framework handler. Opt-in via `@Module({ imports: [BridgeModule.forRoot({ multiTenant })] })`. Keeps jobs and events loosely coupled; the bridge is the *combiner*. To be resolved in BRIDGE-2.
-
-2. **Outbox-drain → bridge_delivery insert atomicity.** The outbox drain must insert `bridge_delivery` + wrapper `job_run` rows in the same transaction it marks the event processed. Otherwise a crash between the two leaves an "event processed, no delivery" state. **Proposal:** single transaction per drained event covers all its matched triggers. To be validated in BRIDGE-4.
-
-3. **Where does `bridgeRegistry` physically live?** `runtime/subsystems/events/generated/bridge.ts` implies events owns it; `runtime/subsystems/jobs/generated/bridge.ts` implies jobs owns it. Neither is quite right — the bridge is the combiner. **Proposal:** `runtime/subsystems/bridge/generated/registry.ts`, with a new skill `.claude/skills/bridge/` that owns the cross-subsystem concern. Avoids making either subsystem import from the other. To be resolved in BRIDGE-3.
-
-4. **Bulk fanout performance.** An event with 50 interested triggers produces 50 `bridge_delivery` + 50 wrapper rows in the drain transaction. For very high fanout, this may dominate drain latency. **Proposal:** measure first; if problematic, batch-insert both tables. Not a Phase 2 blocker.
+1. **Wrapper handler registration** — *resolved*: `BridgeModule.forRoot()` registers the framework `BridgeDeliveryHandler` on all three reserved pools (`events_inbound`, `events_change`, `events_outbound`) at module init. See *`BridgeModule` and subsystem boundaries* above.
+2. **Outbox-drain atomicity** — *resolved*: per-event transaction inside the drain's batch loop; marks `processed_at` + inserts `bridge_delivery` + wrapper `job_run` together. See *Outbox drain atomicity*.
+3. **Where `bridgeRegistry` lives** — *resolved*: `runtime/subsystems/bridge/generated/registry.ts`, owned by the new bridge subsystem. See *The `bridgeRegistry` shape* above.
+4. **Bulk fanout performance** — *unresolved; not a Phase 2 blocker*: an event with 50 interested triggers produces 50 `bridge_delivery` + 50 wrapper rows in the drain transaction. Measure first; if problematic, batch-insert both tables.
+5. **`publishAndStart` + trigger collision** — *resolved*: facade pre-writes `bridge_delivery(status=delivered)` so drain's later insert hits UNIQUE and skips. See *`publishAndStart` + existing `triggers:` collision*.
 
 ## Cross-links
 
 - `ADR-022-job-orchestration-domain-model.md` — jobs domain model. Reserved `events_*` pools originate here; `trigger_source='event'` + `trigger_ref=<event_id>` columns on `job_run` already anticipated this ADR.
 - `ADR-024-events-domain-formalization.md` — events domain model. The typed registry this ADR builds on.
 - `ADR-026-job-observability.md` — selective job lifecycle events; flows back through this bridge.
+- `docs/specs/BRIDGE-PHASE-2-PLAN.md` — PR stack and orchestration plan for the implementation.
 - `.claude/skills/events/phase-roadmap.md` — Phase 2 entry will be promoted from "deferred" to "shipped" once BRIDGE-1..N land.
 - `.claude/skills/jobs/SKILL.md` — reserved pool rules; will gain a cross-link to this ADR's wrapper handler registration.
+- `.claude/skills/bridge/SKILL.md` — new skill created in BRIDGE-10.

--- a/docs/specs/ADR-023-handoff.md
+++ b/docs/specs/ADR-023-handoff.md
@@ -1,82 +1,56 @@
 # ADR-023 Handoff — Event-to-Job Bridge
 
-**Status:** draft ADR written, awaiting second-opinion review before BRIDGE-1..N specs are cut.
+**Status:** ✅ review pass complete (2026-04-21). ADR revised, ready for spec cutting.
 **Primary artifact:** `docs/adrs/ADR-023-event-to-job-bridge.md`
+**Orchestration plan:** `docs/specs/BRIDGE-PHASE-2-PLAN.md`
 **Related context:** ADR-022 (jobs), ADR-024 (events), `.claude/skills/events/phase-roadmap.md` (Phase 2 entry).
 
-## What this is
+## What happened in the review pass
 
-The bridge connects two already-shipped subsystems: the events outbox (ADR-024, EVT-1..8) and the jobs orchestration domain (ADR-022, JOB-1..8). Today that seam is hand-written — consumers subscribe to `IEventBus` and call `IJobOrchestrator.start()` from inside the subscriber. The ADR formalizes it.
+User reviewed the original draft with a second agent on 2026-04-21. The pass produced 10 additions / clarifications, none of which rewrite the original decisions. All are captured inline in the revised ADR under the `2026-04-21 Revision Notes` section at the top.
 
-The reserved `events_inbound | events_change | events_outbound` pools in the jobs subsystem have existed since ADR-022 as placeholders specifically for this bridge. Nothing runs in them today.
+**Decisions 1–6 stand unchanged.** A new **Decision 7** (developer-facing facade) was added. Open Questions 1, 2, 3, and a new 5 are resolved in the revised doc.
 
-## The design in one paragraph
+### Summary of revision content
 
-Triggers are declared on the job (`@JobHandler({ triggers: [{ event, map, when }] })`). Codegen scans handlers and emits a `bridgeRegistry` keyed by event type. When the outbox drain claims a `domain_events` row, it inserts one `bridge_delivery` audit row + one `job_run` row (`type=@framework/bridge_delivery`, `pool=events_<direction>`) per matched trigger. The wrapper `job_run` is claimed by the ordinary job worker; the framework's `BridgeDeliveryHandler` runs it, evaluates `when:`, applies `map:`, and calls `orchestrator.start(userJob, mapped, { parentRunId: self })`. The user job runs in its declared pool, linked to the wrapper as parent so cascade cancel works.
+1. **Three-tier model** framed explicitly: subscribe (in-process, lossy, ms) / direct invoke (request-path, durable, 1 poll cycle) / bridge (async fanout, durable, 2–3 poll cycles). Decision tree included.
+2. **New Decision 7: `IEventFlow` facade** with two verbs — `publish` and `publishAndStart`. Resolves authoring-consistency gap; makes tiers grep-friendly.
+3. **`publishAndStart` + existing `triggers:` collision** resolved by pre-writing `bridge_delivery(status=delivered)` so drain's UNIQUE dedups.
+4. **New subsystem `runtime/subsystems/bridge/`** — resolves Open Q1 + Q3. Has its own `BridgeModule.forRoot({ multiTenant })` that imports Events + Jobs modules.
+5. **Drain atomicity**: per-event transaction within batch loop. Resolves Open Q2.
+6. **Pool alignment guidance** added: two pool layers (events_* wrappers + user pools), pool-per-class-of-work.
+7. **Latency guardrails** on Decision 2: hop-count table, JSDoc on `triggers:` field, "When NOT to use the bridge" CONSUMER-SETUP section committed.
+8. **Reverse-lookup CLI** `codegen events consumers <type>` committed to Phase 2 scope — indexes all three tiers.
+9. **Primer section** *events are facts, jobs are work* for new readers.
+10. **Edge cases added to Consequences**: trigger rename/removal (orphan handling), payload schema evolution rules, multi-tenancy null-tenantId error path, ordering guarantees.
 
-## Six locked decisions (all revisitable; costs noted)
+### Two new rejected alternatives recorded (F, G)
 
-| # | Decision | Reversal cost |
-|---|---|---|
-| 1 | Job-owned triggers via decorator | Low (codegen-only) |
-| 2 | Bridge IS the jobs worker on reserved pools (wrapper `job_run` per delivery) | **Medium — this is the one I'm least certain on** |
-| 3 | Typed TS `map:` / `when:` callbacks (not YAML DSL) | Low |
-| 4 | `bridge_delivery.status = pending/delivered/skipped/failed`, no auto-retry | Low |
-| 5 | Build-time validation against `eventRegistry` | None |
-| 6 | `when:` predicates ship in Phase 2 | Low |
+- **F. Dual-mode triggers** (`mode: 'bridge' | 'immediate'` on the decorator) — rejected; use case doesn't exist yet; would hide execution semantics.
+- **G. Direction-based auto-routing** (direction picks tier automatically) — rejected; direction is provenance, not latency profile.
 
-## Where I'd most want pushback
+## Next step for the executing session
 
-### Decision 2 — wrapper run vs. direct spawn
+Branch off latest `main` and:
 
-Between two variants I considered:
+1. Cut specs: `docs/specs/BRIDGE-1.md` through `docs/specs/BRIDGE-N.md` following the shape of EVT-1..8 / JOB-1..8 / SYNC-1..8. PR stack is in `docs/specs/BRIDGE-PHASE-2-PLAN.md`.
+2. File GitHub issues per spec (one epic + N sub-issues, like `#60 + #126..#133` for SYNC).
+3. Orchestrate per the plan doc's recommendation (single coordinator, sequential `/develop` loops, worktree isolation, three pre-agreed gates).
 
-- **(a) Wrapper runs in reserved pools** (chosen): outbox drain inserts `bridge_delivery` + wrapper `job_run` in reserved pool. Wrapper handler calls `orchestrator.start()` for the user job.
-- **(b) Direct spawn**: outbox drain calls `orchestrator.start()` inline, writes `bridge_delivery` as audit-only. One `job_run` per fanout instead of two.
+The plan doc is **execution-ready**. It specifies file paths, gate locations, dependency order, and the coordinator's first action.
 
-I chose (a) because every operational capability we want (pause fanout, throttle, retry, cancel, schedule, observability) already exists on `job_run` and would need to be reimplemented on `bridge_delivery` in (b). User agreed with (a) on the "control-plane separation" argument.
+## User's known worries — status after revision
 
-Cost of (a): 2× row count per fanout; +1 poll cycle of latency. At realistic rates (100s–1000s/sec), fine. At 10k+/sec with high fanout, revisit.
+- **"`user.created` could generate a bunch of downstream jobs that slow stuff down."** Resolved. Publish is O(1) insert; fanout is async on isolated pools; execution is bounded by pool concurrency. Consequences section names this.
+- **"I want layers of separation for control."** Drove Decision 2 (wrappers over direct spawn). Pool-level concurrency on `events_*` provides the control knob; pool alignment guidance documents how to pick user pools to avoid head-of-line blocking.
+- **"Leaving delegation to implementer style produces inconsistency."** Resolved by Decision 7 (facade).
+- **"I don't love not knowing which path skipped a step."** Resolved by the three-tier model + fanout CLI: all three tiers are visible in the same report; `grep publishAndStart` + `grep @JobHandler.triggers` + `grep @OnEvent` cover them.
+- **"Pools need to align to event types."** Refined: pool-per-class-of-work, not per-event-type. Documented in *Pool alignment guidance*.
 
-**Things an outside reviewer should stress-test:**
-- Is the 2× row count actually free at our target scale, or am I hand-waving? Back-of-envelope for `user.created` with typical fanout.
-- Is the +1 poll cycle latency a real problem for any plausible use case? (Realtime hot paths shouldn't use the bridge — use imperative `orchestrator.start()` from the use case. But is that documented clearly enough?)
-- Does routing wrapper code into reserved pools muddy the "reserved = user can't target" rule? (Proposal: keep the rule; only framework-registered handlers can target.)
+## What the next session should NOT do
 
-### Decision 1 — job-owned vs. event-owned triggers
-
-User originally worried that event-owned triggers would force events to know about jobs. Settled on job-owned. Second opinion question: **is there any reason a declarative event-owned approach would be better at any scale?** (E.g., "this event fans out to these 15 things, visible in one file.") I argued no — the job owns its pool, concurrency, replay; adding trigger spec keeps behavior colocated. But a reviewer who's built reactive systems may have counter-arguments.
-
-### Open question — where `bridgeRegistry` physically lives
-
-Three candidates in the ADR's open questions section:
-- `runtime/subsystems/events/generated/bridge.ts` (events-owned, but events subsystem shouldn't know about jobs)
-- `runtime/subsystems/jobs/generated/bridge.ts` (jobs-owned, but bridge registry consults `eventRegistry`)
-- `runtime/subsystems/bridge/generated/registry.ts` (my lean — new subsystem whose whole job is combining the other two)
-
-Lean is option 3, which implies a new `BridgeModule.forRoot()` that imports `JobsDomainModule` + `EventsModule`. Keeps the import graph clean.
-
-## Reading order for a reviewer
-
-1. **Context + Decision sections of the ADR** (decisions 1 + 2 are the load-bearing ones).
-2. **Alternatives considered** (4 rejected approaches with reasons — easiest place to find disagreement).
-3. **Schema section** for `bridge_delivery` (small table, few columns — quick to evaluate).
-4. **Open questions** at the bottom (all Phase-2 spec concerns, not ADR concerns).
-
-Skip: the framework handler pseudocode is illustrative, not final — BRIDGE-4 will produce the actual implementation.
-
-## User's known worries to sanity-check against
-
-- **"`user.created` could generate a bunch of downstream jobs that slow stuff down."** Resolved in conversation — publish is O(1) insert, fanout is async on isolated pools, execution is bounded by pool concurrency. ADR's consequences section names this explicitly.
-- **"I want layers of separation for control."** Drove decision 2 toward wrappers over direct spawn. Agent should check the control-plane argument holds: does pool-level concurrency on `events_*` actually give the knobs we claim?
-
-## What the next reviewer should NOT do
-
-- Rewrite the ADR. Comments / revision notes only.
+- Rewrite the ADR. It's been through the review pass and is locked for Phase 2.
 - Push for backwards-compat shims. No users exist (CLAUDE.md operating principles).
-- Propose adding a sweeper / retry scheduler for `bridge_delivery.failed`. Explicitly out of scope for Phase 2 (mirrors events outbox stance).
-- Push for event-owned YAML as the *primary* authoring surface. It's deferred as a second, additive codegen source. Either direction is fine; changing the primary surface post-ship is a codegen migration.
-
-## Next task if reviewer approves
-
-Task #3 in the local task list: break ADR-023 into `docs/specs/BRIDGE-1.md` through `BRIDGE-9.md` following the shape of EVT-1..8 / JOB-1..8, plus `docs/specs/ADR-023-phase-2-issues.md` with a dependency graph.
+- Propose adding a sweeper / retry scheduler for `bridge_delivery.failed`. Explicitly out of scope for Phase 2.
+- Re-open dual-mode triggers (F) or auto-routing (G) — rejected alternatives are recorded with reasoning.
+- Push for event-owned YAML as the *primary* authoring surface. It's deferred as a second, additive codegen source.

--- a/docs/specs/BRIDGE-PHASE-2-PLAN.md
+++ b/docs/specs/BRIDGE-PHASE-2-PLAN.md
@@ -1,0 +1,229 @@
+# BRIDGE Phase 2 — Orchestration Plan
+
+**Status:** Ready for orchestration (execution will happen on a different machine).
+**Captured:** 2026-04-21
+**Scope:** codegen-patterns library changes only. Consumer adoption is outside this plan.
+**Read before orchestrating:** `docs/adrs/ADR-023-event-to-job-bridge.md` (revised 2026-04-21) and `docs/specs/ADR-023-handoff.md`. Both are ADR-locked; no design work remains.
+
+---
+
+## Context
+
+ADR-023 is revised and ready. It formalizes the seam between the events subsystem (ADR-024, shipped via EVT-1..EVT-8) and the jobs subsystem (ADR-022, shipped via JOB-1..JOB-8). The bridge is the single typed, observable, durable path from "event published" to "job started."
+
+**Seven locked decisions** (cite freely in PR bodies):
+
+1. Triggers are job-owned via `@JobHandler({ triggers: [...] })`
+2. Bridge IS the jobs worker on reserved `events_*` pools (wrapper `job_run` per delivery)
+3. Typed TS `map:` / `when:` callbacks (no YAML DSL)
+4. Four-state `bridge_delivery.status`, no auto-retry
+5. Build-time validation against `eventRegistry`
+6. `when:` predicates ship in Phase 2
+7. **`IEventFlow` facade** with two verbs (`publish`, `publishAndStart`) — all request-path and fanout publishing goes through this facade, not through `IEventBus` directly
+
+**Resolved open questions**:
+- New `runtime/subsystems/bridge/` subsystem with its own `BridgeModule.forRoot()`; registry at `runtime/subsystems/bridge/generated/registry.ts`
+- Drain atomicity: per-event transaction within batch loop
+- `publishAndStart` + existing `triggers:` collision: facade pre-writes `bridge_delivery(status=delivered)`, UNIQUE constraint dedups
+
+**Scope boundaries**:
+- Library-side only (this repo). Consumer adoption is out of scope.
+- Both `clean` and `clean-lite-ps` pipelines should accept the facade; existing subsystem scaffold pattern from EVT/JOB/SYNC applies.
+- No Phase 2.5 items (YAML authoring, `debounce:`, dashboard hiding) — deferred.
+- No ADR-026 items — that's a separate ADR that happens to flow through this bridge.
+
+---
+
+## The 9-PR stack
+
+Sequential — each builds on the previous. Assign to a single coordinator running sequential `/develop` loops.
+
+| # | Branch | Issue | Scope | Gate |
+|---|---|---|---|---|
+| 1 | `bridge-1/drizzle-schema` | BRIDGE-1 | `runtime/subsystems/bridge/bridge-delivery.schema.ts`: `bridge_delivery` table + `bridge_delivery_status` enum. Round-trip tests. | `just test-unit` green. **CHECKPOINT** after merge (brief direction check). |
+| 2 | `bridge-2/protocols` | BRIDGE-2 | `runtime/subsystems/bridge/bridge.protocol.ts`: `IJobBridge`, `IEventFlow` interfaces; DI tokens (`BRIDGE_DELIVERY_REPO`, `EVENT_FLOW`, `BRIDGE_MULTI_TENANT`); subsystem skeleton barrel `runtime/subsystems/bridge/index.ts`. | `just test-unit` green. |
+| 3 | `bridge-3/memory-backend` | BRIDGE-3 | `MemoryBridgeDeliveryRepo` test double with ergonomic helpers (`getDeliveriesForEvent`, `getByStatus`). | `just test-unit` green. |
+| 4 | `bridge-4/drizzle-backend` | BRIDGE-4 | `DrizzleBridgeDeliveryRepo` (Postgres impl) + outbox drain integration: drain inserts `bridge_delivery + wrapper job_run` per matched trigger inside per-event tx. **GATE** before opening — DB migration surface + drain modification. | `just test-unit` + integration test with real Postgres. |
+| 5 | `bridge-5/framework-handler` | BRIDGE-5 | Framework `BridgeDeliveryHandler` (3 instances, one per reserved pool). Reads `bridge_delivery` → evaluates `when:` → calls `orchestrator.start(userJob)` → updates ledger. Step memoization for replay safety. | `just test-unit` + integration test showing wrapper → user job fanout. |
+| 6 | `bridge-6/codegen` | BRIDGE-6 | Codegen: scan `@JobHandler.triggers` decorator metadata across handler files; emit `runtime/subsystems/bridge/generated/registry.ts`; build-time validation against `eventRegistry`; `just gen-all` hooks. | `just test-unit` + `just gen-all` succeeds on fixture. |
+| 7 | `bridge-7/eventflow-facade` | BRIDGE-7 | `EventFlowService` implementation of `IEventFlow`. `publish()` delegates to `IEventBus`. `publishAndStart()` does: outbox insert + `orchestrator.start()` + (for Case B) pre-write `bridge_delivery(status=delivered)`. **GATE** before opening — facade dedup semantics against real `bridgeRegistry`. | `just test-unit` green, including Case A/B collision tests. |
+| 8 | `bridge-8/module-wiring` | BRIDGE-8 | `BridgeModule.forRoot({ backend, multiTenant })` wiring repo + facade + registering framework handler on 3 reserved pools. Shared `assertTenantId` enforcement at all boundaries. **GATE** before opening — multi-tenancy review (mirrors JOB-8 / SYNC-6 precedent). | `just test-all` green end-to-end: publish → bridge delivery → user job execution. |
+| 9 | `bridge-9/cli-scaffold-docs` | BRIDGE-9 | (a) Fanout CLI `codegen events consumers <type>` indexing all three tiers, (b) Hygen scaffold templates for `bun codegen subsystem install bridge`, (c) CONSUMER-SETUP section + `.claude/skills/bridge/` with load-on-touch triggers. **GATE** before opening — CLI UX + scaffold shape review. | `just test-all` green. Epic closes. |
+
+**Gates where coordinator stops and reports** (same pattern as SYNC / CI-bootstrap orchestrations):
+
+1. **CHECKPOINT after BRIDGE-1** — schema direction sanity check
+2. **GATE before BRIDGE-4 opens** — DB migration + drain modification review
+3. **GATE before BRIDGE-7 opens** — facade dedup semantics against real registry
+4. **GATE before BRIDGE-8 opens** — multi-tenancy review (security-sensitive)
+5. **GATE before BRIDGE-9 opens** — CLI UX + scaffold shape review
+6. Any CI failure not diagnosed in 2 attempts
+7. Any latent bug in another subsystem (events / jobs / sync / patterns / auth) — file separately, don't silently expand scope (discipline from CI-bootstrap and SYNC orchestrations)
+
+---
+
+## Files Touched (~30 total)
+
+Estimated from the ADR's spec. The executing coordinator will refine as BRIDGE-1.md through BRIDGE-9.md are cut.
+
+### NEW (12+ files)
+
+```
+# Subsystem layout
+runtime/subsystems/bridge/bridge.protocol.ts
+runtime/subsystems/bridge/bridge-delivery.schema.ts
+runtime/subsystems/bridge/bridge-delivery.drizzle-backend.ts
+runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
+runtime/subsystems/bridge/bridge-delivery-handler.ts
+runtime/subsystems/bridge/event-flow.service.ts
+runtime/subsystems/bridge/bridge.module.ts
+runtime/subsystems/bridge/generated/registry.ts        # codegen emits
+runtime/subsystems/bridge/index.ts                      # barrel
+
+# Codegen
+src/cli/shared/bridge-registry-generator.ts
+src/cli/shared/bridge-scaffold-locals.ts
+
+# Tests (per backend + facade)
+src/__tests__/runtime/subsystems/bridge-delivery.schema.spec.ts
+src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
+src/__tests__/runtime/subsystems/bridge-delivery.drizzle-backend.spec.ts
+src/__tests__/runtime/subsystems/bridge-delivery-handler.spec.ts
+src/__tests__/runtime/subsystems/event-flow.service.spec.ts
+src/__tests__/cli/bridge-registry-generator.test.ts
+src/__tests__/cli/bridge-scaffold-locals.test.ts
+
+# Hygen scaffold
+templates/subsystem/bridge/prompt.js
+templates/subsystem/bridge/bridge-delivery.schema.ejs.t
+templates/subsystem/bridge-config/prompt.js
+templates/subsystem/bridge-config/codegen-config-bridge-block.ejs.t
+
+# Skill
+.claude/skills/bridge/SKILL.md
+.claude/skills/bridge/routing.md
+```
+
+### MODIFY — runtime subsystems (~4)
+
+```
+runtime/subsystems/events/event-bus.drizzle-backend.ts   # outbox drain inserts bridge_delivery + wrapper job_run per matched trigger
+runtime/subsystems/jobs/jobs-domain.module.ts            # reserves events_* pools for bridge wrappers; no new behavior, reference only
+```
+
+### MODIFY — CLI (~3)
+
+```
+src/cli/commands/subsystem.ts            # add 'bridge' dispatch path (runBridgeScaffold)
+src/cli/shared/subsystem-detect.ts       # add 'bridge' to SubsystemName union
+src/cli/shared/config-block-detect.ts    # add 'bridge' to config-block handling
+src/cli/commands/events/consumers.ts     # NEW: `codegen events consumers <type>` CLI
+```
+
+### MODIFY — docs (~6)
+
+```
+docs/CONSUMER-SETUP.md                   # new "App-defined patterns"-style section for bridge
+README.md                                # one-line subsystem mention
+.claude/skills/events/SKILL.md           # cross-link to bridge
+.claude/skills/events/phase-roadmap.md   # promote Phase 2 entry from deferred → shipped
+.claude/skills/jobs/SKILL.md             # cross-link to bridge wrapper handler registration
+docs/adrs/ADR-023-event-to-job-bridge.md # status: Revised → Shipped after BRIDGE-9 merges
+```
+
+---
+
+## Risks (flag to the coordinator)
+
+1. **Outbox drain modification is the most invasive change.** BRIDGE-4 touches the already-shipped EVT-4 (`event-bus.drizzle-backend.ts`). Baseline + smoke + unit tests must all pass; don't regress the drain's `FOR UPDATE SKIP LOCKED` claim or the per-event `processed_at` stamp.
+2. **`publishAndStart` Case B dedup must be inside a single transaction** with the `orchestrator.start()` call, otherwise a crash between the two leaves the system inconsistent. Explicit in the spec; call it out in the BRIDGE-7 PR body.
+3. **Framework handler registration on 3 pools** (one handler class registered 3× — one per direction) can trip DI if naively coded. Follow the EVT-6 `TYPED_EVENT_BUS` provider shape as precedent.
+4. **Reserved-pool concurrency default**. Set a sane default (e.g., 32) for `events_*` pools. Too low → bridge latency spikes under load. Too high → wastes DB connection headroom. Document the knob in CONSUMER-SETUP.
+5. **AST scan for fanout CLI** in BRIDGE-9 needs to correctly identify `eventFlow.publishAndStart(X, ...)` call sites. If the project uses non-standard injection patterns, the CLI may miss them. Document a fallback: if the AST scan finds zero call sites on a known-present facade user, emit a warning rather than silence.
+6. **Multi-tenancy coverage**. When `multiTenant=true`, three enforcement sites need `assertTenantId`: (a) `EventFlowService.publishAndStart` entry, (b) `BridgeDeliveryHandler.handle` entry, (c) `DrizzleBridgeDeliveryRepo.insertDelivery` before write. Same error message shape at every site (precedent: JOB-8, SYNC-6).
+7. **CI is live and gating.** All PRs must pass `test-all` before merge. No `--admin` bypass without explicit user approval. CI failures from pre-existing latent bugs in other subsystems (like CI-bootstrap and SYNC caught) should be filed as separate issues, not silently bundled.
+
+---
+
+## What's NOT in Phase 2
+
+- **YAML authoring style** (`triggers/*.yaml`) — Phase 2.5
+- **`debounce:` field** — Phase 2.5
+- **Dashboard hiding of `@framework/bridge_delivery` runs** — Phase 2.5
+- **ADR-026 observability** (selective JobEvent broadcast) — separate ADR, flows back through this bridge
+- **Dual-mode triggers** (rejected Alternative F)
+- **Direction-based auto-routing** (rejected Alternative G)
+- **Event-owned triggers as primary surface** (rejected Alternative D)
+- **Sweeper / retry scheduler for `bridge_delivery.failed`** — explicitly out of scope
+- **Consumer adoption in sales-patterns-ts or other repos** — separate orchestrations
+
+---
+
+## Recommended GitHub Structure
+
+When the executing session opens this work:
+
+- **1 Epic issue**: "BRIDGE Phase 2 — event-to-job bridge subsystem." References ADR-023 revision + this plan. Lists the 9 sub-issues.
+- **9 PR-sized issues** (BRIDGE-1 through BRIDGE-9), one per branch in the stack. Each issue body copies scope + file list + gate from this plan. Each links back to the epic.
+- **Dependency chain in labels/body**: BRIDGE-2 blocks on BRIDGE-1; BRIDGE-3 on BRIDGE-2; …; BRIDGE-9 on BRIDGE-8.
+
+Use `gh issue create --repo pattern-stack/codegen-patterns --title ... --body ...` for consistency with the SYNC epic structure (#60 + #126..#133).
+
+---
+
+## Orchestration Recommendation
+
+**One coordinator, sequential `/develop` loops, single branch per issue, dedicated worktree.** Do not parallelize — each PR's output is the input to the next.
+
+**Worktree setup** (from the executing machine):
+```bash
+git worktree add -b orch/bridge-phase2 \
+  /path/to/codegen-patterns-bridge \
+  main
+```
+
+**Coordinator spawn** (pattern matching the SYNC + Patterns Phase 1 + CI-bootstrap orchestrations — act as architect + builder + validator in one thread; team tools not required):
+
+Use `coordinator` agent type with:
+- `model: opus`
+- `mode: bypassPermissions`
+- Pre-created worktree path (do not let agent create its own)
+- Issues listed with dependencies
+- Gate locations explicitly named (5 gates from the table above)
+- File-based reporting protocol (`.orchestration-gate-<n>.md` / `.orchestration-checkpoint-<n>.md`) since `SendMessage` isn't typically available inside coordinator
+- CI gate warnings: `test-all` enforced on main; no `--admin` without approval
+
+The coordinator should:
+1. `cd` into the worktree
+2. Read ADR-023 + this plan + handoff doc
+3. Create 9 GitHub sub-issues under a new epic (or confirm they exist)
+4. For each issue:
+   - Branch off latest `main`
+   - Implement + test locally via `just test-all`
+   - Open PR, wait for CI green
+   - Self-review
+   - Squash-merge + delete branch
+   - Report via file if gate; proceed otherwise
+
+---
+
+## Dependency / Sequencing Notes
+
+- **This plan is independent of any in-flight TEST-SESSION-2 or observability (ADR-026) work.** Ship standalone.
+- **ADR-026 unblocks after Phase 2 lands.** That work can either run in parallel in a different session (touching `JobEventLogger`, not the bridge) or be sequenced after.
+- **No sales-patterns-ts coupling.** Consumers adopt the bridge at their own pace in separate sessions.
+- **Current main state (as of 2026-04-21, commit `9cca553`):** Patterns Phase 1 + CI bootstrap + SYNC Phase 1 + small-bug cleanup all shipped. The next commit on main is expected to be this plan doc and the ADR revision.
+
+---
+
+## References
+
+- `docs/adrs/ADR-023-event-to-job-bridge.md` (revised 2026-04-21) — binding decisions
+- `docs/specs/ADR-023-handoff.md` — revision summary + what the executing session should / should not do
+- `docs/adrs/ADR-022-job-orchestration-domain-model.md` — reserved `events_*` pools originate here
+- `docs/adrs/ADR-024-events-domain-formalization.md` — typed registry this ADR builds on
+- `docs/adrs/ADR-026-job-observability.md` — not yet written; flows back through this bridge
+- `docs/specs/PATTERNS-PHASE-1-PLAN.md` — structural precedent for this plan doc
+- `.claude/skills/events/phase-roadmap.md` — Phase 2 entry to be promoted
+- SYNC epic (#60) + PRs #148–#154 — structural precedent for subsystem scaffolding
+- Patterns epic (#75) + PRs #142–#145 — structural precedent for doc-heavy first PR


### PR DESCRIPTION
## Summary

ADR-023 review pass complete. Revises the draft with 10 additions from the 2026-04-21 review session — original Decisions 1-6 stand; adds **Decision 7: `IEventFlow` facade** (two-verb authoring surface). Open Questions 1, 2, 3, and a new 5 resolved in place.

Also adds `docs/specs/BRIDGE-PHASE-2-PLAN.md` — the execution-ready orchestration plan. **Execution will happen on a different machine**; this PR lands the artifacts so that session can pull main and kick off.

## What changed in the ADR

- **New Decision 7** — `IEventFlow` facade with `publish()` + `publishAndStart()`. Resolves the authoring-consistency gap that was the review's sharpest concern.
- **New section: Three tiers of event-driven work** — subscribe (in-process, lossy, ms) / direct invoke (request-path, durable, 1 poll cycle) / bridge (async fanout, durable, 2–3 poll cycles). With decision tree.
- **New section: Pool alignment guidance** — two pool layers (events_* wrappers + user pools); pool-per-class-of-work, 4–8 pools typical.
- **Primer: Events are facts, jobs are work** — semantic anchor for new readers.
- **`publishAndStart` + existing `triggers:` collision** — facade pre-writes `bridge_delivery(status=delivered)` so drain UNIQUE dedups.
- **New subsystem `runtime/subsystems/bridge/`** with its own `BridgeModule.forRoot()` — resolves registry-location question.
- **Drain atomicity locked** — per-event tx within batch loop.
- **Latency guardrails on Decision 2** — hop-count table, JSDoc on `triggers:`, CONSUMER-SETUP "When NOT to use the bridge" section committed.
- **Reverse-lookup CLI** `codegen events consumers <type>` committed to Phase 2 — indexes all three tiers.
- **Edge cases added to Consequences** — trigger rename, payload schema evolution, multi-tenancy null-tenantId, ordering guarantees.
- **Two new rejected alternatives** — F (dual-mode triggers) and G (direction-based auto-routing).

Pseudocode for `BridgeDeliveryHandler` moved out of the ADR to the BRIDGE-5 spec (implementation detail, not decision content).

## The orchestration plan (new)

`docs/specs/BRIDGE-PHASE-2-PLAN.md` specifies:

- **9 sequential PRs** (BRIDGE-1 through BRIDGE-9) with branch names, scope summaries, gate locations
- **5 pre-agreed coordinator gates** at: BRIDGE-1 checkpoint, BRIDGE-4 (DB migration), BRIDGE-7 (facade dedup), BRIDGE-8 (multi-tenancy), BRIDGE-9 (CLI + scaffold UX)
- **~30 files touched** (12 new, plus modifications across runtime + CLI + docs)
- **Risks** — 7 flagged, mostly around the outbox drain modification and multi-tenancy coverage
- **Recommended GitHub structure** — 1 epic + 9 sub-issues, mirroring SYNC (#60 + #126–#133)
- **Coordinator spawn recipe** — worktree path, agent model/mode, file-based reporting protocol

Structure mirrors `PATTERNS-PHASE-1-PLAN.md` which the Patterns Phase 1 coordinator ran against successfully.

## Handoff doc update

`docs/specs/ADR-023-handoff.md` flipped from "awaiting second-opinion review" to "review pass complete." Documents the 10 revision points + what the next session should NOT do.

## Test plan

- [x] Docs-only PR — CI runs unit + baseline + smoke (no code paths touched)
- [x] All three files render as valid markdown
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)