### PR TITLE
OPENAPI-3: controller decorators + backend ResponseDto

### DIFF
--- a/docs/specs/OPENAPI-3.md
+++ b/docs/specs/OPENAPI-3.md
@@ -59,7 +59,35 @@ Report to lead with diff stats + spot-check output before opening.
 
 ## Acceptance
 
-- [ ] Both pipelines emit decorated controllers.
-- [ ] `just test-all` green.
-- [ ] `/docs-json` on smoke-generated project is fully populated (no empty `schema: {}` anywhere under `paths`).
-- [ ] Gate passed before PR open.
+- [x] Both pipelines emit decorated controllers.
+- [x] `just test-all` green.
+- [ ] `/docs-json` on smoke-generated project is fully populated (no empty `schema: {}` anywhere under `paths`). **Deferred to OPENAPI-4** — smoke test does `tsc --noEmit` only and does not boot Nest; the same gap was accepted in OPENAPI-2. OPENAPI-4 wires AppModule + `SwaggerModule.setup` and should add a boot-and-curl-`/docs-json` step to smoke.
+- [x] Gate passed before PR open.
+
+## Implementation notes (post-merge)
+
+Decisions locked during implementation that deviate from the pre-implementation sketch:
+
+1. **`$ref` everywhere, not `type:` class refs.** Generated DTOs are Zod-derived `type X = z.infer<...>` aliases — TypeScript types, not runtime classes. `@ApiBody({ type: CreateContactDto })` would be a "used as a value, only refers to a type" compile error. The decorators emit `@ApiBody({ schema: { $ref: '#/components/schemas/CreateContactDto' } })` and `@ApiResponse({ ..., schema: { $ref: ... } })`. This is architecturally consistent with OPENAPI-2 — which already registered schemas **by string name** in the `OpenApiRegistry` — and sidesteps the need to generate runtime class shells purely as reflection targets. Swagger UI resolves the `$ref` against the registered schemas emitted on `/docs-json`. Net: Zod-first stays intact, no class duplication.
+
+2. **Backend pipeline gets a `<Entity>ResponseDto` — added to the existing `<entity>.dto.ts` file, not a new template file.** The backend DTO template previously emitted only create + update schemas. OPENAPI-3 extends the same file with `<camelName>ResponseSchema` (Zod) + `<Entity>ResponseDto` (type alias). The response shape mirrors the entity's full select shape: `id` + all declared fields + `createdAt/updatedAt` (if `hasTimestamps`) + `deletedAt` (if `hasSoftDelete`) + `validFrom/validTo/isActive` (if `hasTemporalValidity`). No response-side `.optional()` — columns are present on every returned row.
+
+3. **CLP untouched on DTO side.** CLP already emits `<Entity>OutputDto` with the right shape and register it as `OutputDto` in the registry (OPENAPI-2 note). CLP controller decorators reference `#/components/schemas/<Entity>OutputDto` accordingly. No `ResponseDto` rename — would have broken OPENAPI-2 consistency for zero gain.
+
+4. **Shared `ErrorResponseDto` added to `runtime/shared/openapi/error-response.dto.ts`.** Schema shape matches NestJS's `HttpException` JSON body: `{ statusCode: number.int(), message: string | string[], error?: string }`. The registry **auto-registers** it on construction (and re-seeds it on `reset()`), so every consumer project exposes `components.schemas.ErrorResponseDto` on `/docs-json` without per-entity duplication. Generated 4xx `@ApiResponse` decorators `$ref` this single schema. Vendored via `init-scaffold.ts::VENDORED_RUNTIME_FILES`.
+
+5. **`@nestjs/swagger` is an optional peer dep.** Added to `peerDependencies` (`^7.0.0 || ^8.0.0`) and `peerDependenciesMeta` (optional) in `package.json`. Generated controllers import decorator functions at the top — unlike the `@anatine/zod-openapi` peer which is lazy-imported, these are unconditional static imports. Consumer apps that don't install `@nestjs/swagger` will get a module-not-found error at runtime when any generated controller loads. That matches the OPENAPI-4 bootstrap, which also requires the peer; acceptable because the epic is scoped to projects opting into OpenAPI.
+
+6. **Class-level `@ApiBearerAuth()` is unconditional.** Finalized "universal default" per gate decision — any controller that needs a different security scheme can override at the method level in a manual overlay. Not configurable via YAML in Phase 1.
+
+7. **`operationId` is bare camelCase, no module prefix.** Matches the gate decision; bounded-context operationIds (e.g., `sales.createOpportunity`) are deferred to a future ADR. Naming pattern: `list<Plural>`, `find<Entity>ById`, `create<Entity>`, `update<Entity>`, `delete<Entity>`.
+
+8. **PUT, not PATCH, on the backend pipeline.** The backend controller template uses `@Put(':id')` for updates (pre-existing convention — full replacement semantics via Zod's `.optional()` on every field). CLP uses `@Patch`. Decorators are attached to whichever verb each template actually emits; the spec's reference to PATCH was conformed to the generated code rather than rewriting the routing layer.
+
+9. **Declarative-query methods not added to the backend controller.** The backend `controller.ejs.t` doesn't emit declarative-query handlers today — those live on the query classes but aren't exposed over REST in the backend pipeline. Only the standard five CRUD methods get decorators. (CLP's controller also doesn't emit them — same story.) If a future spec wires declarative-query REST endpoints, decorator emission will land in the same template.
+
+10. **Smoke test gap — not closed here.** The smoke test still runs `tsc --noEmit` only. Booting the generated app and curling `/docs-json` requires OPENAPI-4 (AppModule registers `OPENAPI_REGISTRY` as a provider; `SwaggerModule.setup` awaits `build()` and mounts the UI). Adding the boot step to smoke is the natural place for the `schema.$ref` assertions in §Tests item 2. Captured as an OPENAPI-4 task.
+
+11. **Unit tests updated.** `src/__tests__/runtime/shared/openapi-registry.spec.ts` now asserts the auto-registered `ErrorResponseDto` is always present in `components.schemas` (invariant replaces the previous "empty components.schemas" assertion). `src/__tests__/schema/field-type-to-zod.test.ts` picks up the new template locals (`camelName`, `hasTimestamps`, `hasSoftDelete`, `hasTemporalValidity`) required to render the response schema block.
+
+12. **Baseline diff is within the predicted envelope.** +648/-13 across 32 files: 7 controllers (~42 LOC each, one simpler at +32), 7 DTOs (+12–20 LOC each), 7 modules (+3 LOC each), plus the template + runtime additions. No whitespace/import noise beyond decorator emission and the new response schema.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@cubejs-client/core": ">=1.0.0",
     "@nestjs/common": "^10",
     "@nestjs/core": "^10",
+    "@nestjs/swagger": "^7.0.0 || ^8.0.0",
     "bullmq": ">=5.0.0",
     "class-transformer": ">=0.5.0",
     "class-validator": ">=0.14.0",
@@ -86,6 +87,9 @@
       "optional": true
     },
     "@cubejs-client/core": {
+      "optional": true
+    },
+    "@nestjs/swagger": {
       "optional": true
     },
     "bullmq": {

--- a/runtime/shared/openapi/error-response.dto.ts
+++ b/runtime/shared/openapi/error-response.dto.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared error response schema (OPENAPI-3).
+ *
+ * Generated controllers `@ApiResponse(...)` decorators reference this
+ * schema by `$ref` (name `ErrorResponseDto`) for non-success status codes
+ * (400, 401, 404, etc.). Shape matches NestJS's default `HttpException`
+ * JSON body — see `packages/common/src/exceptions/http.exception.ts`.
+ *
+ * The registry auto-registers this schema on construction so every
+ * consumer project exposes `components.schemas.ErrorResponseDto` on
+ * `/docs-json` without per-entity duplication.
+ */
+import { z } from 'zod';
+
+export const errorResponseSchema = z.object({
+  statusCode: z.number().int(),
+  message: z.union([z.string(), z.array(z.string())]),
+  error: z.string().optional(),
+});
+
+export type ErrorResponseDto = z.infer<typeof errorResponseSchema>;
+
+/** Canonical name used across `$ref` URIs in generated controllers. */
+export const ERROR_RESPONSE_SCHEMA_NAME = 'ErrorResponseDto';

--- a/runtime/shared/openapi/index.ts
+++ b/runtime/shared/openapi/index.ts
@@ -13,3 +13,8 @@ export type {
 } from './registry';
 export { OPENAPI_REGISTRY } from './registry.tokens';
 export { OpenApiPeerDepMissingError, DuplicateSchemaError } from './errors';
+export {
+  ERROR_RESPONSE_SCHEMA_NAME,
+  errorResponseSchema,
+} from './error-response.dto';
+export type { ErrorResponseDto } from './error-response.dto';

--- a/runtime/shared/openapi/registry.ts
+++ b/runtime/shared/openapi/registry.ts
@@ -14,6 +14,7 @@
  */
 import type { z } from 'zod';
 
+import { ERROR_RESPONSE_SCHEMA_NAME, errorResponseSchema } from './error-response.dto';
 import { OpenApiPeerDepMissingError, DuplicateSchemaError } from './errors';
 
 export type HttpMethod = 'get' | 'post' | 'patch' | 'delete' | 'put';
@@ -65,6 +66,13 @@ export class OpenApiRegistry {
   private pathEntries = new Map<string, Map<HttpMethod, PathSpec>>();
   private peer: PeerModule | null = null;
 
+  constructor() {
+    // Auto-register the shared error response schema so controllers that
+    // reference `#/components/schemas/ErrorResponseDto` always resolve
+    // (OPENAPI-3). Consumers can `reset()` + re-register in tests.
+    this.zodSchemas.set(ERROR_RESPONSE_SCHEMA_NAME, errorResponseSchema);
+  }
+
   registerSchema(name: string, schema: z.ZodType): void {
     if (this.zodSchemas.has(name)) {
       throw new DuplicateSchemaError(name);
@@ -114,11 +122,16 @@ export class OpenApiRegistry {
     };
   }
 
-  /** Test helper — clears all registered schemas and paths. */
+  /**
+   * Test helper — clears registered schemas and paths, then re-seeds the
+   * core `ErrorResponseDto` entry so post-reset state matches the
+   * invariant established in the constructor.
+   */
   reset(): void {
     this.zodSchemas.clear();
     this.pathEntries.clear();
     this.peer = null;
+    this.zodSchemas.set(ERROR_RESPONSE_SCHEMA_NAME, errorResponseSchema);
   }
 
   protected async loadPeer(): Promise<PeerModule> {

--- a/src/__tests__/runtime/shared/openapi-registry.spec.ts
+++ b/src/__tests__/runtime/shared/openapi-registry.spec.ts
@@ -65,13 +65,30 @@ describe('OpenApiRegistry', () => {
     expect(() => registry.registerSchema('User', schema)).toThrow(DuplicateSchemaError);
   });
 
-  it('build() with no registrations returns a valid OpenAPIObject with empty components.schemas', async () => {
+  it('build() with no registrations returns a valid OpenAPIObject containing only the auto-registered ErrorResponseDto', async () => {
+    // OPENAPI-3 auto-registers `ErrorResponseDto` on construction so
+    // generated controllers always have `$ref` targets for 4xx responses.
     const doc = await registry.build({ title: 'Empty', version: '0.0.1' });
 
     expect(doc.info.title).toBe('Empty');
     expect(doc.info.version).toBe('0.0.1');
     expect(doc.paths).toEqual({});
-    expect(doc.components.schemas).toEqual({});
+    expect(Object.keys(doc.components.schemas)).toEqual(['ErrorResponseDto']);
+  });
+
+  it('auto-registers ErrorResponseDto with the expected shape', async () => {
+    const doc = await registry.build({ title: 'T', version: '1.0.0' });
+    const err = doc.components.schemas.ErrorResponseDto as {
+      type: string;
+      properties: Record<string, { type?: string; oneOf?: unknown[] }>;
+      required?: string[];
+    };
+
+    expect(err.type).toBe('object');
+    // Zod `.int()` maps to OpenAPI's `integer` type (not `number`).
+    expect(err.properties.statusCode.type).toBe('integer');
+    expect(err.properties.error.type).toBe('string');
+    expect(err.required).toEqual(['statusCode', 'message']);
   });
 
   it('pins openapi version to 3.0.3', async () => {
@@ -110,14 +127,14 @@ describe('OpenApiRegistry', () => {
     );
   });
 
-  it('reset() clears registered schemas and paths', async () => {
+  it('reset() clears registered schemas and paths but re-seeds ErrorResponseDto', async () => {
     registry.registerSchema('User', z.object({ id: z.string() }));
     registry.registerPath('/users', 'get', { summary: 'List' });
 
     registry.reset();
 
     const doc = await registry.build({ title: 'T', version: '1.0.0' });
-    expect(doc.components.schemas).toEqual({});
+    expect(Object.keys(doc.components.schemas)).toEqual(['ErrorResponseDto']);
     expect(doc.paths).toEqual({});
   });
 });

--- a/src/__tests__/schema/field-type-to-zod.test.ts
+++ b/src/__tests__/schema/field-type-to-zod.test.ts
@@ -72,10 +72,18 @@ function render(template: string, locals: Record<string, unknown>): string {
 // Minimal locals matching what prompt.js provides to the DTO template
 const minimalLocals = {
 	className: 'Deal',
+	// OPENAPI-3: response schema uses the entity's camelName as the Zod
+	// binding name (e.g., `dealResponseSchema`).
+	camelName: 'deal',
 	isCleanArchitecture: true,
 	generate: { dtos: true },
 	outputPaths: { dto: 'deal.dto.ts' },
 	hasEntityRefFields: false,
+	// OPENAPI-3: response schema spread — these flags gate the trailing
+	// timestamp / soft-delete / temporal-validity blocks.
+	hasTimestamps: false,
+	hasSoftDelete: false,
+	hasTemporalValidity: false,
 	locations: { dbContextEngine: { import: '@shared/db' } },
 	fields: [
 		{

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -149,6 +149,14 @@ const VENDORED_RUNTIME_FILES: Array<{ runtime: string; target: string }> = [
 	{ runtime: 'shared/openapi/registry.ts', target: 'src/shared/openapi/registry.ts' },
 	{ runtime: 'shared/openapi/registry.tokens.ts', target: 'src/shared/openapi/registry.tokens.ts' },
 	{ runtime: 'shared/openapi/errors.ts', target: 'src/shared/openapi/errors.ts' },
+	// OPENAPI-3: shared error response schema referenced by every generated
+	// controller's 4xx `@ApiResponse` `$ref`. Auto-registered in the registry
+	// constructor so consumer projects expose `ErrorResponseDto` on
+	// `/docs-json` without per-entity duplication.
+	{
+		runtime: 'shared/openapi/error-response.dto.ts',
+		target: 'src/shared/openapi/error-response.dto.ts',
+	},
 	{ runtime: 'shared/openapi/index.ts', target: 'src/shared/openapi/index.ts' },
 ];
 

--- a/templates/entity/new/backend/application/schemas/dto.ejs.t
+++ b/templates/entity/new/backend/application/schemas/dto.ejs.t
@@ -43,3 +43,34 @@ export const update<%= className %>Schema = z.object({
 });
 
 export type Update<%= className %>Dto = z.infer<typeof update<%= className %>Schema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../<%= className %>ResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const <%= camelName %>ResponseSchema = z.object({
+	id: z.string().uuid(),
+<% fields.forEach((field) => { -%>
+<% let zodChain = field.zodType; -%>
+<% if (field.type === 'string' && field.maxLength) { zodChain += `.max(${field.maxLength})`; } -%>
+<% if (field.type === 'string' && field.minLength) { zodChain += `.min(${field.minLength})`; } -%>
+<% if (['integer', 'decimal'].includes(field.type) && field.min !== undefined) { zodChain += `.min(${field.min})`; } -%>
+<% if (['integer', 'decimal'].includes(field.type) && field.max !== undefined) { zodChain += `.max(${field.max})`; } -%>
+<% if (field.choices) { zodChain = `z.enum([${field.choices.map(c => `'${c}'`).join(', ')}])`; } -%>
+<% if (field.nullable) { zodChain += '.nullable()'; } -%>
+	<%- field.camelName %>: <%- zodChain %>,
+<% }) -%>
+<% if (hasTimestamps) { -%>
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+<% } -%>
+<% if (hasSoftDelete) { -%>
+	deletedAt: z.coerce.date().nullable(),
+<% } -%>
+<% if (hasTemporalValidity) { -%>
+	validFrom: z.coerce.date().nullable(),
+	validTo: z.coerce.date().nullable(),
+	isActive: z.boolean(),
+<% } -%>
+});
+
+export type <%= className %>ResponseDto = z.infer<typeof <%= camelName %>ResponseSchema>;

--- a/templates/entity/new/backend/modules/core/module.ejs.t
+++ b/templates/entity/new/backend/modules/core/module.ejs.t
@@ -36,7 +36,7 @@ import { declarativeQueryClasses } from '<%= imports.moduleToDeclarativeQueries 
 import { <%= classNamePlural %>Controller } from '<%= imports.moduleToController %>';
 <% } -%>
 <% if (generate.dtos) { -%>
-import { create<%= className %>Schema, update<%= className %>Schema } from '<%= imports.moduleToDto %>';
+import { create<%= className %>Schema, update<%= className %>Schema, <%= camelName %>ResponseSchema } from '<%= imports.moduleToDto %>';
 <% } -%>
 
 @Module({
@@ -86,6 +86,7 @@ export class <%= classNamePlural %>Module<% if (generate.dtos) { %> implements O
 	onModuleInit(): void {
 		this.openApi.registerSchema('Create<%= className %>Dto', create<%= className %>Schema);
 		this.openApi.registerSchema('Update<%= className %>Dto', update<%= className %>Schema);
+		this.openApi.registerSchema('<%= className %>ResponseDto', <%= camelName %>ResponseSchema);
 	}
 <% } -%>
 }

--- a/templates/entity/new/backend/presentation/controller.ejs.t
+++ b/templates/entity/new/backend/presentation/controller.ejs.t
@@ -24,6 +24,13 @@ import {
 <% } -%>
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { <%= getByIdQueryClass %> } from '<%= imports.controllerToGetByIdQuery %>';
 import { <%= listQueryClass %> } from '<%= imports.controllerToListQuery %>';
 import {
@@ -41,6 +48,13 @@ import { <%= className %> } from '<%= imports.controllerToDomain %>';
 import type { <%= className %>With } from '<%= imports.controllerToDomain %>';
 <% } -%>
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('<%= plural %>')
 export class <%= classNamePlural %>Controller {
 	constructor(
@@ -51,6 +65,12 @@ export class <%= classNamePlural %>Controller {
 		private readonly delete<%= className %>Command: <%= deleteCommandClass %>,
 	) {}
 
+	@ApiOperation({ summary: 'List <%= plural %>', operationId: 'list<%= classNamePlural %>' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/<%= className %>ResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(<%- hasRelationships ? `@Query('include') include?: string` : '' %>): Promise<<%= className %>[]> {
 <% if (hasRelationships) { -%>
@@ -60,6 +80,11 @@ export class <%= classNamePlural %>Controller {
 <% } -%>
 	}
 
+	@ApiOperation({ summary: 'Find <%= name %> by id', operationId: 'find<%= className %>ById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/<%= className %>ResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -74,6 +99,11 @@ export class <%= classNamePlural %>Controller {
 <% } -%>
 	}
 
+	@ApiOperation({ summary: 'Create <%= name %>', operationId: 'create<%= className %>' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/Create<%= className %>Dto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/<%= className %>ResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(create<%= className %>Schema))
 	async create(
@@ -84,6 +114,13 @@ export class <%= classNamePlural %>Controller {
 		return this.create<%= className %>Command.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update <%= name %>', operationId: 'update<%= className %>' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/Update<%= className %>Dto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/<%= className %>ResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -94,6 +131,11 @@ export class <%= classNamePlural %>Controller {
 		return this.update<%= className %>Command.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete <%= name %>', operationId: 'delete<%= className %>' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -141,6 +183,13 @@ import {
 	UseGuards,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { AuthGuard } from '<%= imports.controllerToAuthGuard %>/auth.guard';
 import { CurrentUser } from '<%= imports.controllerToCurrentUser %>/current-user.decorator';
@@ -160,6 +209,7 @@ import { <%= getByIdQueryClass %> } from '<%= imports.controllerToGetByIdQuery %
 import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { <%= className %> } from '<%= imports.controllerToDomain %>';
 
+@ApiBearerAuth()
 @Controller('<%= plural %>')
 @UseGuards(AuthGuard)
 export class <%= classNamePlural %>Controller {
@@ -171,6 +221,8 @@ export class <%= classNamePlural %>Controller {
 		private readonly delete<%= className %>Command: <%= deleteCommandClass %>,
 	) {}
 
+	@ApiOperation({ summary: 'List <%= plural %> (Electric SQL proxy)', operationId: 'list<%= classNamePlural %>' })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(
 		@CurrentUser() user: User,
@@ -186,11 +238,21 @@ export class <%= classNamePlural %>Controller {
 		});
 	}
 
+	@ApiOperation({ summary: 'Find <%= name %> by id', operationId: 'find<%= className %>ById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/<%= className %>ResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(@Param('id', ParseUUIDPipe) id: string): Promise<<%= className %>> {
 		return this.get<%= className %>ByIdQuery.execute(id);
 	}
 
+	@ApiOperation({ summary: 'Create <%= name %>', operationId: 'create<%= className %>' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/Create<%= className %>Dto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/<%= className %>ResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(create<%= className %>Schema))
 	async create(
@@ -201,6 +263,13 @@ export class <%= classNamePlural %>Controller {
 		return this.create<%= className %>Command.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update <%= name %>', operationId: 'update<%= className %>' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/Update<%= className %>Dto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/<%= className %>ResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -211,6 +280,11 @@ export class <%= classNamePlural %>Controller {
 		return this.update<%= className %>Command.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete <%= name %>', operationId: 'delete<%= className %>' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/templates/entity/new/clean-lite-ps/controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/controller.ejs.t
@@ -4,6 +4,7 @@ skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
 force: true
 ---
 import { Controller, Get<% if (generateWrites) { %>, Post, Patch, Delete, Body, Headers<% } %>, NotFoundException, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ApiBearerAuth, <% if (generateWrites) { %>ApiBody, <% } %>ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { <%= classNames.findByIdUseCase %> } from './use-cases/find-<%= entityName %>-by-id.use-case';
 import { <%= classNames.listUseCase %> } from './use-cases/list-<%= entityNamePlural %>.use-case';
 <% if (eavEnabled) { -%>
@@ -22,6 +23,11 @@ import type { <%= classNames.updateDto %> } from './dto/update-<%= entityName %>
 <% } -%>
 import type { <%= classNames.entity %> } from './<%= entityName %>.entity';
 
+// OPENAPI-3: decorators reference registered schemas by `$ref` because
+// CLP DTOs are Zod-derived types (OPENAPI-2 registers them by name at
+// onModuleInit). `ErrorResponseDto` is auto-registered by the shared
+// registry.
+@ApiBearerAuth()
 @Controller('<%= entityNamePlural %>')
 export class <%= classNames.controller %> {
   constructor(
@@ -39,22 +45,47 @@ export class <%= classNames.controller %> {
 <% } -%>
   ) {}
 
+  @ApiOperation({ summary: 'List <%= entityNamePlural %>', operationId: 'list<%= classNames.entity %>s' })
+  @ApiResponse({
+    status: 200,
+    schema: { type: 'array', items: { $ref: '#/components/schemas/<%= classNames.outputDto %>' } },
+  })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
   @Get()
   async getAll(): Promise<<%= classNames.entity %>[]> {
     return this.listUseCase.execute();
   }
 <% if (eavEnabled) { %>
+  @ApiOperation({
+    summary: 'List <%= entityNamePlural %> with EAV fields',
+    operationId: 'list<%= classNames.entity %>sWithFields',
+  })
+  @ApiResponse({ status: 200 })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
   @Get('with-fields')
   async getAllWithFields(): Promise<Array<<%= classNames.entity %> & { fields: Record<string, unknown> }>> {
     return this.listWithFieldsUseCase.execute();
   }
 <% } %>
+  @ApiOperation({ summary: 'Find <%= entityName %> by id', operationId: 'find<%= classNames.entity %>ById' })
+  @ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/<%= classNames.outputDto %>' } })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
   @Get(':id')
   async getById(@Param('id', ParseUUIDPipe) id: string): Promise<<%= classNames.entity %>> {
     // Use case throws NotFoundException on null/undefined (D2)
     return this.findByIdUseCase.execute(id);
   }
 <% if (eavEnabled) { %>
+  @ApiOperation({
+    summary: 'Find <%= entityName %> with EAV fields',
+    operationId: 'find<%= classNames.entity %>ByIdWithFields',
+  })
+  @ApiResponse({ status: 200 })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
   @Get(':id/with-fields')
   async getByIdWithFields(
     @Param('id', ParseUUIDPipe) id: string,
@@ -65,6 +96,11 @@ export class <%= classNames.controller %> {
   }
 <% } %>
 <% if (generateWrites) { %>
+  @ApiOperation({ summary: 'Create <%= entityName %>', operationId: 'create<%= classNames.entity %>' })
+  @ApiBody({ schema: { $ref: '#/components/schemas/<%= classNames.createDto %>' } })
+  @ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/<%= classNames.outputDto %>' } })
+  @ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
   @Post()
   async create(
     @Body(new ZodValidationPipe(<%= classNames.createSchema %>)) dto: <%= classNames.createDto %>,
@@ -74,6 +110,13 @@ export class <%= classNames.controller %> {
     return this.createUseCase.execute(dto, { actor: { tenantId, userId } });
   }
 
+  @ApiOperation({ summary: 'Update <%= entityName %>', operationId: 'update<%= classNames.entity %>' })
+  @ApiBody({ schema: { $ref: '#/components/schemas/<%= classNames.updateDto %>' } })
+  @ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/<%= classNames.outputDto %>' } })
+  @ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
   @Patch(':id')
   async update(
     @Param('id', ParseUUIDPipe) id: string,
@@ -86,6 +129,11 @@ export class <%= classNames.controller %> {
     return entity;
   }
 
+  @ApiOperation({ summary: 'Delete <%= entityName %>', operationId: 'delete<%= classNames.entity %>' })
+  @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+  @ApiParam({ name: 'id', type: 'string', format: 'uuid' })
   @Delete(':id')
   async remove(
     @Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/application/schemas/contact.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/contact.dto.ts
@@ -30,3 +30,23 @@ export const updateContactSchema = z.object({
 });
 
 export type UpdateContactDto = z.infer<typeof updateContactSchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../ContactResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const contactResponseSchema = z.object({
+	id: z.string().uuid(),
+	userId: z.string().uuid(),
+	accountId: z.string().uuid().nullable(),
+	firstName: z.string().max(100),
+	lastName: z.string().max(100),
+	email: z.string().max(255),
+	title: z.string().max(200).nullable(),
+	phone: z.string().max(50).nullable(),
+	linkedinUrl: z.string().max(500).nullable(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+	deletedAt: z.coerce.date().nullable(),
+});
+
+export type ContactResponseDto = z.infer<typeof contactResponseSchema>;

--- a/test/baseline/packages/api/src/application/schemas/deal-state.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/deal-state.dto.ts
@@ -28,3 +28,19 @@ export const updateDealStateSchema = z.object({
 });
 
 export type UpdateDealStateDto = z.infer<typeof updateDealStateSchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../DealStateResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const dealStateResponseSchema = z.object({
+	id: z.string().uuid(),
+	tenantId: z.string().uuid().nullable(),
+	name: z.string().max(50),
+	displayName: z.string().max(100),
+	stateType: z.enum(['open', 'won', 'lost', 'stalled']),
+	sortOrder: z.number().int(),
+	probabilityDefault: z.number().int().min(0).max(100).nullable(),
+	color: z.string().max(20).nullable(),
+});
+
+export type DealStateResponseDto = z.infer<typeof dealStateResponseSchema>;

--- a/test/baseline/packages/api/src/application/schemas/deal.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/deal.dto.ts
@@ -28,3 +28,22 @@ export const updateDealSchema = z.object({
 });
 
 export type UpdateDealDto = z.infer<typeof updateDealSchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../DealResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const dealResponseSchema = z.object({
+	id: z.string().uuid(),
+	name: z.string().max(255),
+	amount: z.coerce.string().nullable(),
+	stage: z.enum(['prospecting', 'qualification', 'proposal', 'negotiation', 'closed_won', 'closed_lost']),
+	ownerId: z.string().uuid(),
+	accountId: z.string().uuid(),
+	closeDate: z.coerce.date().nullable(),
+	probability: z.number().int().nullable(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+	deletedAt: z.coerce.date().nullable(),
+});
+
+export type DealResponseDto = z.infer<typeof dealResponseSchema>;

--- a/test/baseline/packages/api/src/application/schemas/opportunity.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/opportunity.dto.ts
@@ -32,3 +32,21 @@ export const updateOpportunitySchema = z.object({
 });
 
 export type UpdateOpportunityDto = z.infer<typeof updateOpportunitySchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../OpportunityResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const opportunityResponseSchema = z.object({
+	id: z.string().uuid(),
+	tenantId: z.string().uuid(),
+	name: z.string().max(255),
+	organizationId: z.string().uuid(),
+	ownerId: z.string().uuid(),
+	stateId: z.string().uuid(),
+	amount: z.coerce.string().nullable(),
+	currency: z.string().max(3).nullable(),
+	expectedCloseDate: z.coerce.date().nullable(),
+	closedAt: z.coerce.date().nullable(),
+});
+
+export type OpportunityResponseDto = z.infer<typeof opportunityResponseSchema>;

--- a/test/baseline/packages/api/src/application/schemas/organization.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/organization.dto.ts
@@ -22,3 +22,16 @@ export const updateOrganizationSchema = z.object({
 });
 
 export type UpdateOrganizationDto = z.infer<typeof updateOrganizationSchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../OrganizationResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const organizationResponseSchema = z.object({
+	id: z.string().uuid(),
+	tenantId: z.string().uuid(),
+	name: z.string().max(255),
+	domain: z.string().max(255).nullable(),
+	parentId: z.string().uuid().nullable(),
+});
+
+export type OrganizationResponseDto = z.infer<typeof organizationResponseSchema>;

--- a/test/baseline/packages/api/src/application/schemas/person.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/person.dto.ts
@@ -22,3 +22,16 @@ export const updatePersonSchema = z.object({
 });
 
 export type UpdatePersonDto = z.infer<typeof updatePersonSchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../PersonResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const personResponseSchema = z.object({
+	id: z.string().uuid(),
+	tenantId: z.string().uuid(),
+	email: z.string().max(255),
+	firstName: z.string().max(100),
+	lastName: z.string().max(100),
+});
+
+export type PersonResponseDto = z.infer<typeof personResponseSchema>;

--- a/test/baseline/packages/api/src/application/schemas/user.dto.ts
+++ b/test/baseline/packages/api/src/application/schemas/user.dto.ts
@@ -20,3 +20,15 @@ export const updateUserSchema = z.object({
 });
 
 export type UpdateUserDto = z.infer<typeof updateUserSchema>;
+
+// OPENAPI-3: response schema — mirrors the select shape of this entity so
+// controller `@ApiResponse({ schema: { $ref: '.../UserResponseDto' } })`
+// decorators resolve to a fully-typed document on /docs-json.
+export const userResponseSchema = z.object({
+	id: z.string().uuid(),
+	tenantId: z.string().uuid(),
+	email: z.string().max(255),
+	personId: z.string().uuid().nullable(),
+});
+
+export type UserResponseDto = z.infer<typeof userResponseSchema>;

--- a/test/baseline/packages/api/src/modules/contacts.module.ts
+++ b/test/baseline/packages/api/src/modules/contacts.module.ts
@@ -19,7 +19,7 @@ import { DatabaseModule } from '../infrastructure/database/database.module';
 import { ContactRepository } from '../infrastructure/persistence/repositories/contact.repository';
 import { declarativeQueryClasses } from '../application/queries/contact/declarative-queries';
 import { ContactsController } from '../presentation/rest/contacts.controller';
-import { createContactSchema, updateContactSchema } from '../application/schemas/contact.dto';
+import { createContactSchema, updateContactSchema, contactResponseSchema } from '../application/schemas/contact.dto';
 
 @Module({
 	imports: [DatabaseModule],
@@ -57,5 +57,6 @@ export class ContactsModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreateContactDto', createContactSchema);
 		this.openApi.registerSchema('UpdateContactDto', updateContactSchema);
+		this.openApi.registerSchema('ContactResponseDto', contactResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/modules/deal-states.module.ts
+++ b/test/baseline/packages/api/src/modules/deal-states.module.ts
@@ -14,7 +14,7 @@ import { UpdateDealStateCommand } from '../application/commands/deal_state/updat
 import { DatabaseModule } from '../infrastructure/database/database.module';
 import { DealStateRepository } from '../infrastructure/persistence/repositories/deal-state.repository';
 import { DealStatesController } from '../presentation/rest/deal-states.controller';
-import { createDealStateSchema, updateDealStateSchema } from '../application/schemas/deal-state.dto';
+import { createDealStateSchema, updateDealStateSchema, dealStateResponseSchema } from '../application/schemas/deal-state.dto';
 
 @Module({
 	imports: [DatabaseModule],
@@ -49,5 +49,6 @@ export class DealStatesModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreateDealStateDto', createDealStateSchema);
 		this.openApi.registerSchema('UpdateDealStateDto', updateDealStateSchema);
+		this.openApi.registerSchema('DealStateResponseDto', dealStateResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/modules/deals.module.ts
+++ b/test/baseline/packages/api/src/modules/deals.module.ts
@@ -15,7 +15,7 @@ import { DatabaseModule } from '../infrastructure/database/database.module';
 import { DealRepository } from '../infrastructure/persistence/repositories/deal.repository';
 import { declarativeQueryClasses } from '../application/queries/deal/declarative-queries';
 import { DealsController } from '../presentation/rest/deals.controller';
-import { createDealSchema, updateDealSchema } from '../application/schemas/deal.dto';
+import { createDealSchema, updateDealSchema, dealResponseSchema } from '../application/schemas/deal.dto';
 
 @Module({
 	imports: [DatabaseModule],
@@ -53,5 +53,6 @@ export class DealsModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreateDealDto', createDealSchema);
 		this.openApi.registerSchema('UpdateDealDto', updateDealSchema);
+		this.openApi.registerSchema('DealResponseDto', dealResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/modules/opportunities.module.ts
+++ b/test/baseline/packages/api/src/modules/opportunities.module.ts
@@ -14,7 +14,7 @@ import { UpdateOpportunityCommand } from '../application/commands/opportunity/up
 import { DatabaseModule } from '../infrastructure/database/database.module';
 import { OpportunityRepository } from '../infrastructure/persistence/repositories/opportunity.repository';
 import { OpportunitiesController } from '../presentation/rest/opportunities.controller';
-import { createOpportunitySchema, updateOpportunitySchema } from '../application/schemas/opportunity.dto';
+import { createOpportunitySchema, updateOpportunitySchema, opportunityResponseSchema } from '../application/schemas/opportunity.dto';
 
 @Module({
 	imports: [DatabaseModule],
@@ -49,5 +49,6 @@ export class OpportunitiesModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreateOpportunityDto', createOpportunitySchema);
 		this.openApi.registerSchema('UpdateOpportunityDto', updateOpportunitySchema);
+		this.openApi.registerSchema('OpportunityResponseDto', opportunityResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/modules/organizations.module.ts
+++ b/test/baseline/packages/api/src/modules/organizations.module.ts
@@ -14,7 +14,7 @@ import { DatabaseModule } from '../infrastructure/database/database.module';
 import { ElectricModule } from '../infrastructure/electric/electric.module';
 import { OrganizationRepository } from '../infrastructure/persistence/repositories/organization.repository';
 import { OrganizationsController } from '../presentation/rest/organizations.controller';
-import { createOrganizationSchema, updateOrganizationSchema } from '../application/schemas/organization.dto';
+import { createOrganizationSchema, updateOrganizationSchema, organizationResponseSchema } from '../application/schemas/organization.dto';
 
 @Module({
 	imports: [DatabaseModule, ElectricModule],
@@ -47,5 +47,6 @@ export class OrganizationsModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreateOrganizationDto', createOrganizationSchema);
 		this.openApi.registerSchema('UpdateOrganizationDto', updateOrganizationSchema);
+		this.openApi.registerSchema('OrganizationResponseDto', organizationResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/modules/persons.module.ts
+++ b/test/baseline/packages/api/src/modules/persons.module.ts
@@ -14,7 +14,7 @@ import { UpdatePersonCommand } from '../application/commands/person/update.comma
 import { DatabaseModule } from '../infrastructure/database/database.module';
 import { PersonRepository } from '../infrastructure/persistence/repositories/person.repository';
 import { PersonsController } from '../presentation/rest/persons.controller';
-import { createPersonSchema, updatePersonSchema } from '../application/schemas/person.dto';
+import { createPersonSchema, updatePersonSchema, personResponseSchema } from '../application/schemas/person.dto';
 
 @Module({
 	imports: [DatabaseModule],
@@ -49,5 +49,6 @@ export class PersonsModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreatePersonDto', createPersonSchema);
 		this.openApi.registerSchema('UpdatePersonDto', updatePersonSchema);
+		this.openApi.registerSchema('PersonResponseDto', personResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/modules/users.module.ts
+++ b/test/baseline/packages/api/src/modules/users.module.ts
@@ -14,7 +14,7 @@ import { UpdateUserCommand } from '../application/commands/user/update.command';
 import { DatabaseModule } from '../infrastructure/database/database.module';
 import { UserRepository } from '../infrastructure/persistence/repositories/user.repository';
 import { UsersController } from '../presentation/rest/users.controller';
-import { createUserSchema, updateUserSchema } from '../application/schemas/user.dto';
+import { createUserSchema, updateUserSchema, userResponseSchema } from '../application/schemas/user.dto';
 
 @Module({
 	imports: [DatabaseModule],
@@ -49,5 +49,6 @@ export class UsersModule implements OnModuleInit {
 	onModuleInit(): void {
 		this.openApi.registerSchema('CreateUserDto', createUserSchema);
 		this.openApi.registerSchema('UpdateUserDto', updateUserSchema);
+		this.openApi.registerSchema('UserResponseDto', userResponseSchema);
 	}
 }

--- a/test/baseline/packages/api/src/presentation/rest/contacts.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/contacts.controller.ts
@@ -16,6 +16,13 @@ import {
 	Query,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { GetContactByIdQuery } from '../../application/queries/contact/get-by-id.query';
 import { ListContactsQuery } from '../../application/queries/contact/list.query';
 import {
@@ -31,6 +38,13 @@ import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { Contact } from '../../domain';
 import type { ContactWith } from '../../domain';
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('contacts')
 export class ContactsController {
 	constructor(
@@ -41,11 +55,22 @@ export class ContactsController {
 		private readonly deleteContactCommand: DeleteContactCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List contacts', operationId: 'listContacts' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/ContactResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(@Query('include') include?: string): Promise<Contact[]> {
 		return this.listContactsQuery.execute(this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Find contact by id', operationId: 'findContactById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/ContactResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -54,6 +79,11 @@ export class ContactsController {
 		return this.getContactByIdQuery.execute(id, this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Create contact', operationId: 'createContact' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreateContactDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/ContactResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createContactSchema))
 	async create(
@@ -64,6 +94,13 @@ export class ContactsController {
 		return this.createContactCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update contact', operationId: 'updateContact' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdateContactDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/ContactResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -74,6 +111,11 @@ export class ContactsController {
 		return this.updateContactCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete contact', operationId: 'deleteContact' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/presentation/rest/deal_states.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/deal_states.controller.ts
@@ -16,6 +16,13 @@ import {
 	Query,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { GetDealStateByIdQuery } from '../../application/queries/deal_state/get-by-id.query';
 import { ListDealStatesQuery } from '../../application/queries/deal_state/list.query';
 import {
@@ -31,6 +38,13 @@ import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { DealState } from '../../domain';
 import type { DealStateWith } from '../../domain';
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('deal_states')
 export class DealStatesController {
 	constructor(
@@ -41,11 +55,22 @@ export class DealStatesController {
 		private readonly deleteDealStateCommand: DeleteDealStateCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List deal_states', operationId: 'listDealStates' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/DealStateResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(@Query('include') include?: string): Promise<DealState[]> {
 		return this.listDealStatesQuery.execute(this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Find deal_state by id', operationId: 'findDealStateById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/DealStateResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -54,6 +79,11 @@ export class DealStatesController {
 		return this.getDealStateByIdQuery.execute(id, this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Create deal_state', operationId: 'createDealState' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreateDealStateDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/DealStateResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createDealStateSchema))
 	async create(
@@ -64,6 +94,13 @@ export class DealStatesController {
 		return this.createDealStateCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update deal_state', operationId: 'updateDealState' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdateDealStateDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/DealStateResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -74,6 +111,11 @@ export class DealStatesController {
 		return this.updateDealStateCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete deal_state', operationId: 'deleteDealState' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/presentation/rest/deals.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/deals.controller.ts
@@ -16,6 +16,13 @@ import {
 	Query,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { GetDealByIdQuery } from '../../application/queries/deal/get-by-id.query';
 import { ListDealsQuery } from '../../application/queries/deal/list.query';
 import {
@@ -31,6 +38,13 @@ import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { Deal } from '../../domain';
 import type { DealWith } from '../../domain';
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('deals')
 export class DealsController {
 	constructor(
@@ -41,11 +55,22 @@ export class DealsController {
 		private readonly deleteDealCommand: DeleteDealCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List deals', operationId: 'listDeals' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/DealResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(@Query('include') include?: string): Promise<Deal[]> {
 		return this.listDealsQuery.execute(this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Find deal by id', operationId: 'findDealById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/DealResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -54,6 +79,11 @@ export class DealsController {
 		return this.getDealByIdQuery.execute(id, this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Create deal', operationId: 'createDeal' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreateDealDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/DealResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createDealSchema))
 	async create(
@@ -64,6 +94,13 @@ export class DealsController {
 		return this.createDealCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update deal', operationId: 'updateDeal' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdateDealDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/DealResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -74,6 +111,11 @@ export class DealsController {
 		return this.updateDealCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete deal', operationId: 'deleteDeal' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/presentation/rest/opportunities.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/opportunities.controller.ts
@@ -16,6 +16,13 @@ import {
 	Query,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { GetOpportunityByIdQuery } from '../../application/queries/opportunity/get-by-id.query';
 import { ListOpportunitiesQuery } from '../../application/queries/opportunity/list.query';
 import {
@@ -31,6 +38,13 @@ import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { Opportunity } from '../../domain';
 import type { OpportunityWith } from '../../domain';
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('opportunities')
 export class OpportunitiesController {
 	constructor(
@@ -41,11 +55,22 @@ export class OpportunitiesController {
 		private readonly deleteOpportunityCommand: DeleteOpportunityCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List opportunities', operationId: 'listOpportunities' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/OpportunityResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(@Query('include') include?: string): Promise<Opportunity[]> {
 		return this.listOpportunitiesQuery.execute(this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Find opportunity by id', operationId: 'findOpportunityById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/OpportunityResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -54,6 +79,11 @@ export class OpportunitiesController {
 		return this.getOpportunityByIdQuery.execute(id, this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Create opportunity', operationId: 'createOpportunity' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreateOpportunityDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/OpportunityResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createOpportunitySchema))
 	async create(
@@ -64,6 +94,13 @@ export class OpportunitiesController {
 		return this.createOpportunityCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update opportunity', operationId: 'updateOpportunity' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdateOpportunityDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/OpportunityResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -74,6 +111,11 @@ export class OpportunitiesController {
 		return this.updateOpportunityCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete opportunity', operationId: 'deleteOpportunity' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/presentation/rest/organizations.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/organizations.controller.ts
@@ -18,6 +18,13 @@ import {
 	UseGuards,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { AuthGuard } from '../../core/guards/auth.guard';
 import { CurrentUser } from '../../core/decorators/current-user.decorator';
@@ -37,6 +44,7 @@ import { GetOrganizationByIdQuery } from '../../application/queries/organization
 import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { Organization } from '../../domain';
 
+@ApiBearerAuth()
 @Controller('organizations')
 @UseGuards(AuthGuard)
 export class OrganizationsController {
@@ -48,6 +56,8 @@ export class OrganizationsController {
 		private readonly deleteOrganizationCommand: DeleteOrganizationCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List organizations (Electric SQL proxy)', operationId: 'listOrganizations' })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(
 		@CurrentUser() user: User,
@@ -63,11 +73,21 @@ export class OrganizationsController {
 		});
 	}
 
+	@ApiOperation({ summary: 'Find organization by id', operationId: 'findOrganizationById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/OrganizationResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(@Param('id', ParseUUIDPipe) id: string): Promise<Organization> {
 		return this.getOrganizationByIdQuery.execute(id);
 	}
 
+	@ApiOperation({ summary: 'Create organization', operationId: 'createOrganization' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreateOrganizationDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/OrganizationResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createOrganizationSchema))
 	async create(
@@ -78,6 +98,13 @@ export class OrganizationsController {
 		return this.createOrganizationCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update organization', operationId: 'updateOrganization' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdateOrganizationDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/OrganizationResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -88,6 +115,11 @@ export class OrganizationsController {
 		return this.updateOrganizationCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete organization', operationId: 'deleteOrganization' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/presentation/rest/persons.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/persons.controller.ts
@@ -15,6 +15,13 @@ import {
 	Put,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { GetPersonByIdQuery } from '../../application/queries/person/get-by-id.query';
 import { ListPersonsQuery } from '../../application/queries/person/list.query';
 import {
@@ -29,6 +36,13 @@ import { UpdatePersonCommand } from '../../application/commands/person/update.co
 import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { Person } from '../../domain';
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('persons')
 export class PersonsController {
 	constructor(
@@ -39,11 +53,22 @@ export class PersonsController {
 		private readonly deletePersonCommand: DeletePersonCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List persons', operationId: 'listPersons' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/PersonResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(): Promise<Person[]> {
 		return this.listPersonsQuery.execute();
 	}
 
+	@ApiOperation({ summary: 'Find person by id', operationId: 'findPersonById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/PersonResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -51,6 +76,11 @@ export class PersonsController {
 		return this.getPersonByIdQuery.execute(id);
 	}
 
+	@ApiOperation({ summary: 'Create person', operationId: 'createPerson' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreatePersonDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/PersonResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createPersonSchema))
 	async create(
@@ -61,6 +91,13 @@ export class PersonsController {
 		return this.createPersonCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update person', operationId: 'updatePerson' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdatePersonDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/PersonResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -71,6 +108,11 @@ export class PersonsController {
 		return this.updatePersonCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete person', operationId: 'deletePerson' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/baseline/packages/api/src/presentation/rest/users.controller.ts
+++ b/test/baseline/packages/api/src/presentation/rest/users.controller.ts
@@ -16,6 +16,13 @@ import {
 	Query,
 	UsePipes,
 } from '@nestjs/common';
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+} from '@nestjs/swagger';
 import { GetUserByIdQuery } from '../../application/queries/user/get-by-id.query';
 import { ListUsersQuery } from '../../application/queries/user/list.query';
 import {
@@ -31,6 +38,13 @@ import { ZodValidationPipe } from '../../core/pipes/zod-validation.pipe';
 import { User } from '../../domain';
 import type { UserWith } from '../../domain';
 
+// OPENAPI-3: controller decorators reference schemas by `$ref` rather
+// than `type:` class references because generated DTOs are Zod-derived
+// types (not NestJS classes). Schemas are registered by name in the
+// `OpenApiRegistry` at onModuleInit (OPENAPI-2); these `$ref` URIs point
+// at those registered entries. `ErrorResponseDto` is auto-registered by
+// the shared registry.
+@ApiBearerAuth()
 @Controller('users')
 export class UsersController {
 	constructor(
@@ -41,11 +55,22 @@ export class UsersController {
 		private readonly deleteUserCommand: DeleteUserCommand,
 	) {}
 
+	@ApiOperation({ summary: 'List users', operationId: 'listUsers' })
+	@ApiResponse({
+		status: 200,
+		schema: { type: 'array', items: { $ref: '#/components/schemas/UserResponseDto' } },
+	})
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Get()
 	async findAll(@Query('include') include?: string): Promise<User[]> {
 		return this.listUsersQuery.execute(this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Find user by id', operationId: 'findUserById' })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/UserResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Get(':id')
 	async findById(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -54,6 +79,11 @@ export class UsersController {
 		return this.getUserByIdQuery.execute(id, this.parseInclude(include));
 	}
 
+	@ApiOperation({ summary: 'Create user', operationId: 'createUser' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/CreateUserDto' } })
+	@ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/UserResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
 	@Post()
 	@UsePipes(new ZodValidationPipe(createUserSchema))
 	async create(
@@ -64,6 +94,13 @@ export class UsersController {
 		return this.createUserCommand.execute(dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Update user', operationId: 'updateUser' })
+	@ApiBody({ schema: { $ref: '#/components/schemas/UpdateUserDto' } })
+	@ApiResponse({ status: 200, schema: { $ref: '#/components/schemas/UserResponseDto' } })
+	@ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Put(':id')
 	async update(
 		@Param('id', ParseUUIDPipe) id: string,
@@ -74,6 +111,11 @@ export class UsersController {
 		return this.updateUserCommand.execute(id, dto, { actor: { tenantId, userId } });
 	}
 
+	@ApiOperation({ summary: 'Delete user', operationId: 'deleteUser' })
+	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiResponse({ status: 404, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
+	@ApiParam({ name: 'id', type: 'string', format: 'uuid' })
 	@Delete(':id')
 	async delete(
 		@Param('id', ParseUUIDPipe) id: string,

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -40,6 +40,7 @@ const KEEP = process.env.KEEP_SMOKE_DIR === '1';
 const RUNTIME_DEPS = [
 	'@nestjs/common@10',
 	'@nestjs/core@10',
+	'@nestjs/swagger@7',
 	'drizzle-orm@0.45',
 	'reflect-metadata@0.2',
 	'pg@8',


### PR DESCRIPTION
## Summary
Every generated controller method now ships `@ApiOperation` / `@ApiBody` / `@ApiResponse` / `@ApiParam` / `@ApiBearerAuth` decorators. Backend pipeline gains a `<Entity>ResponseDto` (gate decision — "do it right") and a shared `ErrorResponseDto` lands in the runtime.

## Diff envelope
33 files, **+680/-17** — within the predicted ~30–60 LOC per controller × 7 baseline entities + new ResponseDto block + template infra. No whitespace/import churn.

## Key deviations (full notes in `docs/specs/OPENAPI-3.md` §Implementation notes)
1. **`schema: { $ref: ... }`** not `type: <Class>`. Generated DTOs are Zod-derived type aliases (no runtime class to reference). Aligns with OPENAPI-2 name-based registration; no class-shell duplication.
2. **`ErrorResponseDto` auto-registered on registry construction** (single source of truth, not per-entity). Re-seeded on `reset()`. Vendored via `VENDORED_RUNTIME_FILES`.
3. **Backend uses `PUT`** for updates (not `PATCH`) — matches the existing routing template; CLP uses `PATCH`. Decorators conform to actual emitted verb.
4. **Backend ResponseDto added inline to existing `dto.ejs.t`** (single-file pattern), not a new template file.
5. **`@nestjs/swagger` is an optional peer** (`^7.0.0 || ^8.0.0`) — unconditional static import in controllers (unlike `@anatine/zod-openapi` lazy-import); consumers opting into OpenAPI install it.
6. **Class-level `@ApiBearerAuth()`** unconditional; method-level overrides are a future overlay.
7. **Bare camelCase `operationId`s** (no module prefix); bounded-context naming deferred.

## Spot-check
**Simple entity (no declarative queries):**
```ts
@ApiBearerAuth()
@Controller('organizations')
export class OrganizationsController {
  @ApiOperation({ summary: 'Create organization', operationId: 'createOrganization' })
  @ApiBody({ schema: { $ref: '#/components/schemas/CreateOrganizationDto' } })
  @ApiResponse({ status: 201, schema: { $ref: '#/components/schemas/OrganizationResponseDto' } })
  @ApiResponse({ status: 400, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
  @ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
  @Post()
  ...
```

**With include query:**
```ts
@ApiOperation({ summary: 'List deals', operationId: 'listDeals' })
@ApiResponse({ status: 200, schema: { type: 'array', items: { $ref: '#/components/schemas/DealResponseDto' } } })
@ApiResponse({ status: 401, schema: { $ref: '#/components/schemas/ErrorResponseDto' } })
@Get()
async findAll(@Query('include') include?: string): Promise<Deal[]> { ... }
```

## Testing
- `just test-unit`: 1392/1392 pass.
- `just test-baseline`: green (regenerated 21 baseline files).
- `just test-smoke`: pass (`tsc --noEmit --skipLibCheck` clean on fresh-generated project).
- `bun run typecheck`: clean. `bun run build`: clean.

## Known gap (carried to OPENAPI-4)
Smoke test runs `tsc --noEmit` only — does not boot Nest, so it can't curl `/docs-json` and assert `$ref`s resolve. OPENAPI-4 wires `AppModule` + `SwaggerModule.setup` and is the natural place to add a boot+curl smoke step.

Closes #181. Part of epic #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>