### PR TITLE
feat(bridge): BRIDGE-1 — bridge_delivery schema + status enum

### DIFF
--- a/runtime/subsystems/bridge/bridge-delivery.schema.ts
+++ b/runtime/subsystems/bridge/bridge-delivery.schema.ts
@@ -1,0 +1,142 @@
+/**
+ * Drizzle schema for the `bridge_delivery` ledger (ADR-023 Phase 2, BRIDGE-1).
+ *
+ * The `bridge_delivery` table is the idempotency ledger for the event-to-job
+ * bridge. Every (event, trigger) pair the bridge is asked to spawn produces
+ * exactly one row; the `UNIQUE (event_id, trigger_id)` constraint guarantees
+ * that:
+ *
+ *   1. Outbox replays of an event do not double-spawn user job runs — the
+ *      drain attempts to insert the duplicate, the constraint trips, and the
+ *      drain skips that trigger.
+ *   2. The `IEventFlow.publishAndStart` facade can pre-write a
+ *      `(status='delivered')` row before the drain runs (Case B from ADR-023
+ *      §`publishAndStart` + existing `triggers:` collision); the drain then
+ *      hits UNIQUE on that trigger and skips it while still spawning any
+ *      other triggers for the same event normally.
+ *
+ * Status values:
+ *   - `pending`   — wrapper run exists; user job not yet started.
+ *   - `delivered` — user job started; `user_run_id` populated.
+ *   - `skipped`   — intentional no-op (`when:` returned false, or
+ *                   facade-eager path pre-empted the bridge spawn).
+ *   - `failed`    — wrapper exhausted retry policy; no auto-retry past that
+ *                   (mirrors events outbox stance — ops eyes only).
+ *
+ * `wrapper_run_id` is **nullable**: the facade-eager path (Case B) pre-writes
+ * `bridge_delivery` with no wrapper. The bridge-drain path always populates
+ * it.
+ *
+ * `tenant_id` is emitted **unconditionally and nullable** (per JOB-8
+ * 2026-04-20 reversal); enforcement is service-layer (BRIDGE-8) gated on the
+ * `BRIDGE_MULTI_TENANT` DI token, not a DB constraint.
+ *
+ * Indexes:
+ *   - `bridge_delivery_event_idx` — lookup all deliveries for an event.
+ *   - `bridge_delivery_status_idx` — partial; ops dashboards filter by
+ *     `pending | failed`.
+ *   - `bridge_delivery_user_run_idx` — partial; reverse lookup from a
+ *     spawned user run back to its delivery row.
+ *
+ * No service logic, no DI wiring — this is the schema foundation. Backends
+ * (memory + drizzle) and the framework handler land in BRIDGE-3 / BRIDGE-4 /
+ * BRIDGE-5.
+ */
+import {
+  index,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import type { InferSelectModel } from 'drizzle-orm';
+
+import { domainEvents } from '../events/domain-events.schema';
+import { jobRuns } from '../jobs/job-orchestration.schema';
+
+// ─── Enum ───────────────────────────────────────────────────────────────────
+
+export const bridgeDeliveryStatusEnum = pgEnum('bridge_delivery_status', [
+  'pending',
+  'delivered',
+  'skipped',
+  'failed',
+]);
+
+// ─── Table ──────────────────────────────────────────────────────────────────
+
+export const bridgeDelivery = pgTable(
+  'bridge_delivery',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** FK to the source event in the outbox. */
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => domainEvents.id),
+    /**
+     * Stable codegen-emitted identifier for the (job, trigger) pair, of the
+     * form `<job_type>#<triggerIndex>` (BRIDGE-6). Forms the second half of
+     * the UNIQUE idempotency key.
+     */
+    triggerId: text('trigger_id').notNull(),
+    /**
+     * Wrapper `job_run.id` (the framework `@framework/bridge_delivery` run
+     * that drove this delivery). Nullable: the facade-eager path
+     * (`publishAndStart` Case B) pre-writes a delivered row with no wrapper.
+     */
+    wrapperRunId: uuid('wrapper_run_id').references(() => jobRuns.id),
+    /**
+     * Spawned user `job_run.id`. Null until status is `delivered`; remains
+     * null for `skipped` and `failed` deliveries.
+     */
+    userRunId: uuid('user_run_id').references(() => jobRuns.id),
+    status: bridgeDeliveryStatusEnum('status').notNull().default('pending'),
+    /** Populated when status=`skipped` (e.g. `'when_returned_false'`, `'trigger_unregistered'`). */
+    skipReason: text('skip_reason'),
+    /** Populated when status=`failed`. Mirrors `job_run.error` shape. */
+    error: jsonb('error').$type<Record<string, unknown>>(),
+    /**
+     * Emitted unconditionally and nullable (JOB-8 / SYNC-6 precedent).
+     * Enforcement gated on `BRIDGE_MULTI_TENANT` at the service layer
+     * (BRIDGE-8); no DB constraint.
+     */
+    tenantId: text('tenant_id'),
+    attemptedAt: timestamp('attempted_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+  },
+  (t) => ({
+    /**
+     * Idempotency ledger. Outbox replays and facade-vs-drain collisions both
+     * dedup through this constraint.
+     */
+    uqBridgeDeliveryEventTrigger: unique('uq_bridge_delivery_event_trigger').on(
+      t.eventId,
+      t.triggerId,
+    ),
+    /** Lookup all deliveries for an event (fanout report, debugging). */
+    idxBridgeDeliveryEvent: index('idx_bridge_delivery_event').on(t.eventId),
+    /**
+     * Ops dashboard filter — only the actionable states. Partial index keeps
+     * it small at scale (the bulk of rows will be `delivered`).
+     */
+    idxBridgeDeliveryStatus: index('idx_bridge_delivery_status')
+      .on(t.status)
+      .where(sql`${t.status} IN ('pending','failed')`),
+    /**
+     * Reverse lookup from a spawned user run back to its delivery row.
+     * Partial — most rows in the bridge ledger but only successful
+     * deliveries have a `user_run_id`.
+     */
+    idxBridgeDeliveryUserRun: index('idx_bridge_delivery_user_run')
+      .on(t.userRunId)
+      .where(sql`${t.userRunId} IS NOT NULL`),
+  }),
+);
+
+export type BridgeDeliveryRecord = InferSelectModel<typeof bridgeDelivery>;

--- a/runtime/subsystems/bridge/index.ts
+++ b/runtime/subsystems/bridge/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Bridge subsystem — public API (ADR-023 Phase 2).
+ *
+ * The bridge is the formalized seam between events (ADR-024) and jobs
+ * (ADR-022). It is owned by neither subsystem; it imports from both.
+ *
+ * BRIDGE-1 ships only the schema. Protocols, DI tokens, backends, the
+ * framework handler, the `IEventFlow` facade, and the `BridgeModule` wiring
+ * land in subsequent BRIDGE-N issues. The barrel is intentionally minimal at
+ * this point; later issues append exports here as they land.
+ */
+export {
+  bridgeDelivery,
+  bridgeDeliveryStatusEnum,
+} from './bridge-delivery.schema';
+export type { BridgeDeliveryRecord } from './bridge-delivery.schema';

--- a/src/__tests__/runtime/subsystems/bridge-delivery.schema.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-delivery.schema.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the `bridge_delivery` Drizzle schema (BRIDGE-1, ADR-023 Phase 2).
+ *
+ * Pure structural / metadata checks — no Postgres, no Docker. Mirrors the
+ * shape of `domain-events.schema.spec.ts` (EVT-1).
+ *
+ * Index assertions are intentionally omitted: Drizzle stores index metadata
+ * on a non-public table symbol with no stable introspection API. Presence of
+ * the indexes is enforced by the schema source itself (see
+ * `bridge-delivery.schema.ts` index callback).
+ */
+import { describe, it, expect } from 'bun:test';
+import { getTableColumns } from 'drizzle-orm';
+import {
+  bridgeDelivery,
+  bridgeDeliveryStatusEnum,
+  type BridgeDeliveryRecord,
+} from '../../../../runtime/subsystems/bridge/bridge-delivery.schema';
+
+describe('bridge-delivery.schema — import smoke', () => {
+  it('exports the pgTable declaration as an object', () => {
+    expect(typeof bridgeDelivery).toBe('object');
+    expect(bridgeDelivery).not.toBeNull();
+  });
+
+  it('exports the status pgEnum declaration', () => {
+    expect(bridgeDeliveryStatusEnum).toBeDefined();
+    expect(Array.isArray(bridgeDeliveryStatusEnum.enumValues)).toBe(true);
+  });
+});
+
+describe('bridge_delivery — column presence', () => {
+  const cols = getTableColumns(bridgeDelivery) as Record<string, unknown>;
+
+  it.each([
+    'id',
+    'eventId',
+    'triggerId',
+    'wrapperRunId',
+    'userRunId',
+    'status',
+    'skipReason',
+    'error',
+    'tenantId',
+    'attemptedAt',
+    'deliveredAt',
+  ])('includes column %s', (key) => {
+    expect(cols[key]).toBeDefined();
+  });
+});
+
+describe('bridge_delivery_status — enum values', () => {
+  it('declares exactly pending | delivered | skipped | failed', () => {
+    // pgEnum exposes the enum values via `enumValues`. Order is preserved
+    // from the declaration (matches the schema's documented order).
+    expect(bridgeDeliveryStatusEnum.enumValues).toEqual([
+      'pending',
+      'delivered',
+      'skipped',
+      'failed',
+    ]);
+  });
+});
+
+describe('bridge_delivery — column nullability invariants', () => {
+  // The bridge ledger has specific nullability semantics that the schema
+  // file documents at length; pin them here so a refactor cannot quietly
+  // flip them and break the facade-eager dedup or status-machine guarantees.
+  const cols = getTableColumns(bridgeDelivery) as Record<
+    string,
+    { notNull: boolean }
+  >;
+
+  it('event_id is NOT NULL', () => {
+    expect(cols.eventId.notNull).toBe(true);
+  });
+
+  it('trigger_id is NOT NULL', () => {
+    expect(cols.triggerId.notNull).toBe(true);
+  });
+
+  it('wrapper_run_id is nullable (facade-eager path has no wrapper)', () => {
+    expect(cols.wrapperRunId.notNull).toBe(false);
+  });
+
+  it('user_run_id is nullable (null until delivered; never set for skipped/failed)', () => {
+    expect(cols.userRunId.notNull).toBe(false);
+  });
+
+  it('tenant_id is nullable (unconditional emit; service-layer enforcement in BRIDGE-8)', () => {
+    expect(cols.tenantId.notNull).toBe(false);
+  });
+
+  it('status is NOT NULL', () => {
+    expect(cols.status.notNull).toBe(true);
+  });
+});
+
+describe('BridgeDeliveryRecord — type-level compile check', () => {
+  it('resolves to a concrete row type that includes all BRIDGE-1 columns', () => {
+    // If InferSelectModel widened to `any`, TypeScript would not catch a
+    // shape mismatch here. Exercising every field is a compile-time guard.
+    const row: BridgeDeliveryRecord = {
+      id: '00000000-0000-0000-0000-000000000000',
+      eventId: '00000000-0000-0000-0000-000000000001',
+      triggerId: 'send_welcome_email#0',
+      wrapperRunId: null,
+      userRunId: null,
+      status: 'pending',
+      skipReason: null,
+      error: null,
+      tenantId: null,
+      attemptedAt: new Date(),
+      deliveredAt: null,
+    };
+    expect(row.id).toBeDefined();
+    expect(row.triggerId).toBe('send_welcome_email#0');
+    expect(row.status).toBe('pending');
+    expect(row.wrapperRunId).toBeNull();
+    expect(row.userRunId).toBeNull();
+  });
+
+  it('accepts the four valid status values', () => {
+    const statuses: BridgeDeliveryRecord['status'][] = [
+      'pending',
+      'delivered',
+      'skipped',
+      'failed',
+    ];
+    expect(statuses).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary

ADR-023 Phase 2, first PR. Introduces the new `runtime/subsystems/bridge/` subsystem with the `bridge_delivery` ledger table — the idempotency anchor for every (event, trigger) pair the bridge spawns.

The `UNIQUE (event_id, trigger_id)` constraint dedups two distinct collision sources from a single ledger:

1. **Outbox replays** of the same event after a drain crash and re-claim.
2. **`IEventFlow.publishAndStart` Case B** — the facade pre-writes a `(status='delivered')` row so the later bridge-drain insert trips UNIQUE and skips that trigger while still spawning the others (per ADR-023 §`publishAndStart` + existing `triggers:` collision).

## Nullability invariants (pinned by tests)

- `wrapper_run_id` — **nullable**. The facade-eager path has no wrapper.
- `user_run_id` — **nullable**. Only set when status=`delivered`.
- `tenant_id` — **nullable, unconditional emit** per JOB-8 / SYNC-6 reversal. Service-layer enforcement against the `BRIDGE_MULTI_TENANT` DI token lands in BRIDGE-8; no DB constraint.

## Scope

Schema-only. No service logic, no DI wiring, no backend implementations. Backends (memory + drizzle), the framework handler, the `IEventFlow` facade, codegen, the CLI, and `BridgeModule.forRoot()` follow in BRIDGE-2..BRIDGE-9.

## Files

- `runtime/subsystems/bridge/bridge-delivery.schema.ts` — pgTable + pgEnum + indexes + UNIQUE constraint
- `runtime/subsystems/bridge/index.ts` — barrel
- `src/__tests__/runtime/subsystems/bridge-delivery.schema.spec.ts` — column presence, enum values, nullability invariants, type-level compile check

## Test plan

- [x] `just test-unit` — 1258 pass (22 new in this PR)
- [x] `just test-baseline` — green
- [x] `just test-smoke` — green

## Gate

Coordinator stops at the **post-merge CHECKPOINT** (per `docs/specs/BRIDGE-PHASE-2-PLAN.md` gate 1) for a brief schema-direction sanity check before opening BRIDGE-2.

## References

- ADR: `docs/adrs/ADR-023-event-to-job-bridge.md` §Schema
- Spec: `docs/specs/BRIDGE-1.md`
- Plan: `docs/specs/BRIDGE-PHASE-2-PLAN.md` (row 1)
- Epic: #158

Closes #159