### PR TITLE
feat(bridge): BRIDGE-3 — MemoryBridgeDeliveryRepo + UniqueConstraintError

### DIFF
--- a/docs/specs/BRIDGE-3.md
+++ b/docs/specs/BRIDGE-3.md
@@ -57,12 +57,12 @@ MemoryBridgeDeliveryRepo implements IJobBridge
 
 ## Acceptance Criteria
 
-- [ ] `MemoryBridgeDeliveryRepo` implements `IJobBridge`.
-- [ ] Duplicate `(event_id, trigger_id)` insert throws `UniqueConstraintError` with a discriminator constant equal to the Drizzle constraint name.
-- [ ] `findDelivery` returns `null` on miss.
-- [ ] `markDelivered` / `markSkipped` / `markFailed` update in place; unknown id throws.
-- [ ] `getDeliveriesForEvent`, `getByStatus`, `clear` helpers present.
-- [ ] Unit tests pass in `just test-unit` — no Docker.
+- [x] `MemoryBridgeDeliveryRepo` implements `IJobBridge`.
+- [x] Duplicate `(event_id, trigger_id)` insert throws `UniqueConstraintError` with `constraint='uq_bridge_delivery_event_trigger'` (matches BRIDGE-1's named UNIQUE constraint).
+- [x] `findDelivery` returns `null` on miss.
+- [x] `markDelivered` / `markSkipped` / `markFailed` update in place; unknown id throws.
+- [x] `getDeliveriesForEvent`, `getByStatus`, `clear` helpers present.
+- [x] Unit tests pass in `just test-unit` — no Docker.
 
 ## Testing Strategy
 
@@ -75,6 +75,12 @@ None.
 ## Open Questions
 
 None.
+
+## Implementation Notes (added post-merge per CLAUDE.md living-docs rule)
+
+**Constraint discriminator name.** The spec said the discriminator should equal Drizzle's auto-generated constraint name `bridge_delivery_event_id_trigger_id_unique`, but BRIDGE-1 declared the constraint with an explicit name (`uq_bridge_delivery_event_trigger`) via Drizzle's `unique('uq_bridge_delivery_event_trigger')` shorthand. The memory backend's `UniqueConstraintError.constraint` value uses the explicit name so it matches what the Drizzle backend (BRIDGE-4) will see in `pg`'s constraint-violation error metadata. Recorded so BRIDGE-4's ON CONFLICT path and BRIDGE-7's facade tests both branch on the same string.
+
+**Facade Case B simulation test.** Added an extra describe block (`facade Case B simulation`) that pre-writes a `(status='delivered', wrapper_run_id=null)` row and then attempts a drain-style insert with the same `(event_id, trigger_id)`. Asserts the constraint trips AND the existing facade row is not overwritten. Pins the dedup contract that BRIDGE-7 implements and BRIDGE-4 catches.
 
 ## References
 

--- a/runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
+++ b/runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
@@ -1,0 +1,133 @@
+/**
+ * MemoryBridgeDeliveryRepo — in-memory `IJobBridge` (BRIDGE-3, ADR-023 Phase 2).
+ *
+ * Behavioral twin of the Drizzle backend (BRIDGE-4) for use in
+ * `just test-unit`. No Docker, no Postgres, fully synchronous. Backs a
+ * `Map<"${eventId}::${triggerId}", BridgeDeliveryRecord>` so the UNIQUE
+ * `(event_id, trigger_id)` constraint can be simulated cheaply.
+ *
+ * Precedent: `MemoryEventBus` (EVT-5), `MemoryJobOrchestrator`
+ * (jobs subsystem). Same shape — a class implementing the protocol plus
+ * test-only helpers (`getDeliveriesForEvent`, `getByStatus`, `clear`) that
+ * BRIDGE-5's framework-handler tests and BRIDGE-7's facade tests will
+ * exercise.
+ *
+ * The synthetic `UniqueConstraintError` carries a `constraint` field equal
+ * to the Drizzle constraint name (`uq_bridge_delivery_event_trigger`, set
+ * in BRIDGE-1's schema) so consumers — including BRIDGE-4's
+ * `INSERT … ON CONFLICT (event_id, trigger_id) DO NOTHING` path and
+ * BRIDGE-7's Case B dedup tests — can branch on the same discriminator
+ * regardless of which backend is wired up. ADR-023 explicitly relies on
+ * this constraint as the dedup mechanism in two places (replay; facade-
+ * vs-drain Case B); a typed error makes both call sites checkable.
+ */
+import { randomUUID } from 'node:crypto';
+
+import type {
+  BridgeDeliveryInsert,
+  IJobBridge,
+} from './bridge.protocol';
+import type { BridgeDeliveryRecord } from './bridge-delivery.schema';
+import { UniqueConstraintError } from './bridge-errors';
+
+const BRIDGE_DELIVERY_UNIQUE_CONSTRAINT =
+  'uq_bridge_delivery_event_trigger' as const;
+
+function key(eventId: string, triggerId: string): string {
+  return `${eventId}::${triggerId}`;
+}
+
+export class MemoryBridgeDeliveryRepo implements IJobBridge {
+  private readonly deliveries = new Map<string, BridgeDeliveryRecord>();
+
+  async insertDelivery(row: BridgeDeliveryInsert): Promise<void> {
+    const k = key(row.eventId, row.triggerId);
+    if (this.deliveries.has(k)) {
+      throw new UniqueConstraintError(
+        BRIDGE_DELIVERY_UNIQUE_CONSTRAINT,
+        row.eventId,
+        row.triggerId,
+      );
+    }
+    // Materialize a full BridgeDeliveryRecord — fill in DB defaults that
+    // the insert payload allowed to be omitted.
+    const record: BridgeDeliveryRecord = {
+      id: row.id ?? randomUUID(),
+      eventId: row.eventId,
+      triggerId: row.triggerId,
+      wrapperRunId: row.wrapperRunId ?? null,
+      userRunId: row.userRunId ?? null,
+      status: row.status ?? 'pending',
+      skipReason: row.skipReason ?? null,
+      error: (row.error as Record<string, unknown> | null | undefined) ?? null,
+      tenantId: row.tenantId ?? null,
+      attemptedAt:
+        row.attemptedAt instanceof Date ? row.attemptedAt : new Date(),
+      deliveredAt:
+        row.deliveredAt instanceof Date ? row.deliveredAt : null,
+    };
+    this.deliveries.set(k, record);
+  }
+
+  async findDelivery(
+    eventId: string,
+    triggerId: string,
+  ): Promise<BridgeDeliveryRecord | null> {
+    return this.deliveries.get(key(eventId, triggerId)) ?? null;
+  }
+
+  async markDelivered(id: string, userRunId: string): Promise<void> {
+    const record = this.findById(id);
+    record.status = 'delivered';
+    record.userRunId = userRunId;
+    record.deliveredAt = new Date();
+  }
+
+  async markSkipped(id: string, reason: string): Promise<void> {
+    const record = this.findById(id);
+    record.status = 'skipped';
+    record.skipReason = reason;
+  }
+
+  async markFailed(
+    id: string,
+    error: Record<string, unknown>,
+  ): Promise<void> {
+    const record = this.findById(id);
+    record.status = 'failed';
+    record.error = error;
+  }
+
+  // ─── Test helpers ────────────────────────────────────────────────────────
+
+  /** All deliveries for a given event (any status, declaration order). */
+  getDeliveriesForEvent(eventId: string): BridgeDeliveryRecord[] {
+    return [...this.deliveries.values()].filter((r) => r.eventId === eventId);
+  }
+
+  /** All deliveries currently in the given status. */
+  getByStatus(
+    status: BridgeDeliveryRecord['status'],
+  ): BridgeDeliveryRecord[] {
+    return [...this.deliveries.values()].filter((r) => r.status === status);
+  }
+
+  /** Reset the store. Tests use this in `beforeEach`. */
+  clear(): void {
+    this.deliveries.clear();
+  }
+
+  // ─── Internals ───────────────────────────────────────────────────────────
+
+  private findById(id: string): BridgeDeliveryRecord {
+    for (const record of this.deliveries.values()) {
+      if (record.id === id) return record;
+    }
+    throw new Error(
+      `MemoryBridgeDeliveryRepo: no delivery with id '${id}' (transition ` +
+        `methods may not be called for unknown rows; the framework handler ` +
+        `should always findDelivery first or operate on a row it just ` +
+        `inserted).`,
+    );
+  }
+}

--- a/runtime/subsystems/bridge/bridge-errors.ts
+++ b/runtime/subsystems/bridge/bridge-errors.ts
@@ -45,3 +45,38 @@ export class MissingTenantIdError extends Error {
     );
   }
 }
+
+/**
+ * Synthetic error thrown by `MemoryBridgeDeliveryRepo.insertDelivery` when
+ * a duplicate `(event_id, trigger_id)` insert hits the simulated UNIQUE
+ * constraint (BRIDGE-3).
+ *
+ * Carries a `constraint` field equal to the Drizzle constraint name
+ * declared in BRIDGE-1's schema (`uq_bridge_delivery_event_trigger`) so
+ * call sites can branch on the same discriminator regardless of which
+ * backend is wired up. This matters because ADR-023 explicitly leans on
+ * the constraint as the dedup mechanism in two places — outbox replay
+ * and `publishAndStart` Case B — and BRIDGE-4 / BRIDGE-7 will share a
+ * type-check path with BRIDGE-3-driven tests.
+ *
+ * The Drizzle backend (BRIDGE-4) does NOT throw this error: it uses
+ * `INSERT … ON CONFLICT (event_id, trigger_id) DO NOTHING RETURNING id`
+ * per the BRIDGE-4 spec recommendation, so collisions surface as an empty
+ * result set rather than an exception. The error exists so the memory
+ * backend can faithfully model the "duplicate raises" behaviour for tests
+ * that want to assert the constraint actually fires.
+ */
+export class UniqueConstraintError extends Error {
+  override readonly name = 'UniqueConstraintError';
+  constructor(
+    public readonly constraint: string,
+    public readonly eventId: string,
+    public readonly triggerId: string,
+  ) {
+    super(
+      `UniqueConstraintError: duplicate insert into bridge_delivery for ` +
+        `(event_id='${eventId}', trigger_id='${triggerId}') — violates ` +
+        `constraint '${constraint}'.`,
+    );
+  }
+}

--- a/runtime/subsystems/bridge/index.ts
+++ b/runtime/subsystems/bridge/index.ts
@@ -37,5 +37,11 @@ export {
   BRIDGE_REGISTRY,
 } from './bridge.tokens';
 
-// Errors (BRIDGE-2)
-export { MissingTenantIdError } from './bridge-errors';
+// Errors (BRIDGE-2 + BRIDGE-3)
+export {
+  MissingTenantIdError,
+  UniqueConstraintError,
+} from './bridge-errors';
+
+// Memory backend (BRIDGE-3)
+export { MemoryBridgeDeliveryRepo } from './bridge-delivery.memory-backend';

--- a/src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for `MemoryBridgeDeliveryRepo` (BRIDGE-3, ADR-023 Phase 2).
+ *
+ * Pure in-memory; no Postgres, no Docker. The Drizzle backend (BRIDGE-4)
+ * carries the integration counterpart.
+ */
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+import {
+  MemoryBridgeDeliveryRepo,
+  UniqueConstraintError,
+  type BridgeDeliveryInsert,
+  type IJobBridge,
+} from '../../../../runtime/subsystems/bridge';
+
+const EVENT_A = '00000000-0000-0000-0000-00000000000a';
+const EVENT_B = '00000000-0000-0000-0000-00000000000b';
+const TRIGGER_X = 'send_welcome_email#0';
+const TRIGGER_Y = 'sync_contact_to_hubspot#0';
+
+function row(
+  eventId: string,
+  triggerId: string,
+  overrides: Partial<BridgeDeliveryInsert> = {},
+): BridgeDeliveryInsert {
+  return {
+    id: randomUUID(),
+    eventId,
+    triggerId,
+    wrapperRunId: null,
+    userRunId: null,
+    status: 'pending',
+    skipReason: null,
+    error: null,
+    tenantId: null,
+    attemptedAt: new Date(),
+    deliveredAt: null,
+    ...overrides,
+  };
+}
+
+describe('MemoryBridgeDeliveryRepo — protocol compliance', () => {
+  let repo: IJobBridge;
+
+  beforeEach(() => {
+    repo = new MemoryBridgeDeliveryRepo();
+  });
+
+  it('inserts a row and finds it back by (eventId, triggerId)', async () => {
+    const r = row(EVENT_A, TRIGGER_X);
+    await repo.insertDelivery(r);
+    const found = await repo.findDelivery(EVENT_A, TRIGGER_X);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(r.id!);
+    expect(found?.status).toBe('pending');
+  });
+
+  it('returns null for a missing key', async () => {
+    expect(await repo.findDelivery(EVENT_A, TRIGGER_X)).toBeNull();
+  });
+
+  it('throws UniqueConstraintError on duplicate (eventId, triggerId)', async () => {
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_X));
+    let caught: unknown;
+    try {
+      await repo.insertDelivery(row(EVENT_A, TRIGGER_X));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UniqueConstraintError);
+    const err = caught as UniqueConstraintError;
+    // The discriminator must equal the Drizzle constraint name from
+    // BRIDGE-1 so call sites can share branch logic across backends.
+    expect(err.constraint).toBe('uq_bridge_delivery_event_trigger');
+    expect(err.eventId).toBe(EVENT_A);
+    expect(err.triggerId).toBe(TRIGGER_X);
+  });
+
+  it('allows the same triggerId for a different eventId', async () => {
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_X));
+    await repo.insertDelivery(row(EVENT_B, TRIGGER_X));
+    expect((await repo.findDelivery(EVENT_A, TRIGGER_X))?.eventId).toBe(EVENT_A);
+    expect((await repo.findDelivery(EVENT_B, TRIGGER_X))?.eventId).toBe(EVENT_B);
+  });
+
+  it('allows different triggerIds for the same eventId', async () => {
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_X));
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_Y));
+    const found = (
+      repo as MemoryBridgeDeliveryRepo
+    ).getDeliveriesForEvent(EVENT_A);
+    expect(found).toHaveLength(2);
+  });
+});
+
+describe('MemoryBridgeDeliveryRepo — state transitions', () => {
+  let repo: MemoryBridgeDeliveryRepo;
+
+  beforeEach(() => {
+    repo = new MemoryBridgeDeliveryRepo();
+  });
+
+  it('markDelivered sets status, userRunId, and deliveredAt', async () => {
+    const r = row(EVENT_A, TRIGGER_X);
+    await repo.insertDelivery(r);
+    const before = await repo.findDelivery(EVENT_A, TRIGGER_X);
+    expect(before?.status).toBe('pending');
+    expect(before?.deliveredAt).toBeNull();
+
+    await repo.markDelivered(r.id!, 'run-123');
+
+    const after = await repo.findDelivery(EVENT_A, TRIGGER_X);
+    expect(after?.status).toBe('delivered');
+    expect(after?.userRunId).toBe('run-123');
+    expect(after?.deliveredAt).toBeInstanceOf(Date);
+  });
+
+  it('markSkipped sets status and skipReason', async () => {
+    const r = row(EVENT_A, TRIGGER_X);
+    await repo.insertDelivery(r);
+    await repo.markSkipped(r.id!, 'when_returned_false');
+    const found = await repo.findDelivery(EVENT_A, TRIGGER_X);
+    expect(found?.status).toBe('skipped');
+    expect(found?.skipReason).toBe('when_returned_false');
+  });
+
+  it('markFailed sets status and error', async () => {
+    const r = row(EVENT_A, TRIGGER_X);
+    await repo.insertDelivery(r);
+    const errPayload = { message: 'boom', stack: 'stack', retryable: false };
+    await repo.markFailed(r.id!, errPayload);
+    const found = await repo.findDelivery(EVENT_A, TRIGGER_X);
+    expect(found?.status).toBe('failed');
+    expect(found?.error).toEqual(errPayload);
+  });
+
+  it('throws on transition for unknown id', async () => {
+    expect(repo.markDelivered('does-not-exist', 'run-x')).rejects.toThrow(
+      /no delivery with id/,
+    );
+    expect(repo.markSkipped('does-not-exist', 'reason')).rejects.toThrow(
+      /no delivery with id/,
+    );
+    expect(repo.markFailed('does-not-exist', {})).rejects.toThrow(
+      /no delivery with id/,
+    );
+  });
+});
+
+describe('MemoryBridgeDeliveryRepo — test helpers', () => {
+  let repo: MemoryBridgeDeliveryRepo;
+
+  beforeEach(() => {
+    repo = new MemoryBridgeDeliveryRepo();
+  });
+
+  it('getDeliveriesForEvent returns all rows for that event', async () => {
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_X));
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_Y));
+    await repo.insertDelivery(row(EVENT_B, TRIGGER_X));
+    expect(repo.getDeliveriesForEvent(EVENT_A)).toHaveLength(2);
+    expect(repo.getDeliveriesForEvent(EVENT_B)).toHaveLength(1);
+    expect(repo.getDeliveriesForEvent('00000000-0000-0000-0000-000000000fff')).toHaveLength(0);
+  });
+
+  it('getByStatus filters by status', async () => {
+    const r1 = row(EVENT_A, TRIGGER_X);
+    const r2 = row(EVENT_A, TRIGGER_Y);
+    const r3 = row(EVENT_B, TRIGGER_X);
+    await repo.insertDelivery(r1);
+    await repo.insertDelivery(r2);
+    await repo.insertDelivery(r3);
+    await repo.markDelivered(r1.id!, 'run-1');
+    await repo.markSkipped(r2.id!, 'when_returned_false');
+
+    expect(repo.getByStatus('delivered')).toHaveLength(1);
+    expect(repo.getByStatus('skipped')).toHaveLength(1);
+    expect(repo.getByStatus('pending')).toHaveLength(1);
+    expect(repo.getByStatus('failed')).toHaveLength(0);
+  });
+
+  it('clear empties the store', async () => {
+    await repo.insertDelivery(row(EVENT_A, TRIGGER_X));
+    expect(repo.getDeliveriesForEvent(EVENT_A)).toHaveLength(1);
+    repo.clear();
+    expect(repo.getDeliveriesForEvent(EVENT_A)).toHaveLength(0);
+    // Insert with the same key now succeeds — the constraint state is gone.
+    await expect(
+      repo.insertDelivery(row(EVENT_A, TRIGGER_X)),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('MemoryBridgeDeliveryRepo — facade Case B simulation', () => {
+  // ADR-023 §`publishAndStart` + existing `triggers:` collision: the
+  // facade pre-writes a (status='delivered', wrapper_run_id=null) row;
+  // the drain's later insert MUST surface as a constraint violation so
+  // BRIDGE-4 / BRIDGE-7 know to skip that trigger.
+  it('drain insert after facade pre-write throws UniqueConstraintError', async () => {
+    const repo = new MemoryBridgeDeliveryRepo();
+    // Facade pre-write:
+    await repo.insertDelivery(
+      row(EVENT_A, TRIGGER_X, {
+        status: 'delivered',
+        wrapperRunId: null,
+        userRunId: 'eager-run-id',
+        deliveredAt: new Date(),
+      }),
+    );
+    // Simulated drain insert:
+    let caught: unknown;
+    try {
+      await repo.insertDelivery(
+        row(EVENT_A, TRIGGER_X, {
+          status: 'pending',
+          wrapperRunId: 'wrapper-run-id',
+        }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UniqueConstraintError);
+    // Existing row is unchanged — drain didn't overwrite the facade's
+    // `delivered` row.
+    const existing = await repo.findDelivery(EVENT_A, TRIGGER_X);
+    expect(existing?.status).toBe('delivered');
+    expect(existing?.userRunId).toBe('eager-run-id');
+  });
+});


### PR DESCRIPTION
## Summary

ADR-023 Phase 2, third PR. Synchronous in-memory `IJobBridge` for `just test-unit` — behavioral twin of BRIDGE-4's Drizzle backend, no Postgres needed. Backs an internal `Map<"${eventId}::${triggerId}", BridgeDeliveryRecord>` so the UNIQUE constraint can be simulated cheaply.

## What lands

- `MemoryBridgeDeliveryRepo` — implements `IJobBridge` (insert / find / mark-{delivered,skipped,failed}) plus three test helpers (`getDeliveriesForEvent`, `getByStatus`, `clear`) used by BRIDGE-5 / BRIDGE-7 tests.
- `UniqueConstraintError` — typed discriminator with `constraint`, `eventId`, `triggerId`. Value `'uq_bridge_delivery_event_trigger'` matches BRIDGE-1's named constraint (the spec referenced Drizzle's auto-generated default; the actual name is explicit — corrected post-merge per CLAUDE.md living-docs rule).
- 13 tests covering protocol compliance, state transitions, helpers, and the **facade Case B simulation** that pins the dedup contract BRIDGE-7 implements and BRIDGE-4 catches.

## Drizzle backend will NOT throw this error

Per BRIDGE-4 spec: `INSERT … ON CONFLICT (event_id, trigger_id) DO NOTHING RETURNING id` surfaces collisions as an empty result set. `UniqueConstraintError` exists so the memory backend can faithfully model "duplicate raises" — call sites that branch on it (BRIDGE-5 handler, BRIDGE-7 facade) work against either backend.

## Test plan

- [x] `just test-unit` — 1277 pass (13 new in this PR)
- [x] `just test-baseline` — green
- [x] `just test-smoke` — green

## References

- ADR: `docs/adrs/ADR-023-event-to-job-bridge.md` §`publishAndStart` + `triggers:` collision
- Spec: `docs/specs/BRIDGE-3.md` (updated with implementation notes)
- Plan: `docs/specs/BRIDGE-PHASE-2-PLAN.md` (row 3)
- Epic: #158

Closes #161