### PR TITLE
feat(bridge): BRIDGE-2 — IJobBridge + IEventFlow protocols + DI tokens

### DIFF
--- a/docs/specs/BRIDGE-2.md
+++ b/docs/specs/BRIDGE-2.md
@@ -67,12 +67,12 @@ bridge-errors.ts
 
 ## Acceptance Criteria
 
-- [ ] `IEventFlow.publish<T extends EventType>(event: TypedEvent<T>): Promise<void>` declared.
-- [ ] `IEventFlow.publishAndStart<T, J>(event, jobType, input, opts?)` declared with `opts.parentRunId?` and `opts.tenantId?: string | null`.
-- [ ] `IJobBridge` has five methods: `insertDelivery`, `findDelivery`, `markDelivered`, `markSkipped`, `markFailed`. All accept optional `tx` last-arg.
-- [ ] Tokens are string-valued `as const`.
-- [ ] `MissingTenantIdError` exported; constructor takes the call-site name; error message names that site.
-- [ ] Type-level test compiles without casts.
+- [x] `IEventFlow.publish<T extends EventTypeName>(event: EventOfType<T>, tx?: DrizzleTransaction): Promise<void>` declared.
+- [x] `IEventFlow.publishAndStart<T extends EventTypeName>(event: EventOfType<T>, jobType: string, input: unknown, opts?: PublishAndStartOptions): Promise<PublishAndStartResult>` declared with `opts.parentRunId?: string` and `opts.tenantId?: string | null`.
+- [x] `IJobBridge` has five methods: `insertDelivery`, `findDelivery`, `markDelivered`, `markSkipped`, `markFailed`. All accept optional `tx` last-arg.
+- [x] Tokens are string-valued `as const`.
+- [x] `MissingTenantIdError` exported; constructor takes the call-site name; error message names that site.
+- [x] Type-level test compiles without casts.
 
 ## Testing Strategy
 
@@ -85,6 +85,16 @@ None.
 ## Open Questions
 
 None. Token-shape (string vs Symbol) resolved by EVT-6 precedent.
+
+## Implementation Notes (added post-merge per CLAUDE.md living-docs rule)
+
+**Generated type names.** ADR-023 §Decision 7 sketches `IEventFlow` with placeholder type variables `EventType` and `TypedEvent<T>`. The actual generated event types — emitted by the events codegen at `runtime/subsystems/events/generated/types.ts` — are named `EventTypeName` and `EventOfType<T>`. The `IEventFlow` interface uses the real generated names so the contract typechecks against current codegen output without casts. The verb shape and behaviour are unchanged; only the type-variable names differ.
+
+**Job-type parameter typing.** The ADR sketch also shows `JobType` and `JobInputOf<J>`. The jobs subsystem currently models the orchestrator's `start` as `start(type: string, input: unknown, …)` with no generated `JobType` union analogous to events' `EventTypeName` (the `job` table is upserted from `@JobHandler` decorators at boot, not from a project-wide YAML registry). The facade matches that shape today: `publishAndStart(event, jobType: string, input: unknown, …)`. Tightening to a generated `JobType` union is a post-Phase-2 follow-up that requires generated job typing first; recorded as a soft TODO, not a Phase 2 blocker.
+
+**`tx?: DrizzleTransaction` on `publish`.** Added beyond the ADR sketch so the facade implementation in BRIDGE-7 can thread the same transaction through `IEventBus.publish` (already accepts an optional `tx`) and the Case B `bridge_delivery` pre-write. Same-tx invariant for `publishAndStart` is restated in JSDoc on the interface.
+
+**`BridgeDeliveryInsert`.** The repo's `insertDelivery` row argument is typed as `InferInsertModel<typeof bridgeDelivery>` so adding a column to `bridge_delivery` propagates to every backend without a manual sync step. Exported from the barrel.
 
 ## References
 

--- a/runtime/subsystems/bridge/bridge-errors.ts
+++ b/runtime/subsystems/bridge/bridge-errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Typed errors for the bridge subsystem (ADR-023 Phase 2, BRIDGE-2).
+ *
+ * All thrown by the three enforcement sites named in ADR-023 §Multi-tenancy:
+ *   - `EventFlowService.publishAndStart` entry (BRIDGE-7)
+ *   - `BridgeDeliveryHandler.handle` entry (BRIDGE-5)
+ *   - `DrizzleBridgeDeliveryRepo.insertDelivery` pre-write (BRIDGE-4)
+ *
+ * Same shape as `runtime/subsystems/jobs/jobs-errors.ts` and
+ * `runtime/subsystems/events/events-errors.ts` so consumers can catch them
+ * with the same exception-filter pattern across all three subsystems.
+ */
+
+/**
+ * Thrown when `BridgeModule` was configured with `multiTenant: true` but
+ * the caller did not pass a `tenantId` at one of the three enforcement
+ * sites listed above.
+ *
+ * **Strict enforcement rationale (mirrors JOB-8 / SYNC-6 stance, locked
+ * 2026-04-18 for jobs; same rationale applies here).** Cross-tenant data
+ * leakage is the worst class of bug a multi-tenant system can ship;
+ * surfacing the misuse loudly at the call site (rather than silently
+ * defaulting to `null` or to "the last tenant seen") prevents both
+ * accidental global writes and sneaky reads that return a union of tenants.
+ *
+ * - `undefined` `tenantId` → throw this error.
+ * - Explicit `null` `tenantId` → passes; opts the call into cross-tenant
+ *   work (e.g. a system housekeeping event with no owning tenant). The
+ *   `bridge_delivery` row is persisted with `tenant_id = NULL`.
+ *
+ * The `callSite` constructor argument names which of the three enforcement
+ * sites threw — review reports and ops dashboards rely on a stable site
+ * name, so use the canonical strings: `'EventFlowService.publishAndStart'`,
+ * `'BridgeDeliveryHandler.handle'`,
+ * `'DrizzleBridgeDeliveryRepo.insertDelivery'`.
+ */
+export class MissingTenantIdError extends Error {
+  override readonly name = 'MissingTenantIdError';
+  constructor(public readonly callSite: string) {
+    super(
+      `MissingTenantIdError: BridgeModule was configured with ` +
+        `multiTenant=true but ${callSite} was called without tenantId ` +
+        `(undefined). Pass an explicit tenantId, or pass null for ` +
+        `cross-tenant work.`,
+    );
+  }
+}

--- a/runtime/subsystems/bridge/bridge.protocol.ts
+++ b/runtime/subsystems/bridge/bridge.protocol.ts
@@ -1,0 +1,206 @@
+/**
+ * Bridge subsystem — protocols (ports) — ADR-023 Phase 2, BRIDGE-2.
+ *
+ * Two interfaces:
+ *
+ *   - `IJobBridge`  — repo-shaped contract over the `bridge_delivery`
+ *                     ledger. Backends: memory (BRIDGE-3), Drizzle
+ *                     (BRIDGE-4). Consumed by the framework
+ *                     `BridgeDeliveryHandler` (BRIDGE-5), the modified
+ *                     outbox drain (BRIDGE-4), and the `EventFlowService`
+ *                     facade for Case B pre-writes (BRIDGE-7).
+ *
+ *   - `IEventFlow`  — the developer-facing facade from ADR-023 §Decision 7.
+ *                     Two verbs: `publish` and `publishAndStart`. All
+ *                     request-path and fanout publishing should go through
+ *                     this token rather than `IEventBus` / `TYPED_EVENT_BUS`
+ *                     directly so reviewers can grep call sites and the
+ *                     `codegen events consumers <type>` CLI (BRIDGE-9) can
+ *                     index Tier 2 alongside Tier 3 triggers and Tier 1
+ *                     subscribers.
+ *
+ * Both interfaces accept an optional last-arg `DrizzleTransaction` so
+ * callers operating inside an existing transaction can thread it through
+ * (the outbox drain's per-event tx, the facade's Case B pre-write).
+ */
+import type { InferInsertModel } from 'drizzle-orm';
+
+import type { DrizzleTransaction } from '../events/event-bus.protocol';
+import type {
+  EventOfType,
+  EventTypeName,
+} from '../events/generated/types';
+
+import type {
+  BridgeDeliveryRecord,
+  bridgeDelivery,
+} from './bridge-delivery.schema';
+
+// ============================================================================
+// IJobBridge — bridge_delivery ledger repo
+// ============================================================================
+
+/**
+ * Insert payload for `IJobBridge.insertDelivery`. Derived from the
+ * Drizzle schema so the contract stays in sync with the table — adding a
+ * column to `bridge_delivery` propagates to every backend without manual
+ * sync. `id`, `attemptedAt` carry DB defaults; `wrapperRunId`, `userRunId`,
+ * `skipReason`, `error`, `tenantId`, `deliveredAt` are nullable per BRIDGE-1.
+ */
+export type BridgeDeliveryInsert = InferInsertModel<typeof bridgeDelivery>;
+
+export interface IJobBridge {
+  /**
+   * Insert a `bridge_delivery` row.
+   *
+   * **Throws on `UNIQUE (event_id, trigger_id)` conflict.** Callers that
+   * expect collisions (the outbox drain hitting a facade-eager pre-write,
+   * the drain re-claiming after a crash) should catch the conflict and
+   * skip — see ADR-023 §`publishAndStart` + existing `triggers:` collision
+   * and the BRIDGE-4 spec for the recommended `INSERT … ON CONFLICT … DO
+   * NOTHING RETURNING id` shape that turns the throw into an empty result.
+   */
+  insertDelivery(
+    row: BridgeDeliveryInsert,
+    tx?: DrizzleTransaction,
+  ): Promise<void>;
+
+  /**
+   * Lookup a delivery by its idempotency key. Returns `null` when no row
+   * matches. Used by the framework handler (BRIDGE-5) to read the row that
+   * the drain wrote, and by the facade in tests / dashboards.
+   */
+  findDelivery(
+    eventId: string,
+    triggerId: string,
+  ): Promise<BridgeDeliveryRecord | null>;
+
+  /**
+   * Transition `pending` → `delivered`, populating `user_run_id` and
+   * `delivered_at`. Called by `BridgeDeliveryHandler` after
+   * `orchestrator.start(userJob)` returns.
+   */
+  markDelivered(
+    id: string,
+    userRunId: string,
+    tx?: DrizzleTransaction,
+  ): Promise<void>;
+
+  /**
+   * Transition `pending` → `skipped`, populating `skip_reason`. Called by
+   * `BridgeDeliveryHandler` when the trigger's `when:` predicate returns
+   * `false` or when the trigger no longer exists in the registry (rename
+   * scenario from ADR-023 §Consequences).
+   */
+  markSkipped(
+    id: string,
+    reason: string,
+    tx?: DrizzleTransaction,
+  ): Promise<void>;
+
+  /**
+   * Transition `pending` → `failed`, populating `error`. Called by the
+   * wrapper after its retry policy is exhausted; surfaces in ops
+   * dashboards via the `idx_bridge_delivery_status` partial index.
+   */
+  markFailed(
+    id: string,
+    error: Record<string, unknown>,
+    tx?: DrizzleTransaction,
+  ): Promise<void>;
+}
+
+// ============================================================================
+// IEventFlow — developer-facing facade (ADR-023 §Decision 7)
+// ============================================================================
+
+/**
+ * Caller-supplied options for `IEventFlow.publishAndStart`.
+ *
+ * `tenantId` semantics match `IJobOrchestrator.StartOptions.tenantId`
+ * (JOB-8): explicit `null` opts into cross-tenant work; `undefined` throws
+ * `MissingTenantIdError` when `BridgeModule` is configured with
+ * `multiTenant: true`.
+ *
+ * `parentRunId` lets request-path callers attach the eagerly-started run
+ * to an existing run hierarchy (e.g. a higher-level orchestration that
+ * publishes events as side effects of its own steps).
+ */
+export interface PublishAndStartOptions {
+  parentRunId?: string;
+  tenantId?: string | null;
+}
+
+/**
+ * Result of `IEventFlow.publishAndStart`. The facade returns the
+ * eagerly-started user run's id so the caller can subscribe to its
+ * completion or correlate with its own request id.
+ */
+export interface PublishAndStartResult {
+  runId: string;
+}
+
+export interface IEventFlow {
+  /**
+   * Tier 1 + Tier 3 — plain publish.
+   *
+   * Writes the event to the outbox (or in-memory bus, depending on the
+   * backend). Bridge triggers fire asynchronously (via
+   * `@JobHandler.triggers`); in-process `IEventBus.subscribe` handlers
+   * fire in-call. Returns when the outbox row is committed.
+   *
+   * Delegates to `IEventBus.publish` under the hood.
+   *
+   * **Note on signature:** ADR-023 §Decision 7 sketches the verb as
+   * `publish<T extends EventType>(event: TypedEvent<T>)`. The actual
+   * generated types are `EventTypeName` and `EventOfType<T>` (see
+   * `runtime/subsystems/events/generated/types.ts`); we use those here so
+   * the contract typechecks against the real codegen output. The verb
+   * shape and behaviour are unchanged.
+   */
+  publish<T extends EventTypeName>(
+    event: EventOfType<T>,
+    tx?: DrizzleTransaction,
+  ): Promise<void>;
+
+  /**
+   * Tier 2 + Tier 3 + Tier 1 — publish + eagerly start a specific named
+   * job.
+   *
+   * Behaviour:
+   *   1. Writes the event to the outbox (so bridge triggers and Tier 1
+   *      subscribers fire as normal).
+   *   2. Synchronously calls `IJobOrchestrator.start(jobType, input,
+   *      opts)` to enqueue the user job before returning to the caller.
+   *   3. **Case B dedup** — if the (event, jobType) pair has a declared
+   *      `@JobHandler.triggers` entry, the facade pre-writes a
+   *      `bridge_delivery(status='delivered', user_run_id=<eagerRunId>)`
+   *      row in the same transaction as `orchestrator.start(...)`. The
+   *      drain's later `INSERT … ON CONFLICT (event_id, trigger_id) DO
+   *      NOTHING` then sees the existing row and skips that trigger while
+   *      still spawning any other triggers for the same event.
+   *
+   * Use when the caller needs the job enqueued before returning to the
+   * user (request-path, within-transaction durability). For pure async
+   * fanout where Tier 3 alone suffices, use `publish` instead.
+   *
+   * **Same-tx invariant** (BRIDGE-7): the outbox insert, the
+   * `orchestrator.start` insert, and the Case B `bridge_delivery`
+   * pre-write must all share a transaction. A crash between any two
+   * leaves the system inconsistent (e.g. event published but no eager
+   * run, or eager run with no Case B dedup row → drain double-spawns).
+   *
+   * **Note on signature:** ADR-023 §Decision 7 sketches `JobType` /
+   * `JobInputOf<J>` parameters; the jobs subsystem currently models the
+   * orchestrator's `start` as `start(type: string, input: unknown, …)`
+   * with no generated `JobType` union analogous to events' `EventTypeName`.
+   * The facade matches that shape today; tightening the surface is a
+   * post-Phase-2 follow-up that requires generated job typing first.
+   */
+  publishAndStart<T extends EventTypeName>(
+    event: EventOfType<T>,
+    jobType: string,
+    input: unknown,
+    opts?: PublishAndStartOptions,
+  ): Promise<PublishAndStartResult>;
+}

--- a/runtime/subsystems/bridge/bridge.tokens.ts
+++ b/runtime/subsystems/bridge/bridge.tokens.ts
@@ -1,0 +1,53 @@
+/**
+ * Injection tokens for the bridge subsystem (ADR-023 Phase 2, BRIDGE-2).
+ *
+ * String constants (not Symbols) so they match by value across import
+ * boundaries — same convention as `EVENT_BUS` / `EVENTS_MULTI_TENANT` in the
+ * events subsystem (per EVT-6 §Implementation Notes). The jobs subsystem
+ * uses Symbols for its analogous tokens; we keep the bridge file internally
+ * consistent with the events convention because the bridge is conceptually
+ * downstream of (and imports from) the events module.
+ */
+
+/**
+ * Token for the `IJobBridge` repo backend (memory in BRIDGE-3, Drizzle in
+ * BRIDGE-4). Consumed by `BridgeDeliveryHandler` (BRIDGE-5), the outbox
+ * drain (BRIDGE-4 modification), and `EventFlowService` (BRIDGE-7).
+ */
+export const BRIDGE_DELIVERY_REPO = 'BRIDGE_DELIVERY_REPO' as const;
+
+/**
+ * Token for the `IEventFlow` facade implementation (BRIDGE-7). Use cases
+ * inject this in preference to `EVENT_BUS` / `TYPED_EVENT_BUS` — calling
+ * `eventFlow.publish(...)` / `eventFlow.publishAndStart(...)` is the
+ * sanctioned authoring surface (ADR-023 §Decision 7).
+ */
+export const EVENT_FLOW = 'EVENT_FLOW' as const;
+
+/**
+ * Token for the resolved multi-tenancy flag, provided by
+ * `BridgeModule.forRoot({ multiTenant })` in BRIDGE-8. Consumed by
+ * `EventFlowService.publishAndStart` (entry), `BridgeDeliveryHandler.handle`
+ * (entry), and `DrizzleBridgeDeliveryRepo.insertDelivery` (pre-write) — the
+ * three enforcement sites called out in ADR-023 §Multi-tenancy.
+ */
+export const BRIDGE_MULTI_TENANT = 'BRIDGE_MULTI_TENANT' as const;
+
+/**
+ * Token for the resolved `BridgeModuleOptions` object. Provided by
+ * `BridgeModule.forRoot(...)` / `forRootAsync(...)` in BRIDGE-8.
+ * Mirrors `EVENTS_MODULE_OPTIONS` and `JOBS_DOMAIN_OPTIONS` shape — backends
+ * inject this when they need to observe additional module configuration
+ * (e.g. pool overrides) without each adding a dedicated token.
+ */
+export const BRIDGE_MODULE_OPTIONS = 'BRIDGE_MODULE_OPTIONS' as const;
+
+/**
+ * Token for the codegen-emitted `bridgeRegistry` — the
+ * `Record<EventTypeName, BridgeTriggerEntry[]>` map that drives
+ * outbox-drain trigger lookup (BRIDGE-4) and `EventFlowService` Case B
+ * dedup (BRIDGE-7). Provider registration lands in BRIDGE-8; the token is
+ * declared here so generated code (BRIDGE-6) can import it without
+ * depending on the still-being-formalised module.
+ */
+export const BRIDGE_REGISTRY = 'BRIDGE_REGISTRY' as const;

--- a/runtime/subsystems/bridge/index.ts
+++ b/runtime/subsystems/bridge/index.ts
@@ -4,13 +4,38 @@
  * The bridge is the formalized seam between events (ADR-024) and jobs
  * (ADR-022). It is owned by neither subsystem; it imports from both.
  *
- * BRIDGE-1 ships only the schema. Protocols, DI tokens, backends, the
- * framework handler, the `IEventFlow` facade, and the `BridgeModule` wiring
- * land in subsequent BRIDGE-N issues. The barrel is intentionally minimal at
- * this point; later issues append exports here as they land.
+ * BRIDGE-1 added the schema. BRIDGE-2 adds the protocols, DI tokens, and
+ * the typed `MissingTenantIdError`. Backends (memory in BRIDGE-3, Drizzle
+ * in BRIDGE-4), the framework `BridgeDeliveryHandler` (BRIDGE-5), the
+ * codegen-emitted `bridgeRegistry` (BRIDGE-6), the `EventFlowService`
+ * facade (BRIDGE-7), the `BridgeModule.forRoot()` wiring (BRIDGE-8), and
+ * the CLI / scaffold / docs (BRIDGE-9) follow.
  */
+
+// Schema (BRIDGE-1)
 export {
   bridgeDelivery,
   bridgeDeliveryStatusEnum,
 } from './bridge-delivery.schema';
 export type { BridgeDeliveryRecord } from './bridge-delivery.schema';
+
+// Protocols (BRIDGE-2)
+export type {
+  IJobBridge,
+  IEventFlow,
+  BridgeDeliveryInsert,
+  PublishAndStartOptions,
+  PublishAndStartResult,
+} from './bridge.protocol';
+
+// DI tokens (BRIDGE-2)
+export {
+  BRIDGE_DELIVERY_REPO,
+  EVENT_FLOW,
+  BRIDGE_MULTI_TENANT,
+  BRIDGE_MODULE_OPTIONS,
+  BRIDGE_REGISTRY,
+} from './bridge.tokens';
+
+// Errors (BRIDGE-2)
+export { MissingTenantIdError } from './bridge-errors';

--- a/src/__tests__/runtime/subsystems/bridge-protocol.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-protocol.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Compile-time + runtime tests for the bridge protocols (BRIDGE-2).
+ *
+ * The interfaces have no runtime code — these tests assert that:
+ *   1. Stub implementations of `IJobBridge` and `IEventFlow` typecheck
+ *      against the contract WITHOUT casts (catches accidental signature
+ *      drift).
+ *   2. The DI tokens are string-valued (token convention from EVT-6).
+ *   3. `MissingTenantIdError` carries the call-site name in its message.
+ */
+import { describe, it, expect } from 'bun:test';
+
+import {
+  BRIDGE_DELIVERY_REPO,
+  BRIDGE_MODULE_OPTIONS,
+  BRIDGE_MULTI_TENANT,
+  BRIDGE_REGISTRY,
+  EVENT_FLOW,
+  MissingTenantIdError,
+  type BridgeDeliveryInsert,
+  type BridgeDeliveryRecord,
+  type IEventFlow,
+  type IJobBridge,
+  type PublishAndStartResult,
+} from '../../../../runtime/subsystems/bridge';
+import type { EventOfType } from '../../../../runtime/subsystems/events/generated/types';
+
+describe('bridge.tokens — DI tokens', () => {
+  it('all tokens are string-valued (matches events-subsystem convention)', () => {
+    // Per EVT-6, string tokens compare by value across import boundaries.
+    // The bridge subsystem follows that convention rather than the jobs
+    // subsystem's Symbols (the file-local consistency call is documented
+    // in bridge.tokens.ts).
+    expect(typeof BRIDGE_DELIVERY_REPO).toBe('string');
+    expect(typeof EVENT_FLOW).toBe('string');
+    expect(typeof BRIDGE_MULTI_TENANT).toBe('string');
+    expect(typeof BRIDGE_MODULE_OPTIONS).toBe('string');
+    expect(typeof BRIDGE_REGISTRY).toBe('string');
+  });
+
+  it('token values match their identifier names (grep-friendly)', () => {
+    expect(BRIDGE_DELIVERY_REPO).toBe('BRIDGE_DELIVERY_REPO');
+    expect(EVENT_FLOW).toBe('EVENT_FLOW');
+    expect(BRIDGE_MULTI_TENANT).toBe('BRIDGE_MULTI_TENANT');
+    expect(BRIDGE_MODULE_OPTIONS).toBe('BRIDGE_MODULE_OPTIONS');
+    expect(BRIDGE_REGISTRY).toBe('BRIDGE_REGISTRY');
+  });
+});
+
+describe('MissingTenantIdError', () => {
+  it('carries the call-site name in its message and exposes it as a field', () => {
+    const err = new MissingTenantIdError('EventFlowService.publishAndStart');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('MissingTenantIdError');
+    expect(err.callSite).toBe('EventFlowService.publishAndStart');
+    expect(err.message).toContain('EventFlowService.publishAndStart');
+    expect(err.message).toContain('multiTenant=true');
+  });
+});
+
+describe('IJobBridge — stub implementation typechecks', () => {
+  // The stub does not need to do anything; the test value is the type
+  // constraint. If any method signature drifts in the protocol, this stub
+  // will stop compiling.
+  class StubBridge implements IJobBridge {
+    private rows: BridgeDeliveryRecord[] = [];
+    async insertDelivery(_row: BridgeDeliveryInsert): Promise<void> {
+      // intentionally empty
+    }
+    async findDelivery(
+      _eventId: string,
+      _triggerId: string,
+    ): Promise<BridgeDeliveryRecord | null> {
+      return null;
+    }
+    async markDelivered(_id: string, _userRunId: string): Promise<void> {
+      // intentionally empty
+    }
+    async markSkipped(_id: string, _reason: string): Promise<void> {
+      // intentionally empty
+    }
+    async markFailed(
+      _id: string,
+      _error: Record<string, unknown>,
+    ): Promise<void> {
+      // intentionally empty
+    }
+  }
+
+  it('instantiates and implements every method', () => {
+    const stub: IJobBridge = new StubBridge();
+    expect(typeof stub.insertDelivery).toBe('function');
+    expect(typeof stub.findDelivery).toBe('function');
+    expect(typeof stub.markDelivered).toBe('function');
+    expect(typeof stub.markSkipped).toBe('function');
+    expect(typeof stub.markFailed).toBe('function');
+  });
+});
+
+describe('IEventFlow — stub implementation typechecks', () => {
+  class StubFlow implements IEventFlow {
+    async publish<T extends import('../../../../runtime/subsystems/events/generated/types').EventTypeName>(
+      _event: EventOfType<T>,
+    ): Promise<void> {
+      // intentionally empty
+    }
+    async publishAndStart<T extends import('../../../../runtime/subsystems/events/generated/types').EventTypeName>(
+      _event: EventOfType<T>,
+      _jobType: string,
+      _input: unknown,
+    ): Promise<PublishAndStartResult> {
+      return { runId: 'stub-run' };
+    }
+  }
+
+  it('instantiates and returns a runId from publishAndStart', async () => {
+    const flow: IEventFlow = new StubFlow();
+    expect(typeof flow.publish).toBe('function');
+    const result = await flow.publishAndStart(
+      // Use a real generated event shape to prove the typing flows through.
+      {
+        id: '00000000-0000-0000-0000-000000000000',
+        type: 'contact_created',
+        aggregateId: 'agg',
+        aggregateType: 'contact',
+        payload: {
+          accountId: null,
+          contactId: 'c1',
+          createdBy: 'system',
+        },
+        occurredAt: new Date(),
+      },
+      'send_welcome_email',
+      { contactId: 'c1' },
+      { tenantId: null },
+    );
+    expect(result.runId).toBe('stub-run');
+  });
+
+  it('publishAndStart accepts explicit null tenantId for cross-tenant work', async () => {
+    // Compile-time check: the option must accept `null` as well as
+    // `string` and `undefined`. JOB-8 contract.
+    const flow: IEventFlow = new StubFlow();
+    await flow.publishAndStart(
+      {
+        id: '00000000-0000-0000-0000-000000000001',
+        type: 'contact_created',
+        aggregateId: 'agg',
+        aggregateType: 'contact',
+        payload: { accountId: null, contactId: 'c1', createdBy: 'system' },
+        occurredAt: new Date(),
+      },
+      'job-x',
+      {},
+      { tenantId: null, parentRunId: 'parent-1' },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

ADR-023 Phase 2, second PR. Stable public API surface for the bridge subsystem so BRIDGE-3..BRIDGE-9 implement against a fixed contract.

- **`IJobBridge`** — five-method repo over the `bridge_delivery` ledger. Every method accepts an optional last-arg `DrizzleTransaction` so the outbox drain (BRIDGE-4) and facade Case B pre-write (BRIDGE-7) can thread their per-event tx through.
- **`IEventFlow`** — developer facade from ADR-023 §Decision 7, two verbs (`publish`, `publishAndStart`). Same-tx invariant for `publishAndStart` is documented in JSDoc on the interface.
- **DI tokens** — `BRIDGE_DELIVERY_REPO`, `EVENT_FLOW`, `BRIDGE_MULTI_TENANT`, `BRIDGE_MODULE_OPTIONS`, `BRIDGE_REGISTRY`. String-valued `as const`, matching events-subsystem convention.
- **`MissingTenantIdError`** — same shape as `jobs-errors.ts` / `events-errors.ts`. Constructor's `callSite` arg names which of the three enforcement sites threw.

## Type-name reconciliation (recorded in BRIDGE-2.md)

ADR §Decision 7 sketches `EventType` / `TypedEvent<T>` as placeholders; the real codegen emits `EventTypeName` / `EventOfType<T>` (`runtime/subsystems/events/generated/types.ts`). The protocol uses the real names so the contract typechecks against current codegen output. Job-type stays as `string`/`unknown` to match `IJobOrchestrator.start`; tightening to a generated `JobType` union is a post-Phase-2 follow-up. Spec updated per CLAUDE.md living-docs rule.

## Test plan

- [x] `just test-unit` — 1264 pass (6 new in this PR; type-level stub implementations + token + error assertions)
- [x] `just test-baseline` — green
- [x] `just test-smoke` — green

## Files

- `runtime/subsystems/bridge/bridge.protocol.ts` — `IJobBridge`, `IEventFlow`, `BridgeDeliveryInsert`, options/result types
- `runtime/subsystems/bridge/bridge.tokens.ts` — five DI tokens
- `runtime/subsystems/bridge/bridge-errors.ts` — `MissingTenantIdError`
- `runtime/subsystems/bridge/index.ts` — barrel updated
- `src/__tests__/runtime/subsystems/bridge-protocol.spec.ts` — type + runtime checks
- `docs/specs/BRIDGE-2.md` — Implementation Notes section appended

## References

- ADR: `docs/adrs/ADR-023-event-to-job-bridge.md` §Decision 7
- Spec: `docs/specs/BRIDGE-2.md`
- Plan: `docs/specs/BRIDGE-PHASE-2-PLAN.md` (row 2)
- Epic: #158

Closes #160