### PR TITLE
v0.4.1: codegen project upgrade-openapi — AST patcher for existing consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-04-21
+
+### Added
+- **`codegen project upgrade-openapi`** — surgical AST-based codemod that brings an existing consumer `src/app.module.ts` + `src/main.ts` up to the OPENAPI-4 shape `project init` emits on a fresh project. Merges `@nestjs/common` imports, adds `OpenApiModule` (the `@Global()` wrapper around `OPENAPI_REGISTRY`), wires it into `AppModule.imports`, injects the two-pass Swagger bootstrap into `main.ts`, and vendors `src/shared/openapi/*`. Idempotent; `--dry-run` and `--path` supported. Proof-of-concept for issue #188 (additive subsystem install, targeted for 0.5.0).
+- **`src/cli/shared/ast-patch.ts`** — ts-morph patching primitives (`ensureImport`, `ensureClassDeclaration`, `ensureModuleImportEntry`, `ensureMainSwaggerBlock`). Each is idempotent and bails cleanly on exotic shapes (factory-based modules, non-array `imports`, missing `@Module()` decorator).
+
+### Changed
+- **`project init` skip reasons** — when `app.module.ts` or `main.ts` exist, the skip message now points at `codegen project upgrade-openapi` as the automated path (previously instructed manual wiring only).
+
+### Dependencies
+- Added `ts-morph` (runtime dep; CLI-side) for AST manipulation.
+
+
+
 ### Added
 - **Noun-verb CLI** — Clipanion-based CLI replacing the legacy single-file handler. Commands: `entity`, `subsystem`, `project`, `dev`. Each noun has a summary pane with dynamic hints. (ADR-015)
 - **UI toolkit** — chalk theme tokens, icons with ASCII fallback, Ora spinners, pane/hints rendering, `--json` mode across all commands. (ADR-016)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",
@@ -66,6 +66,7 @@
     "glob": "^13.0.6",
     "ora": "^9.3.0",
     "pluralize": "^8.0.0",
+    "ts-morph": "^28.0.0",
     "yaml": "^2.8.3",
     "zod": "^3.22.4"
   },

--- a/src/__tests__/cli/ast-patch.test.ts
+++ b/src/__tests__/cli/ast-patch.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for ast-patch primitives.
+ *
+ * Coverage:
+ *   - Idempotency: applying a patch twice yields byte-identical output.
+ *   - Preservation: existing imports, decorators, JSDoc, unrelated providers
+ *     survive.
+ *   - Bail semantics: exotic shapes (missing @Module, factory decorators,
+ *     non-array `imports`) return `{ changed: false, bail: ... }` and leave
+ *     the file untouched.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { Project, IndentationText, QuoteKind, NewLineKind } from 'ts-morph';
+
+import {
+	ensureImport,
+	ensureClassDeclaration,
+	ensureModuleImportEntry,
+	ensureMainSwaggerBlock,
+} from '../../cli/shared/ast-patch.js';
+
+function mkProject() {
+	return new Project({
+		useInMemoryFileSystem: true,
+		manipulationSettings: {
+			indentationText: IndentationText.TwoSpaces,
+			quoteKind: QuoteKind.Single,
+			newLineKind: NewLineKind.LineFeed,
+		},
+		skipAddingFilesFromTsConfig: true,
+		skipLoadingLibFiles: true,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// ensureImport
+// ---------------------------------------------------------------------------
+
+describe('ensureImport', () => {
+	test('adds a fresh import when module is absent', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile('src/app.module.ts', `export const x = 1;\n`);
+		const res = ensureImport(sf, '@nestjs/common', ['Module', 'Global']);
+		expect(res.changed).toBe(true);
+		const text = sf.getFullText();
+		expect(text).toContain("import { Global, Module } from '@nestjs/common'");
+	});
+
+	test('merges named bindings into an existing import', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\nexport const x = 1;\n`
+		);
+		const res = ensureImport(sf, '@nestjs/common', ['Global', 'Module']);
+		expect(res.changed).toBe(true);
+		const text = sf.getFullText();
+		expect(text).toMatch(/import \{ Module, Global \} from '@nestjs\/common'/);
+	});
+
+	test('is idempotent — applying twice gives identical text', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/a.ts',
+			`import { Module } from '@nestjs/common';\n`
+		);
+		ensureImport(sf, '@nestjs/common', ['Global', 'Module']);
+		const once = sf.getFullText();
+		const res2 = ensureImport(sf, '@nestjs/common', ['Global', 'Module']);
+		expect(res2.changed).toBe(false);
+		expect(sf.getFullText()).toBe(once);
+	});
+
+	test('no-op when import already fully satisfied', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/a.ts',
+			`import { Global, Module } from '@nestjs/common';\n`
+		);
+		const before = sf.getFullText();
+		const res = ensureImport(sf, '@nestjs/common', ['Module']);
+		expect(res.changed).toBe(false);
+		expect(sf.getFullText()).toBe(before);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ensureClassDeclaration
+// ---------------------------------------------------------------------------
+
+describe('ensureClassDeclaration', () => {
+	const SNIPPET = `@Module({ providers: [] })\nclass OpenApiModule {}`;
+
+	test('inserts class before anchor class if missing', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\n\n@Module({ imports: [] })\nexport class AppModule {}\n`
+		);
+		const res = ensureClassDeclaration(sf, 'OpenApiModule', SNIPPET, {
+			insertBeforeClass: 'AppModule',
+		});
+		expect(res.changed).toBe(true);
+		const text = sf.getFullText();
+		expect(text.indexOf('OpenApiModule')).toBeLessThan(text.indexOf('AppModule'));
+	});
+
+	test('is idempotent when class is already present', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`${SNIPPET}\n\nexport class AppModule {}\n`
+		);
+		const before = sf.getFullText();
+		const res = ensureClassDeclaration(sf, 'OpenApiModule', SNIPPET, {
+			insertBeforeClass: 'AppModule',
+		});
+		expect(res.changed).toBe(false);
+		expect(sf.getFullText()).toBe(before);
+	});
+
+	test('preserves existing JSDoc/decorators on anchor class', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\n\n/**\n * Docs here.\n */\n@Module({ imports: [] })\nexport class AppModule {}\n`
+		);
+		ensureClassDeclaration(sf, 'OpenApiModule', SNIPPET, {
+			insertBeforeClass: 'AppModule',
+		});
+		const text = sf.getFullText();
+		expect(text).toContain('Docs here.');
+		expect(text).toContain('@Module({ imports: [] })\nexport class AppModule');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ensureModuleImportEntry
+// ---------------------------------------------------------------------------
+
+describe('ensureModuleImportEntry', () => {
+	test('appends to existing imports array', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\n@Module({ imports: [DatabaseModule] })\nexport class AppModule {}\n`
+		);
+		const cls = sf.getClassOrThrow('AppModule');
+		const res = ensureModuleImportEntry(cls, 'OpenApiModule');
+		expect(res.changed).toBe(true);
+		expect(sf.getFullText()).toContain('[DatabaseModule, OpenApiModule]');
+	});
+
+	test('inserts before spread element (named-before-spread convention)', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\n@Module({ imports: [DatabaseModule, ...GENERATED_MODULES] })\nexport class AppModule {}\n`
+		);
+		const cls = sf.getClassOrThrow('AppModule');
+		ensureModuleImportEntry(cls, 'OpenApiModule');
+		const text = sf.getFullText();
+		const openIdx = text.indexOf('OpenApiModule');
+		const spreadIdx = text.indexOf('...GENERATED_MODULES');
+		expect(openIdx).toBeLessThan(spreadIdx);
+	});
+
+	test('creates imports array when missing', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\n@Module({})\nexport class AppModule {}\n`
+		);
+		const cls = sf.getClassOrThrow('AppModule');
+		const res = ensureModuleImportEntry(cls, 'OpenApiModule');
+		expect(res.changed).toBe(true);
+		expect(sf.getFullText()).toContain('imports: [OpenApiModule]');
+	});
+
+	test('is idempotent — already-present module is a no-op', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\n@Module({ imports: [OpenApiModule, DatabaseModule] })\nexport class AppModule {}\n`
+		);
+		const cls = sf.getClassOrThrow('AppModule');
+		const before = sf.getFullText();
+		const res = ensureModuleImportEntry(cls, 'OpenApiModule');
+		expect(res.changed).toBe(false);
+		expect(sf.getFullText()).toBe(before);
+	});
+
+	test('bails on missing @Module decorator', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`export class AppModule {}\n`
+		);
+		const cls = sf.getClassOrThrow('AppModule');
+		const res = ensureModuleImportEntry(cls, 'OpenApiModule');
+		expect(res.changed).toBe(false);
+		expect(res.bail).toBeDefined();
+		expect(res.bail).toContain('no @Module()');
+	});
+
+	test('bails on non-array imports (alias / spread only)', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/app.module.ts',
+			`import { Module } from '@nestjs/common';\nconst ALL = [];\n@Module({ imports: ALL })\nexport class AppModule {}\n`
+		);
+		const cls = sf.getClassOrThrow('AppModule');
+		const res = ensureModuleImportEntry(cls, 'OpenApiModule');
+		expect(res.changed).toBe(false);
+		expect(res.bail).toContain('array literal');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ensureMainSwaggerBlock
+// ---------------------------------------------------------------------------
+
+describe('ensureMainSwaggerBlock', () => {
+	const IMPORTS = ["import { OPENAPI_REGISTRY, OpenApiRegistry } from './shared/openapi';"];
+	const BLOCK = `  /* SWAGGER_BOOTSTRAP */\n`;
+
+	test('skips when SwaggerModule.setup is already present', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/main.ts',
+			`import { NestFactory } from '@nestjs/core';\nimport { SwaggerModule } from '@nestjs/swagger';\nimport { AppModule } from './app.module';\nasync function bootstrap() { const app = await NestFactory.create(AppModule); SwaggerModule.setup('/docs', app, {} as any); await app.listen(3000); }\nbootstrap();\n`
+		);
+		const before = sf.getFullText();
+		const res = ensureMainSwaggerBlock(sf, {
+			swaggerImports: IMPORTS,
+			swaggerBlock: BLOCK,
+		});
+		expect(res.changed).toBe(false);
+		expect(sf.getFullText()).toBe(before);
+	});
+
+	test('inserts block after NestFactory.create when absent', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/main.ts',
+			`import { NestFactory } from '@nestjs/core';\nimport { AppModule } from './app.module';\nasync function bootstrap() {\n  const app = await NestFactory.create(AppModule);\n  await app.listen(3000);\n}\nbootstrap();\n`
+		);
+		const res = ensureMainSwaggerBlock(sf, {
+			swaggerImports: IMPORTS,
+			swaggerBlock: BLOCK,
+		});
+		expect(res.changed).toBe(true);
+		const text = sf.getFullText();
+		expect(text).toContain('SWAGGER_BOOTSTRAP');
+		expect(text).toContain("from './shared/openapi'");
+		const createIdx = text.indexOf('NestFactory.create');
+		const blockIdx = text.indexOf('SWAGGER_BOOTSTRAP');
+		expect(createIdx).toBeLessThan(blockIdx);
+	});
+
+	test('bails on custom bootstrap (no NestFactory.create)', () => {
+		const project = mkProject();
+		const sf = project.createSourceFile(
+			'src/main.ts',
+			`async function bootstrap() { console.log('hi'); }\nbootstrap();\n`
+		);
+		const res = ensureMainSwaggerBlock(sf, {
+			swaggerImports: IMPORTS,
+			swaggerBlock: BLOCK,
+		});
+		expect(res.changed).toBe(false);
+		expect(res.bail).toContain('NestFactory.create');
+	});
+});

--- a/src/__tests__/cli/project-upgrade-openapi.test.ts
+++ b/src/__tests__/cli/project-upgrade-openapi.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Integration tests for `codegen project upgrade-openapi`.
+ *
+ * Runs the `runUpgradeOpenapi` function directly (same entry point the
+ * Clipanion command uses) against tmp fixtures representing pre-0.4.0
+ * consumer projects.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { runUpgradeOpenapi } from '../../cli/commands/project-upgrade-openapi.js';
+
+let tempRoots: string[] = [];
+
+function mkTempDir(prefix: string): string {
+	const d = fs.mkdtempSync(path.join(os.tmpdir(), `upgrade-oapi-${prefix}-`));
+	tempRoots.push(d);
+	return d;
+}
+
+afterEach(() => {
+	for (const r of tempRoots) {
+		try {
+			fs.rmSync(r, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	}
+	tempRoots = [];
+});
+
+function seedPre041(cwd: string): void {
+	fs.mkdirSync(path.join(cwd, 'src'), { recursive: true });
+	fs.writeFileSync(
+		path.join(cwd, 'src', 'app.module.ts'),
+		`import { Module } from '@nestjs/common';
+import { DatabaseModule } from './shared/database/database.module';
+import { GENERATED_MODULES } from './generated/modules';
+
+/**
+ * AppModule — pre-0.4.0 shape (no OpenApiModule).
+ */
+@Module({
+  imports: [DatabaseModule, ...GENERATED_MODULES],
+})
+export class AppModule {}
+`
+	);
+	fs.writeFileSync(
+		path.join(cwd, 'src', 'main.ts'),
+		`import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();
+`
+	);
+	fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"consumer-pre-041"}');
+}
+
+describe('runUpgradeOpenapi', () => {
+	test('patches a pre-0.4.0 app.module.ts + main.ts', async () => {
+		const cwd = mkTempDir('happy');
+		seedPre041(cwd);
+
+		const report = await runUpgradeOpenapi({ projectRoot: cwd, dryRun: false, force: false });
+		expect(report.bail).toBeUndefined();
+
+		const appText = fs.readFileSync(path.join(cwd, 'src', 'app.module.ts'), 'utf-8');
+		expect(appText).toContain("import { Module, Global } from '@nestjs/common'");
+		expect(appText).toContain("from './shared/openapi'");
+		expect(appText).toContain('class OpenApiModule {}');
+		// OpenApiModule must appear BEFORE the spread (convention).
+		const openIdx = appText.indexOf('OpenApiModule, ...GENERATED_MODULES');
+		expect(openIdx).toBeGreaterThan(-1);
+
+		const mainText = fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8');
+		expect(mainText).toMatch(/SwaggerModule\.setup/);
+		expect(mainText).toContain("from './shared/openapi'");
+
+		// Vendored files created
+		expect(fs.existsSync(path.join(cwd, 'src', 'shared', 'openapi', 'registry.ts'))).toBe(true);
+		expect(fs.existsSync(path.join(cwd, 'src', 'shared', 'openapi', 'index.ts'))).toBe(true);
+
+		// Summary reports at least one created + one updated change.
+		const updated = report.changes.filter((c) => c.action === 'updated');
+		const created = report.changes.filter((c) => c.action === 'created');
+		expect(updated.some((c) => c.path === 'src/app.module.ts')).toBe(true);
+		expect(updated.some((c) => c.path === 'src/main.ts')).toBe(true);
+		expect(created.length).toBeGreaterThan(0);
+	});
+
+	test('is idempotent — running twice leaves files byte-identical', async () => {
+		const cwd = mkTempDir('idempotent');
+		seedPre041(cwd);
+
+		await runUpgradeOpenapi({ projectRoot: cwd, dryRun: false, force: false });
+		const afterFirst = {
+			app: fs.readFileSync(path.join(cwd, 'src', 'app.module.ts'), 'utf-8'),
+			main: fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8'),
+		};
+
+		const report2 = await runUpgradeOpenapi({
+			projectRoot: cwd,
+			dryRun: false,
+			force: false,
+		});
+		expect(report2.bail).toBeUndefined();
+
+		const afterSecond = {
+			app: fs.readFileSync(path.join(cwd, 'src', 'app.module.ts'), 'utf-8'),
+			main: fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8'),
+		};
+		expect(afterSecond.app).toBe(afterFirst.app);
+		expect(afterSecond.main).toBe(afterFirst.main);
+
+		// Every change from the second run must be unchanged / skipped
+		// (nothing should be re-updated).
+		const nonNoop = report2.changes.filter(
+			(c) => c.action !== 'unchanged' && c.action !== 'skipped'
+		);
+		expect(nonNoop.length).toBe(0);
+	});
+
+	test('dry-run writes no files', async () => {
+		const cwd = mkTempDir('dryrun');
+		seedPre041(cwd);
+		const appBefore = fs.readFileSync(path.join(cwd, 'src', 'app.module.ts'), 'utf-8');
+		const mainBefore = fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8');
+
+		const report = await runUpgradeOpenapi({
+			projectRoot: cwd,
+			dryRun: true,
+			force: false,
+		});
+		expect(report.bail).toBeUndefined();
+
+		expect(fs.readFileSync(path.join(cwd, 'src', 'app.module.ts'), 'utf-8')).toBe(appBefore);
+		expect(fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8')).toBe(mainBefore);
+		expect(fs.existsSync(path.join(cwd, 'src', 'shared', 'openapi', 'registry.ts'))).toBe(
+			false
+		);
+		// But the report still lists the planned changes.
+		expect(report.changes.some((c) => c.action === 'updated' || c.action === 'created')).toBe(
+			true
+		);
+	});
+
+	test('bails with clear message when AppModule is missing', async () => {
+		const cwd = mkTempDir('bail');
+		fs.mkdirSync(path.join(cwd, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(cwd, 'package.json'), '{}');
+
+		const report = await runUpgradeOpenapi({
+			projectRoot: cwd,
+			dryRun: false,
+			force: false,
+		});
+		expect(report.bail).toBeDefined();
+		expect(report.bail?.file).toBe('src/app.module.ts');
+	});
+
+	test('bails with snippet when AppModule uses a non-array imports', async () => {
+		const cwd = mkTempDir('bail-exotic');
+		fs.mkdirSync(path.join(cwd, 'src'), { recursive: true });
+		fs.writeFileSync(path.join(cwd, 'package.json'), '{}');
+		fs.writeFileSync(
+			path.join(cwd, 'src', 'app.module.ts'),
+			`import { Module } from '@nestjs/common';
+const ALL_IMPORTS = [];
+@Module({ imports: ALL_IMPORTS })
+export class AppModule {}
+`
+		);
+
+		const report = await runUpgradeOpenapi({
+			projectRoot: cwd,
+			dryRun: false,
+			force: false,
+		});
+		expect(report.bail).toBeDefined();
+		expect(report.bail?.snippet).toContain('OpenApiModule');
+	});
+
+	test('skips main.ts cleanly when SwaggerModule.setup already wired', async () => {
+		const cwd = mkTempDir('main-already');
+		seedPre041(cwd);
+		// Replace main.ts with one that already has Swagger wired.
+		fs.writeFileSync(
+			path.join(cwd, 'src', 'main.ts'),
+			`import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { AppModule } from './app.module';
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  SwaggerModule.setup('/docs', app, SwaggerModule.createDocument(app, new DocumentBuilder().build()));
+  await app.listen(3000);
+}
+bootstrap();
+`
+		);
+		const before = fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8');
+
+		const report = await runUpgradeOpenapi({
+			projectRoot: cwd,
+			dryRun: false,
+			force: false,
+		});
+		expect(report.bail).toBeUndefined();
+
+		expect(fs.readFileSync(path.join(cwd, 'src', 'main.ts'), 'utf-8')).toBe(before);
+		const mainChange = report.changes.find((c) => c.path === 'src/main.ts');
+		expect(mainChange?.action).toBe('unchanged');
+	});
+});

--- a/src/__tests__/cli/project.test.ts
+++ b/src/__tests__/cli/project.test.ts
@@ -44,9 +44,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('project NounModule', () => {
-	test('exports name=project with all five commands', () => {
+	test('exports name=project with all six commands', () => {
 		expect(projectNoun.name).toBe('project');
-		expect(projectNoun.commandClasses.length).toBe(5);
+		expect(projectNoun.commandClasses.length).toBe(6);
 		expect(typeof projectNoun.summary).toBe('function');
 		expect(typeof projectNoun.hints).toBe('function');
 	});

--- a/src/cli/commands/project-upgrade-openapi.ts
+++ b/src/cli/commands/project-upgrade-openapi.ts
@@ -1,0 +1,518 @@
+/**
+ * `codegen project upgrade-openapi` — surgical codemod that brings an existing
+ * consumer's `src/app.module.ts` + `src/main.ts` up to the shape `project
+ * init` emits on a fresh project, covering the OPENAPI-4 gap.
+ *
+ * This is Option A (targeted codemod for the current gap). The generalised
+ * additive-install story is tracked in issue #188 for 0.5.0.
+ *
+ * Behaviour:
+ *   1. Resolve project root (`--path` or cwd, walking up for
+ *      `codegen.config.yaml` / `package.json`).
+ *   2. Vendor the `src/shared/openapi/*` slice of VENDORED_RUNTIME_FILES
+ *      (idempotent; `--force` overwrites).
+ *   3. Patch `src/app.module.ts`:
+ *        - Merge `@nestjs/common` import to include `Global`, `Module`.
+ *        - Add `import { OPENAPI_REGISTRY, OpenApiRegistry } from
+ *          './shared/openapi'`.
+ *        - Insert `@Global() class OpenApiModule {}` above `AppModule` (if
+ *          missing).
+ *        - Add `OpenApiModule` to `AppModule.imports: [...]`.
+ *   4. Patch `src/main.ts` (best-effort):
+ *        - If `SwaggerModule.setup` already present → skip.
+ *        - Else inject the OPENAPI-4 two-pass Swagger block after
+ *          `NestFactory.create(...)`.
+ *   5. Report what changed, exit 0 on success, 1 on bail.
+ *
+ * `--dry-run` prints the diff but writes nothing.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { Command, Option } from 'clipanion';
+import { Project, IndentationText, QuoteKind, NewLineKind } from 'ts-morph';
+
+import { printError, printInfo, printSuccess, printWarning } from '../ui/output.js';
+import { isJsonMode, printJson, setJsonMode } from '../ui/json.js';
+import { theme } from '../ui/theme.js';
+import { icons } from '../ui/icons.js';
+
+import {
+	ensureImport,
+	ensureClassDeclaration,
+	ensureModuleImportEntry,
+	ensureMainSwaggerBlock,
+	type PatchResult,
+} from '../shared/ast-patch.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CONSUMER_SETUP_POINTER =
+	'For manual wiring, see docs/CONSUMER-SETUP.md §OpenAPI or ' +
+	'https://github.com/pattern-stack/codegen-patterns/blob/main/docs/CONSUMER-SETUP.md';
+
+/**
+ * Subset of VENDORED_RUNTIME_FILES relevant to the OpenAPI slice. Kept as a
+ * literal here (rather than imported) so this command is self-contained and
+ * the init-scaffold's private list stays private.
+ */
+const OPENAPI_VENDORED_FILES: Array<{ runtime: string; target: string }> = [
+	{ runtime: 'shared/openapi/registry.ts', target: 'src/shared/openapi/registry.ts' },
+	{
+		runtime: 'shared/openapi/registry.tokens.ts',
+		target: 'src/shared/openapi/registry.tokens.ts',
+	},
+	{ runtime: 'shared/openapi/errors.ts', target: 'src/shared/openapi/errors.ts' },
+	{
+		runtime: 'shared/openapi/error-response.dto.ts',
+		target: 'src/shared/openapi/error-response.dto.ts',
+	},
+	{ runtime: 'shared/openapi/index.ts', target: 'src/shared/openapi/index.ts' },
+];
+
+const OPEN_API_MODULE_SNIPPET = `/**
+ * OpenApiModule — @Global() wrapper around the OPENAPI_REGISTRY singleton.
+ *
+ * OPENAPI-4: every generated entity module @Inject(OPENAPI_REGISTRY) to
+ * register its Zod DTOs at onModuleInit (OPENAPI-2). NestJS's DI scoping
+ * means providers declared in AppModule are NOT automatically visible
+ * inside imported feature modules. Making the provider module @Global()
+ * broadcasts the token to every module in the application graph.
+ */
+@Global()
+@Module({
+  providers: [{ provide: OPENAPI_REGISTRY, useValue: new OpenApiRegistry() }],
+  exports: [OPENAPI_REGISTRY],
+})
+class OpenApiModule {}
+`;
+
+const MAIN_SWAGGER_BLOCK = `  try {
+    // OPENAPI-4: build the document in two passes — registry owns component
+    // schemas (Zod-derived), Nest's scanner owns the paths map. See
+    // docs/CONSUMER-SETUP.md §OpenAPI for details.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fsMod = await import('node:fs');
+    const pathMod = await import('node:path');
+    const { parse: parseYaml } = await import('yaml');
+    const { DocumentBuilder, SwaggerModule } = await import('@nestjs/swagger');
+
+    const configPath = pathMod.resolve(process.cwd(), 'codegen.config.yaml');
+    const cfg: { openapi?: { enabled?: boolean; path?: string; title?: string; version?: string; description?: string; auth?: 'bearer' | 'none'; } } =
+      fsMod.existsSync(configPath)
+        ? (parseYaml(fsMod.readFileSync(configPath, 'utf-8')) ?? {})
+        : {};
+
+    if (cfg.openapi?.enabled) {
+      const registry = app.get<OpenApiRegistry>(OPENAPI_REGISTRY);
+      const registryDocument = await registry.build({
+        title: cfg.openapi.title ?? 'API',
+        version: cfg.openapi.version ?? '0.0.0',
+        description: cfg.openapi.description,
+      });
+
+      const docBuilder = new DocumentBuilder()
+        .setTitle(cfg.openapi.title ?? 'API')
+        .setVersion(cfg.openapi.version ?? '0.0.0');
+      if (cfg.openapi.description) docBuilder.setDescription(cfg.openapi.description);
+      if ((cfg.openapi.auth ?? 'bearer') === 'bearer') docBuilder.addBearerAuth();
+
+      const nestDocument = SwaggerModule.createDocument(app, docBuilder.build());
+      nestDocument.components = {
+        ...nestDocument.components,
+        schemas: {
+          ...(nestDocument.components?.schemas ?? {}),
+          ...registryDocument.components.schemas,
+        } as NonNullable<typeof nestDocument.components>['schemas'],
+      };
+      SwaggerModule.setup(cfg.openapi.path ?? '/docs', app, nestDocument);
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('[openapi] Swagger bootstrap skipped:', e instanceof Error ? e.message : e);
+  }
+`;
+
+const MAIN_SWAGGER_IMPORTS = [
+	"import { OPENAPI_REGISTRY, OpenApiRegistry } from './shared/openapi';",
+];
+
+// ---------------------------------------------------------------------------
+// Runtime-file resolution (mirrors init-scaffold.ts)
+// ---------------------------------------------------------------------------
+
+function runtimeRoot(): string {
+	const pkgRoot = path.resolve(import.meta.dirname, '..', '..', '..');
+	const topLevel = path.join(pkgRoot, 'runtime');
+	if (fs.existsSync(topLevel)) return topLevel;
+	return path.join(pkgRoot, 'dist', 'runtime');
+}
+
+function loadRuntimeFile(rel: string): string {
+	return fs.readFileSync(path.join(runtimeRoot(), rel), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Project root resolution
+// ---------------------------------------------------------------------------
+
+function resolveProjectRoot(startDir: string): string {
+	let dir = path.resolve(startDir);
+	for (let i = 0; i < 16; i++) {
+		if (
+			fs.existsSync(path.join(dir, 'codegen.config.yaml')) ||
+			fs.existsSync(path.join(dir, 'package.json'))
+		) {
+			return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	return path.resolve(startDir);
+}
+
+// ---------------------------------------------------------------------------
+// Report shape
+// ---------------------------------------------------------------------------
+
+interface UpgradeChange {
+	path: string;
+	action: 'created' | 'updated' | 'unchanged' | 'skipped';
+	note?: string;
+	diff?: string;
+}
+
+interface UpgradeReport {
+	projectRoot: string;
+	changes: UpgradeChange[];
+	bail?: { file: string; reason: string; snippet?: string };
+}
+
+// ---------------------------------------------------------------------------
+// Core runner
+// ---------------------------------------------------------------------------
+
+export interface UpgradeOptions {
+	projectRoot: string;
+	dryRun: boolean;
+	force: boolean;
+}
+
+export async function runUpgradeOpenapi(opts: UpgradeOptions): Promise<UpgradeReport> {
+	const { projectRoot, dryRun, force } = opts;
+	const changes: UpgradeChange[] = [];
+
+	// 1. Vendor openapi files
+	for (const v of OPENAPI_VENDORED_FILES) {
+		const target = path.join(projectRoot, v.target);
+		const exists = fs.existsSync(target);
+		const newContent = loadRuntimeFile(v.runtime);
+		if (exists && !force) {
+			const existing = fs.readFileSync(target, 'utf-8');
+			if (existing === newContent) {
+				changes.push({ path: v.target, action: 'unchanged' });
+			} else {
+				changes.push({
+					path: v.target,
+					action: 'skipped',
+					note: 'exists with different content — pass --force to overwrite',
+				});
+			}
+		} else {
+			if (!dryRun) {
+				fs.mkdirSync(path.dirname(target), { recursive: true });
+				fs.writeFileSync(target, newContent);
+			}
+			changes.push({
+				path: v.target,
+				action: exists ? 'updated' : 'created',
+			});
+		}
+	}
+
+	// 2. Patch app.module.ts
+	const appModulePath = path.join(projectRoot, 'src', 'app.module.ts');
+	if (!fs.existsSync(appModulePath)) {
+		return {
+			projectRoot,
+			changes,
+			bail: {
+				file: 'src/app.module.ts',
+				reason: 'file does not exist — run `codegen project init` first, or author it manually',
+			},
+		};
+	}
+
+	const project = new Project({
+		useInMemoryFileSystem: false,
+		manipulationSettings: {
+			indentationText: IndentationText.TwoSpaces,
+			quoteKind: QuoteKind.Single,
+			newLineKind: NewLineKind.LineFeed,
+		},
+		skipAddingFilesFromTsConfig: true,
+		skipFileDependencyResolution: true,
+		skipLoadingLibFiles: true,
+	});
+
+	const appSource = project.addSourceFileAtPath(appModulePath);
+	const appBefore = appSource.getFullText();
+
+	if (!appSource.getClass('AppModule')) {
+		return {
+			projectRoot,
+			changes,
+			bail: {
+				file: 'src/app.module.ts',
+				reason: 'no `AppModule` class found (factory function or unusual shape)',
+				snippet: suggestAppModuleSnippet(),
+			},
+		};
+	}
+
+	const patches: PatchResult[] = [];
+	patches.push(ensureImport(appSource, '@nestjs/common', ['Global', 'Module']));
+	patches.push(
+		ensureImport(appSource, './shared/openapi', ['OPENAPI_REGISTRY', 'OpenApiRegistry'])
+	);
+	patches.push(
+		ensureClassDeclaration(appSource, 'OpenApiModule', OPEN_API_MODULE_SNIPPET, {
+			insertBeforeClass: 'AppModule',
+		})
+	);
+	// Re-resolve AppModule after potential insertText above — ts-morph
+	// forgets nodes when raw text is inserted into the source file.
+	const appModuleClassFresh = appSource.getClass('AppModule');
+	if (!appModuleClassFresh) {
+		return {
+			projectRoot,
+			changes,
+			bail: {
+				file: 'src/app.module.ts',
+				reason: 'AppModule disappeared after patching (parser desync)',
+				snippet: suggestAppModuleSnippet(),
+			},
+		};
+	}
+	const importEntry = ensureModuleImportEntry(appModuleClassFresh, 'OpenApiModule');
+	patches.push(importEntry);
+
+	if (importEntry.bail) {
+		return {
+			projectRoot,
+			changes,
+			bail: {
+				file: 'src/app.module.ts',
+				reason: importEntry.bail,
+				snippet: suggestAppModuleSnippet(),
+			},
+		};
+	}
+
+	const appAfter = appSource.getFullText();
+	const appChanged = appAfter !== appBefore;
+	if (appChanged) {
+		if (!dryRun) appSource.saveSync();
+		const notes = patches
+			.filter((p) => p.changed)
+			.map((p) => p.note)
+			.filter(Boolean)
+			.join('; ');
+		changes.push({
+			path: 'src/app.module.ts',
+			action: 'updated',
+			note: notes,
+			diff: simpleDiff(appBefore, appAfter),
+		});
+	} else {
+		changes.push({ path: 'src/app.module.ts', action: 'unchanged' });
+	}
+
+	// 3. Patch main.ts (best-effort)
+	const mainPath = path.join(projectRoot, 'src', 'main.ts');
+	if (fs.existsSync(mainPath)) {
+		const mainSource = project.addSourceFileAtPath(mainPath);
+		const mainBefore = mainSource.getFullText();
+		const result = ensureMainSwaggerBlock(mainSource, {
+			swaggerImports: MAIN_SWAGGER_IMPORTS,
+			swaggerBlock: MAIN_SWAGGER_BLOCK,
+		});
+		if (result.bail) {
+			changes.push({
+				path: 'src/main.ts',
+				action: 'skipped',
+				note: `${result.bail} — see CONSUMER-SETUP §OpenAPI`,
+			});
+		} else if (result.changed) {
+			const mainAfter = mainSource.getFullText();
+			if (!dryRun) mainSource.saveSync();
+			changes.push({
+				path: 'src/main.ts',
+				action: 'updated',
+				note: result.note,
+				diff: simpleDiff(mainBefore, mainAfter),
+			});
+		} else {
+			changes.push({ path: 'src/main.ts', action: 'unchanged', note: result.note });
+		}
+	} else {
+		changes.push({
+			path: 'src/main.ts',
+			action: 'skipped',
+			note: "does not exist — run `codegen project init` to scaffold",
+		});
+	}
+
+	return { projectRoot, changes };
+}
+
+function suggestAppModuleSnippet(): string {
+	return `Expected shape:
+
+  import { Global, Module } from '@nestjs/common';
+  import { OPENAPI_REGISTRY, OpenApiRegistry } from './shared/openapi';
+
+  @Global()
+  @Module({
+    providers: [{ provide: OPENAPI_REGISTRY, useValue: new OpenApiRegistry() }],
+    exports: [OPENAPI_REGISTRY],
+  })
+  class OpenApiModule {}
+
+  @Module({
+    imports: [/* ...existing, */ OpenApiModule /*, ...GENERATED_MODULES */],
+  })
+  export class AppModule {}
+`;
+}
+
+/**
+ * Very-coarse line-level diff — only used for `--dry-run` user-facing output.
+ * Pure deletions / additions are counted; we don't try to match LCS.
+ */
+function simpleDiff(before: string, after: string): string {
+	const b = before.split('\n');
+	const a = after.split('\n');
+	const bSet = new Set(b);
+	const aSet = new Set(a);
+	const added = a.filter((l) => !bSet.has(l)).map((l) => '+ ' + l);
+	const removed = b.filter((l) => !aSet.has(l)).map((l) => '- ' + l);
+	if (added.length === 0 && removed.length === 0) return '';
+	return [...removed, ...added].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+export class ProjectUpgradeOpenapiCommand extends Command {
+	static paths = [['project', 'upgrade-openapi']];
+	static usage = Command.Usage({
+		description:
+			'Patch an existing consumer app.module.ts + main.ts to wire OpenApiModule (OPENAPI-4)',
+		examples: [
+			['Patch the current project', 'codegen project upgrade-openapi'],
+			['Preview changes without writing', 'codegen project upgrade-openapi --dry-run'],
+			['Target a specific project dir', 'codegen project upgrade-openapi --path ./apps/api'],
+			['Overwrite vendored files', 'codegen project upgrade-openapi --force'],
+		],
+	});
+
+	dryRun = Option.Boolean('--dry-run', false);
+	force = Option.Boolean('--force', false);
+	pathOpt = Option.String('--path', { required: false });
+	json = Option.Boolean('--json', false);
+
+	async execute(): Promise<number> {
+		if (this.json) setJsonMode(true);
+
+		const startDir = this.pathOpt ? path.resolve(this.pathOpt) : process.cwd();
+		if (!fs.existsSync(startDir)) {
+			printError(`Directory not found: ${startDir}`);
+			return 1;
+		}
+		const projectRoot = resolveProjectRoot(startDir);
+
+		let report: UpgradeReport;
+		try {
+			report = await runUpgradeOpenapi({
+				projectRoot,
+				dryRun: this.dryRun,
+				force: this.force,
+			});
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			printError(`upgrade-openapi failed: ${msg}`);
+			process.stderr.write(`\n${CONSUMER_SETUP_POINTER}\n`);
+			return 1;
+		}
+
+		if (isJsonMode()) {
+			printJson({
+				command: 'project upgrade-openapi',
+				projectRoot: report.projectRoot,
+				dryRun: this.dryRun,
+				changes: report.changes,
+				bail: report.bail ?? null,
+			});
+			return report.bail ? 1 : 0;
+		}
+
+		// Render report
+		printInfo(`OpenAPI upgrade summary (${report.projectRoot}):`);
+		console.log('');
+		for (const c of report.changes) {
+			const icon =
+				c.action === 'created' || c.action === 'updated'
+					? theme.success(icons.check)
+					: c.action === 'skipped'
+						? theme.warning(icons.warning)
+						: theme.muted(icons.dash);
+			const tag = c.action.padEnd(10);
+			const reason = c.note ? theme.muted(`  (${c.note})`) : '';
+			console.log(`  ${icon} ${theme.muted(tag)} ${c.path}${reason}`);
+			if (this.dryRun && c.diff) {
+				for (const line of c.diff.split('\n').slice(0, 20)) {
+					const colored = line.startsWith('+')
+						? theme.success(line)
+						: line.startsWith('-')
+							? theme.error(line)
+							: line;
+					console.log(`      ${colored}`);
+				}
+			}
+		}
+
+		if (report.bail) {
+			console.log('');
+			printError(`bail: ${report.bail.file} — ${report.bail.reason}`);
+			if (report.bail.snippet) {
+				process.stderr.write('\n' + report.bail.snippet + '\n');
+			}
+			process.stderr.write('\n' + CONSUMER_SETUP_POINTER + '\n');
+			return 1;
+		}
+
+		console.log('');
+		if (this.dryRun) {
+			printWarning('dry-run — no files written');
+		} else {
+			printSuccess('upgrade-openapi complete');
+		}
+		console.log('');
+		printInfo('Next steps:');
+		console.log(
+			`  1. ${theme.system('bun add @nestjs/swagger @anatine/zod-openapi')} (peer deps)`
+		);
+		console.log(
+			`  2. ${theme.system('codegen subsystem install openapi-config')} (adds openapi: block to config)`
+		);
+		console.log(
+			`  3. ${theme.system('bun run build && bun run start')} — verify /docs and /docs-json`
+		);
+		return 0;
+	}
+}

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -41,6 +41,7 @@ import { scanProject, generateConfig } from '../../scanner/index.js';
 
 import { loadContext, type Context } from '../shared/context.js';
 import { buildInitPlan, writePlan, type InitPlan } from '../shared/init-scaffold.js';
+import { ProjectUpgradeOpenapiCommand } from './project-upgrade-openapi.js';
 
 import { theme } from '../ui/theme.js';
 import { icons } from '../ui/icons.js';
@@ -834,6 +835,7 @@ const projectNoun: NounModule = {
 		ProjectConfigCommand,
 		ProjectInspectCommand,
 		ProjectGraphCommand,
+		ProjectUpgradeOpenapiCommand,
 	] as CommandClass[],
 	summary,
 	hints,

--- a/src/cli/shared/ast-patch.ts
+++ b/src/cli/shared/ast-patch.ts
@@ -1,0 +1,324 @@
+/**
+ * AST patching primitives for consumer code (ts-morph based).
+ *
+ * Used by `codegen project upgrade-openapi` (and future additive-install
+ * commands, issue #188) to bring existing consumer files up to the shape
+ * `project init` emits on a fresh project, **without** clobbering
+ * user-authored content.
+ *
+ * Every helper is:
+ *   - **idempotent**: applying twice leaves the file byte-identical to one
+ *     application.
+ *   - **surgical**: only touches the specific construct it owns. Existing
+ *     imports, decorators, comments, and unrelated providers survive.
+ *   - **honest about bail-outs**: when the file's shape is unexpected (e.g.
+ *     a factory-based module, a `@Module()` decorator on something other
+ *     than a class), the helper returns `{ changed: false, bail: '<reason>' }`
+ *     and leaves the file untouched. Callers surface the bail message + the
+ *     CONSUMER-SETUP pointer to the user.
+ *
+ * The helpers mutate a `SourceFile` in memory; the caller is responsible for
+ * calling `sourceFile.save()` (or equivalent) once all patches are staged.
+ */
+
+import type { SourceFile, ClassDeclaration } from 'ts-morph';
+import { SyntaxKind, Node } from 'ts-morph';
+
+// ---------------------------------------------------------------------------
+// Result shape
+// ---------------------------------------------------------------------------
+
+export interface PatchResult {
+	changed: boolean;
+	/** Human-readable reason the patch could not be applied safely. */
+	bail?: string;
+	/** Short note explaining what was done (or why nothing was done). */
+	note?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure `import { <named...> } from '<moduleSpecifier>'` exists.
+ *
+ * Merge semantics:
+ *   - If an import from the same module specifier already exists, add any
+ *     missing named bindings to that import's named-imports clause.
+ *   - Default or namespace imports from the module are preserved; we only
+ *     append to the named-imports list.
+ *   - Type-only imports are left as type-only and not widened. (We prepend a
+ *     new value-level import if needed — though in our use case we only call
+ *     this for value imports, so the scenario is rare.)
+ */
+export function ensureImport(
+	sourceFile: SourceFile,
+	moduleSpecifier: string,
+	named: string[]
+): PatchResult {
+	if (named.length === 0) return { changed: false, note: 'no names requested' };
+
+	const existing = sourceFile.getImportDeclaration(
+		(imp) => imp.getModuleSpecifierValue() === moduleSpecifier
+	);
+
+	if (!existing) {
+		sourceFile.addImportDeclaration({
+			moduleSpecifier,
+			namedImports: [...named].sort(),
+		});
+		return { changed: true, note: `added import from '${moduleSpecifier}'` };
+	}
+
+	// Don't widen a type-only import to a value import — that changes runtime
+	// semantics. Bail if caller is asking for value bindings from a type-only
+	// import.
+	if (existing.isTypeOnly()) {
+		// Add a *separate* value import directly after the type import to
+		// avoid mangling the existing type-only one.
+		sourceFile.insertImportDeclaration(existing.getChildIndex() + 1, {
+			moduleSpecifier,
+			namedImports: [...named].sort(),
+		});
+		return {
+			changed: true,
+			note: `added value import from '${moduleSpecifier}' (existing was type-only)`,
+		};
+	}
+
+	const current = new Set(existing.getNamedImports().map((n) => n.getName()));
+	const missing = named.filter((n) => !current.has(n));
+	if (missing.length === 0) return { changed: false, note: 'import already satisfied' };
+
+	existing.addNamedImports(missing.map((name) => ({ name })));
+	return {
+		changed: true,
+		note: `added [${missing.join(', ')}] to existing import from '${moduleSpecifier}'`,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Class declarations (OpenApiModule)
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a class declaration with the given name exists in the source file.
+ * If missing, inserts `source` (a verbatim TypeScript snippet containing the
+ * class) immediately **before** the anchor class (usually `AppModule`).
+ *
+ * If a class with the same name already exists, this is a no-op — even if
+ * its decorator/body shape has drifted. We deliberately do **not** rewrite
+ * existing classes: once the user has customised `OpenApiModule`, their
+ * customisation wins. Callers are expected to surface a warning when that
+ * happens so the user knows to audit.
+ */
+export function ensureClassDeclaration(
+	sourceFile: SourceFile,
+	className: string,
+	snippet: string,
+	opts: { insertBeforeClass?: string } = {}
+): PatchResult {
+	const existing = sourceFile.getClass(className);
+	if (existing) {
+		return {
+			changed: false,
+			note: `class '${className}' already present — leaving as-is`,
+		};
+	}
+
+	const anchor = opts.insertBeforeClass
+		? sourceFile.getClass(opts.insertBeforeClass)
+		: undefined;
+
+	if (anchor) {
+		// Insert before everything attached to the anchor class — JSDoc and
+		// decorators included. We anchor on the class's JSDoc block if
+		// present (`getJsDocs()[0]`), fall back to its first decorator, and
+		// finally to the class keyword. Without this, a JSDoc on the anchor
+		// class ends up stranded above the inserted OpenApiModule.
+		const jsDoc = anchor.getJsDocs()[0];
+		const firstDecorator = anchor.getDecorators()[0];
+		const anchorNode = jsDoc ?? firstDecorator ?? anchor;
+		const insertPos = anchorNode.getStart();
+		sourceFile.insertText(insertPos, ensureTrailingNewline(snippet) + '\n');
+	} else {
+		// Fall back to appending at end of file.
+		sourceFile.addStatements('\n' + snippet.trimEnd() + '\n');
+	}
+
+	return { changed: true, note: `inserted class '${className}'` };
+}
+
+function ensureTrailingNewline(s: string): string {
+	return s.endsWith('\n') ? s : s + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// @Module imports array
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure `moduleName` appears in the `@Module({ imports: [...] })` decorator
+ * of the given class declaration.
+ *
+ * Bail-out conditions (return `{ changed: false, bail: '...' }`):
+ *   - Class has no `@Module()` decorator.
+ *   - `@Module()` is not a call expression (e.g. a factory was used).
+ *   - The decorator argument isn't an object literal.
+ *   - `imports` exists but is not an array literal (e.g. a spread of a
+ *     function result, a const alias, etc.).
+ */
+export function ensureModuleImportEntry(
+	classDecl: ClassDeclaration,
+	moduleName: string
+): PatchResult {
+	const decorator = classDecl.getDecorator('Module');
+	if (!decorator) {
+		return {
+			changed: false,
+			bail: `class '${classDecl.getName()}' has no @Module() decorator`,
+		};
+	}
+	if (!decorator.isDecoratorFactory()) {
+		return {
+			changed: false,
+			bail: `@Module on '${classDecl.getName()}' is not a call expression`,
+		};
+	}
+	const [arg] = decorator.getArguments();
+	if (!arg || !Node.isObjectLiteralExpression(arg)) {
+		return {
+			changed: false,
+			bail: `@Module on '${classDecl.getName()}' takes a non-object argument (factory?)`,
+		};
+	}
+
+	let importsProp = arg.getProperty('imports');
+	if (!importsProp) {
+		arg.addPropertyAssignment({
+			name: 'imports',
+			initializer: `[${moduleName}]`,
+		});
+		return { changed: true, note: `created imports: [${moduleName}]` };
+	}
+
+	if (!Node.isPropertyAssignment(importsProp)) {
+		return {
+			changed: false,
+			bail: `@Module.imports on '${classDecl.getName()}' is not a simple property assignment`,
+		};
+	}
+
+	const init = importsProp.getInitializer();
+	if (!init || !Node.isArrayLiteralExpression(init)) {
+		return {
+			changed: false,
+			bail: `@Module.imports on '${classDecl.getName()}' is not an array literal (spread/alias?)`,
+		};
+	}
+
+	// Idempotency: bail out (as no-op) if moduleName already appears as a
+	// top-level element. We only inspect direct children; if the user spreads
+	// a variable that happens to contain `moduleName`, we can't see it, but
+	// that's a rare enough shape not to over-engineer around.
+	const already = init.getElements().some((el) => {
+		// Plain identifier: `OpenApiModule`
+		if (Node.isIdentifier(el) && el.getText() === moduleName) return true;
+		// Spread of something named the same (unlikely, but harmless to check)
+		if (Node.isSpreadElement(el)) {
+			const expr = el.getExpression();
+			if (Node.isIdentifier(expr) && expr.getText() === moduleName) return true;
+		}
+		return false;
+	});
+	if (already) {
+		return { changed: false, note: `${moduleName} already in imports` };
+	}
+
+	// Insert BEFORE the first spread element, if any (convention: named
+	// modules come before `...GENERATED_MODULES`).
+	const elements = init.getElements();
+	const spreadIdx = elements.findIndex((el) => Node.isSpreadElement(el));
+	const insertAt = spreadIdx === -1 ? elements.length : spreadIdx;
+	init.insertElement(insertAt, moduleName);
+
+	return { changed: true, note: `added ${moduleName} to imports` };
+}
+
+// ---------------------------------------------------------------------------
+// main.ts — Swagger bootstrap block
+// ---------------------------------------------------------------------------
+
+export interface MainSwaggerPatchOptions {
+	/** The full Swagger block to inject (imports + in-bootstrap code). */
+	swaggerImports: string[];
+	/** Snippet inserted inside the bootstrap function, after `app` creation. */
+	swaggerBlock: string;
+}
+
+/**
+ * Best-effort patch of `src/main.ts`:
+ *   - Skip if `SwaggerModule.setup(...)` is already called anywhere.
+ *   - Otherwise: find the `NestFactory.create(...)` call, walk up to its
+ *     containing statement, and insert `swaggerBlock` immediately after it.
+ *     Add `swaggerImports` at the top of the file.
+ *
+ * Bails when:
+ *   - `NestFactory.create(...)` is not found (consumer has an exotic
+ *     bootstrap).
+ */
+export function ensureMainSwaggerBlock(
+	sourceFile: SourceFile,
+	opts: MainSwaggerPatchOptions
+): PatchResult {
+	// Already wired?
+	const text = sourceFile.getFullText();
+	if (/SwaggerModule\.setup\s*\(/.test(text)) {
+		return { changed: false, note: 'SwaggerModule.setup already present' };
+	}
+
+	// Find `NestFactory.create(...)` call.
+	const calls = sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression);
+	const createCall = calls.find((c) => {
+		const expr = c.getExpression();
+		return Node.isPropertyAccessExpression(expr) && expr.getText() === 'NestFactory.create';
+	});
+	if (!createCall) {
+		return {
+			changed: false,
+			bail: "couldn't find NestFactory.create(...) — custom bootstrap shape",
+		};
+	}
+
+	// Walk up to the enclosing statement (usually
+	// `const app = await NestFactory.create(...);`).
+	let stmt: Node | undefined = createCall;
+	while (stmt && !Node.isStatement(stmt)) stmt = stmt.getParent();
+	if (!stmt) {
+		return {
+			changed: false,
+			bail: "NestFactory.create(...) is not inside a statement",
+		};
+	}
+
+	// Insert Swagger block right after the statement.
+	const insertPos = stmt.getEnd();
+	sourceFile.insertText(insertPos, '\n\n' + opts.swaggerBlock.trimEnd() + '\n');
+
+	// Add required imports (merging into existing clauses where possible).
+	for (const importLine of opts.swaggerImports) {
+		const match = importLine.match(
+			/^import\s+\{\s*([^}]+)\s*\}\s+from\s+['"]([^'"]+)['"]\s*;?\s*$/
+		);
+		if (match) {
+			const names = match[1]!.split(',').map((s) => s.trim()).filter(Boolean);
+			ensureImport(sourceFile, match[2]!, names);
+		} else {
+			// Fallback: prepend verbatim at top of file.
+			sourceFile.insertStatements(0, importLine);
+		}
+	}
+
+	return { changed: true, note: 'inserted Swagger bootstrap block' };
+}

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -802,7 +802,8 @@ export async function buildInitPlan(
 				path: appModulePath,
 				relPath: relOf(cwd, appModulePath),
 				action: 'skip',
-				reason: 'exists — wire DatabaseModule + GENERATED_MODULES manually',
+				reason:
+					'exists — run `codegen project upgrade-openapi` to patch; see docs/CONSUMER-SETUP.md §OpenAPI for manual wiring',
 			});
 		}
 	}
@@ -825,7 +826,8 @@ export async function buildInitPlan(
 				path: mainPath,
 				relPath: relOf(cwd, mainPath),
 				action: 'skip',
-				reason: 'exists — copy the OpenAPI bootstrap block from CONSUMER-SETUP §OpenAPI manually',
+				reason:
+					'exists — run `codegen project upgrade-openapi` to patch; see docs/CONSUMER-SETUP.md §OpenAPI for manual wiring',
 			});
 		}
 	}


### PR DESCRIPTION
## Summary
Ships `bun codegen project upgrade-openapi` — an AST-based command that brings an existing consumer app up to the OPENAPI-4 wiring shape (`@Global() OpenApiModule` in AppModule + Swagger bootstrap in main.ts + vendored `src/shared/openapi/*`) without manual editing.

Fixes the upgrade-path gap from 0.3.x → 0.4.0 where existing consumers had to hand-edit `src/app.module.ts` because `project init` refuses to clobber existing files.

## What ships
- `src/cli/shared/ast-patch.ts` — ts-morph-based idempotent patchers: `ensureImport`, `ensureClassDeclaration`, `ensureModuleImportEntry`, `ensureMainSwaggerBlock`.
- `src/cli/commands/project-upgrade-openapi.ts` — new Clipanion command under the `project` noun. Runs vendored-file copy + app.module.ts patch + main.ts patch; reports per-file status; supports `--dry-run` and `--path <dir>`.
- Updated skip-reason strings in `init-scaffold.ts` to point consumers at the new command.
- `ts-morph` added as a direct `dependencies` (CLI-side, not peer).
- 22 new tests (16 unit + 6 integration); 1414 total unit tests pass.
- CHANGELOG 0.4.1 entry.

## Key decisions (flagged in implementer report)
1. **main.ts Swagger block uses dynamic imports** inside the bootstrap function — consumers without `@nestjs/swagger` / `@anatine/zod-openapi` don't get broken top-level imports.
2. **Existing OpenApiModule left untouched.** We detect the class name and skip rewriting its body; preserves consumer customizations. Reported as `unchanged`.
3. **Graceful bail-outs.** Non-array `imports`, missing `@Module`, or factory-based modules print a copy-paste fallback to stderr + exit 1.
4. **Idempotent.** Running twice is a no-op. Integration test confirms.

## Scope boundaries
- This is Option A from the design discussion — surgical fix, not the generalized `codegen project upgrade` story.
- Issue #188 tracks the broader additive-install work targeted for 0.5.0 (every `subsystem install` becomes idempotent AppModule/main.ts patcher-capable).

## Testing
- `just test-unit`: 1414 pass.
- `just test-baseline`: no drift (additive only).
- `just test-smoke`: pass.
- `bun run typecheck` / `bun run build`: clean.
- Manual: tmp fixture pre-0.4.0 `app.module.ts` → run command → diff verified.

## Before/after example (from implementer report)

**Before:**
```ts
import { Module } from '@nestjs/common';
import { DatabaseModule } from './shared/database/database.module';
import { GENERATED_MODULES } from './generated/modules';

@Module({ imports: [DatabaseModule, ...GENERATED_MODULES] })
export class AppModule {}
```

**After:**
```ts
import { Module, Global } from '@nestjs/common';
import { DatabaseModule } from './shared/database/database.module';
import { GENERATED_MODULES } from './generated/modules';
import { OPENAPI_REGISTRY, OpenApiRegistry } from './shared/openapi';

@Global()
@Module({
  providers: [{ provide: OPENAPI_REGISTRY, useValue: new OpenApiRegistry() }],
  exports: [OPENAPI_REGISTRY],
})
class OpenApiModule {}

@Module({ imports: [DatabaseModule, OpenApiModule, ...GENERATED_MODULES] })
export class AppModule {}
```

## Refs
- Closes the manual-intervention gap surfaced by the CRM upgrade.
- Generalized follow-up: #188 (additive subsystem install for 0.5.0).
- Version bump: 0.4.0 → 0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>