### PR TITLE
feat(events): add array payload field type (fixes TypedEventBus Zod drop)

### DIFF
--- a/.claude/skills/events/event-codegen.md
+++ b/.claude/skills/events/event-codegen.md
@@ -71,7 +71,7 @@ payload:
 - `aggregate` — entity name (required for `direction: change`; optional elsewhere)
 - `source` — inbound only; logical origin ("stripe", "email")
 - `destination` — outbound only; logical target ("crm", "slack")
-- `payload` — snake_case keys → camelCase TS props; types `uuid | string | number | boolean | date | json`
+- `payload` — snake_case keys → camelCase TS props; types `uuid | string | number | boolean | date | json | array`. For `array`, an `items:` scalar type is required (`items: uuid | string | number | boolean | date`) and emits `T[]` + `z.array(T)`. `json` means "arbitrary JSON object" (`Record<string, unknown>` / `z.record(z.unknown())`) — do NOT use `json` for array-shaped payloads, Zod will reject them at validation time.
 - `pool` — optional override; constrained to the reserved pools of the *same category* (a `change` event cannot opt into `events_inbound`). User pools (`batch`, `interactive`) are NEVER valid targets for events.
 - `retry` — `{ attempts, backoff }`, hints surfaced to the bus
 - `version` — integer, defaults to 1 (schema evolution; not exercised yet)

--- a/src/__tests__/cli/event-codegen-generator.test.ts
+++ b/src/__tests__/cli/event-codegen-generator.test.ts
@@ -289,6 +289,35 @@ describe('buildTypesContent — all six field types', () => {
 	});
 });
 
+describe('buildTypesContent / buildSchemasContent — array field', () => {
+	test('emits T[] in TS and z.array(scalar) in Zod for array + items', () => {
+		const ev: EventDefinition = {
+			type: 'crm_sync_started',
+			direction: 'change',
+			aggregate: 'integration',
+			version: 1,
+			payload: {
+				entity_types: { type: 'array', items: 'string', nullable: false },
+				ids: { type: 'array', items: 'uuid', nullable: false },
+				optional_ids: { type: 'array', items: 'uuid', nullable: true },
+			},
+			retry: { attempts: 3, backoff: 'exponential' },
+			pool: 'events_change',
+		};
+		const typesContent = buildTypesContent([ev]);
+		expect(typesContent).toContain('entityTypes: string[];');
+		expect(typesContent).toContain('ids: string[];');
+		expect(typesContent).toContain('optionalIds: string[] | null;');
+
+		const schemasContent = buildSchemasContent([ev]);
+		expect(schemasContent).toContain('entityTypes: z.array(z.string()),');
+		expect(schemasContent).toContain('ids: z.array(z.string().uuid()),');
+		expect(schemasContent).toContain(
+			'optionalIds: z.array(z.string().uuid()).nullable(),',
+		);
+	});
+});
+
 // ---------------------------------------------------------------------------
 // buildSchemasContent
 // ---------------------------------------------------------------------------

--- a/src/__tests__/schema/event-definition.schema.test.ts
+++ b/src/__tests__/schema/event-definition.schema.test.ts
@@ -350,3 +350,63 @@ describe('EventDefinitionSchema — defaults and transform', () => {
 		}
 	});
 });
+
+describe('EventDefinitionSchema — array payload fields', () => {
+	it('accepts type: array with scalar items', () => {
+		const result = EventDefinitionSchema.safeParse({
+			type: 'crm_sync_started',
+			direction: 'change',
+			aggregate: 'integration',
+			payload: {
+				entity_types: { type: 'array', items: 'string' },
+			},
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.payload.entity_types?.type).toBe('array');
+			expect(result.data.payload.entity_types?.items).toBe('string');
+		}
+	});
+
+	it("rejects type: 'array' without items", () => {
+		const result = EventDefinitionSchema.safeParse({
+			type: 'crm_sync_started',
+			direction: 'change',
+			aggregate: 'integration',
+			payload: { entity_types: { type: 'array' } },
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.some((i) => i.path.includes('items'))).toBe(
+				true,
+			);
+		}
+	});
+
+	it("rejects items: on a non-array type", () => {
+		const result = EventDefinitionSchema.safeParse({
+			type: 'crm_sync_started',
+			direction: 'change',
+			aggregate: 'integration',
+			payload: { entity_types: { type: 'string', items: 'string' } },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects nested arrays (items must be scalar, not 'array' or 'json')", () => {
+		const resultArray = EventDefinitionSchema.safeParse({
+			type: 'crm_sync_started',
+			direction: 'change',
+			aggregate: 'integration',
+			payload: { entity_types: { type: 'array', items: 'array' } },
+		});
+		expect(resultArray.success).toBe(false);
+		const resultJson = EventDefinitionSchema.safeParse({
+			type: 'crm_sync_started',
+			direction: 'change',
+			aggregate: 'integration',
+			payload: { entity_types: { type: 'array', items: 'json' } },
+		});
+		expect(resultJson.success).toBe(false);
+	});
+});

--- a/src/cli/shared/event-codegen-generator.ts
+++ b/src/cli/shared/event-codegen-generator.ts
@@ -107,7 +107,9 @@ export function toPascalCase(input: string): string {
 // TS-type and Zod mapping tables (EventFieldType → TS / Zod)
 // ---------------------------------------------------------------------------
 
-const TS_TYPE_BY_FIELD: Record<EventFieldType, string> = {
+// For non-array types only. `array` goes through its own branch that also
+// needs the `items` hint to emit `T[]` / `z.array(T)`.
+const TS_TYPE_BY_FIELD: Record<Exclude<EventFieldType, 'array'>, string> = {
 	uuid: 'string',
 	string: 'string',
 	number: 'number',
@@ -116,7 +118,7 @@ const TS_TYPE_BY_FIELD: Record<EventFieldType, string> = {
 	json: 'Record<string, unknown>',
 };
 
-const ZOD_EXPR_BY_FIELD: Record<EventFieldType, string> = {
+const ZOD_EXPR_BY_FIELD: Record<Exclude<EventFieldType, 'array'>, string> = {
 	uuid: 'z.string().uuid()',
 	string: 'z.string()',
 	number: 'z.number()',
@@ -126,12 +128,25 @@ const ZOD_EXPR_BY_FIELD: Record<EventFieldType, string> = {
 };
 
 function tsTypeForField(field: EventPayloadField): string {
-	const base = TS_TYPE_BY_FIELD[field.type];
+	let base: string;
+	if (field.type === 'array') {
+		// Schema validation guarantees `items` is defined for `type: 'array'`.
+		const itemType = field.items as Exclude<EventFieldType, 'array' | 'json'>;
+		base = `${TS_TYPE_BY_FIELD[itemType]}[]`;
+	} else {
+		base = TS_TYPE_BY_FIELD[field.type];
+	}
 	return field.nullable ? `${base} | null` : base;
 }
 
 function zodExprForField(field: EventPayloadField): string {
-	const base = ZOD_EXPR_BY_FIELD[field.type];
+	let base: string;
+	if (field.type === 'array') {
+		const itemType = field.items as Exclude<EventFieldType, 'array' | 'json'>;
+		base = `z.array(${ZOD_EXPR_BY_FIELD[itemType]})`;
+	} else {
+		base = ZOD_EXPR_BY_FIELD[field.type];
+	}
 	return field.nullable ? `${base}.nullable()` : base;
 }
 

--- a/src/schema/event-definition.schema.ts
+++ b/src/schema/event-definition.schema.ts
@@ -27,8 +27,24 @@ export const EVENT_FIELD_TYPES = [
 	"boolean",
 	"date",
 	"json",
+	"array",
 ] as const;
 export type EventFieldType = (typeof EVENT_FIELD_TYPES)[number];
+
+/**
+ * Scalar types permitted as `items` of an `array` field. Intentionally narrower
+ * than the full field-type set: nested arrays and nested objects inside a
+ * payload array cross the line from "wire format" into "embedded schema" and
+ * should be modelled either as a separate event or as a `json` blob.
+ */
+export const EVENT_ARRAY_ITEM_TYPES = [
+	"uuid",
+	"string",
+	"number",
+	"boolean",
+	"date",
+] as const;
+export type EventArrayItemType = (typeof EVENT_ARRAY_ITEM_TYPES)[number];
 
 export const RESERVED_EVENT_POOLS = [
 	"events_inbound",
@@ -56,20 +72,40 @@ export const DIRECTION_TO_POOL: Record<EventDirection, EventPool> = {
 
 const EventDirectionSchema = z.enum(EVENT_DIRECTIONS);
 const EventFieldTypeSchema = z.enum(EVENT_FIELD_TYPES);
+const EventArrayItemTypeSchema = z.enum(EVENT_ARRAY_ITEM_TYPES);
 const EventPoolSchema = z.enum(RESERVED_EVENT_POOLS);
 
 /**
  * Per-payload-field metadata. `nullable: true` means the field may be `null`
  * on the wire; `description` is surfaced into the generated interface/Zod
- * schema as a JSDoc.
+ * schema as a JSDoc. `items` is required when `type: 'array'` and rejected
+ * otherwise — enforces "array-ness is declared, item shape is declared"
+ * without opening the door to arbitrary nesting.
  */
 const EventPayloadFieldSchema = z
 	.object({
 		type: EventFieldTypeSchema,
+		items: EventArrayItemTypeSchema.optional(),
 		nullable: z.boolean().optional().default(false),
 		description: z.string().optional(),
 	})
-	.strict();
+	.strict()
+	.superRefine((data, ctx) => {
+		if (data.type === "array" && data.items === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "'items' is required when type is 'array'",
+				path: ["items"],
+			});
+		}
+		if (data.type !== "array" && data.items !== undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: `'items' is only valid when type is 'array' (got '${data.type}')`,
+				path: ["items"],
+			});
+		}
+	});
 
 export type EventPayloadField = z.infer<typeof EventPayloadFieldSchema>;
 


### PR DESCRIPTION
## Summary

Closes a silent validation hole in the event codegen: payloads with list-shaped fields had no well-typed representation. The only option was `type: json`, which emits `Record<string, unknown>` / `z.record(z.unknown())`. Publish-time Zod validation then rejects actual arrays, the event is dropped, and downstream `bridge_delivery` never gets rows — no surfaced error.

Case in point from the live dealbrain run: `crm_sync_started.entityTypes` is a topologically-sorted list of CRM entity type strings, declared as `type: json`, cast at publish with `as unknown as Record<string, unknown>` to appease the generator's TS output. Runtime validation silently drops it.

## Fix

First-class `type: array` with a required scalar `items:` hint.

- **Schema**: `items` allowed only when `type: array`, required then. Scalars only (`uuid | string | number | boolean | date`). Nested arrays and nested json inside an array are deliberately rejected — payloads are a wire format, not an embedded schema; if you need nesting, model a separate event.
- **Codegen**: emits `T[]` / `z.array(<item>)`. Nullable preserved: `string[] | null` / `z.array(z.string()).nullable()`.
- **Skill**: `events/event-codegen.md` field-type list updated with explicit guidance on `json` (objects) vs `array` (arrays).
- **Tests**: 5 new. All 1422 unit tests pass.

## Consumer action

Update any `entity_types` / list-shaped payload fields from `type: json` to `type: array, items: string` (or appropriate scalar), re-run `codegen events`, drop any `as unknown as Record<string, unknown>` casts at publish call sites. Follow-up PR in dealbrain will do exactly this.

## Test plan

- [x] Schema + codegen unit tests (5 new)
- [x] Full upstream unit suite: 1422 pass
- [ ] CI green on PR
- [ ] Consumer verifies bridge_delivery actually gets rows after YAML update + regen