### PR TITLE
OBS-8: smoke installs observability + runtime-copier recursion fix

### DIFF
--- a/runtime/subsystems/observability/observability-errors.ts
+++ b/runtime/subsystems/observability/observability-errors.ts
@@ -10,7 +10,7 @@
 export class ObservabilityError extends Error {
   constructor(
     message: string,
-    readonly cause?: unknown,
+    override readonly cause?: unknown,
   ) {
     super(message);
     this.name = 'ObservabilityError';

--- a/src/cli/shared/runtime-copier.ts
+++ b/src/cli/shared/runtime-copier.ts
@@ -105,16 +105,34 @@ export async function copyRuntime(opts: RuntimeCopyOptions): Promise<RuntimeCopy
 	// Queue of source paths to copy; value is the destination path.
 	const queue: Array<{ src: string; dest: string; isDep: boolean }> = [];
 
-	// Enumerate files in sourceDir
-	const entries = fs.readdirSync(sourceDir);
-	for (const entry of entries) {
-		const src = path.join(sourceDir, entry);
-		const stat = fs.statSync(src);
-		if (!stat.isFile()) continue;
-		if (!entry.endsWith('.ts') && !entry.endsWith('.tsx')) continue;
-		if (filter && !filter(entry)) continue;
-		queue.push({ src, dest: path.join(targetDir, entry), isDep: false });
+	// Enumerate files in sourceDir, recursing into subdirectories so nested
+	// runtime layouts (e.g. observability/reporters/, auth/backends/oauth-*)
+	// reach the user project intact. Preserves the relative path under
+	// sourceDir when computing the destination.
+	//
+	// Skips `generated/` directories by convention — those are produced by
+	// post-install codegen steps (event codegen, scope-entity-type, etc.)
+	// and must not be shipped as static snapshots from the runtime source.
+	function walk(dir: string): void {
+		for (const entry of fs.readdirSync(dir)) {
+			const src = path.join(dir, entry);
+			const stat = fs.statSync(src);
+			if (stat.isDirectory()) {
+				if (entry === 'generated') continue;
+				walk(src);
+				continue;
+			}
+			if (!stat.isFile()) continue;
+			if (!entry.endsWith('.ts') && !entry.endsWith('.tsx')) continue;
+			const rel = path.relative(sourceDir, src);
+			// Filter sees the relative path from sourceDir so callers can
+			// discriminate on subdirectory when needed; historically they
+			// only passed bare filenames, so also support the basename.
+			if (filter && !filter(rel) && !filter(entry)) continue;
+			queue.push({ src, dest: path.join(targetDir, rel), isDep: false });
+		}
 	}
+	walk(sourceDir);
 
 	const visited = new Set<string>();
 

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -216,6 +216,34 @@ async function main(): Promise<number> {
 		// 5. Run `codegen entity new --all`.
 		run(`bun ${CLI_PATH} entity new --all --force`, tmpDir);
 
+		// 5.5. Install the observability subsystem (combiner — ADR-025).
+		// No backend flag, no schema; copies runtime/subsystems/observability via
+		// copyRuntime, injects `observability:` into codegen.config.yaml, and
+		// appends a TODO hint to app.module.ts directing the human to wire
+		// ObservabilityModule.forRoot() AFTER Events/Jobs/Bridge/Sync.
+		//
+		// No siblings installed in this smoke — observability must typecheck
+		// standalone because its @Optional() sibling injections degrade to
+		// empty results when ports are absent (per OBS-5 contract).
+		run(`bun ${CLI_PATH} subsystem install observability`, tmpDir);
+
+		// Verify install artifacts appeared.
+		const configYamlPath = path.join(tmpDir, 'codegen.config.yaml');
+		const configYaml = fs.readFileSync(configYamlPath, 'utf8');
+		if (!configYaml.includes('observability:')) {
+			throw new Error(
+				'observability: block missing from codegen.config.yaml after install',
+			);
+		}
+
+		const appModulePath = path.join(tmpDir, 'src/app.module.ts');
+		const appModule = fs.readFileSync(appModulePath, 'utf8');
+		if (!appModule.includes('ObservabilityModule.forRoot')) {
+			throw new Error(
+				'ObservabilityModule TODO hint missing from app.module.ts after install',
+			);
+		}
+
 		// 6. Syntax-check the scaffolded project.
 		//
 		// Uses `tsc --noEmit --skipLibCheck` to catch parse errors and


### PR DESCRIPTION
Closes #210. Final wave of epic #195.

## Summary

Extends `test/smoke/run-smoke.ts` to install the observability subsystem end-to-end and verify install artifacts. Catches and fixes two real bugs in the process.

### Smoke additions

- `codegen subsystem install observability` runs inside the scratch project
- Asserts `observability:` block appears in `codegen.config.yaml`
- Asserts `ObservabilityModule.forRoot` TODO hint appears in `app.module.ts`
- No siblings pre-installed — verifies observability's `@Optional()` DI contract (composer must typecheck standalone)

### Bugs caught + fixed

**1. `src/cli/shared/runtime-copier.ts`: shallow `readdirSync`.** Only top-level files were being copied into consumer projects. Silently affected:
- `runtime/subsystems/observability/reporters/*` (this epic)
- `runtime/subsystems/auth/backends/*` and `auth/protocols/*` (pre-existing)

Fixed by switching to a recursive `walk()` that skips `generated/` by convention. Filter callers receive both relative path and basename for back-compat.

**2. `runtime/subsystems/observability/observability-errors.ts`: missing `override` on `cause`.** Only surfaced under `noImplicitOverride`, which the consumer-side tsconfig emitted by `project init` turns on. Fixed.

### Decisions honored

- Did NOT add `runtime/subsystems/observability/` to `OUTPUT_PATHS` — runtime is version-controlled, not template-emitted
- No siblings in smoke — tests `@Optional()` contract as designed
- Extra artifact assertions beyond typecheck (yaml block + module hint)

## Test plan

- [x] `just test-smoke` — PASS (observability installs 24 files incl. reporters)
- [x] `just test-baseline` — PASS, zero deltas
- [x] `just test-unit` — 1550 pass / 0 fail
- [x] `just test-all` — PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)