### PR TITLE
fix(bridge): gate registry codegen on bridge subsystem install (#191)

### DIFF
--- a/src/__tests__/cli/bridge-registry-generator.test.ts
+++ b/src/__tests__/cli/bridge-registry-generator.test.ts
@@ -336,6 +336,12 @@ describe('generateBridgeRegistry — orchestration', () => {
     handlersDir = path.join(root, 'src/jobs');
     outputDir = path.join(root, 'runtime/subsystems/bridge/generated');
     fs.mkdirSync(handlersDir, { recursive: true });
+    // Simulate bridge subsystem installed (issue #191 gate).
+    fs.mkdirSync(path.dirname(outputDir), { recursive: true });
+    fs.writeFileSync(
+      path.join(path.dirname(outputDir), 'bridge.protocol.ts'),
+      'export type BridgeRegistry = Record<string, unknown>;\n',
+    );
   });
   afterEach(() => {
     fs.rmSync(root, { recursive: true, force: true });
@@ -410,6 +416,47 @@ describe('generateBridgeRegistry — orchestration', () => {
     await generateBridgeRegistry({ handlersDir, eventsGeneratedDir, outputDir });
     const second = fs.readFileSync(path.join(outputDir, 'registry.ts'), 'utf8');
     expect(second).toBe(first);
+  });
+
+  describe('bridge subsystem not installed (issue #191)', () => {
+    beforeEach(() => {
+      // Remove the stub installed by the outer beforeEach.
+      fs.rmSync(path.join(path.dirname(outputDir), 'bridge.protocol.ts'));
+    });
+
+    it('skips generation and does not write registry.ts', async () => {
+      writeHandler(handlersDir, 'a.ts', HANDLER_TEMPLATE('a_job', `
+  triggers: [{ event: 'evt_x', map: (e) => ({}) }],
+`));
+      const result = await generateBridgeRegistry({ handlersDir, outputDir });
+      expect(result.skipped).toBe(true);
+      expect(result.written).toBe(false);
+      expect(result.triggerCount).toBe(0);
+      expect(result.files).toHaveLength(0);
+      expect(fs.existsSync(path.join(outputDir, 'registry.ts'))).toBe(false);
+    });
+
+    it('removes a stray registry.ts left by a prior run', async () => {
+      fs.mkdirSync(outputDir, { recursive: true });
+      const stray = path.join(outputDir, 'registry.ts');
+      fs.writeFileSync(stray, '// stray\n');
+      const result = await generateBridgeRegistry({ handlersDir, outputDir });
+      expect(result.skipped).toBe(true);
+      expect(fs.existsSync(stray)).toBe(false);
+    });
+
+    it('dryRun=true leaves stray registry.ts alone', async () => {
+      fs.mkdirSync(outputDir, { recursive: true });
+      const stray = path.join(outputDir, 'registry.ts');
+      fs.writeFileSync(stray, '// stray\n');
+      const result = await generateBridgeRegistry({
+        handlersDir,
+        outputDir,
+        dryRun: true,
+      });
+      expect(result.skipped).toBe(true);
+      expect(fs.existsSync(stray)).toBe(true);
+    });
   });
 
   it('dryRun=true does not write', async () => {
@@ -518,6 +565,11 @@ describe('validateNoDuplicateTriggers (BRIDGE-7 follow-up)', () => {
     const handlersDir = path.join(root, 'src/jobs');
     const outputDir = path.join(root, 'runtime/subsystems/bridge/generated');
     fs.mkdirSync(handlersDir, { recursive: true });
+    fs.mkdirSync(path.dirname(outputDir), { recursive: true });
+    fs.writeFileSync(
+      path.join(path.dirname(outputDir), 'bridge.protocol.ts'),
+      'export type BridgeRegistry = Record<string, unknown>;\n',
+    );
     writeHandler(handlersDir, 'dup.ts', HANDLER_TEMPLATE('dup_job', `
   triggers: [
     { event: 'evt_x', map: (e) => ({}) },

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -522,6 +522,11 @@ export class EntityNewCommand extends Command {
 				eventsGeneratedDir: eventCodegenOutputDir,
 				outputDir: bridgeRegistryOutputDir,
 			});
+			if (bridgeRegistryResult.skipped && !isJsonMode()) {
+				printInfo(
+					'bridge subsystem not installed — skipping bridge registry codegen',
+				);
+			}
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
 			if (!isJsonMode()) {

--- a/src/cli/shared/bridge-registry-generator.ts
+++ b/src/cli/shared/bridge-registry-generator.ts
@@ -92,6 +92,13 @@ export interface BridgeRegistryResult {
   eventTypeCount: number;
   written: boolean;
   files: BridgeRegistryFileOutput[];
+  /**
+   * True when the bridge subsystem is not installed in the consumer tree
+   * (no `bridge.protocol.ts` sibling to `outputDir`) and generation was
+   * skipped to avoid emitting a file with a dangling import. Any stray
+   * `registry.ts` left behind from a prior run is removed in this case.
+   */
+  skipped: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -459,6 +466,30 @@ export async function generateBridgeRegistry(
 ): Promise<BridgeRegistryResult> {
   const { handlersDir, eventsGeneratedDir, outputDir, dryRun = false } = opts;
 
+  // 0. Gate on bridge subsystem installation (issue #191). The emitted
+  //    `registry.ts` imports `../bridge.protocol`, which only exists
+  //    after `codegen subsystem install bridge` has vendored the runtime
+  //    files. Consumers with a `bridge:` block in `codegen.config.yaml`
+  //    but no installed subsystem would otherwise end up with a broken
+  //    file on every `entity new --all`. Skip entirely and clean up any
+  //    stray artifact from a previous run.
+  const bridgeProtocolPath = path.resolve(outputDir, '..', 'bridge.protocol.ts');
+  if (!fs.existsSync(bridgeProtocolPath)) {
+    const strayPath = path.join(outputDir, OUTPUT_FILE_NAME);
+    if (!dryRun && fs.existsSync(strayPath)) {
+      fs.rmSync(strayPath);
+    }
+    return {
+      outputDir,
+      triggerCount: 0,
+      triggers: [],
+      eventTypeCount: 0,
+      written: false,
+      files: [],
+      skipped: true,
+    };
+  }
+
   // 1. Scan handler files.
   const triggers = scanHandlerFiles(handlersDir);
 
@@ -495,5 +526,6 @@ export async function generateBridgeRegistry(
     eventTypeCount,
     written,
     files: [file],
+    skipped: false,
   };
 }


### PR DESCRIPTION
Closes #191.

## Summary
- `cdp entity new --all` no longer emits `<subsystemsRoot>/bridge/generated/registry.ts` for consumers who have a `bridge:` block in `codegen.config.yaml` but haven't run `cdp subsystem install bridge`. The emitted file imports `../bridge.protocol`, which only resolves once the subsystem is vendored.
- Gate lives inside `generateBridgeRegistry` (keyed on presence of a sibling `bridge.protocol.ts`), so both call sites in `src/cli/commands/entity.ts` (dryRun + write) pick it up automatically.
- Stray `registry.ts` left behind from a prior (pre-fix) run is removed on the next regen. `dryRun` leaves the stray alone.
- Returns `skipped: true` in the result; CLI prints a one-line info when skipping.

## Test plan
- [x] `just test-unit` — 1417 pass
- [x] `just test-baseline` — snapshot unchanged (fixture has bridge installed, behavior preserved)
- [x] `bun run typecheck`
- [x] New tests in `src/__tests__/cli/bridge-registry-generator.test.ts`:
  - skip path when `bridge.protocol.ts` missing
  - stray `registry.ts` removed on skip
  - `dryRun=true` leaves stray alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)