### PR TITLE
feat(bridge): BRIDGE-7 — EventFlowService facade

### DIFF
--- a/docs/specs/BRIDGE-6.md
+++ b/docs/specs/BRIDGE-6.md
@@ -98,6 +98,10 @@ None.
 
 ## Implementation Notes (added in PR per CLAUDE.md living-docs rule)
 
+**BRIDGE-7 follow-up patch (2026-04-22) — `DuplicateTriggerError`.** Added in the BRIDGE-7 PR alongside the `EventFlowService`. Catches the case where two `@JobHandler.triggers` entries declare the same `(event, jobType)` pair — without it, the facade's Case B pre-write loop would still be correct (it pre-writes all matches; lead decision 2026-04-22 ask 2), but the drain would still spawn two wrappers and handlers would call `orchestrator.start` twice → double-spawn. Build-time rejection is the cleaner long-term fix (lead decision 2026-04-22 ask 3 — belt+suspenders). New `validateNoDuplicateTriggers(triggers)` runs in `generateBridgeRegistry` before the `eventRegistry` validation; tested in `bridge-registry-generator.test.ts` describe block "validateNoDuplicateTriggers (BRIDGE-7 follow-up)".
+
+
+
 **AST toolchain.** No `ts-morph` in deps — used the TypeScript Compiler API directly (`ts.createSourceFile` + `ts.forEachChild` recursion). Lighter than ts-morph for our narrow needs (decorator + array-literal walk).
 
 **Hooked into `entity new --all`** after event codegen completes. Same `try/catch` warn-but-don't-fail pattern as scope-entity-type and event codegen — except `UnknownTriggerEventError` is surfaced via `printError` (not `printWarning`) because it indicates a real authoring bug. The catch still prevents one validation throw from aborting the whole `entity new` invocation.

--- a/docs/specs/BRIDGE-7.md
+++ b/docs/specs/BRIDGE-7.md
@@ -90,14 +90,14 @@ Just `eventBus.publish(event)` — no tx required because caller didn't hand one
 
 ## Acceptance Criteria
 
-- [ ] `EventFlowService implements IEventFlow`.
-- [ ] `publish()` delegates to `IEventBus.publish()`.
-- [ ] Case A (no registry entry for `(event.type, jobType)`): `publishAndStart` writes outbox + starts job; no `bridge_delivery` row written; returns `{ runId }`.
-- [ ] Case B (registry has entry): additional `bridge_delivery(status='delivered', wrapper_run_id=null, user_run_id=<runId>)` pre-write.
-- [ ] All three DB writes in Case B happen inside one transaction (test asserts with a fail-injected `insertDelivery` mock: `orchestrator.start` side effects rolled back).
-- [ ] Later drain attempting to insert same `(event_id, trigger_id)` hits ON CONFLICT DO NOTHING (BRIDGE-4), skips wrapper spawn. Combined integration test in BRIDGE-8.
-- [ ] Multi-tenancy gate at function entry (full enforcement lands in BRIDGE-8; structural hook in place here).
-- [ ] Registry lookup O(1); no perf concern.
+- [x] `EventFlowService implements IEventFlow`.
+- [x] `publish()` delegates to `IEventBus.publish()`. Optional `tx?` threaded through (matches `IEventFlow.publish` BRIDGE-2 signature).
+- [x] Case A (no registry entry for `(event.type, jobType)`): `publishAndStart` writes outbox + starts job; no `bridge_delivery` row written; returns `{ runId }`. Pinned by 2 tests (registry-with-different-jobType + empty-registry).
+- [x] Case B (registry has entry): pre-write `bridge_delivery(status='delivered', wrapper_run_id=null, user_run_id=<runId>)` for **EVERY matching trigger** (lead decision 2026-04-22 — `filter()` not `find()` so duplicate-trigger registries don't double-spawn).
+- [x] All three DB writes in Case B happen inside one transaction. Pinned by call-ordering test (`bus.publish` → `orchestrator.start` → `repo.insertDelivery`) + rollback test (`insertDelivery` throw → tx callback marked rolled back; throw propagates).
+- [x] Later drain attempting to insert same `(event_id, trigger_id)` is dedup'd. Pinned by memory-backend `UniqueConstraintError` test (BRIDGE-3 fidelity simulates BRIDGE-4 ON CONFLICT). End-to-end integration in BRIDGE-8.
+- [x] Multi-tenancy gate at function entry: throws `MissingTenantIdError('EventFlowService.publishAndStart')` when `multiTenant=true && opts?.tenantId === undefined`. Pinned by 3 tests (throw, explicit-null pass-through, explicit-string pass-through to BOTH eager start AND bridge_delivery).
+- [x] Registry lookup is `Map<eventType, BridgeTriggerEntry[]>` keyed read + linear scan over typically-1–5 entries. Effectively O(1) at consumer scale.
 
 ## Testing Strategy
 
@@ -111,7 +111,19 @@ Just `eventBus.publish(event)` — no tx required because caller didn't hand one
 
 ## Open Questions
 
-- [ ] **Protocol `tx` parameter propagation.** If `IEventBus.publish(event)` doesn't already accept `tx?: DrizzleClient`, extending it here is a cross-subsystem modification. Confirm in PR body; update BRIDGE-2 or EVT/JOB spec notes accordingly.
+- [x] **Protocol `tx` parameter propagation — RESOLVED.** `IEventBus.publish(event, tx?)` already accepts `tx` (EVT-4). `IJobBridge.insertDelivery(row, tx?)` already accepts `tx` (BRIDGE-2). `IJobOrchestrator.start(type, input, opts?)` did NOT — extended to `start(type, input, opts?, tx?)` in this PR (lead-approved option (a) at GATE 3). Drizzle backend uses `client = tx ?? this.db` (standard pattern); memory backend ignores. JOB-3 spec updated with appended Implementation Note.
+
+## Implementation Notes (added in PR per CLAUDE.md living-docs rule)
+
+**Same-tx invariant — three writes, one tx.** `db.transaction(async tx => { eventBus.publish(event, tx); orchestrator.start(jobType, input, opts, tx); for (m of matchingTriggers) bridgeRepo.insertDelivery({...}, tx); })`. A throw anywhere in the body propagates and rolls back all three writes; the bridge `UNIQUE (event_id, trigger_id)` makes the next-cycle drain re-claim idempotent.
+
+**Pre-write ALL matching triggers (lead decision 2026-04-22, GATE 3 ask 2).** The facade uses `registry.filter(t => t.jobType === jobType)`, not `find()`. Rationale: duplicate `(event, jobType)` pairs in the registry would otherwise leave one trigger un-pre-written, the drain would spawn a wrapper for that triggerId, and the wrapper handler would call `orchestrator.start` for the same `(event, jobType)` → double-spawn. With filter+loop, every matching trigger is pre-written so the drain's ON CONFLICT skips them all. BRIDGE-6 codegen now also rejects duplicates at build time (see BRIDGE-6 follow-up below) — belt+suspenders.
+
+**`IJobOrchestrator.start` extended with optional `tx?` (lead decision 2026-04-22, GATE 3 ask 1).** Cross-subsystem modification: `runtime/subsystems/jobs/job-orchestrator.protocol.ts` interface signature gained a fourth optional parameter; `runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts` uses `client = (tx ?? this.db) as DrizzleClient` for every read/write inside `start()` (the existing pattern from `DrizzleEventBus.publish` and `DrizzleBridgeDeliveryRepo`); memory backend accepts the parameter as `_tx?: unknown` and ignores it (its "atomic" boundary is a process-wide mutex). No behaviour change for existing callers — `tx` defaults to `undefined`. JOB-3 spec updated with an appended Implementation Note.
+
+**BRIDGE-6 follow-up — codegen `DuplicateTriggerError` (lead decision 2026-04-22, GATE 3 ask 3).** Same-PR patch to `src/cli/shared/bridge-registry-generator.ts`: new `validateNoDuplicateTriggers(triggers)` that throws `DuplicateTriggerError` on the first `(event, jobType)` pair that appears twice. Hooked into `generateBridgeRegistry` before `validateAgainstEventRegistry`. Error message lists every offending occurrence with file + line + triggerId so authors can pick which one to remove. BRIDGE-6 spec Implementation Notes updated.
+
+**Multi-tenancy gate at entry, not inside tx.** Throw before `db.transaction(...)` so the failure surfaces at the call site, not via "tx aborted with error: MissingTenantIdError". Same precedent as `BridgeDeliveryHandler.run` (BRIDGE-5).
 
 ## References
 

--- a/runtime/subsystems/bridge/event-flow.service.ts
+++ b/runtime/subsystems/bridge/event-flow.service.ts
@@ -1,0 +1,171 @@
+/**
+ * EventFlowService — `IEventFlow` facade implementation (BRIDGE-7,
+ * ADR-023 §Decision 7 + §`publishAndStart` + existing `triggers:` collision).
+ *
+ * Two verbs:
+ *
+ *   - `publish(event, tx?)` — thin delegate to `IEventBus.publish(event, tx)`.
+ *     Subscribers + bridge triggers fire as normal. Caller owns transaction.
+ *
+ *   - `publishAndStart(event, jobType, input, opts?)` — the load-bearing
+ *     verb. Opens a transaction and performs THREE writes inside it:
+ *       1. Outbox insert via `eventBus.publish(event, tx)`.
+ *       2. Eager `orchestrator.start(jobType, input, opts, tx)`.
+ *       3. **Case B only** — for every `bridgeRegistry[event.type]` entry
+ *          whose `jobType` matches the argument, pre-write a
+ *          `bridge_delivery(status='delivered', wrapper_run_id=null,
+ *          user_run_id=<eagerRunId>)` row via `bridgeRepo.insertDelivery(
+ *          row, tx)`. The `UNIQUE (event_id, trigger_id)` constraint then
+ *          dedups the drain's later attempt for that trigger; sibling
+ *          triggers (different trigger_id) still spawn normally.
+ *
+ *     Returns `{ runId }` from the eager start. All three writes share
+ *     one tx — a crash anywhere rolls back all of them; the drain
+ *     re-claims the event on the next cycle and the bridge UNIQUE makes
+ *     the retry idempotent.
+ *
+ * **Pre-write ALL matching triggerIds** (lead decision 2026-04-22): the
+ * facade uses `filter()` not `find()`. If a project has two triggers in
+ * the registry for the same `(event, jobType)` pair (rare; codegen-time
+ * `DuplicateTriggerError` from BRIDGE-7's BRIDGE-6 follow-up patch
+ * prevents new occurrences), each gets its own pre-write — otherwise
+ * the un-pre-written sibling would spawn a wrapper that re-runs the user
+ * job, producing a double-spawn.
+ *
+ * **Multi-tenancy gate** at `publishAndStart` entry: when
+ * `BRIDGE_MULTI_TENANT=true` and `opts?.tenantId === undefined`, throw
+ * `MissingTenantIdError('EventFlowService.publishAndStart')`. Site (a)
+ * of the three ADR-023 §Multi-tenancy enforcement sites (BRIDGE-5
+ * handler is (b); BRIDGE-4 drizzle repo is (c)).
+ */
+import { Inject, Injectable, Optional } from '@nestjs/common';
+
+import { DRIZZLE } from '../../constants/tokens';
+import type { DrizzleClient } from '../../types/drizzle';
+
+import { EVENT_BUS } from '../events/events.tokens';
+import type {
+  DomainEvent,
+  DrizzleTransaction,
+  IEventBus,
+} from '../events/event-bus.protocol';
+import type {
+  EventOfType,
+  EventTypeName,
+} from '../events/generated/types';
+
+import { JOB_ORCHESTRATOR } from '../jobs/jobs-domain.tokens';
+import type { IJobOrchestrator } from '../jobs/job-orchestrator.protocol';
+
+import {
+  BRIDGE_DELIVERY_REPO,
+  BRIDGE_MULTI_TENANT,
+  BRIDGE_REGISTRY,
+} from './bridge.tokens';
+import type {
+  BridgeRegistry,
+  BridgeTriggerEntry,
+  IEventFlow,
+  IJobBridge,
+  PublishAndStartOptions,
+  PublishAndStartResult,
+} from './bridge.protocol';
+import { MissingTenantIdError } from './bridge-errors';
+
+@Injectable()
+export class EventFlowService implements IEventFlow {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    @Inject(EVENT_BUS) private readonly eventBus: IEventBus,
+    @Inject(JOB_ORCHESTRATOR) private readonly orchestrator: IJobOrchestrator,
+    @Inject(BRIDGE_DELIVERY_REPO) private readonly bridgeRepo: IJobBridge,
+    @Optional()
+    @Inject(BRIDGE_REGISTRY)
+    private readonly registry: BridgeRegistry = {},
+    @Optional()
+    @Inject(BRIDGE_MULTI_TENANT)
+    private readonly multiTenant: boolean = false,
+  ) {}
+
+  async publish<T extends EventTypeName>(
+    event: EventOfType<T>,
+    tx?: DrizzleTransaction,
+  ): Promise<void> {
+    // Thin delegate. Subscribers + bridge triggers fire as normal via the
+    // outbox drain (BRIDGE-4) and `IEventBus.subscribe` (Tier 1).
+    await this.eventBus.publish(event as DomainEvent, tx);
+  }
+
+  async publishAndStart<T extends EventTypeName>(
+    event: EventOfType<T>,
+    jobType: string,
+    input: unknown,
+    opts: PublishAndStartOptions = {},
+  ): Promise<PublishAndStartResult> {
+    // Multi-tenancy gate — throw before any DB write so failures surface
+    // at the call site, not from inside an aborted tx.
+    if (this.multiTenant && opts.tenantId === undefined) {
+      throw new MissingTenantIdError('EventFlowService.publishAndStart');
+    }
+    // Resolve null → null (cross-tenant work) once, so the same value
+    // flows to both the eager start AND the bridge_delivery row.
+    const tenantId: string | null = opts.tenantId ?? null;
+
+    // Identify Case B — every registry entry whose jobType matches.
+    // Lead decision 2026-04-22: pre-write ALL matches (filter, not find)
+    // so duplicate triggers in the registry don't double-spawn.
+    const matchingTriggers = this.matchingTriggers(event.type as EventTypeName, jobType);
+
+    return this.db.transaction(async (tx) => {
+      // 1. Outbox insert.
+      await this.eventBus.publish(event as DomainEvent, tx);
+
+      // 2. Eager start. Threads tx through (BRIDGE-7 protocol extension
+      //    on IJobOrchestrator.start, JOB-3 backend uses `tx ?? this.db`).
+      const run = await this.orchestrator.start(
+        jobType,
+        input,
+        {
+          parentRunId: opts.parentRunId,
+          tenantId,
+          triggerSource: 'event',
+          triggerRef: event.id,
+        },
+        tx,
+      );
+
+      // 3. Case B pre-writes — one per matching trigger.
+      const now = new Date();
+      for (const trigger of matchingTriggers) {
+        await this.bridgeRepo.insertDelivery(
+          {
+            eventId: event.id,
+            triggerId: trigger.triggerId,
+            wrapperRunId: null, // facade never writes a wrapper
+            userRunId: run.id,
+            status: 'delivered',
+            tenantId,
+            attemptedAt: now,
+            deliveredAt: now,
+          },
+          tx,
+        );
+      }
+
+      return { runId: run.id };
+    });
+  }
+
+  /**
+   * Linear scan of the per-event-type trigger list for entries whose
+   * `jobType` matches. Typical N is 1–5; the table is not big enough to
+   * warrant a secondary index. Returns an empty array for Case A.
+   */
+  private matchingTriggers(
+    eventType: EventTypeName,
+    jobType: string,
+  ): BridgeTriggerEntry[] {
+    const triggers = this.registry[eventType] ?? [];
+    return triggers.filter((t) => t.jobType === jobType) as BridgeTriggerEntry[];
+  }
+}

--- a/runtime/subsystems/bridge/index.ts
+++ b/runtime/subsystems/bridge/index.ts
@@ -62,3 +62,6 @@ export {
 // Drizzle backend + outbox-drain hook (BRIDGE-4)
 export { DrizzleBridgeDeliveryRepo } from './bridge-delivery.drizzle-backend';
 export { BridgeOutboxDrainHook } from './bridge-outbox-drain-hook';
+
+// EventFlow facade (BRIDGE-7)
+export { EventFlowService } from './event-flow.service';

--- a/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, desc, eq, gt, inArray, isNotNull, ne, notInArray, sql } from 'drizzle-orm';
 import type { DrizzleClient } from '../../types/drizzle';
+import type { DrizzleTransaction } from '../events/event-bus.protocol';
 import { DRIZZLE } from '../../constants/tokens';
 import {
   jobRuns,
@@ -104,15 +105,26 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
   // start
   // ==========================================================================
 
-  async start(type: string, input: unknown, opts: StartOptions = {}): Promise<JobRun> {
+  async start(
+    type: string,
+    input: unknown,
+    opts: StartOptions = {},
+    tx?: DrizzleTransaction,
+  ): Promise<JobRun> {
     const payload = (input ?? {}) as Record<string, unknown>;
 
     // JOB-8 — resolve tenant gate up front so `multi_tenant=true` +
     // undefined surfaces before any row is touched.
     const tenantId = this.resolveTenantId('start', opts.tenantId);
 
+    // BRIDGE-7: thread the optional caller tx through every read/write
+    // in this method so EventFlowService.publishAndStart can bundle the
+    // outbox insert, the eager job_run insert, and (for Case B) the
+    // bridge_delivery pre-write into a single transaction.
+    const client = (tx ?? this.db) as DrizzleClient;
+
     // 1a. Load job definition.
-    const [def] = await this.db
+    const [def] = await client
       .select()
       .from(jobs)
       .where(eq(jobs.type, type))
@@ -124,7 +136,7 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
     if (definition.dedupeKeyTemplate && definition.dedupeWindowMs) {
       const dedupeKey = evaluateKeyTemplate(definition.dedupeKeyTemplate, payload);
       const windowStart = new Date(Date.now() - definition.dedupeWindowMs);
-      const existing = await this.db
+      const existing = await client
         .select()
         .from(jobRuns)
         .where(
@@ -150,7 +162,7 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
         definition.concurrencyKeyTemplate,
         payload,
       );
-      const inFlight = await this.db
+      const inFlight = await client
         .select()
         .from(jobRuns)
         .where(
@@ -190,7 +202,7 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
     const newId = randomUUID();
     let rootRunId: string = newId;
     if (opts.parentRunId) {
-      const [parent] = await this.db
+      const [parent] = await client
         .select({ rootRunId: jobRuns.rootRunId })
         .from(jobRuns)
         .where(eq(jobRuns.id, opts.parentRunId))
@@ -208,7 +220,7 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
         ? evaluateKeyTemplate(definition.dedupeKeyTemplate, payload)
         : null;
 
-    const [inserted] = await this.db
+    const [inserted] = await client
       .insert(jobRuns)
       .values({
         id: newId,

--- a/runtime/subsystems/jobs/job-orchestrator.memory-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.memory-backend.ts
@@ -245,6 +245,12 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
     type: string,
     input: unknown,
     opts: StartOptions = {},
+    // BRIDGE-7: signature parity with Drizzle backend. The memory backend
+    // has no real transactions (its "atomic" boundary is a process-wide
+    // mutex acquired by the body below), so the parameter is intentionally
+    // ignored. Accepting it lets EventFlowService unit tests exercise the
+    // same code path without two stub orchestrators.
+    _tx?: unknown,
   ): Promise<JobRun> {
     // JOB-8 — resolve tenant gate outside the mutex so the error throws
     // synchronously-ish from the caller's stack rather than via the mutex's

--- a/runtime/subsystems/jobs/job-orchestrator.protocol.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.protocol.ts
@@ -124,8 +124,22 @@ export interface IJobOrchestrator {
    * Create a `pending` `job_run` row and return it. Does NOT block waiting
    * for the worker to pick the run up; consumers that need completion
    * semantics should subscribe to the emitted completion event.
+   *
+   * **Optional `tx` last-arg** (added 2026-04-22 for ADR-023 BRIDGE-7):
+   * pass an in-flight Drizzle transaction to thread the row insert + any
+   * dedupe/collision lookups onto an existing tx. Used by
+   * `EventFlowService.publishAndStart` to bundle the outbox insert,
+   * eager `job_run`, and `bridge_delivery` Case-B pre-write into one
+   * atomic transaction. Memory backend ignores the parameter (its
+   * "transaction" is a process-wide mutex). Drizzle backend uses the
+   * standard `tx ?? this.db` pattern.
    */
-  start(type: string, input: unknown, opts?: StartOptions): Promise<JobRun>;
+  start(
+    type: string,
+    input: unknown,
+    opts?: StartOptions,
+    tx?: import('../events/event-bus.protocol').DrizzleTransaction,
+  ): Promise<JobRun>;
 
   /**
    * Cancel a run (and, by default, its entire root-run subtree). Idempotent

--- a/src/__tests__/cli/bridge-registry-generator.test.ts
+++ b/src/__tests__/cli/bridge-registry-generator.test.ts
@@ -17,8 +17,10 @@ import {
   generateBridgeRegistry,
   readKnownEventTypes,
   scanHandlerFiles,
+  DuplicateTriggerError,
   UnknownTriggerEventError,
   validateAgainstEventRegistry,
+  validateNoDuplicateTriggers,
   type ScannedTrigger,
 } from '../../cli/shared/bridge-registry-generator';
 import ts from 'typescript';
@@ -421,5 +423,114 @@ describe('generateBridgeRegistry — orchestration', () => {
     });
     expect(result.written).toBe(false);
     expect(fs.existsSync(path.join(outputDir, 'registry.ts'))).toBe(false);
+  });
+});
+
+
+describe('validateNoDuplicateTriggers (BRIDGE-7 follow-up)', () => {
+  // ADR-023 §`publishAndStart` + `triggers:` collision: exactly one
+  // execution per (event, trigger) pair. Two triggers with the same
+  // (event, jobType) double-spawn the user job because triggerId differs
+  // by index. The codegen catches this at build time so authors don't
+  // debug double-spawned jobs in production.
+  it('passes when no duplicates', () => {
+    const triggers: ScannedTrigger[] = [
+      {
+        jobType: 'a_job',
+        triggerId: 'a_job#0',
+        event: 'evt_x',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/a.ts',
+        sourceLine: 1,
+      },
+      {
+        jobType: 'b_job',
+        triggerId: 'b_job#0',
+        event: 'evt_x',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/b.ts',
+        sourceLine: 1,
+      },
+    ];
+    expect(() => validateNoDuplicateTriggers(triggers)).not.toThrow();
+  });
+
+  it('throws DuplicateTriggerError on (event, jobType) duplicate', () => {
+    const triggers: ScannedTrigger[] = [
+      {
+        jobType: 'a_job',
+        triggerId: 'a_job#0',
+        event: 'evt_x',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/file_one.ts',
+        sourceLine: 5,
+      },
+      {
+        jobType: 'a_job',
+        triggerId: 'a_job#1',
+        event: 'evt_x',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/file_two.ts',
+        sourceLine: 12,
+      },
+    ];
+    let caught: unknown;
+    try {
+      validateNoDuplicateTriggers(triggers);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DuplicateTriggerError);
+    const err = caught as DuplicateTriggerError;
+    expect(err.event).toBe('evt_x');
+    expect(err.jobType).toBe('a_job');
+    expect(err.occurrences).toHaveLength(2);
+    expect(err.message).toContain('a_job#0');
+    expect(err.message).toContain('a_job#1');
+    expect(err.message).toContain('/tmp/file_one.ts:5');
+    expect(err.message).toContain('/tmp/file_two.ts:12');
+  });
+
+  it('allows the same jobType to map a different event (no false collision)', () => {
+    const triggers: ScannedTrigger[] = [
+      {
+        jobType: 'a_job',
+        triggerId: 'a_job#0',
+        event: 'evt_x',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/a.ts',
+        sourceLine: 1,
+      },
+      {
+        jobType: 'a_job',
+        triggerId: 'a_job#1',
+        event: 'evt_y',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/a.ts',
+        sourceLine: 5,
+      },
+    ];
+    expect(() => validateNoDuplicateTriggers(triggers)).not.toThrow();
+  });
+
+  it('generateBridgeRegistry surfaces DuplicateTriggerError end-to-end', async () => {
+    const root = makeTmpDir('orch-dup');
+    const handlersDir = path.join(root, 'src/jobs');
+    const outputDir = path.join(root, 'runtime/subsystems/bridge/generated');
+    fs.mkdirSync(handlersDir, { recursive: true });
+    writeHandler(handlersDir, 'dup.ts', HANDLER_TEMPLATE('dup_job', `
+  triggers: [
+    { event: 'evt_x', map: (e) => ({}) },
+    { event: 'evt_x', map: (e) => ({}) },
+  ],
+`));
+    expect(
+      generateBridgeRegistry({
+        handlersDir,
+        eventsGeneratedDir: undefined,
+        outputDir,
+      }),
+    ).rejects.toBeInstanceOf(DuplicateTriggerError);
+    fs.rmSync(root, { recursive: true, force: true });
   });
 });

--- a/src/__tests__/runtime/subsystems/event-flow.service.spec.ts
+++ b/src/__tests__/runtime/subsystems/event-flow.service.spec.ts
@@ -1,0 +1,483 @@
+/**
+ * Unit tests for `EventFlowService` (BRIDGE-7, ADR-023 §Decision 7).
+ *
+ * Wires the facade against a stub `IEventBus`, a stub `IJobOrchestrator`,
+ * and `MemoryBridgeDeliveryRepo` for the bridge ledger. The "transaction"
+ * is faked via a stub `db.transaction(cb)` that simply runs `cb(tx)` —
+ * tests assert call-shape, ordering, rollback semantics, and the
+ * Case-A/B branching exactly per the spec.
+ */
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+import {
+  EventFlowService,
+  MemoryBridgeDeliveryRepo,
+  MissingTenantIdError,
+  type BridgeRegistry,
+  type IJobBridge,
+} from '../../../../runtime/subsystems/bridge';
+import type { DomainEvent, IEventBus } from '../../../../runtime/subsystems/events/event-bus.protocol';
+import type {
+  IJobOrchestrator,
+  JobRun,
+} from '../../../../runtime/subsystems/jobs/job-orchestrator.protocol';
+
+// ─── Test infrastructure ────────────────────────────────────────────────────
+
+const EVENT_ID = '00000000-0000-0000-0000-000000000aaa';
+const EVENT_TYPE = 'contact_created';
+const JOB_TYPE = 'send_welcome_email';
+
+function event(overrides: Partial<DomainEvent> = {}): DomainEvent {
+  return {
+    id: EVENT_ID,
+    type: EVENT_TYPE,
+    aggregateId: 'agg-1',
+    aggregateType: 'contact',
+    payload: { contactId: 'agg-1' },
+    occurredAt: new Date('2026-04-22T00:00:00Z'),
+    metadata: { direction: 'change' },
+    ...overrides,
+  };
+}
+
+interface Harness {
+  /** Fake db with a `transaction(cb)` that simply runs cb(opaqueTx). */
+  db: { transaction: (cb: (tx: unknown) => Promise<unknown>) => Promise<unknown> };
+  bus: { publish: ReturnType<typeof mock>; calls: Array<[DomainEvent, unknown]> };
+  repo: MemoryBridgeDeliveryRepo;
+  orchestrator: IJobOrchestrator;
+  startSpy: ReturnType<typeof mock>;
+  /** Each tx body invocation increments this. */
+  txInvocations: number;
+  /** Tx commits + rollbacks counted via mock harness. */
+  rolledBack: boolean;
+}
+
+function makeHarness(opts: {
+  spawnedRunId?: string;
+  insertDeliveryFails?: boolean;
+} = {}): Harness {
+  let txInvocations = 0;
+  let rolledBack = false;
+
+  const busCalls: Array<[DomainEvent, unknown]> = [];
+  const bus: Harness['bus'] = {
+    publish: mock(async (event: DomainEvent, tx: unknown) => {
+      busCalls.push([event, tx]);
+    }),
+    calls: busCalls,
+  };
+
+  const repo = new MemoryBridgeDeliveryRepo();
+  if (opts.insertDeliveryFails) {
+    // Wrap insertDelivery to throw — tests rollback semantics.
+    const orig = repo.insertDelivery.bind(repo);
+    repo.insertDelivery = mock(async () => {
+      throw new Error('simulated insertDelivery failure');
+    }) as never;
+    void orig;
+  }
+
+  const startSpy = mock(
+    async (
+      type: string,
+      input: unknown,
+      _opts?: unknown,
+      _tx?: unknown,
+    ): Promise<JobRun> => {
+      return {
+        id: opts.spawnedRunId ?? 'eager-run-id',
+        jobType: type,
+        jobVersion: 1,
+        parentRunId: null,
+        rootRunId: 'root-id',
+        parentClosePolicy: 'terminate',
+        scopeEntityType: null,
+        scopeEntityId: null,
+        tenantId: (_opts as { tenantId?: string | null })?.tenantId ?? null,
+        tags: {},
+        pool: 'outbound_email',
+        priority: 0,
+        concurrencyKey: null,
+        dedupeKey: null,
+        status: 'pending',
+        input: input as Record<string, unknown>,
+        output: null,
+        error: null,
+        triggerSource: 'event',
+        triggerRef: EVENT_ID,
+        runAt: new Date(),
+        startedAt: null,
+        finishedAt: null,
+        claimedAt: null,
+        attempts: 0,
+        waitKind: null,
+        resumeToken: null,
+        waitDeadline: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    },
+  );
+
+  const orchestrator: IJobOrchestrator = {
+    start: startSpy as unknown as IJobOrchestrator['start'],
+    cancel: mock(async () => undefined),
+    replay: mock(async () => {
+      throw new Error('not implemented');
+    }),
+    upsertJobRows: mock(async () => ({ orphaned: [] })),
+  };
+
+  const db: Harness['db'] = {
+    transaction: async (cb) => {
+      txInvocations++;
+      const opaqueTx = { __tx: txInvocations };
+      try {
+        const out = await cb(opaqueTx);
+        return out;
+      } catch (err) {
+        rolledBack = true;
+        throw err;
+      }
+    },
+  };
+
+  return {
+    db,
+    bus,
+    repo,
+    orchestrator,
+    startSpy,
+    get txInvocations() {
+      return txInvocations;
+    },
+    get rolledBack() {
+      return rolledBack;
+    },
+  };
+}
+
+function registryWith(
+  ...triggers: Array<{ event?: string; triggerId: string; jobType: string }>
+): BridgeRegistry {
+  const map: Record<string, unknown[]> = {};
+  for (const t of triggers) {
+    const evt = t.event ?? EVENT_TYPE;
+    map[evt] = map[evt] ?? [];
+    (map[evt] as unknown[]).push({
+      triggerId: t.triggerId,
+      jobType: t.jobType,
+      map: () => ({}),
+    });
+  }
+  return map as unknown as BridgeRegistry;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('EventFlowService.publish', () => {
+  it('thin-delegates to IEventBus.publish', async () => {
+    const h = makeHarness();
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      {} as BridgeRegistry,
+      false,
+    );
+    const e = event();
+    await flow.publish(e as never);
+    expect(h.bus.calls).toHaveLength(1);
+    expect(h.bus.calls[0]![0]).toBe(e);
+    expect(h.bus.calls[0]![1]).toBeUndefined();
+    // No tx, no orchestrator call, no bridge writes.
+    expect(h.txInvocations).toBe(0);
+    expect(h.startSpy).not.toHaveBeenCalled();
+    expect(h.repo.getDeliveriesForEvent(EVENT_ID)).toHaveLength(0);
+  });
+});
+
+describe('EventFlowService.publishAndStart — Case A (no registry match)', () => {
+  it('writes outbox + starts job; no bridge_delivery row; one tx', async () => {
+    const h = makeHarness({ spawnedRunId: 'run-A' });
+    // Registry has a trigger for EVENT_TYPE but for a DIFFERENT job type.
+    const reg = registryWith({ triggerId: 'other_job#0', jobType: 'other_job' });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      false,
+    );
+
+    const result = await flow.publishAndStart(event() as never, JOB_TYPE, { contactId: 'c1' });
+
+    expect(result).toEqual({ runId: 'run-A' });
+    expect(h.txInvocations).toBe(1);
+    expect(h.bus.calls).toHaveLength(1);
+    expect(h.startSpy).toHaveBeenCalledTimes(1);
+    // tx was threaded through to both bus.publish and orchestrator.start.
+    expect(h.bus.calls[0]![1]).toBeTruthy();
+    expect(h.startSpy.mock.calls[0]![3]).toBeTruthy();
+    // No bridge_delivery rows.
+    expect(h.repo.getDeliveriesForEvent(EVENT_ID)).toHaveLength(0);
+  });
+
+  it('Case A — empty registry behaves identically', async () => {
+    const h = makeHarness({ spawnedRunId: 'run-A2' });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      {} as BridgeRegistry,
+      false,
+    );
+    const result = await flow.publishAndStart(event() as never, JOB_TYPE, {});
+    expect(result.runId).toBe('run-A2');
+    expect(h.repo.getDeliveriesForEvent(EVENT_ID)).toHaveLength(0);
+  });
+});
+
+describe('EventFlowService.publishAndStart — Case B (single matching trigger)', () => {
+  it('pre-writes one delivered bridge_delivery row with userRunId', async () => {
+    const h = makeHarness({ spawnedRunId: 'run-B' });
+    const reg = registryWith({ triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      false,
+    );
+
+    const result = await flow.publishAndStart(event() as never, JOB_TYPE, { contactId: 'c1' });
+
+    expect(result.runId).toBe('run-B');
+    const deliveries = h.repo.getDeliveriesForEvent(EVENT_ID);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries[0]).toMatchObject({
+      eventId: EVENT_ID,
+      triggerId: `${JOB_TYPE}#0`,
+      wrapperRunId: null,
+      userRunId: 'run-B',
+      status: 'delivered',
+    });
+    expect(deliveries[0]!.deliveredAt).toBeInstanceOf(Date);
+  });
+
+  it('downstream drain insert with same (eventId, triggerId) is dedup\'d', async () => {
+    // Memory backend's UniqueConstraintError simulates the Drizzle ON CONFLICT
+    // DO NOTHING that BRIDGE-4 implements.
+    const h = makeHarness({ spawnedRunId: 'run-B' });
+    const reg = registryWith({ triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      false,
+    );
+    await flow.publishAndStart(event() as never, JOB_TYPE, {});
+
+    // Simulate drain attempt: same (eventId, triggerId) but with wrapper.
+    const dup = h.repo.insertDelivery({
+      eventId: EVENT_ID,
+      triggerId: `${JOB_TYPE}#0`,
+      wrapperRunId: 'wrapper-attempt',
+      status: 'pending',
+    });
+    expect(dup).rejects.toBeInstanceOf((await import('../../../../runtime/subsystems/bridge')).UniqueConstraintError);
+  });
+});
+
+describe('EventFlowService.publishAndStart — Case B (multiple matching triggers)', () => {
+  it('pre-writes ALL matching trigger rows (filter, not find) — pinned by lead 2026-04-22', async () => {
+    const h = makeHarness({ spawnedRunId: 'run-B-multi' });
+    // Two triggers in the registry pointing to the SAME (event, jobType) pair.
+    // Codegen DuplicateTriggerError should prevent this in real projects,
+    // but the facade must be correct independent of codegen guarantees.
+    const reg = registryWith(
+      { triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE },
+      { triggerId: `${JOB_TYPE}#1`, jobType: JOB_TYPE },
+    );
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      false,
+    );
+
+    await flow.publishAndStart(event() as never, JOB_TYPE, {});
+
+    const deliveries = h.repo.getDeliveriesForEvent(EVENT_ID);
+    expect(deliveries).toHaveLength(2);
+    expect(deliveries.map((d) => d.triggerId).sort()).toEqual([
+      `${JOB_TYPE}#0`,
+      `${JOB_TYPE}#1`,
+    ]);
+    // Both reference the same eager run id.
+    expect(deliveries.every((d) => d.userRunId === 'run-B-multi')).toBe(true);
+  });
+});
+
+describe('EventFlowService.publishAndStart — rollback semantics', () => {
+  it('insertDelivery throw rolls back the per-event tx (db.transaction wrapping)', async () => {
+    const h = makeHarness({
+      spawnedRunId: 'run-rollback',
+      insertDeliveryFails: true,
+    });
+    const reg = registryWith({ triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      false,
+    );
+
+    let caught: unknown;
+    try {
+      await flow.publishAndStart(event() as never, JOB_TYPE, {});
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('insertDelivery failure');
+    // The harness flagged the tx callback as rolled back (re-thrown).
+    expect(h.rolledBack).toBe(true);
+    // Bus + orchestrator were called (they're inside the tx); their writes
+    // would roll back in a real DB. The test pins that the throw
+    // propagates AND our tx wrapper marked rolledBack — that's the
+    // observable contract.
+    expect(h.bus.calls).toHaveLength(1);
+    expect(h.startSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('EventFlowService.publishAndStart — multi-tenancy', () => {
+  it('throws MissingTenantIdError when multiTenant=true and tenantId is undefined', async () => {
+    const h = makeHarness();
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      {} as BridgeRegistry,
+      true, // multi-tenant
+    );
+    expect(
+      flow.publishAndStart(event() as never, JOB_TYPE, {}),
+    ).rejects.toBeInstanceOf(MissingTenantIdError);
+    // Throw is at function entry — no DB writes happened.
+    expect(h.txInvocations).toBe(0);
+    expect(h.bus.calls).toHaveLength(0);
+    expect(h.startSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes explicit null tenantId through (cross-tenant work)', async () => {
+    const h = makeHarness({ spawnedRunId: 'run-null-tenant' });
+    const reg = registryWith({ triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      true,
+    );
+    await flow.publishAndStart(event() as never, JOB_TYPE, {}, { tenantId: null });
+    expect(h.startSpy.mock.calls[0]![2]).toMatchObject({ tenantId: null });
+    const deliveries = h.repo.getDeliveriesForEvent(EVENT_ID);
+    expect(deliveries[0]!.tenantId).toBeNull();
+  });
+
+  it('passes explicit string tenantId through to both eager start AND bridge_delivery', async () => {
+    const h = makeHarness({ spawnedRunId: 'run-tenant-9' });
+    const reg = registryWith({ triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      true,
+    );
+    await flow.publishAndStart(event() as never, JOB_TYPE, {}, { tenantId: 'tenant-9' });
+    expect(h.startSpy.mock.calls[0]![2]).toMatchObject({ tenantId: 'tenant-9' });
+    const deliveries = h.repo.getDeliveriesForEvent(EVENT_ID);
+    expect(deliveries[0]!.tenantId).toBe('tenant-9');
+  });
+});
+
+describe('EventFlowService.publishAndStart — call ordering inside tx', () => {
+  it('invokes bus.publish, then orchestrator.start, then bridgeRepo.insertDelivery', async () => {
+    const order: string[] = [];
+    const h = makeHarness({ spawnedRunId: 'run-order' });
+    h.bus.publish = mock(async () => {
+      order.push('bus.publish');
+    });
+    h.startSpy.mockImplementation(async () => {
+      order.push('orchestrator.start');
+      return {
+        id: 'run-order',
+        jobType: JOB_TYPE,
+        jobVersion: 1,
+        parentRunId: null,
+        rootRunId: 'r',
+        parentClosePolicy: 'terminate',
+        scopeEntityType: null,
+        scopeEntityId: null,
+        tenantId: null,
+        tags: {},
+        pool: 'p',
+        priority: 0,
+        concurrencyKey: null,
+        dedupeKey: null,
+        status: 'pending',
+        input: {},
+        output: null,
+        error: null,
+        triggerSource: 'event',
+        triggerRef: EVENT_ID,
+        runAt: new Date(),
+        startedAt: null,
+        finishedAt: null,
+        claimedAt: null,
+        attempts: 0,
+        waitKind: null,
+        resumeToken: null,
+        waitDeadline: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as JobRun;
+    });
+    const origInsert = h.repo.insertDelivery.bind(h.repo);
+    h.repo.insertDelivery = (async (row, tx) => {
+      order.push('repo.insertDelivery');
+      return origInsert(row, tx);
+    }) as never;
+
+    const reg = registryWith({ triggerId: `${JOB_TYPE}#0`, jobType: JOB_TYPE });
+    const flow = new EventFlowService(
+      h.db as never,
+      h.bus as unknown as IEventBus,
+      h.orchestrator,
+      h.repo,
+      reg,
+      false,
+    );
+    await flow.publishAndStart(event() as never, JOB_TYPE, {});
+    expect(order).toEqual(['bus.publish', 'orchestrator.start', 'repo.insertDelivery']);
+  });
+});

--- a/src/cli/shared/bridge-registry-generator.ts
+++ b/src/cli/shared/bridge-registry-generator.ts
@@ -111,6 +111,53 @@ const HEADER =
  * not exist in the generated `eventRegistry`. ADR-023 §Decision 5
  * (build-time validation against `eventRegistry`).
  */
+/**
+ * Thrown when the registry would emit two triggers with the same
+ * `(event, jobType)` pair. ADR-023 §`publishAndStart` + existing
+ * `triggers:` collision: exactly one execution per `(event, trigger)`
+ * pair. Two triggers with the same `(event, jobType)` would produce
+ * two wrappers + two user-job spawns — the bridge ledger UNIQUE only
+ * dedups by `triggerId`, which is `<jobType>#<index>` and therefore
+ * differs between the two entries.
+ *
+ * The facade's Case B pre-write loop pre-writes one delivery per
+ * matching trigger, so it stays correct even with duplicates. But the
+ * codegen catching this at build time is the cleaner long-term fix
+ * (lead decision 2026-04-22 — belt+suspenders): authors see the
+ * mistake immediately rather than debugging double-spawned jobs.
+ *
+ * To resolve: either rename the second trigger's job type, or remove
+ * one of the two `@JobHandler.triggers[]` entries pointing at the same
+ * (event, job) pair.
+ */
+export class DuplicateTriggerError extends Error {
+  override readonly name = 'DuplicateTriggerError';
+  constructor(
+    public readonly event: string,
+    public readonly jobType: string,
+    public readonly occurrences: ReadonlyArray<{
+      sourceFile: string;
+      sourceLine: number;
+      triggerId: string;
+    }>,
+  ) {
+    super(
+      `DuplicateTriggerError: ${occurrences.length} @JobHandler.triggers ` +
+        `entries declare event '${event}' → jobType '${jobType}'. ADR-023 ` +
+        `requires exactly one execution per (event, trigger) pair; ` +
+        `duplicates would double-spawn the user job. Occurrences:\n` +
+        occurrences
+          .map(
+            (o) =>
+              `  - ${o.triggerId} at ${o.sourceFile}:${o.sourceLine}`,
+          )
+          .join('\n') +
+        `\nFix: rename the second job type, or remove one of the ` +
+        `duplicate trigger entries.`,
+    );
+  }
+}
+
 export class UnknownTriggerEventError extends Error {
   override readonly name = 'UnknownTriggerEventError';
   constructor(
@@ -301,6 +348,37 @@ export function readKnownEventTypes(eventsGeneratedDir?: string): string[] {
  * Skips validation when `knownEventTypes` is empty (no registry to
  * validate against).
  */
+/**
+ * Throws `DuplicateTriggerError` on the first `(event, jobType)` pair
+ * that appears in two or more scanned triggers. Codegen-time guard for
+ * the facade's same-tx invariant (BRIDGE-7).
+ */
+export function validateNoDuplicateTriggers(
+  triggers: ScannedTrigger[],
+): void {
+  // Group by `${event}\u0000${jobType}` (NUL separator avoids any
+  // collision with string contents).
+  const grouped = new Map<
+    string,
+    Array<{ sourceFile: string; sourceLine: number; triggerId: string }>
+  >();
+  for (const t of triggers) {
+    const key = `${t.event}\u0000${t.jobType}`;
+    const list = grouped.get(key) ?? [];
+    list.push({
+      sourceFile: t.sourceFile,
+      sourceLine: t.sourceLine,
+      triggerId: t.triggerId,
+    });
+    grouped.set(key, list);
+  }
+  for (const [key, occurrences] of grouped) {
+    if (occurrences.length < 2) continue;
+    const [event, jobType] = key.split('\u0000');
+    throw new DuplicateTriggerError(event!, jobType!, occurrences);
+  }
+}
+
 export function validateAgainstEventRegistry(
   triggers: ScannedTrigger[],
   knownEventTypes: string[],
@@ -384,7 +462,12 @@ export async function generateBridgeRegistry(
   // 1. Scan handler files.
   const triggers = scanHandlerFiles(handlersDir);
 
-  // 2. Validate against eventRegistry (no-op if registry not present).
+  // 2a. Reject duplicate (event, jobType) pairs (BRIDGE-7 follow-up to
+  //     BRIDGE-6: facade's same-tx invariant requires one trigger per
+  //     such pair; without this guard, duplicates double-spawn).
+  validateNoDuplicateTriggers(triggers);
+
+  // 2b. Validate against eventRegistry (no-op if registry not present).
   const knownEventTypes = readKnownEventTypes(eventsGeneratedDir);
   validateAgainstEventRegistry(triggers, knownEventTypes);
 


### PR DESCRIPTION
## Summary

ADR-023 §Decision 7 facade. `EventFlowService` exposes two verbs (`publish`, `publishAndStart`) via the `EVENT_FLOW` token. `publishAndStart` does outbox insert + eager `orchestrator.start()` + (Case B) `bridge_delivery` pre-write inside ONE transaction. **GATE-3 lead-approved 2026-04-22 — all three asks shipped.**

## What lands

- **`EventFlowService`** implementing `IEventFlow`. `publishAndStart` opens `db.transaction(async tx => { eventBus.publish(event, tx); orchestrator.start(jobType, input, opts, tx); for (m of matchingTriggers) bridgeRepo.insertDelivery({...}, tx); })`. Throw rolls all three back; bridge UNIQUE makes next-cycle drain idempotent.
- **Pre-write ALL matching triggers** (`filter` not `find`) — GATE-3 ask 2. Defensive against duplicate `(event, jobType)` pairs in the registry.
- **`IJobOrchestrator.start` extended with optional `tx?`** — GATE-3 ask 1. Cross-subsystem touch: protocol gains a fourth optional parameter; Drizzle backend uses standard `tx ?? this.db` pattern; memory backend ignores. **No behaviour change for existing callers.**
- **`MissingTenantIdError('EventFlowService.publishAndStart')`** at function entry. Site (a) of the three ADR-023 enforcement sites (BRIDGE-5 handler is (b); BRIDGE-4 drizzle repo is (c)).
- **BRIDGE-6 follow-up: codegen `DuplicateTriggerError`** — GATE-3 ask 3 belt+suspenders. New `validateNoDuplicateTriggers` rejects two `@JobHandler.triggers` entries with the same `(event, jobType)` pair at build time. Hooked before `validateAgainstEventRegistry`.

## Test coverage (15 new)

- `event-flow.service.spec.ts` (11): publish delegate, Case A × 2, Case B single-match, Case B multi-match (pins filter+loop), ON CONFLICT dedup simulation via memory `UniqueConstraintError`, rollback on `insertDelivery` throw, multi-tenancy throw + null + string, call-ordering inside tx
- `bridge-registry-generator.test.ts` (4 new in "validateNoDuplicateTriggers"): no-dup, throw on dup, same-jobType-different-event passes, end-to-end orchestrator throw

## Test plan

- [x] `just test-unit` — 1343 pass
- [x] `just test-baseline` — green
- [x] `just test-smoke` — green

## Specs updated (CLAUDE.md living-docs)

- `BRIDGE-7.md` — Implementation Notes (5 items: same-tx, filter+loop, `IJobOrchestrator.start` extension, multi-tenancy, BRIDGE-6 follow-up)
- `BRIDGE-6.md` — Implementation Notes appendix on the DuplicateTriggerError follow-up + cross-link to BRIDGE-7

## References

- ADR: `docs/adrs/ADR-023-event-to-job-bridge.md` §Decision 7, §`publishAndStart` + existing `triggers:` collision
- Spec: `docs/specs/BRIDGE-7.md`
- Plan: `docs/specs/BRIDGE-PHASE-2-PLAN.md` (row 7)
- GATE-3 lead approvals 2026-04-22: extend `IJobOrchestrator.start` with `tx?`; pre-write ALL matching triggers; codegen DuplicateTriggerError
- Epic: #158

Closes #165