### PR TITLE
feat(patterns): orchestration kind — schema + discovery + validator (Phase 3-1)

### DIFF
--- a/.claude/specs/phase-3-1-orchestration-schema-validator.md
+++ b/.claude/specs/phase-3-1-orchestration-schema-validator.md
@@ -1,0 +1,489 @@
+# Phase 3-1 — Orchestration Pattern Schema + Validator
+
+**Status:** Spec ready for build
+**Parent ADRs:** `docs/adrs/ADR-032-orchestration-patterns.md`, `docs/adrs/ADR-031-app-defined-patterns.md`
+**Scope:** Type extension, discovery routing, project-level validator. **No emission.** Phase 3-2/3-3 own templates and runtime.
+
+---
+
+## 1. Goals
+
+Extend the existing `PatternDefinition` surface and discovery pipeline to admit a second pattern `kind` — `"orchestration"` — and add a new validator (`validate-orchestration.ts`) that enforces the four ADR-032 composition rules to the extent that Phase 3-1 can statically check them. No artifact emission. The output of Phase 3-1 is: the validator returns structured `AnalysisIssue[]` from `analyzeDomain()` for orchestration-level conflicts the same way `validatePatternComposition` does for domain conflicts today.
+
+---
+
+## 2. File-by-file change list
+
+### Modify
+
+- `src/patterns/pattern-definition.ts`
+  - Add `kind?: 'domain' | 'orchestration'` (default `'domain'`) to `PatternDefinition`.
+  - Add `OrchestrationPatternDefinition` interface (registry shape per ADR-032).
+  - Add narrowing helpers `isDomainPattern(def)` and `isOrchestrationPattern(def)`.
+  - Add type alias `AnyPatternDefinition = PatternDefinition | OrchestrationPatternDefinition`.
+  - Loosen `isPatternDefinition()` so orchestration shapes also pass — already passes today (only checks `name: string`); add a JSDoc note that the discriminator is enforced downstream.
+- `src/patterns/registry.ts`
+  - Split storage into `DOMAIN_PATTERNS` + `ORCHESTRATION_PATTERNS` (renamed from `LIBRARY_PATTERNS` + `APP_PATTERNS`? — see Section 4: keep library/app axis, add orchestration as a third map. Final pick: keep `LIBRARY_PATTERNS` + `APP_PATTERNS` for domain pattern storage; add a parallel `ORCHESTRATION_APP_PATTERNS`. Library never ships orchestration patterns in Phase 3-1).
+  - Update `assertHasContribution()` to dispatch on `kind`. Orchestration contribution = registry has at least one entry.
+  - Update `loadAppPatterns()` to route on `def.kind`: orchestration → `ORCHESTRATION_APP_PATTERNS`, otherwise → `APP_PATTERNS`.
+  - Add `getOrchestrationPattern(name)`, `getAllOrchestrationPatterns()`, `getOrchestrationPatternNames()`.
+  - Update `getPattern()` JSDoc — narrow it to domain only (orchestration consumers must use `getOrchestrationPattern`). Justification in Section 4.
+  - Cross-kind name-collision detection lives in the validator, not the registry, to keep `loadAppPatterns()` non-throwing.
+- `src/patterns/index.ts`
+  - Export the new types: `OrchestrationPatternDefinition`, `AnyPatternDefinition`, `isDomainPattern`, `isOrchestrationPattern`.
+  - Export new registry accessors: `getOrchestrationPattern`, `getAllOrchestrationPatterns`, `getOrchestrationPatternNames`.
+  - Export new validator: `validateOrchestrationProject`.
+- `src/index.ts`
+  - Wire `validateOrchestrationProject` into `analyzeDomain` alongside `validatePatternProject`.
+  - Append its issues to `allIssues`.
+
+### Add
+
+- `src/patterns/validate-orchestration.ts`
+  - Project-level validator (`validateOrchestrationProject`).
+  - Returns `AnalysisIssue[]` matching `validatePatternProject`'s shape.
+- `src/__tests__/patterns/validate-orchestration.test.ts`
+  - Mirrors `src/__tests__/patterns/validate-composition.test.ts` structure.
+- `src/__tests__/patterns/fixtures/orchestration/` (new dir)
+  - `valid-crm-ports.pattern.ts` — happy path (one registry, two entries, optional dispatcher).
+  - `valid-co-keyed-crm.pattern.ts` — happy path with `coKeyedRegistries`.
+  - `name-collision-with-domain.pattern.ts` — orchestration pattern named `Synced` (collides with library domain pattern).
+  - `duplicate-entry-key.pattern.ts` — registry with two entries sharing the same `key`.
+  - `malformed-entries.pattern.ts` — registry with empty entries array.
+
+### NOT modified
+
+- `templates/**` — Phase 3-2/3-3.
+- `runtime/**` — orchestration emits to `src/orchestration/` in the consumer; runtime base classes unchanged.
+- `src/cli/**` — validator integration is via `analyzeDomain`, not the CLI directly.
+- `src/patterns/library/**` — no library-shipped orchestration patterns in Phase 3-1.
+
+---
+
+## 3. Type definitions (final TS — copy verbatim into `pattern-definition.ts`)
+
+```ts
+/**
+ * Discriminator for the two pattern shapes. Default is "domain" to preserve
+ * Phase 1 (ADR-031) behaviour — every existing PatternDefinition without a
+ * `kind` field continues to register as a domain pattern.
+ */
+export type PatternKind = 'domain' | 'orchestration';
+
+export interface PatternDefinition<TConfig = unknown> {
+  name: string;
+  /** ADR-032: defaults to "domain". Phase 3 adds "orchestration". */
+  kind?: 'domain';
+
+  // ... existing fields unchanged (extends, repositoryClass, serviceClass,
+  //     repositoryImport, serviceImport, repositoryInheritedMethods,
+  //     serviceInheritedMethods, columns, impliedBehaviors, configSchema,
+  //     description) ...
+}
+
+/**
+ * One registry's declarative shape. ADR-032 §"The Proposal".
+ *
+ * Phase 3-1 records this; Phase 3-2 codegen reads it to emit token files,
+ * provider blocks, and dispatcher overload signatures. Phase 3-1 validates
+ * only what is statically checkable from this record alone — see
+ * `validate-orchestration.ts` for the rules and their deferral notes.
+ */
+export interface OrchestrationRegistrySpec {
+  /**
+   * Type alias the consumer's tsconfig resolves (e.g. "CrmAdapterDomain").
+   * Phase 3-1 stores this string verbatim. Resolution that the path actually
+   * imports a concrete TS enum is deferred to Phase 3-2 emission, where the
+   * codegen process will need to read the consumer's source tree.
+   */
+  keyType: string;
+  /** Same shape as keyType — the registry's value-type interface ref. */
+  valueType: string;
+  entries: ReadonlyArray<{
+    /** Stable string key — must be unique within this registry. */
+    key: string;
+    /**
+     * Concrete provider class name (NOT a DI token string). Codegen will
+     * import this and use it as the constructor injectable.
+     * Phase 3-1 records it; Phase 3-2 verifies it resolves.
+     */
+    provider: string;
+  }>;
+}
+
+/**
+ * Orchestration pattern — declarative DI registry + optional dispatcher
+ * scaffold. ADR-032 §"The Proposal" + Decisions 1-8.
+ *
+ * Disjoint from `PatternDefinition` (domain): no columns, no
+ * repository/service base class, no entity-level patternConfig. Composition
+ * with domain patterns happens only at the DI layer in the consumer's
+ * generated code, not in entity YAML.
+ */
+export interface OrchestrationPatternDefinition {
+  name: string;
+  kind: 'orchestration';
+  /** Primary registry (always present). */
+  registry: OrchestrationRegistrySpec;
+  /**
+   * Sibling registries that share the primary registry's key space.
+   * ADR-032 Decision 2 — co-keyed groups are a first-class field.
+   * Validator enforces matching `keyType` across the group.
+   */
+  coKeyedRegistries?: ReadonlyArray<OrchestrationRegistrySpec>;
+  /** Optional dispatcher scaffold spec (ADR-032 Decision 4 + 5). */
+  dispatcher?: {
+    /** Class name to emit (e.g. "CrmPortsDispatcher"). */
+    className: string;
+    /**
+     * Method name the consumer overrides in their subclass to fill the
+     * assembly body (ADR-032 Decision 5).
+     */
+    assemblySlot: string;
+  };
+  /** One-line description for help output and error messages. */
+  description?: string;
+}
+
+/** Union for callers that need to handle both shapes. */
+export type AnyPatternDefinition =
+  | PatternDefinition
+  | OrchestrationPatternDefinition;
+
+export function isOrchestrationPattern(
+  def: AnyPatternDefinition,
+): def is OrchestrationPatternDefinition {
+  return (def as { kind?: PatternKind }).kind === 'orchestration';
+}
+
+export function isDomainPattern(
+  def: AnyPatternDefinition,
+): def is PatternDefinition {
+  return !isOrchestrationPattern(def);
+}
+```
+
+Note: `definePattern()` keeps its existing signature (returns `PatternDefinition<TConfig>` unchanged). Add a sibling identity function:
+
+```ts
+export function defineOrchestrationPattern(
+  def: OrchestrationPatternDefinition,
+): OrchestrationPatternDefinition {
+  return def;
+}
+```
+
+`isPatternDefinition()` stays loose (only checks `name: string`). The kind check happens in the loader.
+
+---
+
+## 4. Discovery loader change
+
+**Decision: separate maps + separate accessors.**
+
+Justification:
+- `getPattern()` is called from `validatePatternComposition` and from template-loading sites that expect domain shape. Returning a possibly-orchestration value would force every caller to narrow, even though the answer is "no" for every legitimate caller. The existing 12+ callsites would each need an `isDomainPattern` check.
+- A `kind` filter parameter on `getPattern(name, kind?)` works but obscures intent at every callsite — the reader must remember that omitting `kind` defaults to domain.
+- Separate accessors (`getPattern` for domain, `getOrchestrationPattern` for orchestration) make the type system enforce the distinction with zero runtime cost. This matches ADR-032 Decision 8: "the surfaces are disjoint."
+
+Storage:
+
+```ts
+// existing — unchanged in role but now domain-only by contract
+const LIBRARY_PATTERNS: Map<string, PatternDefinition> = new Map();
+const APP_PATTERNS: Map<string, PatternDefinition> = new Map();
+
+// new
+const ORCHESTRATION_APP_PATTERNS: Map<string, OrchestrationPatternDefinition> = new Map();
+```
+
+Loader (`loadAppPatterns`) routing:
+
+```ts
+for (const [key, val] of Object.entries(mod)) {
+  if (!key.endsWith('Pattern')) continue;
+  if (!isPatternDefinition(val)) continue;
+
+  if (isOrchestrationPattern(val as AnyPatternDefinition)) {
+    try {
+      assertOrchestrationContribution(val);
+      ORCHESTRATION_APP_PATTERNS.set(val.name, val);
+      loaded.add(val.name);
+    } catch (assertErr) {
+      errors.push(`Orchestration pattern '${val.name}' in ${rel} is invalid: ${...}`);
+    }
+  } else {
+    // existing domain branch — assertHasContribution + APP_PATTERNS.set
+  }
+}
+```
+
+`assertOrchestrationContribution(def)`: must have a `registry` with `keyType`, `valueType`, and at least one `entries[]` element. (Detailed entry validation — duplicate keys, etc. — runs in the validator, not the registry, to keep loader behaviour symmetrical with the domain side.)
+
+New accessors (mirror existing API):
+- `getOrchestrationPattern(name): OrchestrationPatternDefinition | undefined`
+- `getOrchestrationPatternNames(): string[]` (sorted)
+- `getAllOrchestrationPatterns(): OrchestrationPatternDefinition[]` (used by the project-level validator to iterate all orchestration defs in one place)
+
+`_resetRegistryForTests()` clears `ORCHESTRATION_APP_PATTERNS` too. The `includeLibrary` option does not touch it because library doesn't ship orchestration patterns in Phase 3-1.
+
+---
+
+## 5. Validator pseudocode (`src/patterns/validate-orchestration.ts`)
+
+Project-level only — orchestration patterns are not entity-attached, so there is no per-entity pass.
+
+```ts
+export interface OrchestrationProjectContext {
+  /** All orchestration patterns currently registered. */
+  orchestrationPatterns: ReadonlyArray<OrchestrationPatternDefinition>;
+  /** All domain pattern names currently registered (library + app). */
+  domainPatternNames: ReadonlyArray<string>;
+}
+
+export function validateOrchestrationProject(
+  ctx: OrchestrationProjectContext,
+): AnalysisIssue[] {
+  const issues: AnalysisIssue[] = [];
+
+  // --- Rule 1: orchestration <-> domain name collision (ADR-032 row 4) ---
+  // Hard error — names live in one registry across kinds.
+  const domainNameSet = new Set(ctx.domainPatternNames);
+  for (const orch of ctx.orchestrationPatterns) {
+    if (domainNameSet.has(orch.name)) {
+      issues.push({
+        severity: 'error',
+        type: 'pattern_name_collision',
+        entity: '<project>',
+        message:
+          `Orchestration pattern '${orch.name}' shares a name with a domain ` +
+          `pattern. Pattern names are globally unique across kinds (ADR-032 §Composition rules).`,
+      });
+    }
+  }
+
+  // --- Rule 2: orchestration <-> orchestration name collision (ADR-032 row 1) ---
+  // Storage already keys by name so a duplicate would have silently overwritten
+  // during load. Phase 3-1 cannot detect this from the post-load map alone.
+  // Decision: detect at LOAD TIME instead — see Section 4 amendment below.
+  // (Rule still listed here for traceability; the actual issue is emitted by
+  // the loader as an `errors[]` entry, surfaced via the existing
+  // LoadAppPatternsResult.errors plumbing in the CLI.)
+
+  // --- Rule 3: well-formed entries + key uniqueness within a registry ---
+  for (const orch of ctx.orchestrationPatterns) {
+    const allRegistries = [orch.registry, ...(orch.coKeyedRegistries ?? [])];
+
+    for (const reg of allRegistries) {
+      // 3a. entries[] non-empty (defensive — loader already checked primary).
+      if (reg.entries.length === 0) {
+        issues.push({
+          severity: 'error',
+          type: 'pattern_entries_empty',
+          entity: '<project>',
+          message:
+            `Orchestration pattern '${orch.name}' declares a registry with ` +
+            `no entries. Provide at least one { key, provider } pair.`,
+        });
+        continue;
+      }
+
+      // 3b. duplicate keys within this registry.
+      const seen = new Set<string>();
+      for (const entry of reg.entries) {
+        if (!entry.key || typeof entry.key !== 'string') {
+          issues.push({
+            severity: 'error',
+            type: 'pattern_entry_malformed',
+            entity: '<project>',
+            message:
+              `Orchestration pattern '${orch.name}' has an entry with a ` +
+              `missing or non-string 'key'.`,
+          });
+          continue;
+        }
+        if (!entry.provider || typeof entry.provider !== 'string') {
+          issues.push({
+            severity: 'error',
+            type: 'pattern_entry_malformed',
+            entity: '<project>',
+            message:
+              `Orchestration pattern '${orch.name}' entry '${entry.key}' has ` +
+              `a missing or non-string 'provider'.`,
+          });
+          continue;
+        }
+        if (seen.has(entry.key)) {
+          issues.push({
+            severity: 'error',
+            type: 'pattern_entry_key_duplicate',
+            entity: '<project>',
+            message:
+              `Orchestration pattern '${orch.name}' has duplicate entry key ` +
+              `'${entry.key}'. Keys must be unique within a registry.`,
+          });
+          continue;
+        }
+        seen.add(entry.key);
+      }
+    }
+
+    // --- Rule 4: co-keyed registry keyType consistency ---
+    // ADR-032 Decision 2: co-keyed registries share a key space — same keyType.
+    if (orch.coKeyedRegistries && orch.coKeyedRegistries.length > 0) {
+      const primaryKeyType = orch.registry.keyType;
+      for (const reg of orch.coKeyedRegistries) {
+        if (reg.keyType !== primaryKeyType) {
+          issues.push({
+            severity: 'error',
+            type: 'pattern_cokeyed_keytype_mismatch',
+            entity: '<project>',
+            message:
+              `Orchestration pattern '${orch.name}' co-keyed registry has ` +
+              `keyType '${reg.keyType}', expected '${primaryKeyType}'. ` +
+              `Co-keyed registries must share the primary registry's key space (ADR-032 Decision 2).`,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+```
+
+### Issue type inventory (for builder)
+
+| `type` string | Severity | Rule |
+|---|---|---|
+| `pattern_name_collision` | error | Domain ↔ orchestration name share |
+| `pattern_entries_empty` | error | Registry with no entries |
+| `pattern_entry_malformed` | error | Entry missing/non-string key or provider |
+| `pattern_entry_key_duplicate` | error | Two entries in one registry share a key |
+| `pattern_cokeyed_keytype_mismatch` | error | Co-keyed registry diverges from primary |
+
+### Loader-time check (amends Section 4)
+
+`loadAppPatterns()` must detect orchestration ↔ orchestration name collisions before `.set()` overwrites silently. Add to the orchestration branch:
+
+```ts
+if (ORCHESTRATION_APP_PATTERNS.has(val.name)) {
+  errors.push(
+    `Orchestration pattern '${val.name}' in ${rel} duplicates a previously ` +
+    `loaded orchestration pattern. Pattern names must be unique.`,
+  );
+  continue;
+}
+```
+
+The same protection should apply to domain patterns. **Open question (Section 7):** today's loader silently overwrites domain duplicates — should this PR fix that too, or stay scoped to orchestration?
+
+### Deferred rules (explicit non-goals for Phase 3-1)
+
+ADR-032 §"Composition rules" lists four conflicts. Two of them require reading consumer source code that Phase 3-1 cannot import:
+
+- **`keyType`/`valueType` resolution** (row 2): defer to Phase 3-2. The codegen emission step has the consumer source tree resolved; it can verify the type alias resolves before emitting. Phase 3-1 stores the strings verbatim.
+- **Provider not exported by any known module** (row 3): defer to Phase 3-2 + DI runtime. Phase 3-2 emits the import; DI validates at boot. Spec note: emit a warning here in Phase 3-2, not an error, per ADR-032's table.
+
+**Update ADR-032 §"Composition rules"** in the same PR to mark rows 2 and 3 as "Phase 3-2 emission" rather than "generation-time" with no further detail. See doc-updates section.
+
+---
+
+## 6. `analyzeDomain` integration
+
+In `src/index.ts`, after the existing `validatePatternProject` call:
+
+```ts
+const orchestrationProjectIssues = validateOrchestrationProject({
+  orchestrationPatterns: getAllOrchestrationPatterns(),
+  domainPatternNames: getAllPatternNames(),
+});
+
+const allIssues = [
+  ...loadIssues,
+  ...relLoadIssues,
+  ...resolveIssues,
+  ...relResolveIssues,
+  ...consistencyIssues,
+  ...patternIssues,
+  ...patternProjectIssues,
+  ...orchestrationProjectIssues,  // <-- new
+];
+```
+
+`getAllPatternNames()` returns library + app domain names already (it's the union of `LIBRARY_PATTERNS.keys()` + `APP_PATTERNS.keys()`). Confirm it does NOT include orchestration names (it shouldn't, since we route orchestration to a separate map). The collision rule (Rule 1) compares orchestration names against this domain-only set — that's exactly what we want.
+
+---
+
+## 7. Test plan
+
+### Fixtures (`src/__tests__/patterns/fixtures/orchestration/`)
+
+| File | Shape | Purpose |
+|---|---|---|
+| `valid-crm-ports.pattern.ts` | Single registry, two entries, dispatcher block | Happy path |
+| `valid-co-keyed-crm.pattern.ts` | Primary + one coKeyedRegistry, matching keyType | Co-keyed happy path |
+| `name-collision-with-domain.pattern.ts` | `name: 'Synced'` (library pattern name) | Triggers `pattern_name_collision` |
+| `duplicate-entry-key.pattern.ts` | Two entries with `key: 'salesforce-crm'` | Triggers `pattern_entry_key_duplicate` |
+| `malformed-entries.pattern.ts` | Empty `entries: []` and one entry with empty key | Triggers `pattern_entries_empty` + `pattern_entry_malformed` |
+| `cokeyed-mismatch.pattern.ts` | Co-keyed registry with different keyType | Triggers `pattern_cokeyed_keytype_mismatch` |
+
+Fixtures live as `.pattern.ts` files (not YAML) — they exercise both the loader path AND the validator. Use `defineOrchestrationPattern({...})` so type errors in the fixture surface at compile time.
+
+### Tests (`src/__tests__/patterns/validate-orchestration.test.ts`)
+
+Mirror the structure of `validate-composition.test.ts`:
+
+1. **Happy path** — register `valid-crm-ports`, `valid-co-keyed-crm`. Validator returns `[]`.
+2. **Domain ↔ orchestration name collision** — register `name-collision-with-domain` alongside library `Synced`. Expect one `pattern_name_collision` issue.
+3. **Duplicate entry key** — load `duplicate-entry-key`. Expect one `pattern_entry_key_duplicate`.
+4. **Empty entries** — load `malformed-entries`. Expect `pattern_entries_empty`. (Note: loader's `assertOrchestrationContribution` may catch the empty case earlier — if so, this case tests loader errors instead. Builder picks one consistent layer.)
+5. **Malformed entry** — entry with missing `provider`. Expect `pattern_entry_malformed`.
+6. **Co-keyed keyType mismatch** — `cokeyed-mismatch`. Expect `pattern_cokeyed_keytype_mismatch`.
+7. **Loader-level orchestration name duplicate** — register the same orchestration pattern name from two fixture files. Expect `LoadAppPatternsResult.errors` to contain a duplicate-name message.
+8. **`afterAll` cleanup** — same pattern as `validate-composition.test.ts` (reset registry, re-register canonical library patterns).
+
+---
+
+## 8. Open questions
+
+1. **Loader: should the same duplicate-name protection apply to domain patterns now?** Today's `APP_PATTERNS.set(val.name, val)` silently overwrites. Suggested answer: yes, fix in this PR — it's a small symmetric change and avoids re-touching the loader in Phase 3-2. Flag for builder confirmation.
+2. **Library orchestration patterns in Phase 3-1?** Spec assumes none ship. ADR-032 doesn't ship one either. If Phase 3-2 wants to ship a reference orchestration pattern (e.g. for documentation), the registry will need a `LIBRARY_ORCHESTRATION_PATTERNS` map. Defer until then.
+3. **Fixture loading mechanism in tests:** `validate-composition.test.ts` registers patterns inline via `registerLibraryPattern()`. For orchestration we have no `registerLibraryOrchestrationPattern()` — should one be added (test-only API) or should the tests construct `OrchestrationPatternDefinition` literals and pass directly to `validateOrchestrationProject({orchestrationPatterns: [...]})`? Spec recommends the latter (cleaner, mirrors the validator signature).
+4. **Issue `entity` field for project-level orchestration issues:** existing project-level issues (`pattern_clean_pipeline_noop`) attach to a real entity name. Orchestration issues have no entity — spec uses `'<project>'` sentinel string. Confirm this fits `AnalysisIssue` consumers (formatters, CLI output). If they require `string`, sentinel works; if they want `string | undefined`, change `entity` to optional.
+
+---
+
+## 9. Out of scope (head off scope creep)
+
+- All template work (`templates/orchestration/**`) — Phase 3-2/3-3.
+- Token file emission, `DynamicModule` emission, dispatcher class emission.
+- `paths.orchestration_src` config key — Phase 3-2 (no validator needs it).
+- Runtime base classes for orchestration — none planned.
+- Library-shipped orchestration patterns.
+- CLI changes (no new noun, no new flag) — `analyzeDomain` is the integration surface.
+- Frontend or DTO emission.
+- ADR-032 Decision 6 (`forRoot({ overrides })`) — emission concern.
+- Dispatcher subclass-extension contract enforcement — emission concern.
+- Type-resolution of `keyType`/`valueType` strings against the consumer's tsconfig — Phase 3-2.
+- Provider class export verification — Phase 3-2.
+- Any change to existing domain-pattern validation rules.
+
+---
+
+## 10. Doc updates required in same PR (living-docs rule)
+
+- `docs/adrs/ADR-032-orchestration-patterns.md` §"Composition rules":
+  - Annotate row 2 (`keyType` resolution) and row 3 (provider not exported) as "Phase 3-2 emission-time check" rather than "generation-time" with no qualifier. The Phase 3-1 validator cannot enforce these without consumer source-tree access.
+  - Add a note under §"Implementation sequence" Phase 3-1 step 3 listing the issue-type strings the validator emits (cross-references this spec).
+- `docs/adrs/ADR-031-app-defined-patterns.md` §5 (Discovery):
+  - Note that the app-pattern loader now routes by `kind` into one of two maps. Brief — one paragraph.
+- `src/patterns/pattern-definition.ts` JSDoc:
+  - Top-of-file comment mentions both pattern kinds and links to ADR-032.
+  - JSDoc on `isPatternDefinition()` notes the function is intentionally kind-agnostic — discriminator routing happens in the loader.
+
+---
+
+## 11. Builder effort estimate
+
+**S–M.** The type extension and validator are mechanical mirrors of existing code. The registry split is the only place that requires care (don't break the existing two-process determinism test). Test fixtures + 7 unit tests are routine. No template work, no runtime work, no CLI work. Expect 4–6 files modified, 6–8 files added.

--- a/docs/adrs/ADR-031-app-defined-patterns.md
+++ b/docs/adrs/ADR-031-app-defined-patterns.md
@@ -158,6 +158,8 @@ Library-shipped patterns (`SyncedPattern`, `ActivityPattern`, etc.) are pre-regi
 
 The Hygen subprocess (`templates/entity/new/prompt.js`) re-loads the registry independently using the same glob, since it has no shared memory with the CLI process. Both sides do deterministic side-effect-free reads of the same files; the duplication is one extra dynamic import per generation and is acceptable.
 
+**Pattern-kind routing (ADR-032 Phase 3-1).** The loader now branches on the loaded value's `kind` field. Domain patterns (default, no `kind` or `kind: 'domain'`) land in `APP_PATTERNS`; orchestration patterns (`kind: 'orchestration'`) land in the disjoint `ORCHESTRATION_APP_PATTERNS` map and are looked up via `getOrchestrationPattern()` instead of `getPattern()`. The two maps are name-disjoint at load time — registering the same `name` across kinds is a project-level error caught by `validateOrchestrationProject` (`pattern_name_collision`). Same-kind name duplicates within either map are also load-time errors via `LoadAppPatternsResult.errors` (the previous silent-overwrite behaviour was wrong by the architectural-correctness rule).
+
 ## Drifts From the Implementation Spec
 
 The 755-line implementation spec (`docs/specs/app-defined-patterns-implementation.md`, dated 2026-04-18) was drafted before the understand phase examined the existing code in depth. Three of its proposals contradict either the existing codebase or CLAUDE.md and are explicitly overridden here. The spec is being updated in the same commit as this ADR (per CLAUDE.md "specs are living documentation").

--- a/docs/adrs/ADR-032-orchestration-patterns.md
+++ b/docs/adrs/ADR-032-orchestration-patterns.md
@@ -111,12 +111,17 @@ The consumer imports the generated module and invokes the dispatcher. The assemb
 
 | Situation | Mode | Resolution |
 |---|---|---|
-| Two orchestration patterns declare the same `registry.token` | Generation-time hard error | Stop; names must be unique across all patterns |
-| An orchestration pattern references a `keyType` that codegen can't resolve | Generation-time hard error | Same — consumer must author the enum |
-| An orchestration pattern's entries reference a provider that isn't exported by any known module | Generation-time warning | Continue — DI validates at boot |
-| A domain pattern and an orchestration pattern share a name | Generation-time hard error | Names live in one registry |
+| Two orchestration patterns declare the same name | Load-time hard error | Stop; names must be unique across all patterns. Enforced in Phase 3-1 by `loadAppPatterns()` (`registry.ts`) — the duplicate is rejected before it can silently overwrite. |
+| An orchestration pattern references a `keyType` that codegen can't resolve | Phase 3-2 emission-time hard error | Phase 3-1 stores the type-alias string verbatim; resolution against the consumer's tsconfig requires the source-tree access codegen has during emission. |
+| An orchestration pattern's entries reference a provider that isn't exported by any known module | Phase 3-2 emission-time warning | Same reason — Phase 3-1 records `provider: string`; Phase 3-2 emits the import; DI validates at boot. |
+| A domain pattern and an orchestration pattern share a name | Generation-time hard error | Names live in one registry. Enforced in Phase 3-1 by `validateOrchestrationProject` as `pattern_name_collision`. |
 
-These mirror ADR-031 §3's column-conflict rules.
+These mirror ADR-031 §3's column-conflict rules. The Phase 3-1 validator additionally enforces three intra-pattern shape rules that are statically checkable from the registry record alone:
+
+- **`pattern_entries_empty`** — a registry (primary or co-keyed) declared with `entries: []`.
+- **`pattern_entry_malformed`** — an entry with a missing or non-string `key` / `provider`.
+- **`pattern_entry_key_duplicate`** — two entries in the same registry sharing a `key`.
+- **`pattern_cokeyed_keytype_mismatch`** — a co-keyed sibling whose `keyType` diverges from the primary registry's (Decision 2).
 
 ---
 
@@ -308,10 +313,10 @@ A YAML entity declaration can reference `pattern: Synced` or `patterns: [CrmEnti
 
 ## Implementation sequence
 
-**Phase 3-1 — Schema + registry discovery (upstream).**
-1. Extend `PatternDefinition` with `kind` discriminator + orchestration field set.
-2. Extend the pattern discovery pipeline (ADR-031 §5) to route orchestration patterns to a separate validator.
-3. Add the orchestration conflict detector (`src/patterns/validate-orchestration.ts`), mirroring `src/patterns/validate-composition.ts`.
+**Phase 3-1 — Schema + registry discovery (upstream).** *Shipped.*
+1. Extend `PatternDefinition` with `kind` discriminator + add disjoint `OrchestrationPatternDefinition` shape (`src/patterns/pattern-definition.ts`).
+2. Extend the pattern discovery pipeline (ADR-031 §5) to route orchestration patterns to a separate `ORCHESTRATION_APP_PATTERNS` map (`src/patterns/registry.ts`); domain map gains symmetric duplicate-name protection in the same change.
+3. Add the orchestration conflict detector (`src/patterns/validate-orchestration.ts`), mirroring `src/patterns/validate-composition.ts`. Wired into `analyzeDomain()`. Issues emitted: `pattern_name_collision`, `pattern_entries_empty`, `pattern_entry_malformed`, `pattern_entry_key_duplicate`, `pattern_cokeyed_keytype_mismatch`. Loader-time `LoadAppPatternsResult.errors` carries the orchestration ↔ orchestration name-duplicate case (caught before the silent-overwrite window).
 4. **No code emission yet.** Validation + schema only.
 
 **Phase 3-2 — Token + registry emission (upstream).**

--- a/src/__tests__/patterns/fixtures/orchestration/cokeyed-mismatch.pattern.ts
+++ b/src/__tests__/patterns/fixtures/orchestration/cokeyed-mismatch.pattern.ts
@@ -1,0 +1,26 @@
+/**
+ * Fixture: orchestration pattern whose co-keyed registry has a different
+ * `keyType` than the primary registry. Triggers
+ * `pattern_cokeyed_keytype_mismatch`.
+ */
+
+import { defineOrchestrationPattern } from '../../../../patterns/pattern-definition.ts';
+
+export const CoKeyedMismatchPattern = defineOrchestrationPattern({
+	name: 'CoKeyedMismatch',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'CrmAdapterDomain',
+		valueType: 'ICrmPort',
+		entries: [{ key: 'salesforce-crm', provider: 'SalesforceCrmAdapter' }],
+	},
+	coKeyedRegistries: [
+		{
+			keyType: 'AnotherKeySpace',
+			valueType: 'ICrmAuthStrategy',
+			entries: [
+				{ key: 'salesforce-crm', provider: 'SalesforceCrmAuthStrategy' },
+			],
+		},
+	],
+});

--- a/src/__tests__/patterns/fixtures/orchestration/duplicate-entry-key.pattern.ts
+++ b/src/__tests__/patterns/fixtures/orchestration/duplicate-entry-key.pattern.ts
@@ -1,0 +1,19 @@
+/**
+ * Fixture: registry with two entries sharing the same `key`. Triggers
+ * `pattern_entry_key_duplicate`.
+ */
+
+import { defineOrchestrationPattern } from '../../../../patterns/pattern-definition.ts';
+
+export const DuplicateEntryKeyPattern = defineOrchestrationPattern({
+	name: 'DuplicateEntryKey',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'CrmAdapterDomain',
+		valueType: 'ICrmPort',
+		entries: [
+			{ key: 'salesforce-crm', provider: 'SalesforceCrmAdapter' },
+			{ key: 'salesforce-crm', provider: 'AnotherSalesforceAdapter' },
+		],
+	},
+});

--- a/src/__tests__/patterns/fixtures/orchestration/malformed-entries.pattern.ts
+++ b/src/__tests__/patterns/fixtures/orchestration/malformed-entries.pattern.ts
@@ -1,0 +1,28 @@
+/**
+ * Fixture: registry with one well-formed and one malformed entry
+ * (missing `provider`). Triggers `pattern_entry_malformed`.
+ *
+ * Note: the loader's `assertOrchestrationContribution` requires a
+ * non-empty `entries[]`, so we keep at least one valid entry here and
+ * exercise the validator's per-entry malformed check on the second one.
+ * The "empty entries" loader-level case is exercised inline in the test
+ * file via a literal definition that bypasses the loader.
+ */
+
+import type { OrchestrationPatternDefinition } from '../../../../patterns/pattern-definition.ts';
+
+// Cast through unknown so TS lets us produce a deliberately malformed
+// entry for the validator to flag. Real consumer code uses
+// `defineOrchestrationPattern` which would catch this at compile time.
+export const MalformedEntriesPattern: OrchestrationPatternDefinition = {
+	name: 'MalformedEntries',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'CrmAdapterDomain',
+		valueType: 'ICrmPort',
+		entries: [
+			{ key: 'salesforce-crm', provider: 'SalesforceCrmAdapter' },
+			{ key: 'hubspot-crm', provider: '' as unknown as string },
+		],
+	},
+};

--- a/src/__tests__/patterns/fixtures/orchestration/name-collision-with-domain.pattern.ts
+++ b/src/__tests__/patterns/fixtures/orchestration/name-collision-with-domain.pattern.ts
@@ -1,0 +1,16 @@
+/**
+ * Fixture: orchestration pattern named `Synced` — collides with the
+ * library-shipped domain pattern of the same name.
+ */
+
+import { defineOrchestrationPattern } from '../../../../patterns/pattern-definition.ts';
+
+export const SyncedOrchestrationPattern = defineOrchestrationPattern({
+	name: 'Synced',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'SomeKey',
+		valueType: 'SomeValue',
+		entries: [{ key: 'a', provider: 'AProvider' }],
+	},
+});

--- a/src/__tests__/patterns/fixtures/orchestration/valid-co-keyed-crm.pattern.ts
+++ b/src/__tests__/patterns/fixtures/orchestration/valid-co-keyed-crm.pattern.ts
@@ -1,0 +1,29 @@
+/**
+ * Fixture: co-keyed orchestration pattern — primary registry plus one
+ * sibling registry that shares the primary's keyType.
+ */
+
+import { defineOrchestrationPattern } from '../../../../patterns/pattern-definition.ts';
+
+export const CrmPortsCoKeyedPattern = defineOrchestrationPattern({
+	name: 'CrmPortsCoKeyed',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'CrmAdapterDomain',
+		valueType: 'ICrmPort',
+		entries: [
+			{ key: 'salesforce-crm', provider: 'SalesforceCrmAdapter' },
+			{ key: 'hubspot-crm', provider: 'HubSpotCrmAdapter' },
+		],
+	},
+	coKeyedRegistries: [
+		{
+			keyType: 'CrmAdapterDomain',
+			valueType: 'ICrmAuthStrategy',
+			entries: [
+				{ key: 'salesforce-crm', provider: 'SalesforceCrmAuthStrategy' },
+				{ key: 'hubspot-crm', provider: 'HubSpotCrmAuthStrategy' },
+			],
+		},
+	],
+});

--- a/src/__tests__/patterns/fixtures/orchestration/valid-crm-ports.pattern.ts
+++ b/src/__tests__/patterns/fixtures/orchestration/valid-crm-ports.pattern.ts
@@ -1,0 +1,24 @@
+/**
+ * Fixture: happy-path orchestration pattern with one registry, two
+ * entries, and a dispatcher block.
+ */
+
+import { defineOrchestrationPattern } from '../../../../patterns/pattern-definition.ts';
+
+export const CrmPortsPattern = defineOrchestrationPattern({
+	name: 'CrmPorts',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'CrmAdapterDomain',
+		valueType: 'ICrmPort',
+		entries: [
+			{ key: 'salesforce-crm', provider: 'SalesforceCrmAdapter' },
+			{ key: 'hubspot-crm', provider: 'HubSpotCrmAdapter' },
+		],
+	},
+	dispatcher: {
+		className: 'CrmPortsDispatcher',
+		assemblySlot: 'build',
+	},
+	description: 'CRM adapter dispatch by domain.',
+});

--- a/src/__tests__/patterns/validate-orchestration.test.ts
+++ b/src/__tests__/patterns/validate-orchestration.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for `validateOrchestrationProject` and the loader-side
+ * orchestration routing introduced in ADR-032 Phase 3-1.
+ *
+ * The validator takes context literals (orchestrationPatterns +
+ * domainPatternNames) directly — no test-only registration helper. Loader
+ * tests use real fixture files via `loadAppPatterns()` to exercise the
+ * import + routing path end-to-end.
+ */
+
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+	defineOrchestrationPattern,
+	type OrchestrationPatternDefinition,
+} from '../../patterns/pattern-definition.ts';
+import {
+	_resetRegistryForTests,
+	getAllOrchestrationPatterns,
+	getOrchestrationPattern,
+	getOrchestrationPatternNames,
+	loadAppPatterns,
+	registerLibraryPattern,
+} from '../../patterns/registry.ts';
+import { validateOrchestrationProject } from '../../patterns/validate-orchestration.ts';
+
+// Side-effect: pre-register library domain patterns.
+import '../../patterns/index.ts';
+import {
+	ActivityPattern,
+	BasePattern,
+	KnowledgePattern,
+	MetadataPattern,
+	SyncedPattern,
+} from '../../patterns/library/index.ts';
+
+// Re-seed library patterns once this file finishes so subsequent test
+// files in the same Bun process see the canonical registry.
+afterAll(() => {
+	_resetRegistryForTests({ includeLibrary: true });
+	registerLibraryPattern(BasePattern);
+	registerLibraryPattern(SyncedPattern);
+	registerLibraryPattern(ActivityPattern);
+	registerLibraryPattern(KnowledgePattern);
+	registerLibraryPattern(MetadataPattern);
+});
+
+// ============================================================================
+// Direct validator tests (literals)
+// ============================================================================
+
+describe('validateOrchestrationProject — happy paths', () => {
+	test('no orchestration patterns → no issues', () => {
+		expect(
+			validateOrchestrationProject({
+				orchestrationPatterns: [],
+				domainPatternNames: ['Synced', 'Activity'],
+			}),
+		).toEqual([]);
+	});
+
+	test('single well-formed registry, two entries → no issues', () => {
+		const orch = defineOrchestrationPattern({
+			name: 'CrmPorts',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'CrmAdapterDomain',
+				valueType: 'ICrmPort',
+				entries: [
+					{ key: 'salesforce-crm', provider: 'SalesforceCrmAdapter' },
+					{ key: 'hubspot-crm', provider: 'HubSpotCrmAdapter' },
+				],
+			},
+		});
+		expect(
+			validateOrchestrationProject({
+				orchestrationPatterns: [orch],
+				domainPatternNames: ['Synced'],
+			}),
+		).toEqual([]);
+	});
+
+	test('co-keyed registries with matching keyType → no issues', () => {
+		const orch = defineOrchestrationPattern({
+			name: 'CrmPortsCoKeyed',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'CrmAdapterDomain',
+				valueType: 'ICrmPort',
+				entries: [{ key: 'sf', provider: 'SfAdapter' }],
+			},
+			coKeyedRegistries: [
+				{
+					keyType: 'CrmAdapterDomain',
+					valueType: 'ICrmAuth',
+					entries: [{ key: 'sf', provider: 'SfAuth' }],
+				},
+			],
+		});
+		expect(
+			validateOrchestrationProject({
+				orchestrationPatterns: [orch],
+				domainPatternNames: [],
+			}),
+		).toEqual([]);
+	});
+});
+
+describe('validateOrchestrationProject — name collision (Rule 1)', () => {
+	test('orchestration name shared with a domain pattern → error', () => {
+		const orch = defineOrchestrationPattern({
+			name: 'Synced', // collides with the library domain pattern
+			kind: 'orchestration',
+			registry: {
+				keyType: 'K',
+				valueType: 'V',
+				entries: [{ key: 'a', provider: 'AP' }],
+			},
+		});
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: [orch],
+			domainPatternNames: ['Synced', 'Activity'],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.severity).toBe('error');
+		expect(issues[0]!.type).toBe('pattern_name_collision');
+		expect(issues[0]!.message).toMatch(/'Synced'/);
+		expect(issues[0]!.message).toMatch(/domain pattern/);
+	});
+});
+
+describe('validateOrchestrationProject — empty entries (Rule 2)', () => {
+	test('co-keyed registry with empty entries → error', () => {
+		// Loader rejects empty primary; co-keyed siblings can slip through
+		// since they don't go via assertOrchestrationContribution.
+		const orch: OrchestrationPatternDefinition = {
+			name: 'EmptyCoKeyed',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'K',
+				valueType: 'V',
+				entries: [{ key: 'a', provider: 'AP' }],
+			},
+			coKeyedRegistries: [
+				{ keyType: 'K', valueType: 'V2', entries: [] },
+			],
+		};
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: [orch],
+			domainPatternNames: [],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.type).toBe('pattern_entries_empty');
+	});
+});
+
+describe('validateOrchestrationProject — duplicate entry key (Rule 3b)', () => {
+	test('two entries sharing a key → error', () => {
+		const orch: OrchestrationPatternDefinition = {
+			name: 'DupKey',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'K',
+				valueType: 'V',
+				entries: [
+					{ key: 'sf', provider: 'A' },
+					{ key: 'sf', provider: 'B' },
+				],
+			},
+		};
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: [orch],
+			domainPatternNames: [],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.type).toBe('pattern_entry_key_duplicate');
+		expect(issues[0]!.message).toMatch(/'sf'/);
+	});
+});
+
+describe('validateOrchestrationProject — malformed entry (Rule 3a)', () => {
+	test('entry with empty provider → error', () => {
+		const orch: OrchestrationPatternDefinition = {
+			name: 'BadProvider',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'K',
+				valueType: 'V',
+				entries: [
+					{ key: 'sf', provider: 'OK' },
+					{ key: 'hub', provider: '' as unknown as string },
+				],
+			},
+		};
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: [orch],
+			domainPatternNames: [],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.type).toBe('pattern_entry_malformed');
+		expect(issues[0]!.message).toMatch(/'hub'/);
+	});
+
+	test('entry with empty key → error', () => {
+		const orch: OrchestrationPatternDefinition = {
+			name: 'BadKey',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'K',
+				valueType: 'V',
+				entries: [{ key: '' as unknown as string, provider: 'OK' }],
+			},
+		};
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: [orch],
+			domainPatternNames: [],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.type).toBe('pattern_entry_malformed');
+	});
+});
+
+describe('validateOrchestrationProject — co-keyed keyType mismatch (Rule 4)', () => {
+	test('co-keyed registry with divergent keyType → error', () => {
+		const orch = defineOrchestrationPattern({
+			name: 'Mismatch',
+			kind: 'orchestration',
+			registry: {
+				keyType: 'CrmAdapterDomain',
+				valueType: 'ICrmPort',
+				entries: [{ key: 'sf', provider: 'SfAdapter' }],
+			},
+			coKeyedRegistries: [
+				{
+					keyType: 'AnotherKey',
+					valueType: 'ICrmAuth',
+					entries: [{ key: 'sf', provider: 'SfAuth' }],
+				},
+			],
+		});
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: [orch],
+			domainPatternNames: [],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.type).toBe('pattern_cokeyed_keytype_mismatch');
+		expect(issues[0]!.message).toMatch(/'AnotherKey'/);
+		expect(issues[0]!.message).toMatch(/'CrmAdapterDomain'/);
+	});
+});
+
+// ============================================================================
+// Loader integration — fixture files exercise the import path
+// ============================================================================
+
+describe('loadAppPatterns — orchestration routing', () => {
+	const fixturesDir = path.resolve(
+		path.dirname(import.meta.url.replace('file://', '')),
+		'fixtures/orchestration',
+	);
+
+	test('valid orchestration fixture lands in the orchestration map', async () => {
+		_resetRegistryForTests();
+		const result = await loadAppPatterns(
+			['valid-crm-ports.pattern.ts'],
+			fixturesDir,
+		);
+		expect(result.errors).toEqual([]);
+		expect(result.loaded).toContain('CrmPorts');
+		expect(getOrchestrationPattern('CrmPorts')?.name).toBe('CrmPorts');
+		expect(getOrchestrationPatternNames()).toEqual(['CrmPorts']);
+		// Domain accessor must NOT see it.
+		const { getPattern } = await import('../../patterns/registry.ts');
+		expect(getPattern('CrmPorts')).toBeUndefined();
+	});
+
+	test('co-keyed fixture loads cleanly and validator returns []', async () => {
+		_resetRegistryForTests();
+		const result = await loadAppPatterns(
+			['valid-co-keyed-crm.pattern.ts'],
+			fixturesDir,
+		);
+		expect(result.errors).toEqual([]);
+		expect(result.loaded).toContain('CrmPortsCoKeyed');
+		expect(
+			validateOrchestrationProject({
+				orchestrationPatterns: getAllOrchestrationPatterns(),
+				domainPatternNames: [],
+			}),
+		).toEqual([]);
+	});
+});
+
+describe('loadAppPatterns — duplicate-name detection', () => {
+	let tmpdir: string;
+
+	function writePatternFile(relPath: string, source: string): string {
+		const abs = path.join(tmpdir, relPath);
+		fs.mkdirSync(path.dirname(abs), { recursive: true });
+		fs.writeFileSync(abs, source, 'utf8');
+		return abs;
+	}
+
+	afterAll(() => {
+		try {
+			for (const leftover of fs.readdirSync(os.tmpdir())) {
+				if (leftover.startsWith('orch-loader-')) {
+					fs.rmSync(path.join(os.tmpdir(), leftover), {
+						recursive: true,
+						force: true,
+					});
+				}
+			}
+		} catch {
+			// ignore
+		}
+	});
+
+	test('two orchestration fixtures with the same name → loader error', async () => {
+		tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-loader-'));
+		fs.mkdirSync(path.join(tmpdir, 'src', 'patterns'), { recursive: true });
+		_resetRegistryForTests();
+
+		const defModule = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/pattern-definition.ts',
+		);
+
+		const fileBody = (exportName: string) => `
+import { defineOrchestrationPattern } from '${defModule}';
+export const ${exportName} = defineOrchestrationPattern({
+	name: 'DupName',
+	kind: 'orchestration',
+	registry: {
+		keyType: 'K',
+		valueType: 'V',
+		entries: [{ key: 'a', provider: 'AP' }],
+	},
+});
+`;
+
+		writePatternFile('src/patterns/a.pattern.ts', fileBody('FirstPattern'));
+		writePatternFile('src/patterns/b.pattern.ts', fileBody('SecondPattern'));
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+
+		// First load succeeds; second one is rejected with a duplicate-name error.
+		expect(result.loaded).toEqual(['DupName']);
+		expect(result.errors.length).toBe(1);
+		expect(result.errors[0]).toMatch(/duplicates a previously loaded/);
+	});
+
+	test('two domain fixtures with the same name → loader error (symmetric protection)', async () => {
+		tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-loader-'));
+		fs.mkdirSync(path.join(tmpdir, 'src', 'patterns'), { recursive: true });
+		_resetRegistryForTests();
+
+		const defModule = path.resolve(
+			path.dirname(import.meta.url.replace('file://', '')),
+			'../../patterns/pattern-definition.ts',
+		);
+
+		const fileBody = (exportName: string) => `
+import { definePattern } from '${defModule}';
+export const ${exportName} = definePattern({
+	name: 'DupDomain',
+	repositoryClass: 'R',
+});
+`;
+
+		writePatternFile('src/patterns/a.pattern.ts', fileBody('FirstPattern'));
+		writePatternFile('src/patterns/b.pattern.ts', fileBody('SecondPattern'));
+
+		const result = await loadAppPatterns(
+			['src/patterns/*.pattern.ts'],
+			tmpdir,
+		);
+
+		expect(result.loaded).toEqual(['DupDomain']);
+		expect(result.errors.length).toBe(1);
+		expect(result.errors[0]).toMatch(/duplicates a previously loaded app pattern/);
+	});
+});
+
+describe('loadAppPatterns — orchestration assertion failures', () => {
+	const fixturesDir = path.resolve(
+		path.dirname(import.meta.url.replace('file://', '')),
+		'fixtures/orchestration',
+	);
+
+	test('malformed-entries fixture loads (one bad provider, but entries non-empty); validator catches it', async () => {
+		_resetRegistryForTests();
+		const result = await loadAppPatterns(
+			['malformed-entries.pattern.ts'],
+			fixturesDir,
+		);
+		// Loader's assertOrchestrationContribution only checks shape +
+		// non-empty entries — malformed individual entries pass loader but
+		// surface in validator.
+		expect(result.errors).toEqual([]);
+		expect(result.loaded).toContain('MalformedEntries');
+
+		const issues = validateOrchestrationProject({
+			orchestrationPatterns: getAllOrchestrationPatterns(),
+			domainPatternNames: [],
+		});
+		expect(issues.length).toBe(1);
+		expect(issues[0]!.type).toBe('pattern_entry_malformed');
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ import {
 	validatePatternComposition,
 	validatePatternProject,
 } from './patterns/validate-composition.js';
+import { validateOrchestrationProject } from './patterns/validate-orchestration.js';
+import {
+	getAllOrchestrationPatterns,
+	getAllPatternNames,
+} from './patterns/registry.js';
 import type { AnalysisResult, OutputFormat } from './analyzer/types';
 
 /**
@@ -87,6 +92,16 @@ export async function analyzeDomain(
 		architecture: opts.architecture,
 	});
 
+	// ADR-032 Phase 3-1 — orchestration pattern project-level validator.
+	// Compares orchestration names against the domain name set (cross-kind
+	// collision is a hard error), and walks each orchestration pattern's
+	// registry shape for malformed entries, duplicate keys, and co-keyed
+	// keyType drift.
+	const orchestrationProjectIssues = validateOrchestrationProject({
+		orchestrationPatterns: getAllOrchestrationPatterns(),
+		domainPatternNames: getAllPatternNames(),
+	});
+
 	// Compute statistics
 	const statistics = computeStatistics(graph);
 
@@ -99,6 +114,7 @@ export async function analyzeDomain(
 		...consistencyIssues,
 		...patternIssues,
 		...patternProjectIssues,
+		...orchestrationProjectIssues,
 	];
 
 	// Determine validity (only errors make it invalid)

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -12,15 +12,25 @@ import './library/index.js';
 
 export {
 	definePattern,
+	defineOrchestrationPattern,
+	isDomainPattern,
+	isOrchestrationPattern,
 	isPatternDefinition,
+	type AnyPatternDefinition,
+	type OrchestrationPatternDefinition,
+	type OrchestrationRegistrySpec,
 	type PatternColumnContribution,
 	type PatternDefinition,
+	type PatternKind,
 } from './pattern-definition.js';
 
 export {
+	getAllOrchestrationPatterns,
 	getAllPatternNames,
 	getAppPatternNames,
 	getLibraryPatternNames,
+	getOrchestrationPattern,
+	getOrchestrationPatternNames,
 	getPattern,
 	loadAppPatterns,
 	registerLibraryPattern,
@@ -32,6 +42,11 @@ export {
 	validatePatternProject,
 	type PatternProjectContext,
 } from './validate-composition.js';
+
+export {
+	validateOrchestrationProject,
+	type OrchestrationProjectContext,
+} from './validate-orchestration.js';
 
 // Library pattern values — available for consumers that want to reference
 // them programmatically (rare, but cheap to export).

--- a/src/patterns/pattern-definition.ts
+++ b/src/patterns/pattern-definition.ts
@@ -9,9 +9,17 @@
  * registry (see `src/cli/shared/hygen.ts` — the registry loads twice per
  * `entity new` invocation).
  *
+ * Two pattern kinds share this surface:
+ *   - **domain** (default; ADR-031) — `PatternDefinition`. Contributes
+ *     repository/service base classes, columns, behaviors to entities that
+ *     declare `pattern:`/`patterns:` in YAML.
+ *   - **orchestration** (ADR-032) — `OrchestrationPatternDefinition`. Declares
+ *     a DI registry + optional dispatcher scaffold. Not entity-attached;
+ *     codegen emits a NestJS module under `src/orchestration/` instead.
+ *
  * See `docs/adrs/ADR-031-app-defined-patterns.md` §"Decision 1" for the
- * binding surface and `docs/specs/app-defined-patterns-implementation.md` §1
- * for the file-by-file rationale.
+ * domain binding surface and `docs/adrs/ADR-032-orchestration-patterns.md`
+ * for the orchestration kind.
  */
 
 import type { ZodSchema } from 'zod';
@@ -32,6 +40,13 @@ export interface PatternColumnContribution {
 }
 
 /**
+ * Discriminator for the two pattern shapes. Default is `"domain"` to preserve
+ * Phase 1 (ADR-031) behaviour — every existing PatternDefinition without a
+ * `kind` field continues to register as a domain pattern.
+ */
+export type PatternKind = 'domain' | 'orchestration';
+
+/**
  * The full pattern metadata record. Every `definePattern({...})` call
  * returns a value of this shape; the library and consumer registries
  * store these and look them up by `name`.
@@ -39,6 +54,14 @@ export interface PatternColumnContribution {
 export interface PatternDefinition<TConfig = unknown> {
 	/** Unique name used in YAML — e.g. `pattern: Synced` */
 	name: string;
+
+	/**
+	 * ADR-032: defaults to `"domain"`. Phase 3 adds `"orchestration"` as a
+	 * disjoint shape (see `OrchestrationPatternDefinition`). Domain
+	 * `PatternDefinition` instances must omit this field or set it to
+	 * `"domain"`; the loader routes orchestration values to a separate map.
+	 */
+	kind?: 'domain';
 
 	/**
 	 * Built-in patterns this extends, by name. Phase 1 supports single-depth
@@ -118,6 +141,11 @@ export function definePattern<TConfig = unknown>(
  * exists to anchor the `extends` chain without contributing anything).
  * Stricter shape rules belong in the registry's "at-least-one-contribution"
  * check, not here.
+ *
+ * This function is intentionally **kind-agnostic** — both
+ * `PatternDefinition` (domain) and `OrchestrationPatternDefinition`
+ * (orchestration) pass. The discriminator routing happens in the loader
+ * via `isOrchestrationPattern()`/`isDomainPattern()`.
  */
 export function isPatternDefinition(val: unknown): val is PatternDefinition {
 	return (
@@ -126,4 +154,101 @@ export function isPatternDefinition(val: unknown): val is PatternDefinition {
 		'name' in val &&
 		typeof (val as { name: unknown }).name === 'string'
 	);
+}
+
+// ============================================================================
+// Orchestration kind (ADR-032)
+// ============================================================================
+
+/**
+ * One registry's declarative shape. ADR-032 §"The Proposal".
+ *
+ * Phase 3-1 records this; Phase 3-2 codegen reads it to emit token files,
+ * provider blocks, and dispatcher overload signatures. Phase 3-1 validates
+ * only what is statically checkable from this record alone — see
+ * `validate-orchestration.ts` for the rules and their deferral notes.
+ */
+export interface OrchestrationRegistrySpec {
+	/**
+	 * Type alias the consumer's tsconfig resolves (e.g. `"CrmAdapterDomain"`).
+	 * Phase 3-1 stores this string verbatim. Resolution that the path actually
+	 * imports a concrete TS enum is deferred to Phase 3-2 emission, where
+	 * codegen will need to read the consumer's source tree.
+	 */
+	keyType: string;
+	/** Same shape as `keyType` — the registry's value-type interface ref. */
+	valueType: string;
+	entries: ReadonlyArray<{
+		/** Stable string key — must be unique within this registry. */
+		key: string;
+		/**
+		 * Concrete provider class name (NOT a DI token string). Codegen will
+		 * import this and use it as the constructor injectable.
+		 * Phase 3-1 records it; Phase 3-2 verifies it resolves.
+		 */
+		provider: string;
+	}>;
+}
+
+/**
+ * Orchestration pattern — declarative DI registry + optional dispatcher
+ * scaffold. ADR-032 §"The Proposal" + Decisions 1-8.
+ *
+ * Disjoint from `PatternDefinition` (domain): no columns, no
+ * repository/service base class, no entity-level patternConfig. Composition
+ * with domain patterns happens only at the DI layer in the consumer's
+ * generated code, not in entity YAML.
+ */
+export interface OrchestrationPatternDefinition {
+	name: string;
+	kind: 'orchestration';
+	/** Primary registry (always present). */
+	registry: OrchestrationRegistrySpec;
+	/**
+	 * Sibling registries that share the primary registry's key space.
+	 * ADR-032 Decision 2 — co-keyed groups are a first-class field.
+	 * Validator enforces matching `keyType` across the group.
+	 */
+	coKeyedRegistries?: ReadonlyArray<OrchestrationRegistrySpec>;
+	/** Optional dispatcher scaffold spec (ADR-032 Decision 4 + 5). */
+	dispatcher?: {
+		/** Class name to emit (e.g. `"CrmPortsDispatcher"`). */
+		className: string;
+		/**
+		 * Method name the consumer overrides in their subclass to fill the
+		 * assembly body (ADR-032 Decision 5).
+		 */
+		assemblySlot: string;
+	};
+	/** One-line description for help output and error messages. */
+	description?: string;
+}
+
+/** Union for callers that need to handle both shapes. */
+export type AnyPatternDefinition =
+	| PatternDefinition
+	| OrchestrationPatternDefinition;
+
+export function isOrchestrationPattern(
+	def: AnyPatternDefinition,
+): def is OrchestrationPatternDefinition {
+	return (def as { kind?: PatternKind }).kind === 'orchestration';
+}
+
+export function isDomainPattern(
+	def: AnyPatternDefinition,
+): def is PatternDefinition {
+	return !isOrchestrationPattern(def);
+}
+
+/**
+ * Identity function that returns its argument unchanged — orchestration
+ * counterpart to `definePattern()`. The body is trivial on purpose; the
+ * point is to give TypeScript a hook so consumer fixtures get full
+ * compile-time checking against `OrchestrationPatternDefinition`.
+ */
+export function defineOrchestrationPattern(
+	def: OrchestrationPatternDefinition,
+): OrchestrationPatternDefinition {
+	return def;
 }

--- a/src/patterns/registry.ts
+++ b/src/patterns/registry.ts
@@ -1,12 +1,16 @@
 /**
  * Pattern Registry — library + app pattern storage and discovery.
  *
- * Two stores keyed by pattern name:
+ * Three stores keyed by pattern name:
  *   - `LIBRARY_PATTERNS` — seeded by the codegen package itself when the
  *     `src/patterns/library/*` barrel imports execute. Consumers never
- *     list these in `codegen.config.yaml patterns:`.
+ *     list these in `codegen.config.yaml patterns:`. Domain only.
  *   - `APP_PATTERNS`     — populated by `loadAppPatterns()` from a
  *     consumer-supplied glob set (default `src/patterns/*.pattern.ts`).
+ *     Domain only.
+ *   - `ORCHESTRATION_APP_PATTERNS` — populated by the same loader,
+ *     routed by `kind: 'orchestration'` (ADR-032). No library
+ *     orchestration patterns ship in Phase 3-1.
  *
  * `getPattern()` checks app patterns first so a consumer could, in
  * principle, shadow a library pattern by using the same `name`. That's
@@ -26,7 +30,10 @@ import { glob } from 'glob';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
+	isOrchestrationPattern,
 	isPatternDefinition,
+	type AnyPatternDefinition,
+	type OrchestrationPatternDefinition,
 	type PatternDefinition,
 } from './pattern-definition.js';
 
@@ -36,6 +43,15 @@ import {
 
 const LIBRARY_PATTERNS: Map<string, PatternDefinition> = new Map();
 const APP_PATTERNS: Map<string, PatternDefinition> = new Map();
+
+/**
+ * Orchestration patterns (ADR-032). Library never ships orchestration
+ * patterns in Phase 3-1 — only the app-pattern map exists for this kind.
+ * If a library-shipped orchestration pattern ever lands, add a parallel
+ * `LIBRARY_ORCHESTRATION_PATTERNS` map; for now keep storage minimal.
+ */
+const ORCHESTRATION_APP_PATTERNS: Map<string, OrchestrationPatternDefinition> =
+	new Map();
 
 /**
  * Every pattern must contribute *something* — either at least one column
@@ -54,6 +70,50 @@ function assertHasContribution(def: PatternDefinition): void {
 		throw new Error(
 			`Pattern '${def.name}' contributes nothing — at least one of ` +
 				'`columns`, `repositoryClass`, or `serviceClass` is required.',
+		);
+	}
+}
+
+/**
+ * Orchestration counterpart to `assertHasContribution`. An orchestration
+ * pattern's minimum contribution is one registry with at least one entry —
+ * a registry with zero entries would emit a token + module that nothing
+ * resolves to, almost certainly a typo. Detailed entry validation
+ * (duplicate keys, malformed entries, co-keyed mismatches) lives in the
+ * project-level validator so loader behaviour stays symmetrical with the
+ * domain side: load is non-throwing for content-level issues, validator
+ * is the single authoritative reporter.
+ */
+function assertOrchestrationContribution(
+	def: OrchestrationPatternDefinition,
+): void {
+	if (!def.registry || typeof def.registry !== 'object') {
+		throw new Error(
+			`Orchestration pattern '${def.name}' is missing a 'registry' field.`,
+		);
+	}
+	if (
+		typeof def.registry.keyType !== 'string' ||
+		def.registry.keyType.length === 0
+	) {
+		throw new Error(
+			`Orchestration pattern '${def.name}' registry.keyType must be a non-empty string.`,
+		);
+	}
+	if (
+		typeof def.registry.valueType !== 'string' ||
+		def.registry.valueType.length === 0
+	) {
+		throw new Error(
+			`Orchestration pattern '${def.name}' registry.valueType must be a non-empty string.`,
+		);
+	}
+	if (
+		!Array.isArray(def.registry.entries) ||
+		def.registry.entries.length === 0
+	) {
+		throw new Error(
+			`Orchestration pattern '${def.name}' registry.entries must contain at least one entry.`,
 		);
 	}
 }
@@ -79,17 +139,24 @@ export function registerLibraryPattern(def: PatternDefinition): void {
 // ============================================================================
 
 /**
- * Resolve a pattern by name. App patterns shadow library patterns with
- * the same name — useful in principle but not a documented feature.
+ * Resolve a **domain** pattern by name. App patterns shadow library
+ * patterns with the same name — useful in principle but not a documented
+ * feature.
+ *
+ * Orchestration patterns live in a disjoint store; use
+ * `getOrchestrationPattern()` to look those up. The two surfaces are
+ * intentionally separate (ADR-032 Decision 8) so callers don't have to
+ * narrow the result on every callsite.
  */
 export function getPattern(name: string): PatternDefinition | undefined {
 	return APP_PATTERNS.get(name) ?? LIBRARY_PATTERNS.get(name);
 }
 
 /**
- * Return every registered pattern name (library + app), sorted for
+ * Return every registered domain pattern name (library + app), sorted for
  * deterministic output. The two-process determinism test relies on this
- * ordering being stable across processes.
+ * ordering being stable across processes. Orchestration names are NOT
+ * included — see `getOrchestrationPatternNames()`.
  */
 export function getAllPatternNames(): string[] {
 	const set = new Set<string>([
@@ -107,6 +174,33 @@ export function getLibraryPatternNames(): string[] {
 /** App-only view — mainly for debugging and tests. */
 export function getAppPatternNames(): string[] {
 	return [...APP_PATTERNS.keys()].sort();
+}
+
+// ============================================================================
+// Orchestration accessors (ADR-032)
+// ============================================================================
+
+/** Resolve an orchestration pattern by name. */
+export function getOrchestrationPattern(
+	name: string,
+): OrchestrationPatternDefinition | undefined {
+	return ORCHESTRATION_APP_PATTERNS.get(name);
+}
+
+/** Sorted list of orchestration pattern names. */
+export function getOrchestrationPatternNames(): string[] {
+	return [...ORCHESTRATION_APP_PATTERNS.keys()].sort();
+}
+
+/**
+ * Every registered orchestration pattern, sorted by name. The
+ * project-level validator iterates this list in one place so issue
+ * ordering is stable across processes.
+ */
+export function getAllOrchestrationPatterns(): OrchestrationPatternDefinition[] {
+	return getOrchestrationPatternNames().map(
+		(n) => ORCHESTRATION_APP_PATTERNS.get(n)!,
+	);
 }
 
 // ============================================================================
@@ -174,14 +268,49 @@ export async function loadAppPatterns(
 			for (const [key, val] of Object.entries(mod)) {
 				if (!key.endsWith('Pattern')) continue;
 				if (!isPatternDefinition(val)) continue;
-				try {
-					assertHasContribution(val);
+
+				// Route on `kind`. Domain (default) and orchestration land in
+				// disjoint maps; same-name collisions within either map are
+				// load-time errors (silent overwrite was wrong by CLAUDE.md
+				// "architectural correctness" — see ADR-032 §Composition rules
+				// row 1).
+				if (isOrchestrationPattern(val as unknown as AnyPatternDefinition)) {
+					const orch = val as unknown as OrchestrationPatternDefinition;
+					try {
+						assertOrchestrationContribution(orch);
+					} catch (assertErr) {
+						errors.push(
+							`Orchestration pattern '${orch.name}' in ${relPath(filePath, cwd)} is invalid: ${stringifyError(assertErr)}`,
+						);
+						continue;
+					}
+					const existingOrch = ORCHESTRATION_APP_PATTERNS.get(orch.name);
+					if (existingOrch && existingOrch !== orch) {
+						errors.push(
+							`Orchestration pattern '${orch.name}' in ${relPath(filePath, cwd)} duplicates a previously loaded orchestration pattern. Pattern names must be unique.`,
+						);
+						continue;
+					}
+					ORCHESTRATION_APP_PATTERNS.set(orch.name, orch);
+					loaded.add(orch.name);
+				} else {
+					try {
+						assertHasContribution(val);
+					} catch (assertErr) {
+						errors.push(
+							`Pattern '${val.name}' in ${relPath(filePath, cwd)} is invalid: ${stringifyError(assertErr)}`,
+						);
+						continue;
+					}
+					const existingDom = APP_PATTERNS.get(val.name);
+					if (existingDom && existingDom !== val) {
+						errors.push(
+							`Pattern '${val.name}' in ${relPath(filePath, cwd)} duplicates a previously loaded app pattern. Pattern names must be unique.`,
+						);
+						continue;
+					}
 					APP_PATTERNS.set(val.name, val);
 					loaded.add(val.name);
-				} catch (assertErr) {
-					errors.push(
-						`Pattern '${val.name}' in ${relPath(filePath, cwd)} is invalid: ${stringifyError(assertErr)}`,
-					);
 				}
 			}
 		} catch (err) {
@@ -212,6 +341,7 @@ export function _resetRegistryForTests(
 	opts: { includeLibrary?: boolean } = {},
 ): void {
 	APP_PATTERNS.clear();
+	ORCHESTRATION_APP_PATTERNS.clear();
 	if (opts.includeLibrary) {
 		LIBRARY_PATTERNS.clear();
 	}

--- a/src/patterns/validate-orchestration.ts
+++ b/src/patterns/validate-orchestration.ts
@@ -1,0 +1,158 @@
+/**
+ * Orchestration Pattern Validator (ADR-032)
+ *
+ * Project-level only — orchestration patterns are not entity-attached, so
+ * there is no per-entity pass. Mirrors `validatePatternProject`'s shape:
+ * one pure function consuming a context object and returning structured
+ * `AnalysisIssue[]` for `analyzeDomain()` to aggregate.
+ *
+ * Enforces ADR-032 §"Composition rules" to the extent statically checkable
+ * from a `OrchestrationPatternDefinition` alone:
+ *
+ *   | Rule                                                       | Issue type                          |
+ *   |------------------------------------------------------------|-------------------------------------|
+ *   | Domain ↔ orchestration pattern share a name                | pattern_name_collision              |
+ *   | Registry has zero entries                                  | pattern_entries_empty               |
+ *   | Entry missing/non-string `key` or `provider`               | pattern_entry_malformed             |
+ *   | Two entries in the same registry share a `key`             | pattern_entry_key_duplicate         |
+ *   | Co-keyed registry's `keyType` diverges from the primary    | pattern_cokeyed_keytype_mismatch    |
+ *
+ * Two ADR-032 conflicts are NOT enforced here — they need consumer source
+ * access that Phase 3-1 cannot do:
+ *   - `keyType`/`valueType` resolution (row 2): deferred to Phase 3-2 emission.
+ *   - Provider not exported by any known module (row 3): deferred to Phase 3-2
+ *     + DI runtime.
+ *
+ * Orchestration ↔ orchestration name duplicates ARE enforced — but at LOAD
+ * time inside `loadAppPatterns()`, not here, because by the time the
+ * validator runs the duplicate has already been deduped by `Map.set()`
+ * keying on name. The loader emits a `LoadAppPatternsResult.errors` entry.
+ */
+
+import type { AnalysisIssue } from '../analyzer/types.js';
+import type { OrchestrationPatternDefinition } from './pattern-definition.js';
+
+// Sentinel used for the `entity` field on project-level orchestration
+// issues. The orchestration kind is not entity-attached, so there is no
+// real entity name to point at. Existing console + markdown formatters
+// treat `issue.entity` as an opaque truthy string used only in display
+// (`${issue.entity}${issue.field ? '.' + issue.field : ''}`), so a
+// non-entity sentinel is safe — the formatters never look it up against
+// the parsed entity map.
+const PROJECT_SENTINEL = '<project>';
+
+export interface OrchestrationProjectContext {
+	/** All orchestration patterns currently registered. */
+	orchestrationPatterns: ReadonlyArray<OrchestrationPatternDefinition>;
+	/** All domain pattern names currently registered (library + app). */
+	domainPatternNames: ReadonlyArray<string>;
+}
+
+export function validateOrchestrationProject(
+	ctx: OrchestrationProjectContext,
+): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+
+	// Rule 1: orchestration ↔ domain name collision (ADR-032 row 4).
+	const domainNameSet = new Set(ctx.domainPatternNames);
+	for (const orch of ctx.orchestrationPatterns) {
+		if (domainNameSet.has(orch.name)) {
+			issues.push({
+				severity: 'error',
+				type: 'pattern_name_collision',
+				entity: PROJECT_SENTINEL,
+				message:
+					`Orchestration pattern '${orch.name}' shares a name with a domain ` +
+					`pattern. Pattern names are globally unique across kinds (ADR-032 §Composition rules).`,
+			});
+		}
+	}
+
+	// Rules 2-4: per-pattern checks (entries shape + co-keyed keyType).
+	for (const orch of ctx.orchestrationPatterns) {
+		const allRegistries = [
+			orch.registry,
+			...(orch.coKeyedRegistries ?? []),
+		];
+
+		for (const reg of allRegistries) {
+			// Rule 2: entries[] non-empty (defensive — loader already enforced
+			// this for the primary registry, but co-keyed sibling registries
+			// don't go through `assertOrchestrationContribution` and could be
+			// authored as `entries: []`).
+			if (!Array.isArray(reg.entries) || reg.entries.length === 0) {
+				issues.push({
+					severity: 'error',
+					type: 'pattern_entries_empty',
+					entity: PROJECT_SENTINEL,
+					message:
+						`Orchestration pattern '${orch.name}' declares a registry with ` +
+						`no entries. Provide at least one { key, provider } pair.`,
+				});
+				continue;
+			}
+
+			// Rules 3a + 3b: per-entry well-formedness + key uniqueness.
+			const seen = new Set<string>();
+			for (const entry of reg.entries) {
+				if (typeof entry.key !== 'string' || entry.key.length === 0) {
+					issues.push({
+						severity: 'error',
+						type: 'pattern_entry_malformed',
+						entity: PROJECT_SENTINEL,
+						message:
+							`Orchestration pattern '${orch.name}' has an entry with a ` +
+							`missing or non-string 'key'.`,
+					});
+					continue;
+				}
+				if (
+					typeof entry.provider !== 'string' ||
+					entry.provider.length === 0
+				) {
+					issues.push({
+						severity: 'error',
+						type: 'pattern_entry_malformed',
+						entity: PROJECT_SENTINEL,
+						message:
+							`Orchestration pattern '${orch.name}' entry '${entry.key}' has ` +
+							`a missing or non-string 'provider'.`,
+					});
+					continue;
+				}
+				if (seen.has(entry.key)) {
+					issues.push({
+						severity: 'error',
+						type: 'pattern_entry_key_duplicate',
+						entity: PROJECT_SENTINEL,
+						message:
+							`Orchestration pattern '${orch.name}' has duplicate entry key ` +
+							`'${entry.key}'. Keys must be unique within a registry.`,
+					});
+					continue;
+				}
+				seen.add(entry.key);
+			}
+		}
+
+		// Rule 4: co-keyed registry keyType consistency (ADR-032 Decision 2).
+		if (orch.coKeyedRegistries && orch.coKeyedRegistries.length > 0) {
+			const primaryKeyType = orch.registry.keyType;
+			for (const reg of orch.coKeyedRegistries) {
+				if (reg.keyType !== primaryKeyType) {
+					issues.push({
+						severity: 'error',
+						type: 'pattern_cokeyed_keytype_mismatch',
+						entity: PROJECT_SENTINEL,
+						message:
+							`Orchestration pattern '${orch.name}' co-keyed registry has ` +
+							`keyType '${reg.keyType}', expected '${primaryKeyType}'. ` +
+							`Co-keyed registries must share the primary registry's key space (ADR-032 Decision 2).`,
+					});
+				}
+			}
+		}
+	}
+
+	return issues;
+}


### PR DESCRIPTION
## Summary

Phase 3-1 of ADR-032 (orchestration patterns). Extends the pattern surface to admit a second `kind` — `'orchestration'` — alongside the existing ADR-031 domain patterns. **No emission yet** — Phase 3-2 (token + module emission) and Phase 3-3 (dispatcher scaffold) own templates and runtime.

## What's added

- **Type extension** (`src/patterns/pattern-definition.ts`): `kind` discriminator on `PatternDefinition` (defaults to `'domain'`), new disjoint `OrchestrationPatternDefinition` shape with `registry`, optional `coKeyedRegistries`, optional `dispatcher` slot. Sibling identity helper `defineOrchestrationPattern()` and narrowing helpers `isOrchestrationPattern` / `isDomainPattern`.
- **Discovery routing** (`src/patterns/registry.ts`): `loadAppPatterns()` now branches on `kind` and routes orchestration values to a disjoint `ORCHESTRATION_APP_PATTERNS` map. New accessors: `getOrchestrationPattern`, `getOrchestrationPatternNames`, `getAllOrchestrationPatterns`. Symmetric loader-time **duplicate-name protection** for both maps — silent overwrite was wrong by the architectural-correctness rule. Re-imports of the same module instance are still idempotent (object-identity check).
- **Validator** (`src/patterns/validate-orchestration.ts`): project-level only (orchestration patterns are not entity-attached). Wired into `analyzeDomain()`. Five enforced issue types:
  - `pattern_name_collision` — orchestration ↔ domain name share
  - `pattern_entries_empty` — registry with no entries
  - `pattern_entry_malformed` — entry missing/non-string key or provider
  - `pattern_entry_key_duplicate` — two entries in one registry share a key
  - `pattern_cokeyed_keytype_mismatch` — co-keyed registry diverges from primary
- **Tests**: 14 new unit tests + 6 fixture pattern files covering both literal validator API calls and end-to-end loader integration.

## What's deferred to Phase 3-2 / 3-3

- `keyType` / `valueType` resolution against the consumer's tsconfig — needs source-tree access only the emission step has.
- Provider-export verification — same reason; Phase 3-2 emits the import, DI validates at boot.
- All template work, token + `DynamicModule` emission, dispatcher class emission.
- CLI changes (no new noun, no new flag).
- Library-shipped orchestration patterns (no `LIBRARY_ORCHESTRATION_PATTERNS` map yet).
- Runtime base classes for orchestration.

## Doc updates included (living-docs rule)

- `docs/adrs/ADR-032-orchestration-patterns.md` §"Composition rules" reframed: row 1 (orchestration name duplicate) is now load-time-enforced; rows 2-3 (`keyType` resolution / provider export) are explicitly Phase 3-2 emission-time. New paragraph listing the four intra-pattern shape rules. §"Implementation sequence" Phase 3-1 step expanded to list the issue-type strings emitted.
- `docs/adrs/ADR-031-app-defined-patterns.md` §5 notes the kind-routing branch in the loader.

## Test plan

- [x] `bun test src/__tests__/` — 1452 pass, 0 fail (14 new tests; 1 pre-existing `loadAppPatterns idempotent` test still green via object-identity check).
- [x] `just test-baseline` — all generated files match snapshots (Phase 3-1 emits nothing, baseline unchanged).
- [x] `bun run typecheck` — clean.
- [ ] `just test-smoke` — not run locally; CI will exercise it.

## Links

- ADR-032: `docs/adrs/ADR-032-orchestration-patterns.md`
- ADR-031: `docs/adrs/ADR-031-app-defined-patterns.md`
- Spec: `.claude/specs/phase-3-1-orchestration-schema-validator.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)