### PR TITLE
feat(sync)!: cursor-at-seam protocol expansion (#226-2)

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -71,7 +71,7 @@ meaningful.
 
 | When the task involves… | Read |
 |---|---|
-| Designing a new `IChangeSource<T>` / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
+| Designing a new `IChangeSource<T>` (signature `(subscription, cursor) => AsyncIterable<Change<T>>` per ADR-033) / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
 | The orchestrator's run lifecycle, cursor advance, per-item failure, loopback | `orchestrator-flow.md` |
 | `sync_runs` / `sync_run_items` / `sync_subscriptions` shape, `changed_fields` (ADR-0003), worked queries | `audit-model.md` |
 | Writing a feature module, migrating from bespoke sync, multi-tenancy wiring | `consumer-patterns.md` |
@@ -79,15 +79,24 @@ meaningful.
 ## Non-obvious rules (read twice)
 
 1. **One port for three modes.** Poll, CDC, and webhook adapters ALL
-   implement `IChangeSource<T>`. Per-mode concerns (CDC replay_id,
-   webhook event_id, provider-hinted changed fields) live in `Change<T>`
+   implement `IChangeSource<T>` —
+   `listChanges(subscription, cursor): AsyncIterable<Change<T>>`
+   (#226-2 / ADR-033). Per-mode concerns (CDC replay_id, webhook
+   event_id, provider-hinted changed fields) live in `Change<T>`
    metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
    introduce mode-specific ports — we rejected that design explicitly.
 
-2. **Cursors are opaque at the port seam.** `ICursorStore.get/put`
-   takes `unknown`. Each strategy types its cursor internally (poll:
-   `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`). The
-   orchestrator doesn't interpret the shape; it just persists what the
+2. **Cursors are opaque at the port seam, and the orchestrator owns
+   the lifecycle.** `ICursorStore.get/put` takes `unknown`. Each
+   strategy types its cursor internally (poll: `{ systemModstamp }`,
+   CDC: `{ replayId }`, webhook: `{ ts }`). The orchestrator is the
+   only reader of `ICursorStore` — it `get`s the cursor before the
+   run, passes it by value as the second argument to
+   `IChangeSource.listChanges(subscription, cursor)` (#226-2 / ADR-033),
+   advances `latestCursor = change.cursor` as the iterator yields,
+   and `put`s on success. Primitives never inject `ICursorStore`;
+   that would create two readers of the same row. The orchestrator
+   doesn't interpret the cursor shape; it just persists what the
    iterator last yielded.
 
 3. **All-failed runs still advance the cursor.** If every record in a

--- a/.claude/skills/sync/consumer-patterns.md
+++ b/.claude/skills/sync/consumer-patterns.md
@@ -67,9 +67,10 @@ export class SalesforceOpportunityChangeSource
 
   async *listChanges(
     sub: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpportunity>> {
-    const cursor = sub.cursor as { systemModstamp?: string } | null;
-    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const typed = cursor as { systemModstamp?: string } | null;
+    const since = typed?.systemModstamp ?? '1970-01-01T00:00:00Z';
 
     // Session refresh happens before the query — withAuthRetry wraps
     // the SFDC client to force a refresh on 401 and retry once.

--- a/.claude/skills/sync/orchestrator-flow.md
+++ b/.claude/skills/sync/orchestrator-flow.md
@@ -12,7 +12,7 @@ execute(input)
   ├─ cursorBefore = cursors.get(subId, tenantId)
   ├─ runId = recorder.startRun({subId, direction, action, cursorBefore, tenantId})
   │
-  ├─ for await (change of source.listChanges(sub)):
+  ├─ for await (change of source.listChanges(sub, cursorBefore)):
   │    recordsFound++
   │    latestCursor = change.cursor
   │    cursorAdvanced = true

--- a/.claude/skills/sync/protocols-and-ports.md
+++ b/.claude/skills/sync/protocols-and-ports.md
@@ -14,7 +14,10 @@ The one port every sync adapter implements. Three detection modes
 ```ts
 interface IChangeSource<T> {
   readonly label: string;  // e.g. 'salesforce-poll-opportunity'
-  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
+  listChanges(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>>;
 }
 
 interface Change<T> {

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -751,10 +751,11 @@ export class SalesforceOpportunityChangeSource
   readonly label = 'salesforce-poll-opportunity';
 
   async *listChanges(
-    subscription: SyncSubscriptionView,
+    _subscription: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpportunity>> {
-    const cursor = subscription.cursor as { systemModstamp?: string } | null;
-    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const typed = cursor as { systemModstamp?: string } | null;
+    const since = typed?.systemModstamp ?? '1970-01-01T00:00:00Z';
 
     const records = await this.sfdc.query(
       `SELECT ... FROM Opportunity WHERE SystemModstamp > ${since}`,

--- a/docs/guides/sync-migration.md
+++ b/docs/guides/sync-migration.md
@@ -85,10 +85,11 @@ export class SalesforceOpportunityChangeSource
   constructor(private readonly sfdc: SalesforceClient) {}
 
   async *listChanges(
-    sub: SyncSubscriptionView,
+    _sub: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpportunity>> {
-    const cursor = sub.cursor as { systemModstamp?: string } | null;
-    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const typed = cursor as { systemModstamp?: string } | null;
+    const since = typed?.systemModstamp ?? '1970-01-01T00:00:00Z';
     const records = await this.sfdc.query(
       `SELECT ... FROM Opportunity WHERE SystemModstamp > ${since}`,
     );

--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -7,7 +7,7 @@
  * Flow per run:
  *
  *   1. `recorder.startRun(...)` — opens a `sync_runs` row in 'running'.
- *   2. for each change yielded by `source.listChanges(subscription)`:
+ *   2. for each change yielded by `source.listChanges(subscription, cursorBefore)`:
  *        a. if loopback store says "echo of own write" → skip, record
  *           as `status: 'skipped'`, `operation: 'noop'`, changedFields `{}`.
  *        b. differ.diff(existing, incoming) → 'noop' short-circuits to
@@ -153,7 +153,7 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     let status: 'success' | 'no_changes' | 'failed' = 'no_changes';
 
     try {
-      for await (const change of source.listChanges(input.subscription)) {
+      for await (const change of source.listChanges(input.subscription, cursorBefore)) {
         recordsFound++;
         latestCursor = change.cursor;
         cursorAdvanced = true;

--- a/runtime/subsystems/sync/sync-change-source.protocol.ts
+++ b/runtime/subsystems/sync/sync-change-source.protocol.ts
@@ -10,7 +10,15 @@
  * `Change.source` / `dedupKey` / `providerChangedFields` metadata fields,
  * not in separate ports.
  *
- * See epic #60 (parent) and upstream ADR-008 subsystem architecture.
+ * Cursor is passed by-value as the second argument (#226-2 / ADR-033). The
+ * orchestrator owns cursor lifecycle (read-before-iterate, advance-on-yield,
+ * persist-on-success); the primitive receives the current value at the start
+ * of each run rather than reading it from a side store. This eliminates the
+ * "two readers of the same row" problem that arose when adapters injected
+ * `ICursorStore` directly.
+ *
+ * See epic #60 (parent), ADR-033 (config-driven change sources), and
+ * upstream ADR-008 subsystem architecture.
  */
 
 // ============================================================================
@@ -91,9 +99,16 @@ export interface IChangeSource<T> {
 
   /**
    * Async-iterate upstream changes, newest cursor last. The orchestrator
+   * passes the current persisted cursor by-value as the second argument and
    * persists `change.cursor` as it advances; strategies MUST yield at least
    * one change before the async iterable completes if anything changed
    * upstream, otherwise cursor advance is a no-op.
+   *
+   * `cursor` is opaque at this seam — the primitive's cursor strategy types
+   * it internally. `null` means "first run, no cursor yet."
    */
-  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
+  listChanges(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>>;
 }

--- a/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
+++ b/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
@@ -45,10 +45,13 @@ interface CanonicalOpp extends Record<string, unknown> {
 
 class ArrayChangeSource implements IChangeSource<CanonicalOpp> {
   readonly label = 'test-array';
+  readonly seenCursors: Array<unknown | null> = [];
   constructor(private readonly changes: Change<CanonicalOpp>[]) {}
   async *listChanges(
     _sub: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpp>> {
+    this.seenCursors.push(cursor);
     for (const c of this.changes) yield c;
   }
 }
@@ -61,6 +64,7 @@ class ThrowingChangeSource implements IChangeSource<CanonicalOpp> {
   ) {}
   async *listChanges(
     _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpp>> {
     for (const c of this.initial) yield c;
     throw this.err;
@@ -510,6 +514,36 @@ describe('ExecuteSyncUseCase', () => {
         'tenant-a',
       );
       expect(recorder.items[0].tenantId).toBe('tenant-a');
+    });
+  });
+
+  describe('cursor passthrough (#226-2)', () => {
+    it('passes null cursor on first run (no prior persisted cursor)', async () => {
+      const source = new ArrayChangeSource([]);
+      const orch = makeOrchestrator(source, sink, recorder, cursors);
+      await orch.execute(makeInput());
+
+      expect(source.seenCursors).toEqual([null]);
+    });
+
+    it('passes the persisted cursor value on subsequent runs', async () => {
+      // Seed the cursor store with a prior value.
+      await cursors.put(SUB.id, { systemModstamp: '2026-04-21T10:00:00Z' });
+
+      const change: Change<CanonicalOpp> = {
+        externalId: 'ext-1',
+        operation: 'created',
+        record: { external_id: 'ext-1', amount: 100 },
+        cursor: { systemModstamp: '2026-04-21T13:00:00Z' },
+        source: 'poll',
+      };
+      const source = new ArrayChangeSource([change]);
+      const orch = makeOrchestrator(source, sink, recorder, cursors);
+      await orch.execute(makeInput());
+
+      expect(source.seenCursors).toEqual([
+        { systemModstamp: '2026-04-21T10:00:00Z' },
+      ]);
     });
   });
 

--- a/src/__tests__/runtime/subsystems/sync.module.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync.module.spec.ts
@@ -51,7 +51,10 @@ interface CanonicalOpp extends Record<string, unknown> {
 class EmptySource implements IChangeSource<CanonicalOpp> {
   readonly label = 'test';
   // eslint-disable-next-line @typescript-eslint/require-yield
-  async *listChanges(_sub: SyncSubscriptionView): AsyncIterable<Change<CanonicalOpp>> {
+  async *listChanges(
+    _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
+  ): AsyncIterable<Change<CanonicalOpp>> {
     // yields nothing
     return;
   }
@@ -59,7 +62,10 @@ class EmptySource implements IChangeSource<CanonicalOpp> {
 
 class OneChangeSource implements IChangeSource<CanonicalOpp> {
   readonly label = 'test';
-  async *listChanges(_sub: SyncSubscriptionView): AsyncIterable<Change<CanonicalOpp>> {
+  async *listChanges(
+    _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
+  ): AsyncIterable<Change<CanonicalOpp>> {
     yield {
       externalId: 'ext-1',
       operation: 'created',


### PR DESCRIPTION
## Summary

- Expand `IChangeSource<T>.listChanges` from `(subscription)` to `(subscription, cursor)` so the orchestrator passes its already-read `cursorBefore` by-value into the primitive — eliminating the "two readers of the same row" pattern (decision memo Q1, ADR-033).
- Orchestrator (`execute-sync.use-case.ts:156`) threads `cursorBefore` through. JSDoc updated; no other behavior change.
- Every in-tree adapter shape (test fakes under `src/__tests__/runtime/subsystems/`) + consumer docs (`docs/CONSUMER-SETUP.md`, `docs/guides/sync-migration.md`) updated to the new shape. No `// TODO cursor` shims.

**BREAKING** — replaces the prior single-arg signature cleanly per CLAUDE.md "no backwards compat." No shims, no parallel old/new, no deprecation notices.

Closes #228. Part of epic #226.

## Diff size

81 LOC across 6 files — well under the 500-LOC budget called out in plan §5 risks.

## Acceptance

- [x] `IChangeSource<T>.listChanges` signature is `(subscription: SyncSubscriptionView, cursor: unknown | null) => AsyncIterable<Change<T>>`.
- [x] Orchestrator passes `cursorBefore` (the value read at `execute-sync.use-case.ts:137`) into the call.
- [x] Every in-tree implementation + test double compiles. No shims.
- [x] `just test-unit` green (1587 pass / 0 fail).
- [x] `just test-baseline` green.

## Test plan

- [x] Unit: cursor passthrough — null on first run, persisted value on subsequent runs (new `describe('cursor passthrough (#226-2)')` block in `execute-sync.use-case.spec.ts`).
- [x] Unit: full existing orchestrator suite still passes against the new signature.
- [x] Module: `SyncModule` end-to-end memory + Drizzle compile-time wiring still resolves with updated source fakes.
- [x] Baseline: snapshot generation unchanged.

## Skill update pending — see § Skill update; orchestrator will apply pre-merge.

## Skill update (apply pre-merge)

The orchestrator will apply this diff to `.claude/skills/sync/SKILL.md` before merge. Harness gates writes to `.claude/**` so the bot cannot edit it directly.

### Edit 1 — Rule 2: cursors at the port seam (now dual reader)

File: `.claude/skills/sync/SKILL.md`

Old (exact):
```
2. **Cursors are opaque at the port seam.** `ICursorStore.get/put`
   takes `unknown`. Each strategy types its cursor internally (poll:
   `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`). The
   orchestrator doesn't interpret the shape; it just persists what the
   iterator last yielded.
```

New:
```
2. **Cursors are opaque at the port seam, and the orchestrator owns
   the lifecycle.** `ICursorStore.get/put` takes `unknown`. Each
   strategy types its cursor internally (poll: `{ systemModstamp }`,
   CDC: `{ replayId }`, webhook: `{ ts }`). The orchestrator is the
   only reader of `ICursorStore` — it `get`s the cursor before the
   run, passes it by value as the second argument to
   `IChangeSource.listChanges(subscription, cursor)` (#226-2 / ADR-033),
   advances `latestCursor = change.cursor` as the iterator yields,
   and `put`s on success. Primitives never inject `ICursorStore`;
   that would create two readers of the same row. The orchestrator
   doesn't interpret the cursor shape; it just persists what the
   iterator last yielded.
```

### Edit 2 — Rule 1: clarify port signature

File: `.claude/skills/sync/SKILL.md`

Old (exact):
```
1. **One port for three modes.** Poll, CDC, and webhook adapters ALL
   implement `IChangeSource<T>`. Per-mode concerns (CDC replay_id,
   webhook event_id, provider-hinted changed fields) live in `Change<T>`
   metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
   introduce mode-specific ports — we rejected that design explicitly.
```

New:
```
1. **One port for three modes.** Poll, CDC, and webhook adapters ALL
   implement `IChangeSource<T>` —
   `listChanges(subscription, cursor): AsyncIterable<Change<T>>`
   (#226-2 / ADR-033). Per-mode concerns (CDC replay_id, webhook
   event_id, provider-hinted changed fields) live in `Change<T>`
   metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
   introduce mode-specific ports — we rejected that design explicitly.
```

### Edit 3 — Routing row L73–74 (`protocols-and-ports.md` covers the new signature)

File: `.claude/skills/sync/SKILL.md`

Old (exact):
```
| Designing a new `IChangeSource<T>` / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
```

New:
```
| Designing a new `IChangeSource<T>` (signature `(subscription, cursor) => AsyncIterable<Change<T>>` per ADR-033) / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
```

### Edit 4 — `protocols-and-ports.md` snippet

File: `.claude/skills/sync/protocols-and-ports.md`

Old (exact):
```
  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
```

New:
```
  listChanges(
    subscription: SyncSubscriptionView,
    cursor: unknown | null,
  ): AsyncIterable<Change<T>>;
```

### Edit 5 — `orchestrator-flow.md` ascii loop

File: `.claude/skills/sync/orchestrator-flow.md`

Old (exact):
```
  ├─ for await (change of source.listChanges(sub)):
```

New:
```
  ├─ for await (change of source.listChanges(sub, cursorBefore)):
```

### Edit 6 — `consumer-patterns.md` adapter sketch (line ~68)

File: `.claude/skills/sync/consumer-patterns.md`

Old (exact):
```
  async *listChanges(
```

(Reviewer: confirm the surrounding context — the snippet's signature should grow a `cursor: unknown | null` second arg matching the updated `docs/CONSUMER-SETUP.md` example. If the file already shows the new signature post-merge, skip this edit.)

New:
```
  async *listChanges(
```
followed by a `cursor: unknown | null,` second parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)