### PR TITLE
OBS-3: add getStatusHistogram to IJobBridge

### DIFF
--- a/runtime/subsystems/bridge/bridge-delivery.drizzle-backend.ts
+++ b/runtime/subsystems/bridge/bridge-delivery.drizzle-backend.ts
@@ -23,7 +23,7 @@
  * `SELECT … LIMIT 1` / `UPDATE … WHERE id = ?` queries.
  */
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, gte, isNull, sql } from 'drizzle-orm';
 
 import { DRIZZLE } from '../../constants/tokens';
 import type { DrizzleClient } from '../../types/drizzle';
@@ -34,6 +34,7 @@ import type { BridgeDeliveryRecord } from './bridge-delivery.schema';
 import type {
   BridgeDeliveryInsert,
   IJobBridge,
+  StatusHistogram,
 } from './bridge.protocol';
 import { assertTenantId } from './assert-tenant-id';
 import { BRIDGE_MULTI_TENANT } from './bridge.tokens';
@@ -145,5 +146,63 @@ export class DrizzleBridgeDeliveryRepo implements IJobBridge {
       .update(bridgeDelivery)
       .set({ status: 'failed', error })
       .where(eq(bridgeDelivery.id, id));
+  }
+
+  /**
+   * Observability read — see `IJobBridge.getStatusHistogram` JSDoc for the
+   * tenant-filter and windowHours contract.
+   *
+   * Tenant-filter note: this method intentionally does NOT call
+   * `assertTenantId`. The write methods on this repo (`insertDelivery`)
+   * treat `tenantId === undefined` as a misconfiguration and fail fast.
+   * Reads are different — `undefined` is the supported "cross-tenant
+   * admin view" mode that OBS-5 uses to render a framework-wide health
+   * panel. Callers that need strict tenant scoping pass an explicit
+   * string or `null`.
+   *
+   * Cast note: `count(*)::int` is applied in SQL so the node-pg driver
+   * returns a `number` instead of the default `bigint → string` for
+   * `count(*)`. Don't relax this cast — consumers (and the protocol)
+   * type the result as `number`.
+   */
+  async getStatusHistogram(
+    windowHours: number,
+    tenantId?: string | null,
+  ): Promise<StatusHistogram> {
+    if (!Number.isFinite(windowHours) || windowHours <= 0) {
+      throw new RangeError('windowHours must be positive');
+    }
+
+    const cutoff = sql<Date>`now() - make_interval(hours => ${windowHours})`;
+
+    const conditions = [gte(bridgeDelivery.attemptedAt, cutoff)];
+    if (tenantId === null) {
+      conditions.push(isNull(bridgeDelivery.tenantId));
+    } else if (typeof tenantId === 'string') {
+      conditions.push(eq(bridgeDelivery.tenantId, tenantId));
+    }
+    // tenantId === undefined → no tenant filter (cross-tenant view).
+
+    const rows = await this.db
+      .select({
+        status: bridgeDelivery.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(bridgeDelivery)
+      .where(and(...conditions))
+      .groupBy(bridgeDelivery.status);
+
+    const histogram: StatusHistogram = {
+      pending: 0,
+      delivered: 0,
+      skipped: 0,
+      failed: 0,
+    };
+    for (const row of rows) {
+      // row.status is typed as the enum union; narrow is safe because the
+      // enum values match StatusHistogram keys 1:1 (BRIDGE-1 schema).
+      histogram[row.status as keyof StatusHistogram] = Number(row.count);
+    }
+    return histogram;
   }
 }

--- a/runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
+++ b/runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
@@ -26,6 +26,7 @@ import { randomUUID } from 'node:crypto';
 import type {
   BridgeDeliveryInsert,
   IJobBridge,
+  StatusHistogram,
 } from './bridge.protocol';
 import type { BridgeDeliveryRecord } from './bridge-delivery.schema';
 import { UniqueConstraintError } from './bridge-errors';
@@ -103,6 +104,42 @@ export class MemoryBridgeDeliveryRepo implements IJobBridge {
     const record = this.findById(id);
     record.status = 'failed';
     record.error = error;
+  }
+
+  /**
+   * Observability read — see `IJobBridge.getStatusHistogram` JSDoc for the
+   * tenant-filter and windowHours contract.
+   *
+   * Unlike `insertDelivery`, this read does NOT call `assertTenantId`:
+   * `tenantId === undefined` is the supported cross-tenant admin view.
+   */
+  async getStatusHistogram(
+    windowHours: number,
+    tenantId?: string | null,
+  ): Promise<StatusHistogram> {
+    if (!Number.isFinite(windowHours) || windowHours <= 0) {
+      throw new RangeError('windowHours must be positive');
+    }
+
+    const cutoffMs = Date.now() - windowHours * 3_600_000;
+    const histogram: StatusHistogram = {
+      pending: 0,
+      delivered: 0,
+      skipped: 0,
+      failed: 0,
+    };
+
+    for (const record of this.deliveries.values()) {
+      if (record.attemptedAt.getTime() < cutoffMs) continue;
+      if (tenantId === null && record.tenantId !== null) continue;
+      if (typeof tenantId === 'string' && record.tenantId !== tenantId) {
+        continue;
+      }
+      // tenantId === undefined → no tenant filter.
+      histogram[record.status] += 1;
+    }
+
+    return histogram;
   }
 
   // ─── Test helpers ────────────────────────────────────────────────────────

--- a/runtime/subsystems/bridge/bridge.protocol.ts
+++ b/runtime/subsystems/bridge/bridge.protocol.ts
@@ -49,6 +49,26 @@ import type {
  */
 export type BridgeDeliveryInsert = InferInsertModel<typeof bridgeDelivery>;
 
+/**
+ * Status histogram returned by IJobBridge.getStatusHistogram.
+ *
+ * Keys match the bridge_delivery_status enum values (bridge-delivery.schema.ts).
+ * Missing statuses in the underlying result set are zero-filled so consumers
+ * can render a fixed 4-row chart without branching.
+ *
+ * PHASE 1: plain counts only. The time-bucketed variant (per-interval series
+ * for a sparkline / timeline chart) is reserved for the Cube.js analytics
+ * layer (see epic-195-architecture-decisions.md §6) and must NOT be added to
+ * this protocol. If a consumer needs buckets, that's a signal to route the
+ * query through Cube, not to grow the core contract.
+ */
+export type StatusHistogram = {
+  pending: number;
+  delivered: number;
+  skipped: number;
+  failed: number;
+};
+
 export interface IJobBridge {
   /**
    * Insert a `bridge_delivery` row.
@@ -118,6 +138,36 @@ export interface IJobBridge {
     error: Record<string, unknown>,
     tx?: DrizzleTransaction,
   ): Promise<void>;
+
+  /**
+   * Count bridge_delivery rows by status, filtered to rows where
+   * attemptedAt >= (now - windowHours) and (optionally) tenantId matches.
+   *
+   * Tenant semantics mirror the jobs subsystem (job-orchestrator.protocol.ts):
+   *   - tenantId omitted or explicit undefined: no tenant filter (counts across
+   *     all tenants — appropriate for framework-internal admin dashboards).
+   *   - tenantId === null: match rows where tenant_id IS NULL (cross-tenant
+   *     housekeeping deliveries).
+   *   - tenantId === '<string>': match rows where tenant_id = '<string>'.
+   *
+   * Returns all-zero StatusHistogram when no rows match — never empty object,
+   * never undefined. Consumers rely on fixed keys for rendering.
+   *
+   * `windowHours` must be positive; implementations throw `RangeError` for
+   * `windowHours <= 0`. No upper bound is enforced — the caller is
+   * responsible for choosing a sensible window.
+   *
+   * Unlike the write methods on this port, this read intentionally does NOT
+   * invoke `assertTenantId`: `tenantId === undefined` is a supported
+   * cross-tenant admin view, not a policy violation.
+   *
+   * PHASE 1: plain counts only. Do NOT add a bucketing / time-series variant
+   * to this method or the protocol — see StatusHistogram JSDoc.
+   */
+  getStatusHistogram(
+    windowHours: number,
+    tenantId?: string | null,
+  ): Promise<StatusHistogram>;
 }
 
 // ============================================================================

--- a/runtime/subsystems/bridge/index.ts
+++ b/runtime/subsystems/bridge/index.ts
@@ -30,6 +30,7 @@ export type {
   BridgeTriggerEntry,
   PublishAndStartOptions,
   PublishAndStartResult,
+  StatusHistogram,
 } from './bridge.protocol';
 
 // DI tokens (BRIDGE-2 + BRIDGE-4 drain hook)

--- a/src/__tests__/runtime/subsystems/bridge-delivery.drizzle-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-delivery.drizzle-backend.spec.ts
@@ -144,3 +144,90 @@ describe('DrizzleBridgeDeliveryRepo — state transitions', () => {
     expect(captures[0]!.params).toContain(DELIVERY_ID);
   });
 });
+
+describe('DrizzleBridgeDeliveryRepo — getStatusHistogram (OBS-3)', () => {
+  it('issues GROUP BY status with count(*)::int cast and now()-interval cutoff', async () => {
+    const { db, captures } = makeCapturingDb([]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+
+    await repo.getStatusHistogram(24);
+
+    expect(captures).toHaveLength(1);
+    const sql = captures[0]!.sql.toLowerCase();
+    expect(sql).toContain('from "bridge_delivery"');
+    expect(sql).toContain('group by');
+    expect(sql).toContain('"status"');
+    expect(sql).toContain('count(*)::int');
+    // Cutoff predicate should be a now()-interval expression, not a
+    // JS-computed timestamp — this guards against accidentally depending
+    // on client clock sync.
+    expect(sql).toContain('now()');
+    expect(sql).toContain('make_interval');
+    expect(captures[0]!.params).toContain(24);
+  });
+
+  it('returns zero-filled histogram when the query returns no rows', async () => {
+    const { db } = makeCapturingDb([]); // empty result set
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    const h = await repo.getStatusHistogram(24);
+    expect(h).toEqual({ pending: 0, delivered: 0, skipped: 0, failed: 0 });
+  });
+
+  it('zero-fills statuses missing from the result set', async () => {
+    // pg-proxy returns arrays-of-arrays in driver order; Drizzle maps
+    // columns positionally. Our select is { status, count } — so the
+    // row shape is [status, count].
+    const { db } = makeCapturingDb([
+      ['pending', 3],
+      ['delivered', 7],
+    ]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    const h = await repo.getStatusHistogram(24);
+    expect(h).toEqual({ pending: 3, delivered: 7, skipped: 0, failed: 0 });
+  });
+
+  it('casts count to number even if the driver surfaces a string', async () => {
+    // Guard against a regression where we drop the ::int cast and the
+    // driver yields bigint strings.
+    const { db } = makeCapturingDb([
+      ['failed', '42'],
+    ]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    const h = await repo.getStatusHistogram(1);
+    expect(h.failed).toBe(42);
+    expect(typeof h.failed).toBe('number');
+  });
+
+  it('adds tenant_id IS NULL filter when tenantId === null', async () => {
+    const { db, captures } = makeCapturingDb([]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    await repo.getStatusHistogram(24, null);
+    const sql = captures[0]!.sql.toLowerCase();
+    expect(sql).toContain('"tenant_id" is null');
+  });
+
+  it('adds tenant_id = ? filter when tenantId is a string', async () => {
+    const { db, captures } = makeCapturingDb([]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    await repo.getStatusHistogram(24, 't-1');
+    const sql = captures[0]!.sql.toLowerCase();
+    expect(sql).toContain('"tenant_id" =');
+    expect(captures[0]!.params).toContain('t-1');
+  });
+
+  it('omits tenant filter when tenantId is undefined', async () => {
+    const { db, captures } = makeCapturingDb([]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    await repo.getStatusHistogram(24);
+    const sql = captures[0]!.sql.toLowerCase();
+    expect(sql).not.toContain('"tenant_id"');
+  });
+
+  it('throws RangeError for windowHours <= 0 (no SQL issued)', async () => {
+    const { db, captures } = makeCapturingDb([]);
+    const repo = new DrizzleBridgeDeliveryRepo(db);
+    expect(repo.getStatusHistogram(0)).rejects.toThrow(RangeError);
+    expect(repo.getStatusHistogram(-5)).rejects.toThrow(RangeError);
+    expect(captures).toHaveLength(0);
+  });
+});

--- a/src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
@@ -192,6 +192,123 @@ describe('MemoryBridgeDeliveryRepo — test helpers', () => {
   });
 });
 
+describe('MemoryBridgeDeliveryRepo — getStatusHistogram (OBS-3)', () => {
+  let repo: MemoryBridgeDeliveryRepo;
+
+  beforeEach(() => {
+    repo = new MemoryBridgeDeliveryRepo();
+  });
+
+  it('returns all-zero histogram when no deliveries exist', async () => {
+    const h = await repo.getStatusHistogram(24);
+    expect(h).toEqual({ pending: 0, delivered: 0, skipped: 0, failed: 0 });
+  });
+
+  it('counts one delivery in each status correctly', async () => {
+    const now = new Date();
+    const pending = row(EVENT_A, 'trig#0', { attemptedAt: now });
+    const delivered = row(EVENT_A, 'trig#1', { attemptedAt: now });
+    const skipped = row(EVENT_A, 'trig#2', { attemptedAt: now });
+    const failed = row(EVENT_A, 'trig#3', { attemptedAt: now });
+    await repo.insertDelivery(pending);
+    await repo.insertDelivery(delivered);
+    await repo.insertDelivery(skipped);
+    await repo.insertDelivery(failed);
+    await repo.markDelivered(delivered.id!, 'run-d');
+    await repo.markSkipped(skipped.id!, 'predicate_false');
+    await repo.markFailed(failed.id!, { message: 'boom' });
+
+    const h = await repo.getStatusHistogram(24);
+    expect(h).toEqual({ pending: 1, delivered: 1, skipped: 1, failed: 1 });
+  });
+
+  it('excludes deliveries attempted before the windowHours cutoff', async () => {
+    const old = new Date(Date.now() - 48 * 3_600_000); // 48h ago
+    const recent = new Date();
+    await repo.insertDelivery(row(EVENT_A, 'old#0', { attemptedAt: old }));
+    await repo.insertDelivery(row(EVENT_A, 'new#0', { attemptedAt: recent }));
+
+    const h = await repo.getStatusHistogram(24); // 24h window
+    expect(h).toEqual({ pending: 1, delivered: 0, skipped: 0, failed: 0 });
+  });
+
+  it('includes deliveries exactly at the boundary (>= cutoff)', async () => {
+    // Freeze the comparison: put the delivery at exactly cutoff by using
+    // an attemptedAt that is `now - windowHours * 3_600_000` — this is
+    // the precise boundary. We rely on the implementation using `<`
+    // (strict) to exclude BELOW cutoff, so equal should be INCLUDED.
+    const windowHours = 1;
+    const boundary = new Date(Date.now() - windowHours * 3_600_000);
+    await repo.insertDelivery(
+      row(EVENT_A, 'boundary#0', { attemptedAt: boundary }),
+    );
+    const h = await repo.getStatusHistogram(windowHours);
+    expect(h.pending).toBe(1);
+  });
+
+  it('tenantId undefined matches all rows regardless of tenant', async () => {
+    const now = new Date();
+    await repo.insertDelivery(
+      row(EVENT_A, 'a#0', { attemptedAt: now, tenantId: 't-1' }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'b#0', { attemptedAt: now, tenantId: 't-2' }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'c#0', { attemptedAt: now, tenantId: null }),
+    );
+    const h = await repo.getStatusHistogram(24);
+    expect(h.pending).toBe(3);
+  });
+
+  it('tenantId === null matches only rows with tenantId IS NULL', async () => {
+    const now = new Date();
+    await repo.insertDelivery(
+      row(EVENT_A, 'a#0', { attemptedAt: now, tenantId: 't-1' }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'b#0', { attemptedAt: now, tenantId: null }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'c#0', { attemptedAt: now, tenantId: null }),
+    );
+    const h = await repo.getStatusHistogram(24, null);
+    expect(h.pending).toBe(2);
+  });
+
+  it('tenantId === string matches only rows where tenantId equals that string', async () => {
+    const now = new Date();
+    await repo.insertDelivery(
+      row(EVENT_A, 'a#0', { attemptedAt: now, tenantId: 't-1' }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'b#0', { attemptedAt: now, tenantId: 't-1' }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'c#0', { attemptedAt: now, tenantId: 't-2' }),
+    );
+    await repo.insertDelivery(
+      row(EVENT_A, 'd#0', { attemptedAt: now, tenantId: null }),
+    );
+    const h = await repo.getStatusHistogram(24, 't-1');
+    expect(h.pending).toBe(2);
+  });
+
+  it('returns zero-fill for statuses with no matching rows', async () => {
+    const now = new Date();
+    const r = row(EVENT_A, 'only-pending#0', { attemptedAt: now });
+    await repo.insertDelivery(r);
+    const h = await repo.getStatusHistogram(24);
+    expect(h).toEqual({ pending: 1, delivered: 0, skipped: 0, failed: 0 });
+  });
+
+  it('throws RangeError for windowHours <= 0', async () => {
+    expect(repo.getStatusHistogram(0)).rejects.toThrow(RangeError);
+    expect(repo.getStatusHistogram(-1)).rejects.toThrow(RangeError);
+    expect(repo.getStatusHistogram(Number.NaN)).rejects.toThrow(RangeError);
+  });
+});
+
 describe('MemoryBridgeDeliveryRepo — facade Case B simulation', () => {
   // ADR-023 §`publishAndStart` + existing `triggers:` collision: the
   // facade pre-writes a (status='delivered', wrapper_run_id=null) row;


### PR DESCRIPTION
Closes #205. Part of epic #195.

## Summary

- Adds `getStatusHistogram(windowHours, tenantId?)` to **`IJobBridge`** for the observability composer.
- Returns plain status counts `{ pending, delivered, skipped, failed }` over the window. Time-bucketed variants are reserved for a future Cube.js analytics layer (noted in protocol JSDoc).
- Both Drizzle and Memory backends implement; tenant semantics mirror the jobs subsystem (`undefined` = cross-tenant view, `null` = `tenantId IS NULL`, string = exact match).
- `windowHours <= 0` or `NaN` throws `RangeError` (fail-loud on bad input).

## Naming note

The epic plan referred to `IBridgeDeliveryRepo`; the actual protocol is `IJobBridge`. This PR extends `IJobBridge` under its real name. No rename in scope.

## Deviations from spec

- Drizzle "integration" tests use the existing pg-proxy capture harness (asserting SQL shape + canned-row behavior), not Docker — matching the repo's established bridge test pattern. True Docker integration coverage will be exercised by OBS-5's end-to-end composer tests or by CI.
- Additional `NaN` guard on `windowHours` (not in spec but fails loud for the same reason `<= 0` does).

## Test plan

- [x] `just test-unit` — 1455 pass / 0 fail (17 new)
- [x] `bun run typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)