### PR TITLE
fix(jobs): pool-name claim filter + cross-module handler DI scope

### DIFF
--- a/.claude/skills/jobs/handler-authoring.md
+++ b/.claude/skills/jobs/handler-authoring.md
@@ -81,7 +81,7 @@ All fields optional except `type` (the string positional arg). Defaults come fro
 | `timeoutMs` | number | Hard wall-clock cap across all retries. Breach → `status='timed_out'`. |
 | `replayFrom` | `'scratch' \| 'last_step' \| 'last_checkpoint'` | Default `'last_checkpoint'`. Only affects behaviour on `replay(runId)`. |
 
-Constructor injection works like any Nest provider — no special setup. Declare the handler in `providers` (or an entity/feature module's providers) so Nest can resolve its deps.
+Constructor injection works like any Nest provider, but with one hard requirement: **the handler class MUST be registered as a provider in its owning module** (or an entity/feature module's `providers`). `@JobHandler` registers the class with the job registry for orchestration, but it does NOT register it with Nest's DI container — that's on you. The worker resolves handlers via `moduleRef.get(HandlerClass, { strict: false })`; a handler that isn't a registered provider will throw at claim time with an unresolvable-provider error. Cross-module `@Inject` deps work as long as the providing module is imported in the handler's owning module.
 
 ## Using `JobContext`
 

--- a/runtime/subsystems/jobs/job-orchestrator.memory-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.memory-backend.ts
@@ -596,10 +596,14 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
     // ModuleRef so `@Inject` constructor params work. ModuleRef is
     // @Optional() — zero-dep test stubs that construct this orchestrator
     // manually still hit the legacy `new HandlerClass()` path.
+    // `get({ strict: false })` (not `create()`) — the handler must be a
+    // provider in its owning module so cross-module @Inject dependencies
+    // resolve. See job-worker.ts for the full rationale.
     const handler = this.moduleRef
-      ? ((await this.moduleRef.create(
+      ? (this.moduleRef.get(
           HandlerClass as unknown as new (...args: unknown[]) => unknown,
-        )) as JobHandlerBase<unknown>)
+          { strict: false },
+        ) as JobHandlerBase<unknown>)
       : new HandlerClass();
 
     const ctx: JobContext<unknown> = {

--- a/runtime/subsystems/jobs/job-worker.module.ts
+++ b/runtime/subsystems/jobs/job-worker.module.ts
@@ -177,8 +177,16 @@ export class JobWorkerOrchestrator implements OnModuleInit, OnModuleDestroy {
             `the resolved pool config. Configured pools: [${[...poolConfig.keys()].join(', ')}].`,
         );
       }
+      // `pool` here is the logical pool name (e.g. 'crm_sync') — the same
+      // value the orchestrator persists into `job_run.pool` from
+      // `@JobHandler.meta.pool`, and therefore the value the worker's
+      // claim query filters on. `def.queue` is a display/routing alias
+      // (e.g. 'jobs-crm-sync') used by BullMQ-style backends for queue
+      // naming; it MUST NOT be passed as the claim-filter pool, or the
+      // worker will never match any row and the pool silently never
+      // drains. See v0.4.4 fix notes.
       const workerOptions: JobWorkerOptions = {
-        pool: def.queue,
+        pool: poolName,
         concurrency: def.concurrency,
         shutdownTimeoutMs:
           this.options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS,
@@ -192,7 +200,7 @@ export class JobWorkerOrchestrator implements OnModuleInit, OnModuleDestroy {
       worker.onModuleInit();
       this.workers.push(worker);
       this.logger.log(
-        `JobWorker started: pool='${def.queue}' concurrency=${def.concurrency}`,
+        `JobWorker started: pool='${poolName}' (queue='${def.queue}') concurrency=${def.concurrency}`,
       );
     }
   }

--- a/runtime/subsystems/jobs/job-worker.ts
+++ b/runtime/subsystems/jobs/job-worker.ts
@@ -421,16 +421,22 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
     const meta = registryEntry.meta as JobHandlerMeta<unknown>;
     const HandlerClass = registryEntry.handlerClass;
 
-    // (c) Build JobContext. Instantiate handler via Nest's ModuleRef so
-    //     `@Inject` constructor params resolve. `create({ strict: false })`
-    //     walks the whole module graph for providers (handlers don't need to
-    //     be registered as providers themselves; the @JobHandler decorator
-    //     is the only registration required). A fresh instance per run
-    //     mirrors the contract handlers were authored against and keeps
-    //     run-scoped state from leaking across claims.
-    const handler = (await this.moduleRef.create(
+    // (c) Build JobContext. Resolve the handler instance from Nest's DI
+    //     graph so its `@Inject` constructor params (which may come from
+    //     any module in the app graph) are satisfied. `moduleRef.create()`
+    //     would otherwise instantiate a fresh class within JobWorkerModule's
+    //     scope only — which blows up with "not a provider of the current
+    //     module" for any handler that consumes a service from a peer
+    //     module (e.g. CrmSyncJob injecting CrmSyncFactory from CrmModule).
+    //     Consequence: handlers MUST be registered as providers in their
+    //     owning module (@Injectable + `providers: [HandlerClass]`). The
+    //     @JobHandler decorator handles registry registration only, not DI.
+    //     See the jobs skill's handler-authoring.md for the registration
+    //     rule.
+    const handler = this.moduleRef.get(
       HandlerClass as unknown as new (...args: unknown[]) => unknown,
-    )) as JobHandlerBase<unknown>;
+      { strict: false },
+    ) as JobHandlerBase<unknown>;
     const ctx: JobContext<unknown> = {
       input: claimed.input,
       run: claimed as JobRun,


### PR DESCRIPTION
## Summary

Two severe-but-silent framework bugs discovered in a consumer stack's Stage 2 validation. Ports vetted fixes from that mirror back upstream.

### Bug 1 — Pool-name claim filter mismatch (SEVERITY: silent outage)

`JobWorkerModule` passed `def.queue` (`'jobs-crm-sync'`) as the worker's claim-filter pool. The orchestrator writes the logical `poolName` (`'crm_sync'`) into `job_run.pool` from `@JobHandler.meta.pool`, so **the claim query never matched any row**. Every stack using `@JobHandler` since pools-and-queues diverged has had zero jobs claimed by workers, silently. No exception, no log, just an idle pool.

Fix: `pool: poolName` instead of `pool: def.queue`.

### Bug 2 — moduleRef.create cross-module scope

`moduleRef.create(HandlerClass)` instantiates inside the calling module's scope only. Any handler with a cross-module `@Inject` dep (e.g. `CrmSyncJob` injecting `CrmSyncFactory` from `CrmModule`) crashed with "not a provider of the current module". The v0.4.3 `ModuleRef` fix was necessary but not sufficient for real-world handlers.

Fix: `moduleRef.get(HandlerClass, { strict: false })`. Applied in both `job-worker.ts` (Drizzle path) and `job-orchestrator.memory-backend.ts` (memory backend).

New hard requirement: handler classes MUST be registered as providers in their owning module. `@JobHandler` handles registry registration; it does NOT register with Nest DI. Documented in `.claude/skills/jobs/handler-authoring.md` (the skill's living-docs update lands in this PR per CLAUDE.md).

## Test plan

- [x] `just test-unit` — 1417 tests pass
- [ ] CI green on PR
- [ ] Consumer (dealbrain) verifies live sync claims jobs + bridge_delivery populates after deleting its local mirror