### PR TITLE
fix(templates): declarative queries delegate via service, not repo

### DIFF
--- a/templates/entity/new/clean-lite-ps/service.ejs.t
+++ b/templates/entity/new/clean-lite-ps/service.ejs.t
@@ -54,6 +54,19 @@ export class <%= classNames.service %> extends WithAnalytics(
 <%_ serviceInheritedMethods.forEach(line => { _%>
   //   <%= line %>
 <%_ }) _%>
+<% if (hasDeclarativeQueries) { %>
+  // ═══════════════════════════════════════════════════════════════════════
+  // Declarative queries (from queries: block in entity YAML)
+  // Pass-through to repository — keeps use-cases on the service layer so
+  // cross-cutting concerns (analytics, events) stay uniform.
+  // ═══════════════════════════════════════════════════════════════════════
+<%_ processedQueries.forEach((q) => { _%>
+
+  async <%= q.methodName %>(<%- q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
+    return this.repository.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
+  }
+<%_ }) _%>
+<% } %>
 <% if (eavEnabled) { %>
   /**
    * EAV paired read (ADR-13): fetch the entity and merge dynamic `field_values`

--- a/templates/entity/new/clean-lite-ps/use-cases/declarative-queries.ejs.t
+++ b/templates/entity/new/clean-lite-ps/use-cases/declarative-queries.ejs.t
@@ -7,21 +7,21 @@ force: true
  * Declarative Query Use Cases for <%= classNames.entity %>
  * Generated from queries: block in entity YAML — do not edit directly.
  *
- * Each query is an injectable use case class that delegates to the repository.
+ * Each query is an injectable use case class that delegates to the service.
  * Register all via `declarativeQueryClasses` in the module providers.
  */
 
 import { Injectable } from '@nestjs/common';
-import { <%= classNames.repository %> } from '../<%= entityName %>.repository';
+import { <%= classNames.service %> } from '../<%= entityName %>.service';
 import type { <%= classNames.entity %> } from '../<%= entityName %>.entity';
 
 <% processedQueries.forEach((q) => { -%>
 @Injectable()
 export class <%= q.useCaseClassName %> {
-  constructor(private readonly repository: <%= classNames.repository %>) {}
+  constructor(private readonly service: <%= classNames.service %>) {}
 
   async execute(<%- q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
-    return this.repository.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
+    return this.service.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
   }
 }
 

--- a/templates/relationship/new/service.ejs.t
+++ b/templates/relationship/new/service.ejs.t
@@ -28,4 +28,17 @@ export class <%= classNames.service %> extends WithAnalytics(
   //
   // Inherited from BaseService:
   //   findById, findByIds, list, count, exists, create, update, delete
+<% if (hasDeclarativeQueries) { %>
+  // ═══════════════════════════════════════════════════════════════════════
+  // Declarative queries (from queries: block in relationship YAML)
+  // Pass-through to repository — keeps use-cases on the service layer so
+  // cross-cutting concerns (analytics, events) stay uniform.
+  // ═══════════════════════════════════════════════════════════════════════
+<%_ processedQueries.forEach((q) => { _%>
+
+  async <%= q.methodName %>(<%- q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
+    return this.repository.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
+  }
+<%_ }) _%>
+<% } %>
 }

--- a/templates/relationship/new/use-cases/declarative-queries.ejs.t
+++ b/templates/relationship/new/use-cases/declarative-queries.ejs.t
@@ -7,21 +7,21 @@ force: true
  * Declarative Query Use Cases for <%= classNames.entity %>
  * Generated from queries: block in relationship YAML — do not edit directly.
  *
- * Each query is an injectable use case class that delegates to the repository.
+ * Each query is an injectable use case class that delegates to the service.
  * Register all via `declarativeQueryClasses` in the module providers.
  */
 
 import { Injectable } from '@nestjs/common';
-import { <%= classNames.repository %> } from '../<%= name %>.repository';
+import { <%= classNames.service %> } from '../<%= name %>.service';
 import type { <%= classNames.entity %> } from '../<%= name %>.entity';
 
 <% processedQueries.forEach((q) => { -%>
 @Injectable()
 export class <%= q.useCaseClassName %> {
-  constructor(private readonly repository: <%= classNames.repository %>) {}
+  constructor(private readonly service: <%= classNames.service %>) {}
 
   async execute(<%- q.params.map(p => `${p.camelName}: ${p.tsType}`).join(', ') %>): Promise<<%- q.returnType %>> {
-    return this.repository.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
+    return this.service.<%= q.methodName %>(<%= q.params.map(p => p.camelName).join(', ') %>);
   }
 }
 


### PR DESCRIPTION
Closes #200.

## Summary

Every use-case in the `clean-lite-ps` pipeline correctly goes use-case → service → repo **except** declarative-query use-cases, which inject the repository directly and bypass the service. Caught while planning epic #195.

Two template fixes:

1. **`service.ejs.t`** emits a pass-through method per declarative query that delegates `return this.repository.methodName(...)`. Mirrors repo signatures exactly.
2. **`use-cases/declarative-queries.ejs.t`** injects the service (matching `find-by-id.ejs.t` and every other use-case in the pipeline) and calls `this.service.methodName(...)`.

## Pipelines audited

| Pipeline | Status |
|---|---|
| `clean-lite-ps` | VIOLATION — **fixed** |
| `relationship` | VIOLATION — **fixed** |
| `backend` (Clean Architecture) | Has no service layer at all — its use-cases inject the repo directly across the board. **This is an oversight, not a design choice** — the pipeline needs a service layer added so the same `use-case → service → repo` rule can apply uniformly. Out of scope for this PR; tracked as a separate issue. |

## Net effect (this PR)

Behavior unchanged in the clean-lite-ps + relationship pipelines — services are thin pass-throughs to repo methods. But cross-cutting concerns on `WithAnalytics(BaseService)` (analytics hooks, lifecycle event emission) now apply to declarative queries too, matching the rest of the use-case surface.

## Test plan

- [x] `just test-unit` — 1550 pass / 0 fail
- [x] `just test-baseline` — green, no diffs (baseline fixture uses `architecture: clean`, which is the backend pipeline that's unchanged here)
- [x] `just test-smoke` — PASS (smoke exercises clean-lite-ps; fresh project typechecks)
- [x] `bun run typecheck` — clean
- [ ] CI green

## Follow-ups

- Add a service layer to the backend (Clean Architecture) pipeline so `use-case → service → repo` is uniform across all pipelines. Filed separately.
- ESLint/Biome rule `no-direct-repository-in-use-cases` to enforce the layering for hand-authored use-cases. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)