### PR TITLE
feat(observability): add 5th infra subsystem (ADR-008, closes #195)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ docs/                   # ADRs
 
 ### Infrastructure Subsystems (ADR-008)
 
-Four subsystems following Protocol → Backend → Factory pattern:
+Five subsystems following Protocol → Backend → Factory pattern:
 
 | Subsystem | Protocol | Default Backend | Test Backend |
 |-----------|----------|----------------|--------------|
@@ -114,6 +114,7 @@ Four subsystems following Protocol → Backend → Factory pattern:
 | Jobs | `IJobQueue` | Drizzle (pg-boss) | Memory |
 | Cache | `ICacheService` | Drizzle (TTL) | Memory |
 | Storage | `IStorageService` | Local filesystem | Memory |
+| Observability | `IObservabilityService` | Drizzle (read-only facade) | Memory |
 
 All use `DynamicModule.forRoot({ backend })` with `global: true`.
 

--- a/docs/adrs/ADR-008-subsystem-architecture.md
+++ b/docs/adrs/ADR-008-subsystem-architecture.md
@@ -41,11 +41,12 @@ export const EVENT_BUS = Symbol('EVENT_BUS');
 export const JOB_QUEUE = Symbol('JOB_QUEUE');
 export const CACHE = Symbol('CACHE');
 export const STORAGE = Symbol('STORAGE');
+export const OBSERVABILITY = Symbol('OBSERVABILITY'); // added 2026-04-22 — 5th subsystem
 ```
 
 ### Infrastructure Subsystems
 
-Four infrastructure subsystems are generated as one-time scaffolds. None of these exist yet — this ADR proposes their creation via new `bun codegen subsystem <name>` commands and corresponding templates.
+Five infrastructure subsystems are generated as one-time scaffolds. None of these exist yet — this ADR proposes their creation via new `bun codegen subsystem <name>` commands and corresponding templates.
 
 #### Events
 
@@ -210,6 +211,69 @@ export interface IStorageService {
 **Memory backend** stores Buffers in a Map. For tests.
 
 No Drizzle backend — files in Postgres is an antipattern. Users implement S3/GCS backends by implementing `IStorageService`.
+
+#### Observability (added 2026-04-22)
+
+```
+subsystems/observability/
+├── observability.protocol.ts         # IObservabilityService (5 core methods)
+├── observability.drizzle-backend.ts  # Postgres queries over framework tables
+├── observability.memory-backend.ts   # Seedable fixture backend for tests
+├── observability.module.ts           # ObservabilityModule.forRoot({ backend, reporters })
+├── observability.tokens.ts           # OBSERVABILITY, OBSERVABILITY_REPORTERS
+├── reporters/
+│   └── bridge-metrics.reporter.ts    # Opt-in 60s log sampler over bridge_delivery
+└── index.ts
+```
+
+**Protocol — the five core methods:**
+```typescript
+export interface IObservabilityService {
+  getPoolDepths(): Promise<PoolDepth[]>;
+  getRecentSyncRuns(limit: number, integrationId?: string): Promise<SyncRunSummary[]>;
+  getBridgeDeliveryHistogram(windowHours: number): Promise<StatusHistogram>;
+  getRecentFailedJobs(limit: number): Promise<JobRunFailure[]>;
+  getCursors(): Promise<CursorSnapshot[]>;
+}
+```
+
+The subsystem owns **no tables**. It's a read-only query facade over state
+that other subsystems (jobs, bridge, events, sync) already persist:
+`job_run`, `bridge_delivery`, `domain_events`, `sync_runs`, `sync_subscriptions`.
+
+**Build-first-extract-later trigger:** two concrete consumers in dealbrain
+(`BridgeMetricsReporter` sampler and `StackStatusService` `/dev/status`
+endpoint) ran the same ad-hoc SQL over framework tables. That's the
+extraction trigger — #195.
+
+**Drizzle backend** implements the five methods via SQL. Enrichment columns
+on sync runs (integration/adapter/domain) come from a join against
+`sync_subscriptions`, which owns those labels. The histogram windows on
+`COALESCE(delivered_at, attempted_at)` so terminal skipped/failed rows are
+counted alongside delivered.
+
+**Memory backend** is a fixture holder with `seed*` methods — tests stage
+slices and the protocol reads return them verbatim. No replay simulation.
+
+**Reporters** (`reporters/`) are orthogonal to backends. `BridgeMetricsReporter`
+is the first: a 60s interval sampler that logs per-window
+`(status × eventType × skipReason)` aggregates. Opt in via
+`ObservabilityModule.forRoot({ ..., reporters: { bridgeMetrics: true } })`.
+Gated so consumers without the bridge subsystem don't pay the
+`@nestjs/schedule` + bridge-schema import tax.
+
+**Extensions** (per CLAUDE.md "core/extensions"): Drizzle-specific
+capabilities that don't belong on the core interface — `pg_stat_activity`
+sampling, advisory-lock inspection, `LISTEN/NOTIFY` tie-ins — live as
+methods on the drizzle backend class. Consumers opting in accept
+backend-specific coupling. A future OTel exporter backend would likewise
+expose span-export extensions without lifting them into the core
+protocol.
+
+**No lifecycle hooks on the backends themselves.** The drizzle backend
+runs on-demand queries; the memory backend is state-only. Reporters may
+have their own `OnModuleInit`/`OnModuleDestroy` (e.g. timer setup), but
+those are per-reporter concerns.
 
 ### Lifecycle Management
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@cubejs-client/core": ">=1.0.0",
     "@nestjs/common": "^10",
     "@nestjs/core": "^10",
+    "@nestjs/schedule": "^4.0.0 || ^5.0.0",
     "@nestjs/swagger": "^7.0.0 || ^8.0.0",
     "bullmq": ">=5.0.0",
     "class-transformer": ">=0.5.0",
@@ -89,6 +90,9 @@
       "optional": true
     },
     "@cubejs-client/core": {
+      "optional": true
+    },
+    "@nestjs/schedule": {
       "optional": true
     },
     "@nestjs/swagger": {
@@ -115,6 +119,7 @@
     "@cubejs-client/core": "^1.0.0",
     "@nestjs/common": "10",
     "@nestjs/core": "10",
+    "@nestjs/schedule": "^4.0.0",
     "@nestjs/testing": "^10",
     "@types/bun": "latest",
     "@types/ejs": "^3.1.5",

--- a/runtime/subsystems/index.ts
+++ b/runtime/subsystems/index.ts
@@ -33,6 +33,29 @@ export { STORAGE } from './storage';
 export type { IStorageService } from './storage';
 export { StorageModule, LocalStorageBackend, MemoryStorageBackend } from './storage';
 
+// Observability (ADR-008, 5th subsystem)
+export { OBSERVABILITY, OBSERVABILITY_REPORTERS } from './observability';
+export type {
+  CursorSnapshot,
+  IObservabilityService,
+  JobRunFailure,
+  PoolDepth,
+  StatusHistogram,
+  SyncRunSummary,
+} from './observability';
+export {
+  ObservabilityModule,
+  DrizzleObservabilityService,
+  MemoryObservabilityService,
+  BridgeMetricsReporter,
+} from './observability';
+export type {
+  ObservabilityModuleOptions,
+  ObservabilityReporterOptions,
+  BridgeMetricsRow,
+  BridgeMetricsTick,
+} from './observability';
+
 // Auth
 export {
   ENCRYPTION_KEY,

--- a/runtime/subsystems/observability/index.ts
+++ b/runtime/subsystems/observability/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Observability subsystem public API (ADR-008, 5th subsystem).
+ *
+ * Import token + protocol in services/controllers:
+ * ```typescript
+ * import { OBSERVABILITY, type IObservabilityService } from '@pattern-stack/codegen/runtime/subsystems/observability';
+ * ```
+ *
+ * Import the module in AppModule:
+ * ```typescript
+ * import { ObservabilityModule } from '@pattern-stack/codegen/runtime/subsystems/observability';
+ * ObservabilityModule.forRoot({ backend: 'drizzle', reporters: { bridgeMetrics: true } })
+ * ```
+ */
+export { OBSERVABILITY, OBSERVABILITY_REPORTERS } from './observability.tokens';
+export type {
+  CursorSnapshot,
+  IObservabilityService,
+  JobRunFailure,
+  PoolDepth,
+  StatusHistogram,
+  SyncRunSummary,
+} from './observability.protocol';
+export {
+  ObservabilityModule,
+  type ObservabilityModuleOptions,
+  type ObservabilityReporterOptions,
+} from './observability.module';
+export { DrizzleObservabilityService } from './observability.drizzle-backend';
+export { MemoryObservabilityService } from './observability.memory-backend';
+export {
+  BridgeMetricsReporter,
+  type BridgeMetricsRow,
+  type BridgeMetricsTick,
+} from './reporters/bridge-metrics.reporter';

--- a/runtime/subsystems/observability/observability.drizzle-backend.ts
+++ b/runtime/subsystems/observability/observability.drizzle-backend.ts
@@ -1,0 +1,223 @@
+/**
+ * DrizzleObservabilityService — production backend for IObservabilityService.
+ *
+ * Pure read-only SQL over framework-owned tables:
+ *   - `job_run`            (jobs subsystem)
+ *   - `bridge_delivery`    (bridge subsystem)
+ *   - `domain_events`      (events subsystem)
+ *   - `sync_runs`          (sync subsystem)
+ *   - `sync_subscriptions` (sync subsystem)
+ *
+ * No new tables, no background loops, no lifecycle hooks. This is a query
+ * facade — each call hits the DB and returns. Rate-limit / dashboard-cadence
+ * coordination is the caller's responsibility.
+ *
+ * # Error behavior
+ *
+ * Methods throw on DB failure (consistent with the rest of the ADR-008
+ * family's write-ish backends). Dashboards and `/dev/status` endpoints are
+ * expected to handle the error surface — returning an empty snapshot on a
+ * transient DB blip would silently hide "Postgres is down" from operators,
+ * which is the opposite of what observability is for.
+ *
+ * # Drizzle-specific extensions (documented per CLAUDE.md core/extensions)
+ *
+ * Extensions MAY be added to this class that leverage Postgres-specific
+ * capability (e.g. `pg_stat_activity` sampling, advisory-lock inspection).
+ * Consumers opting into extensions accept backend-specific coupling; the
+ * core five methods below stay backend-portable.
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { desc, eq, sql } from 'drizzle-orm';
+
+import { DRIZZLE } from '../../constants/tokens';
+import type { DrizzleClient } from '../../types/drizzle';
+import { bridgeDelivery } from '../bridge/bridge-delivery.schema';
+import { jobRuns } from '../jobs/job-orchestration.schema';
+import { syncRuns, syncSubscriptions } from '../sync/sync-audit.schema';
+import type {
+  CursorSnapshot,
+  IObservabilityService,
+  JobRunFailure,
+  PoolDepth,
+  StatusHistogram,
+  SyncRunSummary,
+} from './observability.protocol';
+
+@Injectable()
+export class DrizzleObservabilityService implements IObservabilityService {
+  constructor(@Inject(DRIZZLE) private readonly db: DrizzleClient) {}
+
+  async getPoolDepths(): Promise<PoolDepth[]> {
+    // Raw SQL: Drizzle's builder drops AS-aliases on bare `sql<>` columns,
+    // which the pg driver then can't map back by name. Raw execute with
+    // explicit aliases keeps the result shape deterministic.
+    const result = await this.db.execute(sql`
+      SELECT
+        pool AS name,
+        COUNT(*) FILTER (WHERE status = 'pending')::int AS pending,
+        COUNT(*) FILTER (WHERE status = 'running')::int AS running,
+        (percentile_cont(0.95) WITHIN GROUP (
+          ORDER BY EXTRACT(EPOCH FROM (now() - claimed_at)) * 1000
+        ) FILTER (WHERE status = 'running' AND claimed_at IS NOT NULL))::int
+          AS claimed_age_p95_ms
+      FROM job_run
+      WHERE status IN ('pending','running')
+      GROUP BY pool
+      ORDER BY pool
+    `);
+
+    const rows = extractRows<{
+      name: string;
+      pending: number;
+      running: number;
+      claimed_age_p95_ms: number | null;
+    }>(result);
+
+    return rows.map((r) => ({
+      name: r.name,
+      pending: r.pending,
+      running: r.running,
+      claimedAgeP95Ms: r.claimed_age_p95_ms,
+    }));
+  }
+
+  async getRecentSyncRuns(
+    limit: number,
+    integrationId?: string,
+  ): Promise<SyncRunSummary[]> {
+    // Join to sync_subscriptions to recover integration/adapter/domain so
+    // callers don't re-hydrate the subscription row themselves. Upstream
+    // sync_runs owns only subscription_id; the enrichment columns live on
+    // the subscription side.
+    const base = this.db
+      .select({
+        id: syncRuns.id,
+        subscriptionId: syncRuns.subscriptionId,
+        integrationId: syncSubscriptions.integrationId,
+        adapter: syncSubscriptions.adapter,
+        domain: syncSubscriptions.domain,
+        direction: syncRuns.direction,
+        action: syncRuns.action,
+        status: syncRuns.status,
+        recordsFound: syncRuns.recordsFound,
+        recordsProcessed: syncRuns.recordsProcessed,
+        durationMs: syncRuns.durationMs,
+        error: syncRuns.error,
+        startedAt: syncRuns.startedAt,
+        completedAt: syncRuns.completedAt,
+      })
+      .from(syncRuns)
+      .innerJoin(
+        syncSubscriptions,
+        eq(syncRuns.subscriptionId, syncSubscriptions.id),
+      );
+
+    const filtered =
+      integrationId !== undefined
+        ? base.where(eq(syncSubscriptions.integrationId, integrationId))
+        : base;
+
+    const rows = await filtered.orderBy(desc(syncRuns.startedAt)).limit(limit);
+
+    return rows.map((r) => ({
+      id: r.id,
+      subscriptionId: r.subscriptionId,
+      integrationId: r.integrationId,
+      adapter: r.adapter,
+      domain: r.domain,
+      direction: r.direction,
+      action: r.action,
+      status: r.status,
+      recordsFound: r.recordsFound,
+      recordsProcessed: r.recordsProcessed,
+      durationMs: r.durationMs,
+      error: r.error,
+      startedAt: r.startedAt,
+      completedAt: r.completedAt,
+    }));
+  }
+
+  async getBridgeDeliveryHistogram(
+    windowHours: number,
+  ): Promise<StatusHistogram> {
+    // Window on COALESCE(delivered_at, attempted_at) so terminal skipped/
+    // failed rows (which never get delivered_at) are counted alongside
+    // delivered rows. The histogram is a flat Record<status, count>.
+    const result = await this.db.execute(sql`
+      SELECT status, COUNT(*)::int AS count
+      FROM bridge_delivery
+      WHERE COALESCE(delivered_at, attempted_at) > now() - make_interval(hours => ${windowHours})
+      GROUP BY status
+    `);
+
+    const rows = extractRows<{ status: string; count: number }>(result);
+    const hist: StatusHistogram = {};
+    for (const r of rows) hist[r.status] = r.count;
+    return hist;
+  }
+
+  async getRecentFailedJobs(limit: number): Promise<JobRunFailure[]> {
+    const rows = await this.db
+      .select({
+        id: jobRuns.id,
+        jobType: jobRuns.jobType,
+        pool: jobRuns.pool,
+        status: jobRuns.status,
+        error: jobRuns.error,
+        startedAt: jobRuns.startedAt,
+        finishedAt: jobRuns.finishedAt,
+        attempts: jobRuns.attempts,
+      })
+      .from(jobRuns)
+      .where(eq(jobRuns.status, 'failed'))
+      .orderBy(desc(jobRuns.finishedAt))
+      .limit(limit);
+
+    return rows.map((r) => ({
+      id: r.id,
+      jobType: r.jobType,
+      pool: r.pool,
+      status: r.status,
+      error: r.error,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      attempts: r.attempts,
+    }));
+  }
+
+  async getCursors(): Promise<CursorSnapshot[]> {
+    const rows = await this.db
+      .select({
+        id: syncSubscriptions.id,
+        integrationId: syncSubscriptions.integrationId,
+        adapter: syncSubscriptions.adapter,
+        domain: syncSubscriptions.domain,
+        cursor: syncSubscriptions.cursor,
+        lastSyncAt: syncSubscriptions.lastSyncAt,
+      })
+      .from(syncSubscriptions)
+      .where(eq(syncSubscriptions.enabled, true))
+      .orderBy(syncSubscriptions.integrationId, syncSubscriptions.domain);
+
+    return rows.map((r) => ({
+      subscriptionId: r.id,
+      integrationId: r.integrationId,
+      adapter: r.adapter,
+      domain: r.domain,
+      lastCursor: r.cursor,
+      lastSyncAt: r.lastSyncAt,
+    }));
+  }
+}
+
+/**
+ * Normalize `db.execute()` return shape. `node-postgres` returns `{ rows: [] }`
+ * while some pg-compatible drivers return the row array directly.
+ */
+function extractRows<T>(result: unknown): T[] {
+  const maybe = result as { rows?: unknown };
+  if (Array.isArray(maybe.rows)) return maybe.rows as T[];
+  if (Array.isArray(result)) return result as T[];
+  return [];
+}

--- a/runtime/subsystems/observability/observability.memory-backend.ts
+++ b/runtime/subsystems/observability/observability.memory-backend.ts
@@ -1,0 +1,111 @@
+/**
+ * MemoryObservabilityService — in-memory test backend for
+ * IObservabilityService.
+ *
+ * Stores snapshot data set by the test harness and returns it verbatim.
+ * This is deliberately NOT a replay-from-events simulator — the point of
+ * the memory backend is to let tests assert "when the subsystem returns
+ * X, does the caller render Y correctly?" without standing up Postgres.
+ *
+ * Tests populate the backend via the `seed*` methods, then exercise the
+ * protocol reads. Each seed method replaces (not merges) its slice, which
+ * keeps the mental model simple: the backend is a fixture holder.
+ *
+ * No lifecycle hooks (no background work to manage).
+ */
+import { Injectable } from '@nestjs/common';
+import type {
+  CursorSnapshot,
+  IObservabilityService,
+  JobRunFailure,
+  PoolDepth,
+  StatusHistogram,
+  SyncRunSummary,
+} from './observability.protocol';
+
+@Injectable()
+export class MemoryObservabilityService implements IObservabilityService {
+  private pools: PoolDepth[] = [];
+  private syncRuns: SyncRunSummary[] = [];
+  private bridgeHistogram: StatusHistogram = {};
+  private failedJobs: JobRunFailure[] = [];
+  private cursors: CursorSnapshot[] = [];
+
+  // ─── Core contract ─────────────────────────────────────────────────────
+
+  async getPoolDepths(): Promise<PoolDepth[]> {
+    return [...this.pools];
+  }
+
+  async getRecentSyncRuns(
+    limit: number,
+    integrationId?: string,
+  ): Promise<SyncRunSummary[]> {
+    const filtered =
+      integrationId !== undefined
+        ? this.syncRuns.filter((r) => r.integrationId === integrationId)
+        : this.syncRuns;
+    return filtered
+      .slice()
+      .sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime())
+      .slice(0, limit);
+  }
+
+  async getBridgeDeliveryHistogram(
+    _windowHours: number,
+  ): Promise<StatusHistogram> {
+    // Memory backend ignores the window — tests that care about windowing
+    // should seed the histogram for the window they're simulating.
+    return { ...this.bridgeHistogram };
+  }
+
+  async getRecentFailedJobs(limit: number): Promise<JobRunFailure[]> {
+    return this.failedJobs
+      .slice()
+      .sort(
+        (a, b) =>
+          (b.finishedAt?.getTime() ?? 0) - (a.finishedAt?.getTime() ?? 0),
+      )
+      .slice(0, limit);
+  }
+
+  async getCursors(): Promise<CursorSnapshot[]> {
+    return [...this.cursors];
+  }
+
+  // ─── Test seams ────────────────────────────────────────────────────────
+
+  /** Replace the pool-depth slice. */
+  seedPools(pools: PoolDepth[]): void {
+    this.pools = [...pools];
+  }
+
+  /** Replace the sync-run slice. */
+  seedSyncRuns(runs: SyncRunSummary[]): void {
+    this.syncRuns = [...runs];
+  }
+
+  /** Replace the bridge-delivery histogram. */
+  seedBridgeHistogram(hist: StatusHistogram): void {
+    this.bridgeHistogram = { ...hist };
+  }
+
+  /** Replace the failed-jobs slice. */
+  seedFailedJobs(jobs: JobRunFailure[]): void {
+    this.failedJobs = [...jobs];
+  }
+
+  /** Replace the cursor slice. */
+  seedCursors(cursors: CursorSnapshot[]): void {
+    this.cursors = [...cursors];
+  }
+
+  /** Reset every slice — for afterEach hooks. */
+  reset(): void {
+    this.pools = [];
+    this.syncRuns = [];
+    this.bridgeHistogram = {};
+    this.failedJobs = [];
+    this.cursors = [];
+  }
+}

--- a/runtime/subsystems/observability/observability.module.ts
+++ b/runtime/subsystems/observability/observability.module.ts
@@ -1,0 +1,115 @@
+/**
+ * ObservabilityModule — DynamicModule factory for the observability
+ * subsystem (ADR-008, 5th subsystem).
+ *
+ * Usage in AppModule:
+ * ```typescript
+ * ObservabilityModule.forRoot({
+ *   backend: 'drizzle',
+ *   reporters: { bridgeMetrics: true }, // optional — requires bridge subsystem
+ * })
+ * ```
+ *
+ * Usage in tests:
+ * ```typescript
+ * ObservabilityModule.forRoot({ backend: 'memory' })
+ * ```
+ *
+ * `global: true` means any module that needs `IObservabilityService` can
+ * inject `OBSERVABILITY` without importing this module. Register once in
+ * AppModule.
+ *
+ * The drizzle backend requires `DRIZZLE` to be provided globally (e.g.,
+ * via DatabaseModule). The memory backend has no dependencies.
+ *
+ * # Reporters
+ *
+ * Reporters are orthogonal to backends — they compose on top of either
+ * drizzle or memory. The `reporters.bridgeMetrics` flag enables the
+ * `BridgeMetricsReporter` sampler. Gated because the reporter imports the
+ * bridge + events schemas; consumers without the bridge subsystem should
+ * leave it off (the default).
+ *
+ * `ScheduleModule.forRoot()` is imported conditionally — only when a
+ * reporter that needs it is enabled. Keeps the module dependency-light
+ * for consumers that only want the read surface.
+ */
+import { type DynamicModule, Module } from '@nestjs/common';
+
+import { DrizzleObservabilityService } from './observability.drizzle-backend';
+import { MemoryObservabilityService } from './observability.memory-backend';
+import {
+  OBSERVABILITY,
+  OBSERVABILITY_REPORTERS,
+} from './observability.tokens';
+
+export interface ObservabilityReporterOptions {
+  /**
+   * Register `BridgeMetricsReporter` — periodic log sampler over
+   * `bridge_delivery`. Requires the bridge subsystem (schemas imported
+   * transitively). Defaults to `false`.
+   */
+  bridgeMetrics?: boolean;
+}
+
+export interface ObservabilityModuleOptions {
+  backend: 'drizzle' | 'memory';
+  reporters?: ObservabilityReporterOptions;
+}
+
+@Module({})
+export class ObservabilityModule {
+  static forRoot(
+    options: ObservabilityModuleOptions = { backend: 'drizzle' },
+  ): DynamicModule {
+    const ConcreteClass =
+      options.backend === 'drizzle'
+        ? DrizzleObservabilityService
+        : MemoryObservabilityService;
+
+    const wantsBridgeMetrics = options.reporters?.bridgeMetrics === true;
+
+    const providers: DynamicModule['providers'] = [
+      // Register the concrete class as the canonical instance.
+      ConcreteClass,
+      // OBSERVABILITY token points at the same instance — no duplicate.
+      { provide: OBSERVABILITY, useExisting: ConcreteClass },
+      // Expose the resolved reporter config for introspection / tests.
+      {
+        provide: OBSERVABILITY_REPORTERS,
+        useValue: options.reporters ?? {},
+      },
+    ];
+
+    const exports: DynamicModule['exports'] = [OBSERVABILITY];
+    if (wantsBridgeMetrics) {
+      // Lazy-require keeps the reporter file (and its @nestjs/schedule +
+      // bridge schema imports) off the hot path for consumers who don't
+      // enable the reporter.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { BridgeMetricsReporter } = require('./reporters/bridge-metrics.reporter');
+      providers.push(BridgeMetricsReporter);
+      exports.push(BridgeMetricsReporter);
+    }
+
+    // ScheduleModule is a PEER dep (optional) — only resolved when a
+    // reporter that uses it is enabled. Consumers using the read-only
+    // surface (default) are free of the @nestjs/schedule install tax.
+    const imports: DynamicModule['imports'] = [];
+    if (wantsBridgeMetrics) {
+      // Lazy-require: avoids parse-time failure for consumers that haven't
+      // installed @nestjs/schedule and don't need reporters.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ScheduleModule } = require('@nestjs/schedule');
+      imports.push(ScheduleModule.forRoot());
+    }
+
+    return {
+      module: ObservabilityModule,
+      global: true,
+      imports,
+      providers,
+      exports,
+    };
+  }
+}

--- a/runtime/subsystems/observability/observability.protocol.ts
+++ b/runtime/subsystems/observability/observability.protocol.ts
@@ -1,0 +1,167 @@
+/**
+ * IObservabilityService — core contract for the observability subsystem
+ * (ADR-008, 5th subsystem in the infrastructure family alongside events,
+ * jobs, cache, storage).
+ *
+ * The contract is a **read-only reflection surface** over framework-owned
+ * tables (`job_run`, `bridge_delivery`, `domain_events`, `sync_runs`,
+ * `sync_subscriptions`). The subsystem itself owns no tables — it's a query
+ * facade over state the other subsystems already persist.
+ *
+ * # Core + extensions (per CLAUDE.md "Backend swappability")
+ *
+ * The five methods below are the **core contract** — every backend MUST
+ * implement them. App code that calls only these is portable across
+ * backends (drizzle / memory / future OpenTelemetry exporter / etc).
+ *
+ * Backend-specific capabilities (e.g. Postgres `pg_stat_activity` sampling,
+ * an OTel span exporter, a Prometheus scrape endpoint) are exposed as
+ * **extensions** on the concrete backend class, not lifted into this
+ * interface. Consumers opting into extensions accept backend-specific
+ * coupling — that's the whole point; the core contract is what guarantees
+ * portability.
+ *
+ * # The five core methods
+ *
+ * Finalized against two concrete consumers in `dealbrain-v2`:
+ *   - `BridgeMetricsReporter` (60s sampler over `bridge_delivery`)
+ *   - `StackStatusService` (on-demand `GET /dev/status` snapshot).
+ *
+ * Every distinct SQL query those two files run is covered by one of these
+ * five methods (or relocated entirely — see `reporters/`).
+ */
+export interface IObservabilityService {
+  /**
+   * Current pool depths for the jobs subsystem.
+   *
+   * One row per pool that has at least one pending or running `job_run`.
+   * Empty pools (no activity) are omitted — the surface is "what's
+   * active", not a pool-config dump.
+   *
+   * `claimedAgeP95Ms` is the p95 of `(now - claimed_at)` in milliseconds
+   * over currently-running runs, or `null` when the pool has no running
+   * runs. Useful for spotting stuck workers.
+   */
+  getPoolDepths(): Promise<PoolDepth[]>;
+
+  /**
+   * Recent sync_runs, most-recent-first.
+   *
+   * When `integrationId` is provided, the query filters to that integration;
+   * when omitted, returns the N most recent runs across all integrations.
+   * For "last N per integration" fan-out, callers run the method per
+   * integration id rather than adding a per-group LATERAL variant to the
+   * core — LATERAL is a Postgres-ism that doesn't port cleanly to memory
+   * or hypothetical OTel/Redis backends.
+   *
+   * @param limit cap on rows returned
+   * @param integrationId optional integration filter
+   */
+  getRecentSyncRuns(
+    limit: number,
+    integrationId?: string,
+  ): Promise<SyncRunSummary[]>;
+
+  /**
+   * Count of `bridge_delivery` rows grouped by terminal status over a
+   * trailing window.
+   *
+   * The window is measured against `COALESCE(delivered_at, attempted_at)`
+   * so terminal `skipped` / `failed` rows are counted alongside
+   * `delivered`. Rows still `pending` at query time appear under
+   * `'pending'` if they fall in the window.
+   *
+   * @param windowHours trailing window size; typical values are 1h
+   * (dashboards) or 24h (daily summary).
+   */
+  getBridgeDeliveryHistogram(windowHours: number): Promise<StatusHistogram>;
+
+  /**
+   * Most recent `job_run` rows with `status = 'failed'`, newest-first.
+   *
+   * Intended for on-demand ops drill-down (dashboard panel, `/dev/status`
+   * endpoint). Consumers that need structured alerting should subscribe to
+   * job events via the jobs subsystem directly rather than polling this.
+   */
+  getRecentFailedJobs(limit: number): Promise<JobRunFailure[]>;
+
+  /**
+   * Cursor state per enabled `sync_subscriptions` row.
+   *
+   * Returns the opaque cursor payload verbatim — strategies type it
+   * internally (poll: `{ systemModstamp }`, cdc: `{ replayId }`, webhook:
+   * `{ ts }`), but the observability surface stays untyped so it works
+   * across adapter shapes.
+   */
+  getCursors(): Promise<CursorSnapshot[]>;
+}
+
+// ─── Return shapes ───────────────────────────────────────────────────────
+
+export interface PoolDepth {
+  /** Pool name (matches `job_run.pool`). */
+  name: string;
+  /** Count of `status = 'pending'` runs. */
+  pending: number;
+  /** Count of `status = 'running'` runs. */
+  running: number;
+  /**
+   * p95 of `now - claimed_at` in ms over currently-running runs, or null
+   * when the pool has no running runs.
+   */
+  claimedAgeP95Ms: number | null;
+}
+
+export interface SyncRunSummary {
+  id: string;
+  /** Subscription id the run belongs to (FK → `sync_subscriptions.id`). */
+  subscriptionId: string;
+  /**
+   * Integration id — recovered via join on `sync_subscriptions` so
+   * consumers don't have to re-hydrate the subscription to answer
+   * "which integration ran?".
+   */
+  integrationId: string | null;
+  /** Adapter label from the subscription (e.g. `'salesforce'`). */
+  adapter: string | null;
+  /** Domain label from the subscription (e.g. `'opportunity'`). */
+  domain: string | null;
+  direction: string;
+  action: string;
+  status: string;
+  recordsFound: number;
+  recordsProcessed: number;
+  durationMs: number | null;
+  error: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+}
+
+/**
+ * Histogram of bridge-delivery rows keyed by status. Keys are a subset of
+ * `'pending' | 'delivered' | 'skipped' | 'failed'`; statuses with zero
+ * rows in the window are omitted.
+ */
+export type StatusHistogram = Record<string, number>;
+
+export interface JobRunFailure {
+  id: string;
+  jobType: string;
+  pool: string;
+  status: string;
+  error: unknown;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  attempts: number;
+}
+
+export interface CursorSnapshot {
+  /** `sync_subscriptions.id`. */
+  subscriptionId: string;
+  integrationId: string;
+  adapter: string;
+  domain: string;
+  /** Opaque cursor payload; null until the first successful run advances it. */
+  lastCursor: unknown;
+  lastSyncAt: Date | null;
+}

--- a/runtime/subsystems/observability/observability.tokens.ts
+++ b/runtime/subsystems/observability/observability.tokens.ts
@@ -1,0 +1,18 @@
+/**
+ * Injection token for the observability service (ADR-008, 5th subsystem).
+ *
+ * ```typescript
+ * constructor(@Inject(OBSERVABILITY) private readonly obs: IObservabilityService) {}
+ * ```
+ *
+ * Per ADR-008, tokens use `Symbol()` for collision avoidance.
+ */
+export const OBSERVABILITY = Symbol('OBSERVABILITY');
+
+/**
+ * Opt-in config token that tells the module whether to register the
+ * `BridgeMetricsReporter` sampler. Consumers without the bridge subsystem
+ * leave this `false` (the default) so the module doesn't import the
+ * reporter's bridge-schema deps.
+ */
+export const OBSERVABILITY_REPORTERS = Symbol('OBSERVABILITY_REPORTERS');

--- a/runtime/subsystems/observability/reporters/bridge-metrics.reporter.ts
+++ b/runtime/subsystems/observability/reporters/bridge-metrics.reporter.ts
@@ -1,0 +1,222 @@
+/**
+ * BridgeMetricsReporter — periodic structured-log sampler for the
+ * `bridge_delivery` ledger.
+ *
+ * Runs on a timer (default 60s, configurable via
+ * `BRIDGE_METRICS_INTERVAL_MS`) and emits ONE `Logger.log` line per tick
+ * describing counts of rows that transitioned through each terminal
+ * status in the last tick window, grouped by `(status, event_type,
+ * skip_reason)`.
+ *
+ * # Placement
+ *
+ * Lives under `observability/reporters/` rather than in the bridge
+ * subsystem itself because:
+ *   1. It's not part of the bridge's functional surface — a reporter is
+ *      an observability concern composed on top.
+ *   2. Future reporters (Prometheus exporter, OTel bridge, etc.) slot in
+ *      here with no cross-subsystem import churn.
+ *
+ * # Opt-in via ObservabilityModule
+ *
+ * The reporter is NOT provided automatically. Opt in via
+ * `ObservabilityModule.forRoot({ backend, reporters: { bridgeMetrics: true } })`
+ * — the module only registers the reporter when that flag is set, which
+ * keeps consumers without the bridge subsystem free of its schema import
+ * tax (tree-shaken; see `observability.module.ts` for the gate).
+ *
+ * # Why a sampler instead of in-handler logs
+ *
+ * The bridge subsystem writes the `bridge_delivery` ledger directly; adding
+ * per-transition log lines inside the handler would double every row at
+ * 1:1 cardinality. Aggregating per-tick produces the "counts per event
+ * type of delivered/skipped/failed" shape that ops dashboards want,
+ * without touching the bridge runtime.
+ *
+ * # Why aggregate-per-tick rather than per-row
+ *
+ * Deliveries flow at bulk-sync cadence (one event per persisted CRM
+ * record). Per-row logs would be noisy and duplicative of the ledger
+ * itself; aggregates match the "counts per event type of
+ * delivered/skipped/failed" operator surface.
+ */
+import {
+  Inject,
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { and, eq, gt, sql } from 'drizzle-orm';
+
+import { DRIZZLE } from '../../../constants/tokens';
+import type { DrizzleClient } from '../../../types/drizzle';
+import { bridgeDelivery } from '../../bridge/bridge-delivery.schema';
+import { domainEvents } from '../../events/domain-events.schema';
+
+const INTERVAL_NAME = 'bridge-metrics-tick';
+
+/** Default sampling interval (1 minute). */
+const DEFAULT_INTERVAL_MS = 60_000;
+
+/** Minimum allowed interval — guards against env misconfig producing a hot loop. */
+const MIN_INTERVAL_MS = 1_000;
+
+export interface BridgeMetricsRow {
+  status: 'pending' | 'delivered' | 'skipped' | 'failed';
+  eventType: string;
+  skipReason: string | null;
+  count: number;
+}
+
+export interface BridgeMetricsTick {
+  windowStart: Date;
+  windowEnd: Date;
+  rows: BridgeMetricsRow[];
+}
+
+@Injectable()
+export class BridgeMetricsReporter implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(BridgeMetricsReporter.name);
+  private readonly intervalMs: number;
+  private lastTickAt: Date;
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleClient,
+    private readonly scheduler: SchedulerRegistry,
+  ) {
+    this.intervalMs = this.resolveIntervalMs();
+    // Initialize the window tail at boot so the first tick reports only
+    // deliveries that transitioned after the reporter started.
+    this.lastTickAt = new Date();
+  }
+
+  onModuleInit(): void {
+    this.logger.log(
+      `BridgeMetricsReporter starting (intervalMs=${this.intervalMs}).`,
+    );
+    const timer = setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+    // Allow the process to exit naturally in test runs — setInterval
+    // otherwise pins the event loop open.
+    timer.unref?.();
+    this.scheduler.addInterval(INTERVAL_NAME, timer);
+  }
+
+  onModuleDestroy(): void {
+    if (this.scheduler.getIntervals().includes(INTERVAL_NAME)) {
+      this.scheduler.deleteInterval(INTERVAL_NAME);
+    }
+  }
+
+  /**
+   * Run one sampling tick. Public so tests can drive it deterministically
+   * without waiting on the timer.
+   */
+  async tick(): Promise<BridgeMetricsTick> {
+    const windowStart = this.lastTickAt;
+    const windowEnd = new Date();
+    this.lastTickAt = windowEnd;
+
+    let rows: BridgeMetricsRow[] = [];
+    try {
+      rows = await this.sample(windowStart, windowEnd);
+    } catch (err) {
+      this.logger.error(
+        `bridge metrics sample failed: ${(err as Error).message}`,
+      );
+      return { windowStart, windowEnd, rows: [] };
+    }
+
+    this.emit({ windowStart, windowEnd, rows });
+    return { windowStart, windowEnd, rows };
+  }
+
+  private async sample(
+    windowStart: Date,
+    windowEnd: Date,
+  ): Promise<BridgeMetricsRow[]> {
+    // Terminal transitions land `delivered_at` for `delivered`, and leave
+    // `attempted_at` as the most recent timestamp for `skipped`/`failed`.
+    // Window on COALESCE so terminal skipped/failed rows are captured
+    // alongside delivered. Upper edge bounded by windowEnd so a long tick
+    // can't double-count rows that transitioned between sample and emit.
+    const lastTransition = sql<Date>`COALESCE(${bridgeDelivery.deliveredAt}, ${bridgeDelivery.attemptedAt})`;
+
+    const result = await this.db
+      .select({
+        status: bridgeDelivery.status,
+        eventType: domainEvents.type,
+        skipReason: bridgeDelivery.skipReason,
+        count: sql<number>`COUNT(*)::int`,
+      })
+      .from(bridgeDelivery)
+      .innerJoin(domainEvents, eq(bridgeDelivery.eventId, domainEvents.id))
+      .where(
+        and(
+          gt(lastTransition, windowStart),
+          sql`${lastTransition} <= ${windowEnd}`,
+        ),
+      )
+      .groupBy(
+        bridgeDelivery.status,
+        domainEvents.type,
+        bridgeDelivery.skipReason,
+      );
+
+    return result.map((r) => ({
+      status: r.status as BridgeMetricsRow['status'],
+      eventType: r.eventType,
+      skipReason: r.skipReason,
+      count: r.count,
+    }));
+  }
+
+  private emit(tick: BridgeMetricsTick): void {
+    if (tick.rows.length === 0) {
+      // Heartbeat — confirms the sampler is alive when deliveries are idle.
+      // Cheap enough at default 60s cadence; operators rely on this signal
+      // to distinguish "bridge quiet" from "reporter dead".
+      this.logger.log(
+        `bridge_metrics tick=empty window=[${tick.windowStart.toISOString()}..${tick.windowEnd.toISOString()}]`,
+      );
+      return;
+    }
+
+    const totals = tick.rows.reduce(
+      (acc, r) => {
+        acc[r.status] = (acc[r.status] ?? 0) + r.count;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    const detail = tick.rows
+      .map(
+        (r) =>
+          `${r.eventType}|${r.status}${r.skipReason ? `:${r.skipReason}` : ''}=${r.count}`,
+      )
+      .join(' ');
+
+    this.logger.log(
+      `bridge_metrics tick window=[${tick.windowStart.toISOString()}..${tick.windowEnd.toISOString()}] ` +
+        `totals=${JSON.stringify(totals)} detail=[${detail}]`,
+    );
+  }
+
+  private resolveIntervalMs(): number {
+    const raw = process.env['BRIDGE_METRICS_INTERVAL_MS'];
+    if (!raw) return DEFAULT_INTERVAL_MS;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < MIN_INTERVAL_MS) {
+      new Logger(BridgeMetricsReporter.name).warn(
+        `Ignoring BRIDGE_METRICS_INTERVAL_MS='${raw}' (invalid or < ${MIN_INTERVAL_MS}ms); ` +
+          `using default ${DEFAULT_INTERVAL_MS}ms.`,
+      );
+      return DEFAULT_INTERVAL_MS;
+    }
+    return parsed;
+  }
+}

--- a/src/__tests__/runtime/subsystems/observability-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/observability-module.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * ObservabilityModule unit tests (ADR-008, 5th subsystem).
+ *
+ * Verifies the `forRoot` factory wires the right backend under each of:
+ *   - `backend: 'memory'`       (tests / CI)
+ *   - `backend: 'drizzle'`      (production — mock DRIZZLE provider)
+ *   - `reporters.bridgeMetrics` (opt-in reporter registration)
+ *
+ * Also drives the smoke path from the epic #195 acceptance criteria: the
+ * module boots under BOTH backends and exposes `IObservabilityService`
+ * via the OBSERVABILITY token.
+ */
+import 'reflect-metadata';
+import { describe, expect, it, mock } from 'bun:test';
+import { Test } from '@nestjs/testing';
+import { Global, Module } from '@nestjs/common';
+import { ObservabilityModule } from '../../../../runtime/subsystems/observability/observability.module';
+import {
+  OBSERVABILITY,
+  OBSERVABILITY_REPORTERS,
+} from '../../../../runtime/subsystems/observability/observability.tokens';
+import { DrizzleObservabilityService } from '../../../../runtime/subsystems/observability/observability.drizzle-backend';
+import { MemoryObservabilityService } from '../../../../runtime/subsystems/observability/observability.memory-backend';
+import { BridgeMetricsReporter } from '../../../../runtime/subsystems/observability/reporters/bridge-metrics.reporter';
+import { DRIZZLE } from '../../../../runtime/constants/tokens';
+
+describe('ObservabilityModule.forRoot — backend selection', () => {
+  it('resolves OBSERVABILITY to MemoryObservabilityService for backend: memory', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ObservabilityModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(OBSERVABILITY)).toBeInstanceOf(
+      MemoryObservabilityService,
+    );
+    await moduleRef.close();
+  });
+
+  it('resolves OBSERVABILITY to DrizzleObservabilityService for backend: drizzle (with DRIZZLE provided)', async () => {
+    @Global()
+    @Module({
+      providers: [{ provide: DRIZZLE, useValue: {} }],
+      exports: [DRIZZLE],
+    })
+    class FakeDrizzleModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FakeDrizzleModule,
+        ObservabilityModule.forRoot({ backend: 'drizzle' }),
+      ],
+    }).compile();
+
+    expect(moduleRef.get(OBSERVABILITY)).toBeInstanceOf(
+      DrizzleObservabilityService,
+    );
+    await moduleRef.close();
+  });
+
+  it('returns a global DynamicModule that exports OBSERVABILITY', () => {
+    const dyn = ObservabilityModule.forRoot({ backend: 'memory' });
+    expect(dyn.global).toBe(true);
+    expect(dyn.exports).toContain(OBSERVABILITY);
+  });
+
+  it('defaults backend to drizzle when options omitted', () => {
+    const dyn = ObservabilityModule.forRoot();
+    // The default path requires DRIZZLE at boot; we only assert the
+    // DynamicModule shape here — the provider map includes the drizzle
+    // concrete class.
+    const providers = (dyn.providers ?? []) as unknown[];
+    const hasDrizzle = providers.some(
+      (p) => p === DrizzleObservabilityService,
+    );
+    expect(hasDrizzle).toBe(true);
+  });
+});
+
+describe('ObservabilityModule.forRoot — reporters gate', () => {
+  it('does NOT register BridgeMetricsReporter by default', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ObservabilityModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    // Resolving an unregistered provider throws — assert that happens.
+    expect(() => moduleRef.get(BridgeMetricsReporter)).toThrow();
+    expect(moduleRef.get(OBSERVABILITY_REPORTERS)).toEqual({});
+    await moduleRef.close();
+  });
+
+  it('registers BridgeMetricsReporter when reporters.bridgeMetrics=true', async () => {
+    @Global()
+    @Module({
+      providers: [{ provide: DRIZZLE, useValue: {} }],
+      exports: [DRIZZLE],
+    })
+    class FakeDrizzleModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FakeDrizzleModule,
+        ObservabilityModule.forRoot({
+          backend: 'drizzle',
+          reporters: { bridgeMetrics: true },
+        }),
+      ],
+    }).compile();
+
+    const reporter = moduleRef.get(BridgeMetricsReporter);
+    expect(reporter).toBeInstanceOf(BridgeMetricsReporter);
+    expect(moduleRef.get(OBSERVABILITY_REPORTERS)).toEqual({
+      bridgeMetrics: true,
+    });
+    await moduleRef.close();
+  });
+});
+
+describe('MemoryObservabilityService — core contract', () => {
+  it('returns seeded pool depths', async () => {
+    const svc = new MemoryObservabilityService();
+    svc.seedPools([
+      { name: 'default', pending: 2, running: 1, claimedAgeP95Ms: 500 },
+    ]);
+    const result = await svc.getPoolDepths();
+    expect(result).toEqual([
+      { name: 'default', pending: 2, running: 1, claimedAgeP95Ms: 500 },
+    ]);
+  });
+
+  it('returns empty array when no pools seeded', async () => {
+    const svc = new MemoryObservabilityService();
+    expect(await svc.getPoolDepths()).toEqual([]);
+  });
+
+  it('filters recent sync runs by integrationId', async () => {
+    const svc = new MemoryObservabilityService();
+    const now = Date.now();
+    svc.seedSyncRuns([
+      makeSyncRun({ id: 'a', integrationId: 'i-1', startedAt: new Date(now - 1000) }),
+      makeSyncRun({ id: 'b', integrationId: 'i-2', startedAt: new Date(now - 2000) }),
+      makeSyncRun({ id: 'c', integrationId: 'i-1', startedAt: new Date(now - 500) }),
+    ]);
+
+    const i1Only = await svc.getRecentSyncRuns(10, 'i-1');
+    expect(i1Only.map((r) => r.id)).toEqual(['c', 'a']);
+
+    const all = await svc.getRecentSyncRuns(10);
+    expect(all.map((r) => r.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('respects limit on recent sync runs', async () => {
+    const svc = new MemoryObservabilityService();
+    const now = Date.now();
+    svc.seedSyncRuns([
+      makeSyncRun({ id: 'a', startedAt: new Date(now - 1000) }),
+      makeSyncRun({ id: 'b', startedAt: new Date(now - 500) }),
+      makeSyncRun({ id: 'c', startedAt: new Date(now - 100) }),
+    ]);
+    const runs = await svc.getRecentSyncRuns(2);
+    expect(runs.map((r) => r.id)).toEqual(['c', 'b']);
+  });
+
+  it('returns the seeded bridge histogram', async () => {
+    const svc = new MemoryObservabilityService();
+    svc.seedBridgeHistogram({ delivered: 3, skipped: 1 });
+    expect(await svc.getBridgeDeliveryHistogram(24)).toEqual({
+      delivered: 3,
+      skipped: 1,
+    });
+  });
+
+  it('sorts failed jobs newest-first and respects limit', async () => {
+    const svc = new MemoryObservabilityService();
+    svc.seedFailedJobs([
+      makeFailedJob({ id: '1', finishedAt: new Date(1_000) }),
+      makeFailedJob({ id: '2', finishedAt: new Date(3_000) }),
+      makeFailedJob({ id: '3', finishedAt: new Date(2_000) }),
+    ]);
+    const jobs = await svc.getRecentFailedJobs(2);
+    expect(jobs.map((j) => j.id)).toEqual(['2', '3']);
+  });
+
+  it('returns seeded cursors', async () => {
+    const svc = new MemoryObservabilityService();
+    svc.seedCursors([
+      {
+        subscriptionId: 's-1',
+        integrationId: 'i-1',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        lastCursor: { systemModstamp: '2024-01-01T00:00:00Z' },
+        lastSyncAt: new Date(),
+      },
+    ]);
+    const cursors = await svc.getCursors();
+    expect(cursors).toHaveLength(1);
+    expect(cursors[0]!.adapter).toBe('salesforce');
+  });
+
+  it('reset() clears every slice', async () => {
+    const svc = new MemoryObservabilityService();
+    svc.seedPools([{ name: 'p', pending: 1, running: 0, claimedAgeP95Ms: null }]);
+    svc.seedBridgeHistogram({ delivered: 5 });
+    svc.reset();
+    expect(await svc.getPoolDepths()).toEqual([]);
+    expect(await svc.getBridgeDeliveryHistogram(1)).toEqual({});
+  });
+});
+
+describe('ObservabilityModule — smoke: boots under both backends end-to-end', () => {
+  it('memory backend: module compiles and protocol reads return', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ObservabilityModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    const svc = moduleRef.get(OBSERVABILITY) as MemoryObservabilityService;
+    expect(await svc.getPoolDepths()).toEqual([]);
+    expect(await svc.getRecentSyncRuns(5)).toEqual([]);
+    expect(await svc.getBridgeDeliveryHistogram(24)).toEqual({});
+    expect(await svc.getRecentFailedJobs(5)).toEqual([]);
+    expect(await svc.getCursors()).toEqual([]);
+
+    await moduleRef.close();
+  });
+
+  it('drizzle backend: module compiles with DRIZZLE mock and exposes the drizzle backend', async () => {
+    // Mock db for a query that would otherwise hit Postgres. The drizzle
+    // backend calls `db.execute(sql`...`)` for pool depths — we stub it.
+    const db = {
+      execute: mock(async () => ({ rows: [] })),
+      select: mock(() => ({
+        from: mock(() => ({
+          innerJoin: mock(() => ({
+            where: mock(() => ({
+              orderBy: mock(() => ({
+                limit: mock(async () => []),
+              })),
+            })),
+            orderBy: mock(() => ({
+              limit: mock(async () => []),
+            })),
+          })),
+          where: mock(() => ({
+            orderBy: mock(() => ({
+              limit: mock(async () => []),
+            })),
+          })),
+        })),
+      })),
+    };
+
+    @Global()
+    @Module({
+      providers: [{ provide: DRIZZLE, useValue: db }],
+      exports: [DRIZZLE],
+    })
+    class FakeDrizzleModule {}
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        FakeDrizzleModule,
+        ObservabilityModule.forRoot({ backend: 'drizzle' }),
+      ],
+    }).compile();
+
+    const svc = moduleRef.get(OBSERVABILITY);
+    expect(svc).toBeInstanceOf(DrizzleObservabilityService);
+
+    // Drives at least one method through the mock to prove the provider
+    // is wired to the mock DRIZZLE (not constructed with a null db).
+    const pools = await (svc as DrizzleObservabilityService).getPoolDepths();
+    expect(pools).toEqual([]);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+
+    await moduleRef.close();
+  });
+});
+
+// ─── Test fixtures ────────────────────────────────────────────────────────
+
+function makeSyncRun(
+  overrides: Partial<Parameters<MemoryObservabilityService['seedSyncRuns']>[0][number]>,
+): Parameters<MemoryObservabilityService['seedSyncRuns']>[0][number] {
+  return {
+    id: 'run-x',
+    subscriptionId: 'sub-x',
+    integrationId: 'i-x',
+    adapter: 'salesforce',
+    domain: 'opportunity',
+    direction: 'inbound',
+    action: 'poll',
+    status: 'success',
+    recordsFound: 0,
+    recordsProcessed: 0,
+    durationMs: null,
+    error: null,
+    startedAt: new Date(),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function makeFailedJob(
+  overrides: Partial<Parameters<MemoryObservabilityService['seedFailedJobs']>[0][number]>,
+): Parameters<MemoryObservabilityService['seedFailedJobs']>[0][number] {
+  return {
+    id: 'j-x',
+    jobType: 'job.t',
+    pool: 'default',
+    status: 'failed',
+    error: null,
+    startedAt: null,
+    finishedAt: new Date(),
+    attempts: 1,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `observability` as the 5th infrastructure subsystem alongside events, jobs, cache, storage. Closes #195.

Extraction trigger met per build-first-extract-later: two concrete consumers in `dealbrain-v2` (`BridgeMetricsReporter` sampler + `StackStatusService` `/dev/status`) were running the same ad-hoc SQL over framework-owned tables.

## Core contract

Five methods, every backend implements:

- \`getPoolDepths()\`
- \`getRecentSyncRuns(limit, integrationId?)\`
- \`getBridgeDeliveryHistogram(windowHours)\`
- \`getRecentFailedJobs(limit)\`
- \`getCursors()\`

The subsystem owns **no tables** — it's a read-only query facade over state that other subsystems persist (\`job_run\`, \`bridge_delivery\`, \`domain_events\`, \`sync_runs\`, \`sync_subscriptions\`).

## Backends + reporters

- **drizzle** (production) — SQL with enrichment via \`sync_subscriptions\` join; histogram windows on \`COALESCE(delivered_at, attempted_at)\`.
- **memory** (tests) — seedable fixture holder (\`seedPools\`, \`seedSyncRuns\`, etc).
- **BridgeMetricsReporter** (opt-in) — relocated from dealbrain under \`reporters/\`. Gated so consumers without the bridge subsystem don't pay the \`@nestjs/schedule\` install tax (optional peer dep, lazy-required).

## Extensions (per CLAUDE.md core/extensions rule)

Drizzle-specific features (e.g. \`pg_stat_activity\`, \`LISTEN/NOTIFY\`) belong on the concrete backend class, not the core protocol. A future OTel exporter backend would expose span-export extensions the same way.

## Test plan

- [x] 16 unit tests — factory wiring under both backends, reporter gate, end-to-end smoke through OBSERVABILITY token
- [x] \`just test-unit\` — 1438 tests pass (0 new failures)
- [x] \`bun run typecheck\` — clean
- [x] ADR-008 updated with 5th subsystem section + OBSERVABILITY token entry
- [x] CLAUDE.md subsystem table expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)