### PR TITLE
fix(bridge): resolve handlers dir via paths.backend_src (#193)

### DIFF
--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -319,9 +319,18 @@ export class EntityNewCommand extends Command {
 			subsystemsRoot,
 			'bridge/generated',
 		);
-		// Default handlers dir; consumer can override via codegen.config.yaml later.
+		// Handlers dir resolves under `paths.backend_src` (matching where the
+		// rest of the backend tree lives) with `src` as final fallback — the
+		// same default `subsystems-path.ts` uses for `subsystems` root.
 		// Recursive scan tolerates absent dir (returns empty registry).
-		const bridgeHandlersDir = path.resolve(ctx.cwd, 'src/jobs');
+		const backendSrcForHandlers =
+			(ctx.config as { paths?: { backend_src?: string } } | null | undefined)
+				?.paths?.backend_src ?? 'src';
+		const bridgeHandlersDir = path.resolve(
+			ctx.cwd,
+			backendSrcForHandlers,
+			'jobs',
+		);
 
 		if (this.dryRun) {
 			const barrelPlan = await regenerateBarrels({


### PR DESCRIPTION
## Summary
- `entity new --all` hard-coded `bridgeHandlersDir = <cwd>/src/jobs`, so any consumer using `paths.backend_src: packages/api/src` (or any non-default layout) scanned a non-existent directory and emitted an empty `bridgeRegistry` regardless of their `@JobHandler.triggers` declarations.
- Resolve handlers dir under `paths.backend_src` (fallback `src`), matching the default used by `subsystems-path.ts` for the subsystems root itself.
- The #191/#192 gate already covers the "bridge not installed, stray file with broken import" case. This fix closes out the other half of #193: handlers that exist but never materialize in the generated registry.

## Test plan
- [x] `just test-unit` — 1417/1417 pass
- [x] Manual repro with `backend_src: packages/api/src`: handler at `packages/api/src/jobs/demo.job.ts` now appears in `bridgeRegistry` after `entity new --all`
- [x] Existing `bridge-registry-generator.test.ts` (29 tests) still passes

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)