### PR TITLE
docs(adr): promote orchestration patterns RFC to ADR-032

### DIFF
--- a/docs/adrs/ADR-031-app-defined-patterns.md
+++ b/docs/adrs/ADR-031-app-defined-patterns.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-04-19
 **Owner:** Doug
-**Related:** ADR-005 (superseded), ADR-008 (Subsystem Architecture, mirrored shape)
+**Related:** ADR-005 (superseded), ADR-008 (Subsystem Architecture, mirrored shape), ADR-032 (Orchestration Patterns — extends this ADR with a second `pattern:` kind for DI registries + dispatch)
 **RFC:** `docs/RFC-app-defined-patterns.md`
 **Implementation spec:** `docs/specs/app-defined-patterns-implementation.md`
 

--- a/docs/adrs/ADR-032-orchestration-patterns.md
+++ b/docs/adrs/ADR-032-orchestration-patterns.md
@@ -1,7 +1,7 @@
-# RFC: Orchestration Patterns (Phase 3 successor to ADR-031)
+# ADR-032: Orchestration Patterns
 
-**Status:** Approved — Q1–Q4 locked 2026-04-23. Ready to promote to ADR-032 and implement.
-**Date:** 2026-04-22 (drafted), 2026-04-23 (decisions locked)
+**Status:** Accepted
+**Date:** 2026-04-23
 **Author:** Doug + Claude
 **Relates to:** Issue #196, ADR-031 (App-Defined Patterns Phase 1), `docs/RFC-app-defined-patterns.md`, ADR-008 (Subsystem Architecture)
 **Research notes:** `docs/specs/RFC-orchestration-patterns-research.md`


### PR DESCRIPTION
Promotes the locked RFC to ADR-032. No code changes. Updates cross-refs in ADR-031 and README.