### PR TITLE
OBS-4: add listRecent + listAll to sync run recorder and cursor store

### DIFF
--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -20,7 +20,10 @@ export type {
   IChangeSource,
   SyncSubscriptionView,
 } from './sync-change-source.protocol';
-export type { ICursorStore } from './sync-cursor-store.protocol';
+export type {
+  CursorSnapshot,
+  ICursorStore,
+} from './sync-cursor-store.protocol';
 export type {
   DiffResult,
   FieldDiff,
@@ -37,6 +40,7 @@ export type {
   ISyncRunRecorder,
   RecordItemInput,
   StartRunInput,
+  SyncRunSummary,
 } from './sync-run-recorder.protocol';
 export type { ILoopbackFingerprintStore } from './sync-loopback.protocol';
 
@@ -77,6 +81,7 @@ export { MemoryCursorStore } from './sync-cursor-store.memory-backend';
 export {
   MemoryRunRecorder,
   type MemoryRunRecord,
+  type MemorySyncSubscription,
 } from './sync-run-recorder.memory-backend';
 
 // Runtime (SYNC-5) — orchestrator + default differ

--- a/runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.drizzle-backend.ts
@@ -27,10 +27,13 @@
  * the caller's problem in single-tenant deployments.
  */
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { and, eq, type SQL } from 'drizzle-orm';
+import { and, desc, eq, type SQL } from 'drizzle-orm';
 import type { DrizzleClient } from '../../types/drizzle';
 import { DRIZZLE } from '../../constants/tokens';
-import type { ICursorStore } from './sync-cursor-store.protocol';
+import type {
+  CursorSnapshot,
+  ICursorStore,
+} from './sync-cursor-store.protocol';
 import { syncSubscriptions } from './sync-audit.schema';
 import { SYNC_MULTI_TENANT } from './sync.tokens';
 import { assertTenantId } from './sync-errors';
@@ -77,6 +80,45 @@ export class PostgresCursorStore implements ICursorStore {
         updatedAt: new Date(),
       })
       .where(where);
+  }
+
+  async listAll(tenantId?: string | null): Promise<CursorSnapshot[]> {
+    assertTenantId(tenantId, {
+      multiTenant: this.multiTenant,
+      operation: 'cursor.listAll',
+    });
+
+    const where = this.multiTenant
+      ? eq(syncSubscriptions.tenantId, tenantId as string)
+      : undefined;
+
+    const rows = await this.db
+      .select({
+        id: syncSubscriptions.id,
+        integrationId: syncSubscriptions.integrationId,
+        adapter: syncSubscriptions.adapter,
+        domain: syncSubscriptions.domain,
+        externalRef: syncSubscriptions.externalRef,
+        cursor: syncSubscriptions.cursor,
+        lastSyncAt: syncSubscriptions.lastSyncAt,
+        updatedAt: syncSubscriptions.updatedAt,
+        tenantId: syncSubscriptions.tenantId,
+      })
+      .from(syncSubscriptions)
+      .where(where)
+      .orderBy(desc(syncSubscriptions.updatedAt));
+
+    return rows.map((row) => ({
+      subscriptionId: row.id,
+      integrationId: row.integrationId,
+      adapter: row.adapter,
+      domain: row.domain,
+      externalRef: row.externalRef,
+      cursor: row.cursor ?? null,
+      lastSyncAt: row.lastSyncAt,
+      updatedAt: row.updatedAt,
+      tenantId: row.tenantId,
+    }));
   }
 
   /**

--- a/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
@@ -27,7 +27,11 @@
  *   - SYNC-6 module tests (`SyncModule.forRoot({ backend: 'memory' })`)
  */
 import { Injectable } from '@nestjs/common';
-import type { ICursorStore } from './sync-cursor-store.protocol';
+import type {
+  CursorSnapshot,
+  ICursorStore,
+} from './sync-cursor-store.protocol';
+import type { MemorySyncSubscription } from './sync-run-recorder.memory-backend';
 
 @Injectable()
 export class MemoryCursorStore implements ICursorStore {
@@ -36,6 +40,17 @@ export class MemoryCursorStore implements ICursorStore {
    * or pre-seed state; production callers MUST go through `get`/`put`.
    */
   readonly cursors: Map<string, unknown> = new Map();
+
+  /**
+   * Seedable subscription metadata for `listAll` — the memory backend
+   * stores only `subscriptionId → cursor` in its write path, so the
+   * snapshot shape (`integrationId`, `adapter`, `domain`, `externalRef`,
+   * timestamps) has no natural source without test seeding. Tests populate
+   * this map; unseeded entries get empty-string metadata and `new Date(0)`
+   * timestamps so the shape stays stable. Production paths go through the
+   * Drizzle backend.
+   */
+  readonly subscriptions: Map<string, MemorySyncSubscription> = new Map();
 
   async get(
     subscriptionId: string,
@@ -57,8 +72,32 @@ export class MemoryCursorStore implements ICursorStore {
     this.cursors.set(subscriptionId, cursor);
   }
 
+  async listAll(_tenantId?: string | null): Promise<CursorSnapshot[]> {
+    // Accepts tenantId for contract symmetry but does not filter on it —
+    // the memory backend never enforces tenancy (see class-level comment).
+    const snapshots: CursorSnapshot[] = [];
+    for (const [subscriptionId, cursor] of this.cursors.entries()) {
+      const meta = this.subscriptions.get(subscriptionId);
+      snapshots.push({
+        subscriptionId,
+        integrationId: meta?.integrationId ?? '',
+        adapter: meta?.adapter ?? '',
+        domain: meta?.domain ?? '',
+        externalRef: meta?.externalRef ?? null,
+        cursor: cursor ?? null,
+        lastSyncAt: meta?.lastSyncAt ?? null,
+        updatedAt: meta?.updatedAt ?? new Date(0),
+        tenantId: null,
+      });
+    }
+    return snapshots.sort(
+      (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+    );
+  }
+
   /** Reset state. Tests call this in `beforeEach`. */
   clear(): void {
     this.cursors.clear();
+    this.subscriptions.clear();
   }
 }

--- a/runtime/subsystems/sync/sync-cursor-store.protocol.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.protocol.ts
@@ -25,6 +25,28 @@
  * hide who's enforcing. Matches JOB-8 / EVT-6 precedent — tenant ids flow
  * through input shapes, not through wrapper layers.
  */
+/**
+ * Denormalized snapshot of one `sync_subscriptions` row for the OBS-5
+ * observability composer (epic #195). `cursor` is opaque (the port's
+ * contract); the rest is subscription metadata needed to label the snapshot
+ * in a dashboard/API surface.
+ *
+ * The Drizzle backend reads this directly from `sync_subscriptions`. Memory
+ * backends derive it from the seedable `subscriptions` side-map — tests
+ * that want meaningful snapshots must seed first.
+ */
+export interface CursorSnapshot {
+  readonly subscriptionId: string;
+  readonly integrationId: string;
+  readonly adapter: string;
+  readonly domain: string;
+  readonly externalRef: string | null;
+  readonly cursor: unknown | null;
+  readonly lastSyncAt: Date | null;
+  readonly updatedAt: Date;
+  readonly tenantId: string | null;
+}
+
 export interface ICursorStore {
   /**
    * Return the last persisted cursor for `subscriptionId`, or `null`.
@@ -50,4 +72,15 @@ export interface ICursorStore {
     cursor: unknown,
     tenantId?: string | null,
   ): Promise<void>;
+
+  /**
+   * Return one `CursorSnapshot` per `sync_subscriptions` row, ordered by
+   * `updated_at DESC`. Consumed by the OBS-5 observability composer to
+   * surface current cursor state per subscription.
+   *
+   * @param tenantId  required by Drizzle backend when `SYNC_MULTI_TENANT`
+   *                  is on (throws `MissingTenantIdError` otherwise); memory
+   *                  backend accepts but ignores.
+   */
+  listAll(tenantId?: string | null): Promise<CursorSnapshot[]>;
 }

--- a/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
@@ -28,7 +28,7 @@
  *     the run-id for downstream mutations.
  */
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { eq } from 'drizzle-orm';
+import { and, desc, eq, type SQL } from 'drizzle-orm';
 import type { DrizzleClient } from '../../types/drizzle';
 import { DRIZZLE } from '../../constants/tokens';
 import type {
@@ -36,8 +36,9 @@ import type {
   ISyncRunRecorder,
   RecordItemInput,
   StartRunInput,
+  SyncRunSummary,
 } from './sync-run-recorder.protocol';
-import { syncRuns, syncRunItems } from './sync-audit.schema';
+import { syncRuns, syncRunItems, syncSubscriptions } from './sync-audit.schema';
 import { FieldDiffSchema } from './sync-field-diff.protocol';
 import { SYNC_MULTI_TENANT } from './sync.tokens';
 import { assertTenantId } from './sync-errors';
@@ -104,6 +105,65 @@ export class DrizzleSyncRunRecorder implements ISyncRunRecorder {
       error: input.error ?? null,
       tenantId: input.tenantId ?? null,
     });
+  }
+
+  async listRecent(
+    limit: number,
+    subscriptionId?: string,
+    tenantId?: string | null,
+  ): Promise<SyncRunSummary[]> {
+    assertTenantId(tenantId, {
+      multiTenant: this.multiTenant,
+      operation: 'listRecent',
+    });
+
+    // JOIN against sync_subscriptions to resolve `integration_id` per run.
+    // `sync_runs.subscription_id` is a non-null FK so INNER JOIN is correct;
+    // there should be no orphaned runs.
+    const conditions: SQL[] = [];
+    if (subscriptionId !== undefined) {
+      conditions.push(eq(syncRuns.subscriptionId, subscriptionId));
+    }
+    if (this.multiTenant) {
+      conditions.push(eq(syncRuns.tenantId, tenantId as string));
+    }
+    const where =
+      conditions.length === 0
+        ? undefined
+        : conditions.length === 1
+          ? conditions[0]
+          : and(...conditions);
+
+    const rows = await this.db
+      .select({
+        id: syncRuns.id,
+        subscriptionId: syncRuns.subscriptionId,
+        integrationId: syncSubscriptions.integrationId,
+        status: syncRuns.status,
+        startedAt: syncRuns.startedAt,
+        completedAt: syncRuns.completedAt,
+        recordsProcessed: syncRuns.recordsProcessed,
+        tenantId: syncRuns.tenantId,
+      })
+      .from(syncRuns)
+      .innerJoin(
+        syncSubscriptions,
+        eq(syncRuns.subscriptionId, syncSubscriptions.id),
+      )
+      .where(where)
+      .orderBy(desc(syncRuns.startedAt))
+      .limit(limit);
+
+    return rows.map((row) => ({
+      id: row.id,
+      subscriptionId: row.subscriptionId,
+      integrationId: row.integrationId,
+      status: row.status,
+      startedAt: row.startedAt,
+      completedAt: row.completedAt,
+      recordsProcessed: row.recordsProcessed,
+      tenantId: row.tenantId,
+    }));
   }
 
   async completeRun(runId: string, input: CompleteRunInput): Promise<void> {

--- a/runtime/subsystems/sync/sync-run-recorder.memory-backend.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.memory-backend.ts
@@ -30,8 +30,27 @@ import type {
   ISyncRunRecorder,
   RecordItemInput,
   StartRunInput,
+  SyncRunSummary,
 } from './sync-run-recorder.protocol';
 import { FieldDiffSchema } from './sync-field-diff.protocol';
+
+/**
+ * Optional per-subscription metadata a test can seed on the memory backend
+ * so `listRecent` can surface `integrationId`. The memory recorder's write
+ * path never persists subscription rows (it only stores runs + items), so
+ * `listRecent` has no way to derive `integrationId` on its own. Tests that
+ * care about the field should populate `subscriptions` before calling
+ * `listRecent`; calls that don't seed get an empty string and a stable
+ * shape (see `listRecent` below).
+ */
+export interface MemorySyncSubscription {
+  integrationId: string;
+  adapter: string;
+  domain: string;
+  externalRef: string | null;
+  lastSyncAt?: Date | null;
+  updatedAt: Date;
+}
 
 /**
  * Concrete run row as held in memory. Shape mirrors the interesting
@@ -68,6 +87,15 @@ export class MemoryRunRecorder implements ISyncRunRecorder {
    * in Postgres.
    */
   readonly items: Map<string, RecordItemInput[]> = new Map();
+
+  /**
+   * Seedable subscription metadata — tests populate this to make
+   * `listRecent` return meaningful `integrationId` values. The memory
+   * backend doesn't track subscriptions on its own (only runs + items), so
+   * this map is the intentional extension point: tests write entries for
+   * the subscription ids they use, production code never touches it.
+   */
+  readonly subscriptions: Map<string, MemorySyncSubscription> = new Map();
 
   async startRun(input: StartRunInput): Promise<{ id: string }> {
     const id = crypto.randomUUID();
@@ -121,10 +149,43 @@ export class MemoryRunRecorder implements ISyncRunRecorder {
     run.completedAt = new Date();
   }
 
+  async listRecent(
+    limit: number,
+    subscriptionId?: string,
+    _tenantId?: string | null,
+  ): Promise<SyncRunSummary[]> {
+    // Memory backend accepts tenantId for contract symmetry but does not
+    // filter on it — state is process-local and cross-tenant isolation is
+    // not meaningful here (matches MemoryCursorStore behavior).
+    const all = Array.from(this.runs.values());
+    const filtered =
+      subscriptionId === undefined
+        ? all
+        : all.filter((r) => r.subscriptionId === subscriptionId);
+    return filtered
+      .sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime())
+      .slice(0, limit)
+      .map((r) => ({
+        id: r.id,
+        subscriptionId: r.subscriptionId,
+        // integrationId is only knowable if the test seeded subscriptions
+        // metadata; empty string otherwise. The Drizzle backend resolves
+        // it via JOIN, which is the production path.
+        integrationId:
+          this.subscriptions.get(r.subscriptionId)?.integrationId ?? '',
+        status: r.status,
+        startedAt: r.startedAt,
+        completedAt: r.completedAt,
+        recordsProcessed: r.recordsProcessed,
+        tenantId: r.tenantId,
+      }));
+  }
+
   /** Reset state. Tests call this in `beforeEach`. */
   clear(): void {
     this.runs.clear();
     this.items.clear();
+    this.subscriptions.clear();
   }
 
   // ─── test ergonomics ─────────────────────────────────────────────────

--- a/runtime/subsystems/sync/sync-run-recorder.protocol.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.protocol.ts
@@ -67,6 +67,36 @@ export interface CompleteRunInput {
 }
 
 // ============================================================================
+// Read projection — `listRecent`
+// ============================================================================
+
+/**
+ * Denormalized view of one `sync_runs` row, JOINed against
+ * `sync_subscriptions` to surface `integrationId` in a single read. Consumed
+ * by the OBS-5 observability composer (epic #195).
+ *
+ * `recordsProcessed` is the denormalized column on `sync_runs` — it does NOT
+ * count `sync_run_items` rows. A correlated subquery per run would be
+ * required for a true item count; deferred as a follow-up if needed.
+ *
+ * Memory backends can't know `integrationId` without subscription metadata
+ * — see each memory backend for the seedable `subscriptions` side-map that
+ * tests populate. When metadata is missing, memory backends emit an empty
+ * string so the shape stays stable (documented in the memory backend).
+ */
+export interface SyncRunSummary {
+  readonly id: string;
+  readonly subscriptionId: string;
+  /** Resolved by Drizzle via JOIN; empty string from memory if not seeded. */
+  readonly integrationId: string;
+  readonly status: 'running' | 'success' | 'no_changes' | 'failed';
+  readonly startedAt: Date;
+  readonly completedAt: Date | null;
+  readonly recordsProcessed: number;
+  readonly tenantId: string | null;
+}
+
+// ============================================================================
 // ISyncRunRecorder
 // ============================================================================
 
@@ -83,4 +113,24 @@ export interface ISyncRunRecorder {
    * `'failed'` when the iteration body threw.
    */
   completeRun(runId: string, input: CompleteRunInput): Promise<void>;
+
+  /**
+   * Recent `sync_runs` rows ordered by `started_at DESC`, capped at `limit`.
+   *
+   * Filter is `subscriptionId` — the natural FK on `sync_runs`. An
+   * integration-wide view requires filtering on `sync_subscriptions.integration_id`
+   * through the JOIN and is deferred as a follow-up (epic #195 OBS-4 spec).
+   *
+   * @param limit           hard cap on rows returned (no implicit default)
+   * @param subscriptionId  optional FK filter; omit for cross-subscription view
+   * @param tenantId        required by Drizzle backend when
+   *                        `SYNC_MULTI_TENANT` is on (throws
+   *                        `MissingTenantIdError` otherwise); memory backend
+   *                        accepts but ignores
+   */
+  listRecent(
+    limit: number,
+    subscriptionId?: string,
+    tenantId?: string | null,
+  ): Promise<SyncRunSummary[]>;
 }

--- a/src/__tests__/runtime/subsystems/sync-cursor-store.drizzle-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-cursor-store.drizzle-backend.spec.ts
@@ -194,6 +194,85 @@ describe('PostgresCursorStore — multi-tenant', () => {
   });
 });
 
+describe('PostgresCursorStore.listAll (OBS-4) — single-tenant', () => {
+  let store: PostgresCursorStore;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({ rows: [] }));
+    store = new PostgresCursorStore(db);
+  });
+
+  it('returns [] when no subscriptions exist', async () => {
+    expect(await store.listAll()).toEqual([]);
+    expect(captures).toHaveLength(1);
+    const [{ sql }] = captures;
+    expect(sql.toLowerCase()).toContain('select');
+    expect(sql).toContain('"sync_subscriptions"');
+  });
+
+  it('SELECTs subscription metadata ORDERed by updated_at DESC', async () => {
+    await store.listAll();
+    expect(captures).toHaveLength(1);
+    const [{ sql }] = captures;
+    expect(sql).toContain('"sync_subscriptions"');
+    expect(sql).toContain('"integration_id"');
+    expect(sql).toContain('"adapter"');
+    expect(sql).toContain('"domain"');
+    expect(sql).toContain('"external_ref"');
+    expect(sql).toContain('"cursor"');
+    expect(sql).toContain('"last_sync_at"');
+    expect(sql).toContain('"updated_at"');
+    // ORDER BY updated_at DESC.
+    expect(sql.toLowerCase()).toContain('order by');
+    expect(sql.toLowerCase()).toContain('desc');
+    // Single-tenant: no WHERE clause at all (tenant_id appears only in
+    // the SELECT projection, since it's a column on sync_subscriptions).
+    expect(sql.toLowerCase()).not.toContain('where');
+  });
+
+  it('ignores tenantId when multi-tenant mode is off', async () => {
+    await store.listAll('tenant-a');
+    const [{ sql, params }] = captures;
+    // No WHERE clause — tenant_id in SELECT projection is the column,
+    // not a filter.
+    expect(sql.toLowerCase()).not.toContain('where');
+    expect(params).not.toContain('tenant-a');
+  });
+});
+
+describe('PostgresCursorStore.listAll (OBS-4) — multi-tenant', () => {
+  let store: PostgresCursorStore;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({ rows: [] }));
+    store = new PostgresCursorStore(db, true);
+  });
+
+  it('throws MissingTenantIdError when tenantId is omitted', async () => {
+    await expect(store.listAll()).rejects.toBeInstanceOf(MissingTenantIdError);
+    expect(captures).toHaveLength(0);
+  });
+
+  it('throws MissingTenantIdError when tenantId is explicit null', async () => {
+    await expect(store.listAll(null)).rejects.toBeInstanceOf(
+      MissingTenantIdError,
+    );
+    expect(captures).toHaveLength(0);
+  });
+
+  it('WHERE includes tenant_id and binds the param', async () => {
+    await store.listAll('tenant-a');
+    expect(captures).toHaveLength(1);
+    const [{ sql, params }] = captures;
+    expect(sql.toLowerCase()).toContain('tenant_id');
+    expect(params).toContain('tenant-a');
+  });
+});
+
 describe('PostgresCursorStore — multiTenant constructor default', () => {
   it('defaults multiTenant to false when the token is not provided', async () => {
     // When the @Optional() inject yields undefined, the store falls back

--- a/src/__tests__/runtime/subsystems/sync-cursor-store.memory-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-cursor-store.memory-backend.spec.ts
@@ -123,4 +123,110 @@ describe('MemoryCursorStore', () => {
       expect(store.cursors.has('sub-1')).toBe(true);
     });
   });
+
+  describe('listAll (OBS-4)', () => {
+    it('returns [] when no cursors have been put', async () => {
+      expect(await store.listAll()).toEqual([]);
+    });
+
+    it('returns one snapshot per cursor, ordered by updatedAt DESC', async () => {
+      await store.put('sub-a', { v: 1 });
+      await store.put('sub-b', { v: 2 });
+      await store.put('sub-c', { v: 3 });
+
+      store.subscriptions.set('sub-a', {
+        integrationId: 'int-a',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: null,
+        updatedAt: new Date(1_000),
+      });
+      store.subscriptions.set('sub-b', {
+        integrationId: 'int-b',
+        adapter: 'hubspot',
+        domain: 'contact',
+        externalRef: 'filter-x',
+        updatedAt: new Date(3_000),
+      });
+      store.subscriptions.set('sub-c', {
+        integrationId: 'int-c',
+        adapter: 'github',
+        domain: 'issue',
+        externalRef: null,
+        updatedAt: new Date(2_000),
+      });
+
+      const snapshots = await store.listAll();
+      expect(snapshots.map((s) => s.subscriptionId)).toEqual([
+        'sub-b',
+        'sub-c',
+        'sub-a',
+      ]);
+    });
+
+    it('emits empty metadata when no subscription is seeded', async () => {
+      await store.put('sub-a', { v: 1 });
+      const [snapshot] = await store.listAll();
+      expect(snapshot).toEqual({
+        subscriptionId: 'sub-a',
+        integrationId: '',
+        adapter: '',
+        domain: '',
+        externalRef: null,
+        cursor: { v: 1 },
+        lastSyncAt: null,
+        updatedAt: new Date(0),
+        tenantId: null,
+      });
+    });
+
+    it('preserves seeded metadata end-to-end', async () => {
+      await store.put('sub-a', { systemModstamp: '2026-04-21' });
+      store.subscriptions.set('sub-a', {
+        integrationId: 'int-a',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: 'filter-1',
+        lastSyncAt: new Date(4_000),
+        updatedAt: new Date(5_000),
+      });
+
+      const [snapshot] = await store.listAll();
+      expect(snapshot).toEqual({
+        subscriptionId: 'sub-a',
+        integrationId: 'int-a',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: 'filter-1',
+        cursor: { systemModstamp: '2026-04-21' },
+        lastSyncAt: new Date(4_000),
+        updatedAt: new Date(5_000),
+        tenantId: null,
+      });
+    });
+
+    it('ignores tenantId (memory backend does not filter on it)', async () => {
+      await store.put('sub-a', { v: 1 });
+      await store.put('sub-b', { v: 2 });
+
+      const snapshots = await store.listAll('tenant-a');
+      expect(snapshots).toHaveLength(2);
+    });
+
+    it('clear() wipes subscriptions metadata too', async () => {
+      await store.put('sub-a', { v: 1 });
+      store.subscriptions.set('sub-a', {
+        integrationId: 'int-a',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: null,
+        updatedAt: new Date(1_000),
+      });
+
+      store.clear();
+
+      expect(store.subscriptions.size).toBe(0);
+      expect(await store.listAll()).toEqual([]);
+    });
+  });
 });

--- a/src/__tests__/runtime/subsystems/sync-run-recorder.drizzle-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-run-recorder.drizzle-backend.spec.ts
@@ -326,6 +326,102 @@ describe('DrizzleSyncRunRecorder — multi-tenant', () => {
   });
 });
 
+describe('DrizzleSyncRunRecorder.listRecent (OBS-4) — single-tenant', () => {
+  let recorder: DrizzleSyncRunRecorder;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({ rows: [] }));
+    recorder = new DrizzleSyncRunRecorder(db);
+  });
+
+  it('returns [] when no runs exist', async () => {
+    expect(await recorder.listRecent(10)).toEqual([]);
+    expect(captures).toHaveLength(1);
+  });
+
+  it('JOINs sync_runs against sync_subscriptions and SELECTs integration_id', async () => {
+    await recorder.listRecent(5);
+    expect(captures).toHaveLength(1);
+    const [{ sql }] = captures;
+    expect(sql.toLowerCase()).toContain('select');
+    expect(sql).toContain('"sync_runs"');
+    expect(sql).toContain('"sync_subscriptions"');
+    expect(sql.toLowerCase()).toContain('join');
+    expect(sql).toContain('"integration_id"');
+    // ORDER BY started_at DESC LIMIT.
+    expect(sql.toLowerCase()).toContain('order by');
+    expect(sql.toLowerCase()).toContain('desc');
+    expect(sql.toLowerCase()).toContain('limit');
+  });
+
+  it('does not include records_processed from a correlated subquery — reads the column directly', async () => {
+    await recorder.listRecent(5);
+    const [{ sql }] = captures;
+    expect(sql).toContain('"records_processed"');
+    // No nested `select count` — we read the denormalized column.
+    expect(sql.toLowerCase()).not.toContain('count(');
+  });
+
+  it('binds subscriptionId when provided', async () => {
+    await recorder.listRecent(5, 'sub-1');
+    const [{ sql, params }] = captures;
+    expect(params).toContain('sub-1');
+    // Filter lands on sync_runs.subscription_id (the FK), not the join target id.
+    expect(sql).toContain('"subscription_id"');
+  });
+
+  it('ignores tenantId when multi-tenant mode is off', async () => {
+    await recorder.listRecent(5, undefined, 'tenant-a');
+    const [{ sql, params }] = captures;
+    // `tenant_id` appears in the SELECT projection (column on sync_runs),
+    // but must NOT appear in a WHERE/filter. Single-tenant has no WHERE
+    // when subscriptionId is also omitted.
+    expect(sql.toLowerCase()).not.toContain('where');
+    expect(params).not.toContain('tenant-a');
+  });
+});
+
+describe('DrizzleSyncRunRecorder.listRecent (OBS-4) — multi-tenant', () => {
+  let recorder: DrizzleSyncRunRecorder;
+  let captures: Captured[];
+  let db: DrizzleClient;
+
+  beforeEach(() => {
+    ({ db, captures } = makeCapturingDb({ rows: [] }));
+    recorder = new DrizzleSyncRunRecorder(db, true);
+  });
+
+  it('throws MissingTenantIdError when tenantId is omitted', async () => {
+    await expect(recorder.listRecent(5)).rejects.toBeInstanceOf(
+      MissingTenantIdError,
+    );
+    expect(captures).toHaveLength(0);
+  });
+
+  it('throws MissingTenantIdError when tenantId is explicit null', async () => {
+    await expect(recorder.listRecent(5, undefined, null)).rejects.toBeInstanceOf(
+      MissingTenantIdError,
+    );
+  });
+
+  it('binds tenantId into the WHERE clause', async () => {
+    await recorder.listRecent(5, undefined, 'tenant-a');
+    expect(captures).toHaveLength(1);
+    const [{ sql, params }] = captures;
+    expect(sql.toLowerCase()).toContain('tenant_id');
+    expect(params).toContain('tenant-a');
+  });
+
+  it('combines subscriptionId + tenantId filters', async () => {
+    await recorder.listRecent(5, 'sub-1', 'tenant-a');
+    const [{ params }] = captures;
+    expect(params).toContain('sub-1');
+    expect(params).toContain('tenant-a');
+  });
+});
+
 describe('DrizzleSyncRunRecorder — multiTenant constructor default', () => {
   it('defaults multiTenant to false when the token is not provided', async () => {
     const { db, captures } = makeCapturingDb({

--- a/src/__tests__/runtime/subsystems/sync-run-recorder.memory-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync-run-recorder.memory-backend.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for MemoryRunRecorder.listRecent (OBS-4).
+ *
+ * Pure `bun:test` — covers the read projection introduced in OBS-4 against
+ * the memory backend. The write-path paths (`startRun`, `recordItem`,
+ * `completeRun`) are exercised elsewhere; this suite focuses on
+ * `listRecent` + the seedable `subscriptions` side-map.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { MemoryRunRecorder } from '../../../../runtime/subsystems/sync/sync-run-recorder.memory-backend';
+import type { ISyncRunRecorder } from '../../../../runtime/subsystems/sync/sync-run-recorder.protocol';
+
+async function seedRun(
+  recorder: MemoryRunRecorder,
+  subscriptionId: string,
+  startedAtMs: number,
+  options: {
+    recordsProcessed?: number;
+    status?: 'running' | 'success' | 'no_changes' | 'failed';
+    tenantId?: string | null;
+  } = {},
+): Promise<string> {
+  const { id } = await recorder.startRun({
+    subscriptionId,
+    direction: 'inbound',
+    action: 'poll',
+    cursorBefore: null,
+    tenantId: options.tenantId ?? null,
+  });
+  const run = recorder.runs.get(id);
+  if (!run) throw new Error(`seedRun: missing run ${id}`);
+  run.startedAt = new Date(startedAtMs);
+  if (options.status && options.status !== 'running') {
+    run.status = options.status;
+    run.recordsProcessed = options.recordsProcessed ?? 0;
+    run.completedAt = new Date(startedAtMs + 1000);
+  }
+  return id;
+}
+
+describe('MemoryRunRecorder.listRecent', () => {
+  let recorder: MemoryRunRecorder;
+
+  beforeEach(() => {
+    recorder = new MemoryRunRecorder();
+  });
+
+  describe('contract conformance', () => {
+    it('implements ISyncRunRecorder structurally', () => {
+      const asPort: ISyncRunRecorder = recorder;
+      expect(typeof asPort.listRecent).toBe('function');
+    });
+  });
+
+  describe('empty state', () => {
+    it('returns [] when no runs have been started', async () => {
+      expect(await recorder.listRecent(10)).toEqual([]);
+    });
+
+    it('returns [] when filter matches nothing', async () => {
+      await seedRun(recorder, 'sub-a', 1_000);
+      expect(await recorder.listRecent(10, 'sub-missing')).toEqual([]);
+    });
+  });
+
+  describe('ordering + limit', () => {
+    it('orders by startedAt DESC', async () => {
+      await seedRun(recorder, 'sub-a', 3_000);
+      await seedRun(recorder, 'sub-a', 1_000);
+      await seedRun(recorder, 'sub-a', 2_000);
+
+      const rows = await recorder.listRecent(10);
+      expect(rows.map((r) => r.startedAt.getTime())).toEqual([
+        3_000, 2_000, 1_000,
+      ]);
+    });
+
+    it('truncates to `limit`', async () => {
+      await seedRun(recorder, 'sub-a', 1_000);
+      await seedRun(recorder, 'sub-a', 2_000);
+      await seedRun(recorder, 'sub-a', 3_000);
+
+      const rows = await recorder.listRecent(2);
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.startedAt.getTime()).toBe(3_000);
+      expect(rows[1]?.startedAt.getTime()).toBe(2_000);
+    });
+  });
+
+  describe('subscription filter', () => {
+    it('filters by subscriptionId when provided', async () => {
+      await seedRun(recorder, 'sub-a', 1_000);
+      await seedRun(recorder, 'sub-b', 2_000);
+      await seedRun(recorder, 'sub-a', 3_000);
+
+      const rows = await recorder.listRecent(10, 'sub-a');
+      expect(rows).toHaveLength(2);
+      expect(rows.every((r) => r.subscriptionId === 'sub-a')).toBe(true);
+    });
+
+    it('returns all subscriptions when filter is omitted', async () => {
+      await seedRun(recorder, 'sub-a', 1_000);
+      await seedRun(recorder, 'sub-b', 2_000);
+      const rows = await recorder.listRecent(10);
+      expect(rows).toHaveLength(2);
+    });
+  });
+
+  describe('tenantId parameter', () => {
+    it('accepts tenantId but does NOT filter on it (memory contract)', async () => {
+      await seedRun(recorder, 'sub-a', 1_000, { tenantId: 'tenant-a' });
+      await seedRun(recorder, 'sub-a', 2_000, { tenantId: 'tenant-b' });
+
+      // Memory backend ignores tenantId — both rows come back regardless
+      // of the value passed. This matches MemoryCursorStore's behavior.
+      const rowsA = await recorder.listRecent(10, undefined, 'tenant-a');
+      expect(rowsA).toHaveLength(2);
+      const rowsNone = await recorder.listRecent(10);
+      expect(rowsNone).toHaveLength(2);
+    });
+  });
+
+  describe('integrationId resolution via subscriptions side-map', () => {
+    it('returns empty string when no subscription metadata has been seeded', async () => {
+      await seedRun(recorder, 'sub-a', 1_000);
+      const [row] = await recorder.listRecent(10);
+      expect(row?.integrationId).toBe('');
+    });
+
+    it('returns the seeded integrationId when the subscription is populated', async () => {
+      recorder.subscriptions.set('sub-a', {
+        integrationId: 'int-1',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: null,
+        updatedAt: new Date(500),
+      });
+      await seedRun(recorder, 'sub-a', 1_000);
+
+      const [row] = await recorder.listRecent(10);
+      expect(row?.integrationId).toBe('int-1');
+    });
+  });
+
+  describe('SyncRunSummary shape', () => {
+    it('projects run into the documented summary shape', async () => {
+      recorder.subscriptions.set('sub-a', {
+        integrationId: 'int-1',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: 'ref-x',
+        updatedAt: new Date(500),
+      });
+      const id = await seedRun(recorder, 'sub-a', 1_000, {
+        status: 'success',
+        recordsProcessed: 7,
+        tenantId: 'tenant-a',
+      });
+
+      const [row] = await recorder.listRecent(10);
+      expect(row).toEqual({
+        id,
+        subscriptionId: 'sub-a',
+        integrationId: 'int-1',
+        status: 'success',
+        startedAt: new Date(1_000),
+        completedAt: new Date(2_000),
+        recordsProcessed: 7,
+        tenantId: 'tenant-a',
+      });
+    });
+  });
+
+  describe('clear', () => {
+    it('resets runs, items, and subscriptions together', async () => {
+      recorder.subscriptions.set('sub-a', {
+        integrationId: 'int-1',
+        adapter: 'salesforce',
+        domain: 'opportunity',
+        externalRef: null,
+        updatedAt: new Date(500),
+      });
+      await seedRun(recorder, 'sub-a', 1_000);
+
+      recorder.clear();
+
+      expect(recorder.runs.size).toBe(0);
+      expect(recorder.items.size).toBe(0);
+      expect(recorder.subscriptions.size).toBe(0);
+      expect(await recorder.listRecent(10)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #206. Part of epic #195.

## Summary

Adds read methods to sync's existing ports for the observability composer:

- `ISyncRunRecorder.listRecent(limit, subscriptionId?, tenantId?)` — returns `SyncRunSummary[]`, newest first
- `ICursorStore.listAll(tenantId?)` — returns `CursorSnapshot[]`, most-recently-updated first

Drizzle backends JOIN `sync_runs` against `sync_subscriptions` to resolve `integrationId` per run; cursor `listAll` reads `sync_subscriptions` directly. Memory backends gain a seedable `subscriptions: Map` side-map so tests can populate metadata that the in-memory store doesn't otherwise track.

## Design choices (from spec)

- **Filter param on `listRecent` is `subscriptionId`**, not `integrationId` — `sync_runs` FKs to subscriptions (a single integration can own multiple subscriptions). Integration-wide views are deferred to a follow-up.
- **`recordsProcessed`** uses `sync_runs.records_processed` (denormalized column) rather than a `COUNT(sync_run_items)` correlated subquery.
- **Memory backends**: `MemorySyncSubscription` type lives in the run-recorder memory backend; the cursor store memory backend imports it. Each backend has an independent `subscriptions: Map` — callers wanting shared seed data populate both.

## Test plan

- [x] `just test-unit` — 1485 pass / 0 fail
- [x] `bun run typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)