### PR TITLE
feat(schema): entity YAML detection: block schema validation (#226-6)

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -15,8 +15,10 @@ surface — `ISyncSink<T>`. Everything else (cursor persistence, diffing,
 per-record audit, run lifecycle) is provided by the subsystem.
 
 This skill covers the Phase 1 runtime (SYNC-1..SYNC-8, epic #60). Phase
-2 (the `syncable:` YAML flag + codegen-produced per-entity sync binding
-modules) is gated on the App-Defined Patterns RFC and not shipped.
+2 lands in two halves: the entity-YAML `detection:` block is now
+schema-validated upstream against the canonical `DetectionConfigSchema`
+(ADR-033, #226-6); the codegen factory-module emission that consumes
+the parsed block is still pending (#226-7).
 
 ## Mental model
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,32 @@ queries:
   - by: [user_id, status]    # → FindContactByUserIdAndStatusUseCase (compound)
 ```
 
+## Sync Detection (`detection:` block)
+
+Entities that participate in the sync subsystem may declare a `detection:` block describing how upstream changes are detected. The block is parsed by the canonical `DetectionConfigSchema` shipped from `runtime/subsystems/sync` — primitives (`PollChangeSource<T>`, `WebhookChangeSource<T>`) and the per-entity factory module emitted by codegen consume the same parsed shape, so YAML and runtime stay in lockstep (ADR-033, epic #226).
+
+```yaml
+detection:
+  mode: poll                       # poll | webhook
+  poll:
+    cursor:
+      kind: systemModstamp         # systemModstamp | replayId | timestamp | eventId
+      field: SystemModstamp
+    provenance: poll               # 'poll' (default) or 'cdc' for Stripe-style event endpoints
+  mapping:
+    - source: Name
+      target: name
+    - source: Amount
+      target: amount
+      transform: decimal-string    # opt-in tag adapters interpret
+  filters:                         # flat AND of resolved triples
+    - field: IsDeleted
+      op: eq                       # eq | neq | in | nin | gt | gte | lt | lte
+      value: false
+```
+
+`webhook` mode requires a `webhook.eventIdField` naming the column on the consumer-owned inbound staging row that populates `Change<T>.dedupKey`. The block is optional and additive — entities without a `detection:` block are unaffected. Codegen emission of the per-entity factory module lands in #226-7; this PR validates the schema only.
+
 ## Configuration
 
 `codegen.config.yaml` in your project root:

--- a/src/__tests__/schema/detection-block.test.ts
+++ b/src/__tests__/schema/detection-block.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for the entity-YAML `detection:` block (#226-6).
+ *
+ * Validates that `EntityDefinitionSchema` accepts an optional `detection`
+ * field, parsed by the canonical `DetectionConfigSchema` re-exported from
+ * `runtime/subsystems/sync`. No template/codegen emission yet — schema
+ * validation only.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { EntityDefinitionSchema } from '../../schema/entity-definition.schema';
+import { loadEntityFromYaml } from '../../utils/yaml-loader';
+import { resolve } from 'path';
+
+describe('detection block (#226-6)', () => {
+	const base = {
+		entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities' },
+		fields: { name: { type: 'string', required: true } },
+	};
+
+	it('detection is optional', () => {
+		const result = EntityDefinitionSchema.safeParse(base);
+		expect(result.success).toBe(true);
+		expect(result.data!.detection).toBeUndefined();
+	});
+
+	it('accepts a minimal poll-mode detection block', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'poll',
+				poll: {
+					cursor: { kind: 'systemModstamp', field: 'SystemModstamp' },
+				},
+				mapping: [{ source: 'Name', target: 'name' }],
+			},
+		});
+		expect(result.success).toBe(true);
+		expect(result.data!.detection!.mode).toBe('poll');
+	});
+
+	it('accepts poll mode with provenance: cdc and filters', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'poll',
+				poll: {
+					cursor: { kind: 'eventId', field: 'id' },
+					provenance: 'cdc',
+				},
+				mapping: [
+					{ source: 'Name', target: 'name' },
+					{ source: 'Amount', target: 'amount', transform: 'decimal-string' },
+				],
+				filters: [
+					{ field: 'StageName', op: 'neq', value: 'Closed Lost' },
+					{ field: 'OwnerId', op: 'in', value: ['a', 'b'] },
+				],
+			},
+		});
+		expect(result.success).toBe(true);
+		const detection = result.data!.detection!;
+		expect(detection.mode).toBe('poll');
+		if (detection.mode === 'poll') {
+			expect(detection.poll.provenance).toBe('cdc');
+			expect(detection.filters).toHaveLength(2);
+		}
+	});
+
+	it('accepts a webhook-mode detection block', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'webhook',
+				webhook: { eventIdField: 'event_id' },
+				mapping: [{ source: 'name', target: 'name' }],
+			},
+		});
+		expect(result.success).toBe(true);
+		expect(result.data!.detection!.mode).toBe('webhook');
+	});
+
+	it('rejects an unknown detection mode', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'cdc',
+				mapping: [{ source: 'Name', target: 'name' }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a poll block missing the cursor strategy', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'poll',
+				poll: {},
+				mapping: [{ source: 'Name', target: 'name' }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an unknown cursor kind', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'poll',
+				poll: { cursor: { kind: 'bogus', field: 'x' } },
+				mapping: [{ source: 'Name', target: 'name' }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an empty mapping array', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'poll',
+				poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } },
+				mapping: [],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a filter with an unknown op', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'poll',
+				poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } },
+				mapping: [{ source: 'Name', target: 'name' }],
+				filters: [{ field: 'x', op: 'like', value: 'y' }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects webhook mode without eventIdField', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			detection: {
+				mode: 'webhook',
+				webhook: {},
+				mapping: [{ source: 'name', target: 'name' }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('parses the opportunity fixture YAML containing a detection block', () => {
+		const yamlPath = resolve(__dirname, '../../../test/fixtures/opportunity.yaml');
+		const result = loadEntityFromYaml(yamlPath);
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		const definition = result.definition;
+		expect(definition.detection).toBeDefined();
+		expect(definition.detection!.mode).toBe('poll');
+		if (definition.detection!.mode === 'poll') {
+			expect(definition.detection!.poll.cursor.kind).toBe('systemModstamp');
+			expect(definition.detection!.mapping.length).toBeGreaterThan(0);
+			expect(definition.detection!.filters.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DetectionConfigSchema } from "../../runtime/subsystems/sync";
 
 /**
  * Entity Definition Schema
@@ -791,6 +792,19 @@ export const EntityDefinitionSchema = z
     // v2: Integration sync configuration (CODEGEN-EVOLUTION-PLAN Phase 2)
     // Electric SQL + provider sync (Salesforce, HubSpot, etc.)
     sync: SyncConfigSchema.optional(),
+
+    // #226-6: Config-driven change-source detection (ADR-033).
+    //
+    // Declarative detection config consumed by the runtime change-source
+    // primitives (`PollChangeSource<T>` / `WebhookChangeSource<T>`) and by
+    // the per-entity factory module emitted by Phase 2 codegen (#226-7).
+    // The Zod schema is the canonical source of filter / mapping / cursor
+    // shape and is imported from `runtime/subsystems/sync` so this
+    // validator and the runtime parser stay in lockstep — drift between
+    // the two sites must be a compile error, not a runtime mismatch.
+    //
+    // Optional and additive: existing entity YAMLs are unaffected.
+    detection: DetectionConfigSchema.optional(),
 
     // v2: Domain event declarations (CODEGEN-EVOLUTION-PLAN Phase 2)
     // Generates typed event classes, handlers, and queue registration

--- a/test/fixtures/opportunity.yaml
+++ b/test/fixtures/opportunity.yaml
@@ -74,3 +74,31 @@ relationships:
     type: belongs_to
     target: deal_state
     foreign_key: state_id
+
+# Config-driven change-source detection (#226-6, ADR-033).
+# Schema-validated by the canonical DetectionConfigSchema from
+# runtime/subsystems/sync. No codegen emission yet — that lands in #226-7.
+detection:
+  mode: poll
+  poll:
+    cursor:
+      kind: systemModstamp
+      field: SystemModstamp
+  mapping:
+    - source: Name
+      target: name
+    - source: Amount
+      target: amount
+      transform: decimal-string
+    - source: CloseDate
+      target: expected_close_date
+      transform: date-iso
+    - source: OwnerId
+      target: owner_id
+  filters:
+    - field: IsDeleted
+      op: eq
+      value: false
+    - field: StageName
+      op: neq
+      value: "Closed Lost"


### PR DESCRIPTION
## Summary

- Extend `EntityDefinitionSchema` with optional `detection?: DetectionConfig`, importing the canonical Zod schema from `runtime/subsystems/sync` (re-exported via `index.ts`) so the codegen YAML validator and runtime primitives parse the exact same shape — drift between the two sites is a compile error, not a runtime mismatch (ADR-033).
- Extend `test/fixtures/opportunity.yaml` with a poll-mode `detection:` block exercising `systemModstamp` cursor, mapping with transform tags, and flat-AND filters.
- Add unit-test coverage for the new field (`src/__tests__/schema/detection-block.test.ts`, 11 cases): poll/webhook acceptance, optionality, fixture YAML round-trip, and rejection paths (unknown mode, missing cursor, unknown cursor `kind`, empty mapping, unknown filter op, webhook missing `eventIdField`).
- Add a `## Sync Detection (`detection:` block)` section to README between Declarative Queries and Configuration.

No template / codegen emission yet — that lands in #226-7. Cross-tree import (`src/schema/` → `runtime/subsystems/sync/`) compiles out of the box; no tsconfig changes were required (sibling `runtime/` already resolves under the existing `baseUrl`).

Closes #229
Part of epic #226

## Test plan

- [x] `bun test src/__tests__/schema/detection-block.test.ts` — 11/11 green
- [x] `bun test src/__tests__/` — 1596 pass, 0 fail
- [x] `just test-baseline` — green
- [x] `bunx tsc --noEmit` — no new errors (only pre-existing TS6 deprecation warning on `baseUrl`)
- [x] `codegen entity validate test/fixtures` — same FAIL count before/after my change (additive; my new `detection:` block on `opportunity.yaml` introduces no new validation errors)

## Skill update (apply pre-merge)

The orchestrator will apply this diff to `.claude/skills/sync/SKILL.md` before merge.

### Edit 1
File: `.claude/skills/sync/SKILL.md`

Old (exact, with surrounding context for unique anchoring):
````
per-record audit, run lifecycle) is provided by the subsystem.

This skill covers the Phase 1 runtime (SYNC-1..SYNC-8, epic #60). Phase
2 (the `syncable:` YAML flag + codegen-produced per-entity sync binding
modules) is gated on the App-Defined Patterns RFC and not shipped.

## Mental model
````

New:
````
per-record audit, run lifecycle) is provided by the subsystem.

This skill covers the Phase 1 runtime (SYNC-1..SYNC-8, epic #60). Phase
2 lands in two halves: the entity-YAML `detection:` block is now
schema-validated upstream against the canonical `DetectionConfigSchema`
(ADR-033, #226-6); the codegen factory-module emission that consumes
the parsed block is still pending (#226-7).

## Mental model
````

**Skill update pending — see § Skill update; orchestrator will apply pre-merge.**