### PR TITLE
feat(events): tier: audit — bridge-inert events for lifecycle/observability

### DIFF
--- a/.claude/skills/events/SKILL.md
+++ b/.claude/skills/events/SKILL.md
@@ -20,6 +20,19 @@ If you are tempted to put `status`, `attempts`, or `retry_policy` fields on an e
 
 **Three event directions** — this is the single most important routing concern in the subsystem:
 
+**Two event tiers — domain vs audit — orthogonal to direction:**
+
+| tier     | semantics                                                                | bridge eligible? | pool                      |
+|----------|--------------------------------------------------------------------------|------------------|---------------------------|
+| `domain` | A fact other components may want to react to.                            | yes              | derived from `direction`  |
+| `audit`  | A fact about the system itself (a sync ran, a feature was used). Observational only. | **no**           | **none** (pool & direction both null) |
+
+Default is `domain`. Use `audit` for high-volume lifecycle events that should be queryable/replayable in the outbox but must not spawn jobs — the motivating case was a polling CRM sync emitting per-row "I scanned this" events that flooded the reserved change pool with a thousand inert jobs. The discipline: **domain events are facts consumers react to; audit events are facts humans inspect.** If a well-behaved subscriber would write another row or enqueue work, it's domain; if they'd bump a counter or update a dashboard, it's audit.
+
+Full design: `docs/specs/events-codegen-plan.md` §4.
+
+**Three event directions — for domain events only:**
+
 | direction  | what it carries                                     | example                          | default pool       |
 |------------|-----------------------------------------------------|----------------------------------|--------------------|
 | `inbound`  | external → us. Webhooks, pub/sub, inbound email     | `stripe_payment_received`        | `events_inbound`   |
@@ -27,6 +40,8 @@ If you are tempted to put `status`, `attempts`, or `retry_policy` fields on an e
 | `outbound` | us → external. Webhooks fired, sync pushes          | `webhook_outbound_contact_sync`  | `events_outbound`  |
 
 Direction is a **routing** concern, not a payload concern. Payload shape is per-event-type. The same direction can carry wildly different payloads; two events with identical payloads can have different directions. Don't collapse them.
+
+Audit-tier events do NOT have a direction — they are not about data movement between systems.
 
 **Reserved `events_*` pools** — the jobs subsystem (ADR-022, jobs SKILL.md) reserves three pools — `events_inbound`, `events_change`, `events_outbound` — *exclusively* for the IEventBus outbox drain. User `@JobHandler` decorations that target a reserved pool fail at build time. These pools exist so a slow outbound handler cannot stall change-event propagation. The Drizzle outbox drain loop claims rows by pool (see `outbox-and-transactions.md`).
 
@@ -62,6 +77,7 @@ Direction is a **routing** concern, not a payload concern. Payload shape is per-
 5. **Phase ordering matters.** Events codegen is a hard prerequisite for the jobs Event-to-Job Bridge (ADR-023). The bridge reads the event registry to validate trigger references, extract typed scope from payloads, and auto-assign pools. Ship events registry → ship events typed facade → *then* land the bridge. Don't skip.
 6. **Change events MAY be declared via the entity `events:` block.** At parse time the generator desugars the entity block into top-level `events/<name>.yaml` with `direction: change` and `aggregate: <entity>`. Per-entity inline blocks are sugar; they are not a second source of truth.
 7. **Entity auto-emission requires opt-in via `emits:`.** The target design (Phase C) is: entities declare `emits: [contact_created, contact_updated, ...]` in their YAML; generated use-cases emit typed events via `TypedEventBus.publish(type, aggregateId, payload, { tx })` inside the transaction. Silent auto-emission by name is being phased out.
+8. **Tier: audit events are outbox-only, never bridge-eligible.** `tier: audit` in the YAML produces registry entries with `pool: null, direction: null`. The bridge dispatcher skips them by construction. Audit events still flow through the outbox so the observability viewer can query/replay them, but they never spawn a job. A job YAML that names an audit event as a trigger MUST fail codegen — the error message names the event and points to §4 of the plan.
 
 ## Do not
 

--- a/.claude/skills/events/directions-and-pools.md
+++ b/.claude/skills/events/directions-and-pools.md
@@ -1,6 +1,8 @@
 # Directions & Pools
 
-The events subsystem has exactly three directions: `inbound`, `change`, `outbound`. Each drains through its own reserved pool in the jobs subsystem. This file explains the distinction, why the pools are kept separate, and how events and jobs connect across that boundary.
+The events subsystem has exactly three **directions** for domain-tier events: `inbound`, `change`, `outbound`. Each drains through its own reserved pool in the jobs subsystem. This file explains the distinction, why the pools are kept separate, and how events and jobs connect across that boundary.
+
+There is also a fourth class: **audit-tier events** (`tier: audit`), which have no direction and no pool. They flow through the outbox but the bridge refuses to bind jobs to them. See §Tier at the bottom.
 
 ## The three directions
 
@@ -110,9 +112,30 @@ Default configuration gives parallelism, not ordering.
 
 ## Custom pools — not for events
 
-Users can declare custom pools in `codegen.config.yaml` (e.g., an `agents` pool for long-running LLM jobs). Those pools **cannot be targets for events** — the reserved-pool set (`events_inbound | events_change | events_outbound`) is the whole legal universe of event pools. A user pool can host event-*triggered* jobs (after the bridge runs), but events themselves only ever drain through the three reserved lanes.
+Users can declare custom pools in `codegen.config.yaml` (e.g., an `agents` pool for long-running LLM jobs). Those pools **cannot be targets for events** — the reserved-pool set (`events_inbound | events_change | events_outbound`) is the whole legal universe of domain-event pools. A user pool can host event-*triggered* jobs (after the bridge runs), but events themselves only ever drain through the three reserved lanes.
 
-If you find yourself wanting a fourth event pool ("events_telemetry", "events_audit"), stop and model the underlying concern differently — either split into an existing direction, or treat the thing as an audit table rather than a domain event.
+If you find yourself wanting a fourth *pool* for event traffic, stop — that's almost always the `tier: audit` case (see below), not a new pool.
+
+## Tier: audit events have no direction and no pool
+
+The tier field (`domain` | `audit`, default `domain`) is orthogonal to direction. It controls **whether the event is bridge-eligible**:
+
+| tier     | direction       | pool           | can a job trigger on it? |
+|----------|-----------------|----------------|--------------------------|
+| `domain` | required        | from direction | yes                      |
+| `audit`  | MUST be omitted | **null**       | **no — codegen error**   |
+
+Audit events represent facts about the system itself ("a sync run completed," "a feature was used") rather than facts about domain data flow. They still land in `domain_events` and are queryable/replayable like any other event, but:
+
+- Neither `pool` nor `direction` is stamped. Both columns are NULL.
+- The bridge dispatcher refuses to bind jobs to them. A `triggers: [crm_sync_completed]` on a job YAML where that event is `tier: audit` fails codegen with a pointed error.
+- Subscribers via `IEventBus.subscribe()` may still opt in directly. Audit events are not firewalled from in-process listeners, only from the bridge.
+
+**When to reach for it:** polling/sync lifecycle events, feature-use telemetry, background-task cycle markers, anything where you want the outbox record but explicitly do NOT want downstream work to spawn. The motivating case: a CRM polling sync emitting a `found_row` event per scanned record was silently queuing thousands of inert bridge jobs per run. The `audit` tier fixes this cleanly.
+
+**When NOT to use it:** anything a subscriber could legitimately react to by writing domain state or enqueuing work. That's a domain event.
+
+Full design: `docs/specs/events-codegen-plan.md` §4.
 
 ## Do not
 

--- a/.claude/skills/events/event-codegen.md
+++ b/.claude/skills/events/event-codegen.md
@@ -67,16 +67,17 @@ payload:
 
 **Fields:**
 - `type` — unique snake_case business key, matches filename
-- `direction` — `inbound | change | outbound`; drives default pool
+- `tier` — optional; `domain | audit`; default `domain`. Audit events bypass the bridge; see §Tier below and plan §4.
+- `direction` — `inbound | change | outbound`; drives default pool. **Required for `tier: domain`, omitted for `tier: audit`.**
 - `aggregate` — entity name (required for `direction: change`; optional elsewhere)
 - `source` — inbound only; logical origin ("stripe", "email")
 - `destination` — outbound only; logical target ("crm", "slack")
 - `payload` — snake_case keys → camelCase TS props; types `uuid | string | number | boolean | date | json | array`. For `array`, an `items:` scalar type is required (`items: uuid | string | number | boolean | date`) and emits `T[]` + `z.array(T)`. `json` means "arbitrary JSON object" (`Record<string, unknown>` / `z.record(z.unknown())`) — do NOT use `json` for array-shaped payloads, Zod will reject them at validation time.
-- `pool` — optional override; constrained to the reserved pools of the *same category* (a `change` event cannot opt into `events_inbound`). User pools (`batch`, `interactive`) are NEVER valid targets for events.
+- `pool` — optional override; constrained to the reserved pools of the *same category* (a `change` event cannot opt into `events_inbound`). User pools (`batch`, `interactive`) are NEVER valid targets for events. **MUST be omitted when `tier: audit`.**
 - `retry` — `{ attempts, backoff }`, hints surfaced to the bus
 - `version` — integer, defaults to 1 (schema evolution; not exercised yet)
 
-**Default pool from direction:**
+**Default pool from direction (domain tier only):**
 
 | direction  | default pool       |
 |------------|--------------------|
@@ -85,6 +86,46 @@ payload:
 | `outbound` | `events_outbound`  |
 
 Override is rarely needed. If you find yourself overriding, revisit the direction.
+
+## Tier: domain vs audit
+
+`tier` classifies what kind of fact the event represents, and controls whether the bridge can bind jobs to it. Default `domain` — normal event, behaves exactly as before. `audit` is the escape hatch for **lifecycle / observational events that should exist in the outbox but must not spawn work**.
+
+| tier     | direction       | pool           | bridge binding | notes                                            |
+|----------|-----------------|----------------|----------------|--------------------------------------------------|
+| `domain` | required        | from direction | allowed        | existing behavior                                |
+| `audit`  | omitted         | null           | **rejected**   | outbox-only, observability viewer sees it        |
+
+```yaml
+# events/crm_sync_completed.yaml
+type: crm_sync_completed
+tier: audit                  # ← this is the escape hatch
+aggregate: integration       # still scoped to an aggregate for query-by-id
+version: 1
+description: |
+  A CRM sync run finished. Observational — no domain state changed because of
+  this event firing; row mutations were already signaled by crm_entity_persisted.
+payload:
+  integration_id: { type: uuid }
+  provider:       { type: string }
+  counts:         { type: json }
+  duration_ms:    { type: number }
+```
+
+**What the generator stamps for audit events:** registry entry has `pool: null, direction: null`. Typed facade writes `metadata.pool = null, metadata.direction = null`. First-class columns (when shipped) land as NULL. Observability viewer renders no pool chip — correct, because there is no pool.
+
+**Bridge enforcement:** a job YAML that declares `triggers: [crm_sync_completed]` when `crm_sync_completed` is `tier: audit` MUST fail codegen. Error: `Job 'xyz' triggers on audit-tier event 'crm_sync_completed'. Audit events are not bridge-eligible. Use a domain event, or remove the trigger.`
+
+**Use when:**
+- Polling/sync lifecycle events (`*_sync_started`, `*_sync_completed`, `*_sync_failed`)
+- Feature-use telemetry
+- Background-task cycle markers
+- Anything high-volume where downstream reaction is "record it" not "do more work"
+
+**Do NOT use for:**
+- Anything a subscriber might legitimately react to by writing domain state or enqueuing work. That's a domain event.
+
+Full design: `docs/specs/events-codegen-plan.md` §4.
 
 ## Entity `events:` block is sugar
 

--- a/docs/specs/events-codegen-plan.md
+++ b/docs/specs/events-codegen-plan.md
@@ -62,6 +62,7 @@ top-level files.
 
 ```ts
 const EventDirectionSchema = z.enum(['inbound', 'change', 'outbound']);
+const EventTierSchema = z.enum(['domain', 'audit']);
 
 const EventPayloadFieldSchema = z.object({
   type: z.enum(['uuid', 'string', 'number', 'boolean', 'date', 'json']),
@@ -71,7 +72,18 @@ const EventPayloadFieldSchema = z.object({
 
 const EventDefinitionSchema = z.object({
   type: z.string().regex(/^[a-z][a-z0-9_]*$/),
-  direction: EventDirectionSchema,
+
+  // Tier — orthogonal to direction. Controls whether this event is
+  // eligible for bridge triggers (domain) or is purely observational
+  // (audit). Default: 'domain'. When 'audit', the event still flows
+  // through the outbox and is queryable/replayable, but the bridge
+  // dispatcher refuses to bind jobs to it. See §4.2 below.
+  tier: EventTierSchema.optional().default('domain'),
+
+  // Direction describes the data-flow axis of domain events. Required
+  // when tier === 'domain'; optional (and typically omitted) when
+  // tier === 'audit' because audit events are not about data flow.
+  direction: EventDirectionSchema.optional(),
 
   // Aggregate / source binding.
   //   - for `change`: required, must be a declared entity name
@@ -87,7 +99,8 @@ const EventDefinitionSchema = z.object({
   // Pool is *derived* from direction unless explicitly overridden.
   // Override is constrained to reserved pools of the same category; a `change`
   // event cannot opt into `events_inbound`. User pools (batch/interactive) are
-  // NOT valid targets for events.
+  // NOT valid targets for events. When tier === 'audit', pool MUST be
+  // omitted — audit events have no pool (see §4.2).
   pool: z.enum(['events_inbound', 'events_change', 'events_outbound']).optional(),
 
   // Routing / retry metadata surfaced to the bus backend.
@@ -99,7 +112,15 @@ const EventDefinitionSchema = z.object({
   // Optional free-form metadata pinned at codegen time (e.g. schema version).
   version: z.number().int().positive().default(1),
   description: z.string().optional(),
-}).strict();
+}).strict().refine(
+  // Cross-field rule 1: domain events require direction.
+  (e) => e.tier !== 'domain' || e.direction !== undefined,
+  { message: 'tier: domain requires direction (inbound | change | outbound)' },
+).refine(
+  // Cross-field rule 2: audit events must not declare pool.
+  (e) => e.tier !== 'audit' || e.pool === undefined,
+  { message: 'tier: audit events must not declare pool — audit events have no pool' },
+);
 ```
 
 Derivation rule (`direction` → default `pool`):
@@ -168,6 +189,29 @@ retry:
   attempts: 3
   backoff: exponential
 ```
+
+**4. Audit / lifecycle (NOT a data-flow event)**
+
+```yaml
+# events/crm_sync_completed.yaml
+type: crm_sync_completed
+tier: audit                 # ← bypasses bridge binding; no pool/direction
+aggregate: integration      # still has an aggregate for query-by-scope
+version: 1
+description: |
+  A CRM sync run finished. Fires once per run completion. Observational only —
+  no domain state mutated because of this event firing; the row mutations were
+  already signaled by crm_entity_persisted.
+payload:
+  integration_id: { type: uuid }
+  provider:       { type: string }
+  counts:         { type: json }
+  duration_ms:    { type: number }
+```
+
+Note: no `direction`, no `pool`. The typed facade stamps neither. The event
+still lands in `domain_events` and is queryable/replayable like any other;
+it just never becomes a job trigger.
 
 ## 2. Generated artifacts in `src/generated/events/`
 
@@ -385,7 +429,102 @@ trigger / in-memory fill during `publish` — preferred: the generated
 `TypedEventBus.publish` passes pool both in metadata and as an explicit column
 (the backend can pluck it).
 
-## 4. Auto-emission from entity templates
+## 4. Event tiers: domain vs audit
+
+### 4.1 What the tier field means
+
+Two tiers, declared via optional `tier:` field on every event, default
+`domain`:
+
+| tier     | semantics                                                      | bridge eligible? | pool                      |
+|----------|----------------------------------------------------------------|------------------|---------------------------|
+| `domain` | A fact about the application's domain data flow.               | yes              | derived from `direction` |
+| `audit`  | A fact about the system itself (a sync ran; a feature was used; a background task completed its cycle). Observational. | **no**           | **none**                  |
+
+The axis is **orthogonal to direction**. Every domain event has a direction
+(inbound / change / outbound describes where data flows). An audit event
+does not: "the sync finished" is not data flowing between systems.
+
+### 4.2 Why the distinction matters
+
+When every emitted event flows through the event-to-job bridge, high-volume
+"I did a thing" observations silently amplify into queued jobs. A polling
+sync that scans 2000 rows and emits an audit-ish event per scan fills the
+reserved `events_change` pool with 2000 jobs-to-decide-whether-to-enqueue,
+even when the net domain change is zero. This has actually happened; it's
+the motivating case for introducing the tier.
+
+The discipline the tier enforces:
+
+- **Domain events = facts other components may want to react to.** Job
+  triggers bind to them. Volume should track the rate of real domain
+  change.
+- **Audit events = facts you want to record and inspect, but no consumer
+  should react via a job.** Volume can be high. They live in the outbox
+  so the observability viewer can show them, and so they replay correctly
+  for debugging, but the bridge treats them as inert.
+
+### 4.3 Behavior of audit events
+
+- `tier: audit` events MAY omit `direction`, MUST omit `pool`.
+- The generated registry stamps `metadata.pool = null, metadata.direction = null`
+  at publish time for audit events.
+- The typed facade validates payload shape identically to domain events.
+- The outbox insert is identical — audit events land in `domain_events`
+  and are queryable, replayable, and visible to the observability viewer.
+- **The event-to-job bridge dispatcher treats audit-tier events as
+  non-triggerable.** A job YAML that declares a trigger on an audit-tier
+  event MUST fail codegen with a hard error:
+  `Job 'xyz' triggers on audit-tier event 'crm_sync_completed'. Audit events are not bridge-eligible. Use a domain event, or remove the trigger.`
+- Subscribers via `IEventBus.subscribe()` CAN still listen to audit events
+  explicitly. This is the escape hatch for custom in-process listeners
+  (metrics emitters, log shippers) that want the event stream but opt
+  out of the job/queue machinery. Subscriptions are declarative opt-in;
+  they do not queue work by default.
+
+### 4.4 When to use audit
+
+Rule of thumb:
+
+- Would a well-behaved subscriber react by writing another row, sending a
+  notification, or enqueuing work? → **domain**.
+- Would a well-behaved subscriber react by updating a dashboard, bumping
+  a counter, or logging? → **audit**.
+- Uncertain? Default is `domain`. If nothing ends up binding and the
+  volume is high, downgrade to `audit` with a note in the YAML `description`.
+
+### 4.5 Worked example
+
+The CRM sync on a polling cadence:
+
+```yaml
+# events/crm_sync_started.yaml      tier: audit    (lifecycle fact)
+# events/crm_sync_completed.yaml    tier: audit    (lifecycle fact)
+# events/crm_sync_failed.yaml       tier: audit    (lifecycle fact)
+# events/crm_entity_persisted.yaml  tier: domain   (actual domain write occurred)
+#                                   direction: change, aggregate: <entity>
+```
+
+Per run of the sync: 3 audit events (start, end-or-fail) + N domain events
+(one per entity that *actually changed*, post-diff). The bridge sees the
+N domain events. The queue stays proportional to real change.
+
+### 4.6 Relationship to the `direction` axis
+
+`direction` is a data-flow label for domain events. It can be one of three
+values. `tier: audit` events do not have a direction because they are not
+about data moving between systems. The axes do not compose beyond these
+rules:
+
+- `tier: domain` ⇒ `direction` is required; pool derives from direction.
+- `tier: audit` ⇒ `direction` omitted; no pool.
+
+There is no `tier: audit, direction: inbound` state. An inbound webhook
+IS a domain event (data flowed in); the receiver-side lifecycle ("I
+finished processing the webhook batch") is a separate audit event if
+you want to track it.
+
+## 5. Auto-emission from entity templates
 
 ### Today
 
@@ -463,7 +602,7 @@ async execute(input: CreateContactInput): Promise<Contact> {
 No more reliance on `BaseService` silently emitting events for declared
 change types — that path becomes the fallback only.
 
-## 5. Phase integration with the jobs plan
+## 6. Phase integration with the jobs plan
 
 The jobs plan is Layers 1–6, with the Event-to-Job Bridge sitting at Phase 3
 (triggers from event types). The bridge needs:
@@ -501,7 +640,7 @@ This final phase is independent of jobs and can slip without blocking.
 5. Jobs Phase 4, 5, 6 proceed; Events Phase B interleaves at jobs Phase 5
 6. Events Phase C (entity auto-emission rewrite) ships standalone
 
-## 6. Connection to the Event-to-Job Bridge
+## 7. Connection to the Event-to-Job Bridge
 
 ### Safe reference from Job YAML
 
@@ -568,7 +707,7 @@ overrides. This keeps user jobs off the reserved pools by default:
 
 This is a subtle point and probably worth an open question (#Q6).
 
-## 7. Open questions
+## 8. Open questions
 
 1. **Top-level `events/*.yaml` vs. inline entity `events:` block — keep both,
    desugar, or drop one?** Proposal above keeps both, with inline as sugar


### PR DESCRIPTION
## Problem

Every declared event today is eligible to spawn jobs via the bridge. For high-volume **lifecycle / observational events** (a polling sync ran, a feature was used, a background task completed its cycle), this silently amplifies emission into queued work. The reserved `events_*` pools — the only legal pools for events — are the only options the generator can stamp, so lifecycle events get squeezed into whichever direction lies the least. They don't belong there.

**Motivating incident (real, happened yesterday):** a CRM polling sync emits `crm_entity_persisted` per scanned record regardless of whether anything actually changed. Running against a portal with 22 deals, one re-sync emitted ~30 events (sync_started, sync_completed, per-entity persisted, entity lifecycle hooks) — most of them semantically noise. All landed in the reserved `events_change` pool. Bridge amplification would enqueue ~30 inert CDC jobs per run. At production cadence this blows up the pool.

Two problems stacked:
1. Lifecycle events (`crm_sync_started`, `crm_sync_completed`, `crm_sync_failed`) are not domain-change events. Labeling them `events_change` is a lie: the viewer says "Events Change" on a row that represents "a sync finished." Consumers reading pool semantically are misled.
2. There's no escape hatch. The only way to emit something outbox-queryable today is via `TypedEventBus.publish()`, which inevitably stamps a pool and enables bridge bindings.

## Design

Introduce `tier: domain | audit` as an orthogonal field on event YAML. Default `domain` — existing behavior, every current event continues to work unchanged.

`tier: audit` means:
- MAY omit `direction`; MUST omit `pool`.
- Registry: `pool: null, direction: null`.
- Typed facade stamps nulls.
- **Bridge refuses to bind jobs to audit events.** A `triggers: [crm_sync_completed]` on a job YAML when that event is `tier: audit` fails codegen with a pointed error.
- `IEventBus.subscribe()` still works. In-process opt-in listeners (metrics, log shippers) can consume; audit events are firewalled from the bridge specifically, not from all consumers.
- Outbox insert is unchanged. Observability viewer queries/replays them like any other event.

The rule of thumb the tier makes explicit:
- **Domain events** = facts consumers react to by writing state or enqueuing work.
- **Audit events** = facts humans inspect (dashboards, counters, logs).

If you're uncertain, default domain. If nothing binds and the volume is high, downgrade to audit with a note in the YAML `description`.

## Scope of this PR

Design + skills docs only. The events-codegen work is still phase-in-flight (per §0 of the plan and the "design in flight" banners on the skills). This PR:

- Updates `docs/specs/events-codegen-plan.md` — new §4 "Event tiers: domain vs audit", Zod schema additions, fourth worked example, section renumbering.
- Updates `.claude/skills/events/event-codegen.md` — YAML shape includes `tier`, new "Tier: domain vs audit" section with CRM sync lifecycle YAML and the bridge-enforcement error template.
- Updates `.claude/skills/events/directions-and-pools.md` — new "Tier" section describing bridge-eligibility; updated custom-pool guidance to point at tier instead of a fourth pool.
- Updates `.claude/skills/events/SKILL.md` — tier table at top; "Non-obvious rule" #8 documenting audit's bridge bypass.

## Intentionally NOT in this PR

- Generator implementation. When the generator lands, it will honor `tier` per the design here.
- Runtime schema changes. The existing `domain_events.metadata` column is already permissive; the first-class `pool`/`direction` columns (EVT-1 Phase A) will land nullable, which matches audit's null requirement.
- Bridge enforcement code. The bridge-dispatcher validator that reads the registry will gain the `tier: audit` guard when the registry exposes it.

## Why skill docs first

The generator hasn't shipped. Consumers (`dealbrain-v2`) are running hand-rolled early implementations of the typed bus. By landing the design + skills now:
1. Consumers can update their hand-rolled generated code to honor `tier` today (local patch).
2. Whoever implements the official generator inherits the decision already made.
3. Future engineers searching "how do I emit an event without spawning a job" land on the tier pattern immediately.

## Follow-ups

- When runtime adds first-class `pool` / `direction` columns to `domain_events`, confirm nullability is preserved.
- When the generator lands, add a test that `{ tier: 'audit', pool: 'events_change' }` is a codegen hard-error.
- When the bridge ships, add a test that a job triggering on an audit event is a codegen hard-error with the documented message.

## Ref

Motivating discussion: dealbrain-v2 HubSpot CRM sync re-sync observed 30 events emitted for zero real domain change, pool column mislabeled as "Events Change" on `crm_sync_completed`, user called out the architectural gap directly.