### PR TITLE
feat(sync): PollChangeSource<T> primitive (#226-3)

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -71,7 +71,7 @@ meaningful.
 
 | When the task involves… | Read |
 |---|---|
-| Designing a new `IChangeSource<T>` / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
+| Designing a new `IChangeSource<T>` (signature `(subscription, cursor) => AsyncIterable<Change<T>>` per ADR-033) / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
 | The orchestrator's run lifecycle, cursor advance, per-item failure, loopback | `orchestrator-flow.md` |
 | `sync_runs` / `sync_run_items` / `sync_subscriptions` shape, `changed_fields` (ADR-0003), worked queries | `audit-model.md` |
 | Writing a feature module, migrating from bespoke sync, multi-tenancy wiring | `consumer-patterns.md` |
@@ -79,15 +79,24 @@ meaningful.
 ## Non-obvious rules (read twice)
 
 1. **One port for three modes.** Poll, CDC, and webhook adapters ALL
-   implement `IChangeSource<T>`. Per-mode concerns (CDC replay_id,
-   webhook event_id, provider-hinted changed fields) live in `Change<T>`
+   implement `IChangeSource<T>` —
+   `listChanges(subscription, cursor): AsyncIterable<Change<T>>`
+   (#226-2 / ADR-033). Per-mode concerns (CDC replay_id, webhook
+   event_id, provider-hinted changed fields) live in `Change<T>`
    metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
    introduce mode-specific ports — we rejected that design explicitly.
 
-2. **Cursors are opaque at the port seam.** `ICursorStore.get/put`
-   takes `unknown`. Each strategy types its cursor internally (poll:
-   `{ systemModstamp }`, CDC: `{ replayId }`, webhook: `{ ts }`). The
-   orchestrator doesn't interpret the shape; it just persists what the
+2. **Cursors are opaque at the port seam, and the orchestrator owns
+   the lifecycle.** `ICursorStore.get/put` takes `unknown`. Each
+   strategy types its cursor internally (poll: `{ systemModstamp }`,
+   CDC: `{ replayId }`, webhook: `{ ts }`). The orchestrator is the
+   only reader of `ICursorStore` — it `get`s the cursor before the
+   run, passes it by value as the second argument to
+   `IChangeSource.listChanges(subscription, cursor)` (#226-2 / ADR-033),
+   advances `latestCursor = change.cursor` as the iterator yields,
+   and `put`s on success. Primitives never inject `ICursorStore`;
+   that would create two readers of the same row. The orchestrator
+   doesn't interpret the cursor shape; it just persists what the
    iterator last yielded.
 
 3. **All-failed runs still advance the cursor.** If every record in a

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -162,6 +162,17 @@ meaningful.
     — drift between the two sites must be a compile error, not a
     runtime mismatch. See ADR-033 (`docs/adrs/ADR-033-config-driven-change-sources.md`).
 
+11. **`userId` / `tenantId` are NOT in `PollFetchContext`.** The poll
+    primitive's adapter callback receives exactly
+    `{ subscription, cursor, filters }` (decision memo Q5). Run-scope
+    identity (`userId`, `tenantId`) is closed over by the consumer at
+    adapter construction (or resolved inside the callback via consumer
+    services) — never threaded through the port seam. Threading it
+    forces port expansion every time run-context grows, and the
+    orchestrator already enforces tenancy at `execute()` entry. The
+    same rule applies to `WebhookChangeSource<T>` when it lands in
+    #226-4. See ADR-033 + decision memo Q5.
+
 ## Do not
 
 - Do not introduce `IPollSource`, `ICdcSource`, or `IWebhookSource`.
@@ -207,6 +218,13 @@ Files that ship to the consumer app (not templates):
   `ChangeIterator<T>` + `ChangeMiddleware<T>` types; the universal
   composition seam consumed by primitives (loopback ships here in
   #226-5) (ADR-033)
+- `runtime/subsystems/sync/poll-change-source.ts` —
+  `PollChangeSource<T>` poll-mode primitive: parameterized by a parsed
+  `DetectionConfig` + `PollFetchCallback<T>`; owns filter resolution
+  (flat-AND), field-mapping → `externalId`, middleware composition,
+  and `Change<T>.source` provenance (`'poll'` default; `'cdc'` opt-in
+  via `poll.provenance` for Stripe-style event endpoints — #226-4)
+  (#226-3 / ADR-033)
 - `runtime/subsystems/sync/sync-run-recorder.protocol.ts` —
   `ISyncRunRecorder` + `StartRunInput` / `RecordItemInput` /
   `CompleteRunInput`

--- a/.claude/skills/sync/consumer-patterns.md
+++ b/.claude/skills/sync/consumer-patterns.md
@@ -67,9 +67,10 @@ export class SalesforceOpportunityChangeSource
 
   async *listChanges(
     sub: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpportunity>> {
-    const cursor = sub.cursor as { systemModstamp?: string } | null;
-    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const typed = cursor as { systemModstamp?: string } | null;
+    const since = typed?.systemModstamp ?? '1970-01-01T00:00:00Z';
 
     // Session refresh happens before the query — withAuthRetry wraps
     // the SFDC client to force a refresh on 401 and retry once.

--- a/.claude/skills/sync/orchestrator-flow.md
+++ b/.claude/skills/sync/orchestrator-flow.md
@@ -12,7 +12,7 @@ execute(input)
   ├─ cursorBefore = cursors.get(subId, tenantId)
   ├─ runId = recorder.startRun({subId, direction, action, cursorBefore, tenantId})
   │
-  ├─ for await (change of source.listChanges(sub)):
+  ├─ for await (change of source.listChanges(sub, cursorBefore)):
   │    recordsFound++
   │    latestCursor = change.cursor
   │    cursorAdvanced = true

--- a/.claude/skills/sync/protocols-and-ports.md
+++ b/.claude/skills/sync/protocols-and-ports.md
@@ -14,7 +14,10 @@ The one port every sync adapter implements. Three detection modes
 ```ts
 interface IChangeSource<T> {
   readonly label: string;  // e.g. 'salesforce-poll-opportunity'
-  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
+  listChanges(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>>;
 }
 
 interface Change<T> {

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -751,10 +751,11 @@ export class SalesforceOpportunityChangeSource
   readonly label = 'salesforce-poll-opportunity';
 
   async *listChanges(
-    subscription: SyncSubscriptionView,
+    _subscription: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpportunity>> {
-    const cursor = subscription.cursor as { systemModstamp?: string } | null;
-    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const typed = cursor as { systemModstamp?: string } | null;
+    const since = typed?.systemModstamp ?? '1970-01-01T00:00:00Z';
 
     const records = await this.sfdc.query(
       `SELECT ... FROM Opportunity WHERE SystemModstamp > ${since}`,

--- a/docs/guides/sync-migration.md
+++ b/docs/guides/sync-migration.md
@@ -85,10 +85,11 @@ export class SalesforceOpportunityChangeSource
   constructor(private readonly sfdc: SalesforceClient) {}
 
   async *listChanges(
-    sub: SyncSubscriptionView,
+    _sub: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpportunity>> {
-    const cursor = sub.cursor as { systemModstamp?: string } | null;
-    const since = cursor?.systemModstamp ?? '1970-01-01T00:00:00Z';
+    const typed = cursor as { systemModstamp?: string } | null;
+    const since = typed?.systemModstamp ?? '1970-01-01T00:00:00Z';
     const records = await this.sfdc.query(
       `SELECT ... FROM Opportunity WHERE SystemModstamp > ${since}`,
     );

--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -7,7 +7,7 @@
  * Flow per run:
  *
  *   1. `recorder.startRun(...)` — opens a `sync_runs` row in 'running'.
- *   2. for each change yielded by `source.listChanges(subscription)`:
+ *   2. for each change yielded by `source.listChanges(subscription, cursorBefore)`:
  *        a. if loopback store says "echo of own write" → skip, record
  *           as `status: 'skipped'`, `operation: 'noop'`, changedFields `{}`.
  *        b. differ.diff(existing, incoming) → 'noop' short-circuits to
@@ -153,7 +153,7 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     let status: 'success' | 'no_changes' | 'failed' = 'no_changes';
 
     try {
-      for await (const change of source.listChanges(input.subscription)) {
+      for await (const change of source.listChanges(input.subscription, cursorBefore)) {
         recordsFound++;
         latestCursor = change.cursor;
         cursorAdvanced = true;

--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -70,6 +70,15 @@ export type {
   ComposeChangeMiddleware,
 } from './sync-middleware.protocol';
 
+// Poll primitive (#226-3) — generic poll-mode IChangeSource<T>
+export {
+  PollChangeSource,
+  type PollChangeSourceOptions,
+  type PollCursor,
+  type PollFetchCallback,
+  type PollFetchContext,
+} from './poll-change-source';
+
 // Tokens
 export {
   SYNC_CHANGE_SOURCE,

--- a/runtime/subsystems/sync/poll-change-source.ts
+++ b/runtime/subsystems/sync/poll-change-source.ts
@@ -1,0 +1,205 @@
+/**
+ * Sync subsystem — `PollChangeSource<T>` primitive (#226-3, ADR-033).
+ *
+ * Generic poll-mode `IChangeSource<T>` implementation parameterized by a
+ * parsed `DetectionConfig` (poll mode) and a consumer-supplied
+ * `PollFetchCallback<T>`. The primitive owns:
+ *
+ *   - filter resolution (flat-AND vocabulary per epic decision Q3 — richer
+ *     boolean expressions deferred);
+ *   - field mapping → `Change.externalId` derivation;
+ *   - cursor strategy passthrough (the orchestrator passes the prior cursor
+ *     by-value per ADR-033 / #226-2; the callback yields the next cursor
+ *     per record; the primitive simply stamps it onto `Change<T>`);
+ *   - `Change<T>.source` provenance (`'poll'` by default);
+ *   - middleware-chain composition (the `ChangeMiddleware<T>` shape
+ *     locked in #226-1).
+ *
+ * Shape locks (decision memo Q5):
+ *   - `PollFetchContext = { subscription, cursor, filters }` — explicitly
+ *     NO `userId` / `tenantId`. Run-scope identity is closed over by the
+ *     consumer at adapter construction (or resolved inside the callback
+ *     via consumer services). Threading it through the seam would force
+ *     port expansion every time run-context grows.
+ *
+ * The adapter callback returns `{ record: T; cursor: PollCursor }` — the
+ * primitive does not reach into the record to extract a cursor itself.
+ * `cursor.field` from `DetectionConfig.poll.cursor` is metadata for codegen
+ * + adapters; the primitive trusts what the callback yielded.
+ */
+
+import type {
+  DetectionConfig,
+  ResolvedFilter,
+} from './detection-config.schema';
+import type {
+  Change,
+  ChangeSource,
+  IChangeSource,
+  SyncSubscriptionView,
+} from './sync-change-source.protocol';
+import type {
+  ChangeIterator,
+  ChangeMiddleware,
+} from './sync-middleware.protocol';
+
+// ============================================================================
+// Cursor + adapter callback shapes
+// ============================================================================
+
+/**
+ * Opaque poll-cursor shape. Each provider/entity pair binds it concretely
+ * via the cursor strategy (`{ systemModstamp }`, `{ replayId }`, etc.); the
+ * primitive treats it as an opaque value to pass through.
+ */
+export type PollCursor = unknown;
+
+/**
+ * The context the primitive forwards to the adapter callback. Locked to
+ * exactly three fields per decision memo Q5 — `userId` / `tenantId` are
+ * NOT here on purpose.
+ */
+export interface PollFetchContext {
+  readonly subscription: SyncSubscriptionView;
+  readonly cursor: PollCursor | null;
+  readonly filters: readonly ResolvedFilter[];
+}
+
+/**
+ * Consumer-supplied fetch callback. Returns an async iterable of
+ * `{ record, cursor }` pairs — `record` is already the canonical `T`
+ * (the adapter does provider-side translation), `cursor` is the post-record
+ * cursor the orchestrator should persist if the run completes successfully.
+ */
+export type PollFetchCallback<T> = (
+  ctx: PollFetchContext,
+) => AsyncIterable<{ record: T; cursor: PollCursor }>;
+
+// ============================================================================
+// Constructor options
+// ============================================================================
+
+export interface PollChangeSourceOptions<T> {
+  /** Consumer-supplied fetch callback. */
+  readonly adapter: PollFetchCallback<T>;
+  /**
+   * Parsed detection config. MUST be `mode: 'poll'`; the constructor
+   * throws if a webhook config is supplied. Codegen-emitted factories
+   * call `DetectionConfigSchema.parse(...)` upstream so this is a safety
+   * net, not the primary validation point.
+   */
+  readonly config: DetectionConfig;
+  /**
+   * Optional middleware chain. First element is the outermost layer:
+   * sees `(subscription, cursor)` first and yielded `Change<T>` last.
+   * Locked shape (#226-1) — the primitive composes them with its own
+   * `listChanges` implementation as the innermost iterator.
+   */
+  readonly middlewares?: ReadonlyArray<ChangeMiddleware<T>>;
+  /**
+   * Optional human label for run logs (e.g. `'salesforce-poll-opportunity'`).
+   * Defaults to a derived label based on the subscription domain at
+   * construction time fallback — adapters are encouraged to provide one.
+   */
+  readonly label?: string;
+}
+
+// ============================================================================
+// PollChangeSource<T>
+// ============================================================================
+
+export class PollChangeSource<T> implements IChangeSource<T> {
+  public readonly label: string;
+
+  private readonly adapter: PollFetchCallback<T>;
+  private readonly filters: readonly ResolvedFilter[];
+  private readonly externalIdSourceField: string;
+  private readonly source: ChangeSource;
+  private readonly composed: ChangeIterator<T>;
+
+  constructor(opts: PollChangeSourceOptions<T>) {
+    if (opts.config.mode !== 'poll') {
+      throw new Error(
+        `PollChangeSource requires DetectionConfig.mode === 'poll'; got '${(opts.config as { mode: string }).mode}'`,
+      );
+    }
+    const config = opts.config;
+
+    // Field mapping: locate the canonical `external_id` target. Adapters
+    // emit T already-mapped, but the primitive needs to know which key on
+    // T carries the external id so it can stamp `Change.externalId`. Source
+    // of truth is the mapping table — codegen emits it from YAML, the
+    // primitive reads it here.
+    const externalIdMapping = config.mapping.find(
+      (m) => m.target === 'external_id',
+    );
+    if (!externalIdMapping) {
+      throw new Error(
+        "PollChangeSource: DetectionConfig.mapping must include an entry with target 'external_id' so emitted Change<T>.externalId can be populated",
+      );
+    }
+    this.externalIdSourceField = externalIdMapping.target;
+
+    this.adapter = opts.adapter;
+    this.filters = config.filters;
+    // Provenance: `mode: 'poll'` defaults to `'poll'`; opt into `'cdc'` via
+    // `poll.provenance` (Stripe-style event endpoints — wired in #226-4).
+    this.source = config.poll.provenance === 'cdc' ? 'cdc' : 'poll';
+
+    this.label =
+      opts.label ?? `poll-change-source:${externalIdMapping.source}`;
+
+    // Compose middleware chain. The terminal iterator is `this.fetch`
+    // bound to `this`. First middleware in the array is the outermost
+    // layer (sees subscription/cursor first, yielded changes last).
+    const inner: ChangeIterator<T> = (sub, cur) => this.fetch(sub, cur);
+    const middlewares = opts.middlewares ?? [];
+    this.composed = middlewares.reduceRight<ChangeIterator<T>>(
+      (next, mw) => mw(next),
+      inner,
+    );
+  }
+
+  listChanges(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>> {
+    return this.composed(subscription, cursor);
+  }
+
+  private async *fetch(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>> {
+    const ctx: PollFetchContext = {
+      subscription,
+      cursor: cursor as PollCursor | null,
+      filters: this.filters,
+    };
+
+    for await (const { record, cursor: nextCursor } of this.adapter(ctx)) {
+      const externalIdRaw = (record as Record<string, unknown>)[
+        this.externalIdSourceField
+      ];
+      if (typeof externalIdRaw !== 'string' || externalIdRaw.length === 0) {
+        throw new Error(
+          `PollChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping target`,
+        );
+      }
+      const change: Change<T> = {
+        externalId: externalIdRaw,
+        // Polling cannot distinguish create vs. update vs. delete on its
+        // own — all yielded records are surfaced as 'updated'. The
+        // orchestrator's diff stage classifies create-vs-update against
+        // local state; soft-delete detection is out of scope for the
+        // primitive (consumer drives via tombstone records or a separate
+        // sweep — see ADR-033).
+        operation: 'updated',
+        record,
+        cursor: nextCursor,
+        source: this.source,
+      };
+      yield change;
+    }
+  }
+}

--- a/runtime/subsystems/sync/sync-change-source.protocol.ts
+++ b/runtime/subsystems/sync/sync-change-source.protocol.ts
@@ -10,7 +10,15 @@
  * `Change.source` / `dedupKey` / `providerChangedFields` metadata fields,
  * not in separate ports.
  *
- * See epic #60 (parent) and upstream ADR-008 subsystem architecture.
+ * Cursor is passed by-value as the second argument (#226-2 / ADR-033). The
+ * orchestrator owns cursor lifecycle (read-before-iterate, advance-on-yield,
+ * persist-on-success); the primitive receives the current value at the start
+ * of each run rather than reading it from a side store. This eliminates the
+ * "two readers of the same row" problem that arose when adapters injected
+ * `ICursorStore` directly.
+ *
+ * See epic #60 (parent), ADR-033 (config-driven change sources), and
+ * upstream ADR-008 subsystem architecture.
  */
 
 // ============================================================================
@@ -91,9 +99,16 @@ export interface IChangeSource<T> {
 
   /**
    * Async-iterate upstream changes, newest cursor last. The orchestrator
+   * passes the current persisted cursor by-value as the second argument and
    * persists `change.cursor` as it advances; strategies MUST yield at least
    * one change before the async iterable completes if anything changed
    * upstream, otherwise cursor advance is a no-op.
+   *
+   * `cursor` is opaque at this seam — the primitive's cursor strategy types
+   * it internally. `null` means "first run, no cursor yet."
    */
-  listChanges(subscription: SyncSubscriptionView): AsyncIterable<Change<T>>;
+  listChanges(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>>;
 }

--- a/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
+++ b/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
@@ -45,10 +45,13 @@ interface CanonicalOpp extends Record<string, unknown> {
 
 class ArrayChangeSource implements IChangeSource<CanonicalOpp> {
   readonly label = 'test-array';
+  readonly seenCursors: Array<unknown | null> = [];
   constructor(private readonly changes: Change<CanonicalOpp>[]) {}
   async *listChanges(
     _sub: SyncSubscriptionView,
+    cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpp>> {
+    this.seenCursors.push(cursor);
     for (const c of this.changes) yield c;
   }
 }
@@ -61,6 +64,7 @@ class ThrowingChangeSource implements IChangeSource<CanonicalOpp> {
   ) {}
   async *listChanges(
     _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
   ): AsyncIterable<Change<CanonicalOpp>> {
     for (const c of this.initial) yield c;
     throw this.err;
@@ -510,6 +514,36 @@ describe('ExecuteSyncUseCase', () => {
         'tenant-a',
       );
       expect(recorder.items[0].tenantId).toBe('tenant-a');
+    });
+  });
+
+  describe('cursor passthrough (#226-2)', () => {
+    it('passes null cursor on first run (no prior persisted cursor)', async () => {
+      const source = new ArrayChangeSource([]);
+      const orch = makeOrchestrator(source, sink, recorder, cursors);
+      await orch.execute(makeInput());
+
+      expect(source.seenCursors).toEqual([null]);
+    });
+
+    it('passes the persisted cursor value on subsequent runs', async () => {
+      // Seed the cursor store with a prior value.
+      await cursors.put(SUB.id, { systemModstamp: '2026-04-21T10:00:00Z' });
+
+      const change: Change<CanonicalOpp> = {
+        externalId: 'ext-1',
+        operation: 'created',
+        record: { external_id: 'ext-1', amount: 100 },
+        cursor: { systemModstamp: '2026-04-21T13:00:00Z' },
+        source: 'poll',
+      };
+      const source = new ArrayChangeSource([change]);
+      const orch = makeOrchestrator(source, sink, recorder, cursors);
+      await orch.execute(makeInput());
+
+      expect(source.seenCursors).toEqual([
+        { systemModstamp: '2026-04-21T10:00:00Z' },
+      ]);
     });
   });
 

--- a/src/__tests__/runtime/subsystems/poll-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/poll-change-source.spec.ts
@@ -1,0 +1,335 @@
+/**
+ * PollChangeSource<T> unit tests (#226-3)
+ *
+ * Validates the poll-mode primitive: a `DetectionConfig`-parameterized
+ * `IChangeSource<T>` that delegates the actual fetch to a consumer
+ * callback (`PollFetchCallback<T>`) and emits canonical `Change<T>`
+ * records with `source: 'poll'`.
+ *
+ * Key invariants under test:
+ *   - constructor accepts `{ adapter, config, middlewares? }`
+ *   - `listChanges(subscription, cursor)` yields `Change<T>` with
+ *     `source: 'poll'`, advancing cursor as the adapter yields
+ *   - `PollFetchContext` is exactly `{ subscription, cursor, filters }`
+ *     (Q5 lock — no `userId`/`tenantId`)
+ *   - filters resolved from `DetectionConfig` are forwarded to the callback
+ *   - field mapping resolves `external_id` on emitted records
+ *   - middleware chain composes left-to-right (first middleware = outermost)
+ *   - errors thrown by the callback propagate to the iterator consumer
+ */
+import { describe, it, expect } from 'bun:test';
+import {
+  PollChangeSource,
+  type PollFetchCallback,
+  type PollFetchContext,
+} from '../../../../runtime/subsystems/sync/poll-change-source';
+import type {
+  Change,
+  SyncSubscriptionView,
+} from '../../../../runtime/subsystems/sync/sync-change-source.protocol';
+import type { ChangeMiddleware } from '../../../../runtime/subsystems/sync/sync-middleware.protocol';
+import type { DetectionConfig } from '../../../../runtime/subsystems/sync/detection-config.schema';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+interface OppRecord {
+  external_id: string;
+  name: string;
+  modstamp: string;
+}
+
+const subscription: SyncSubscriptionView = {
+  id: 'sub-1',
+  domain: 'opportunity',
+  externalRef: 'sf-org-A',
+};
+
+function makeConfig(extra?: Partial<DetectionConfig>): DetectionConfig {
+  return {
+    mode: 'poll',
+    poll: {
+      cursor: { kind: 'systemModstamp', field: 'modstamp' },
+    },
+    mapping: [
+      { source: 'Id', target: 'external_id' },
+      { source: 'Name', target: 'name' },
+    ],
+    filters: [{ field: 'StageName', op: 'eq', value: 'Won' }],
+    ...(extra as object),
+  } as DetectionConfig;
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const x of it) out.push(x);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Empty cursor (first run)
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — empty cursor (first run)', () => {
+  it('passes cursor: null through to the adapter', async () => {
+    let seen: PollFetchContext | undefined;
+    const adapter: PollFetchCallback<OppRecord> = async function* (ctx) {
+      seen = ctx;
+      // first run: nothing to yield
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toEqual([]);
+    expect(seen).toBeDefined();
+    expect(seen!.cursor).toBeNull();
+    expect(seen!.subscription.id).toBe('sub-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advancing cursor
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — advancing cursor', () => {
+  it('yields Change<T> records with source: "poll" and cursor from callback', async () => {
+    const adapter: PollFetchCallback<OppRecord> = async function* () {
+      yield {
+        record: { external_id: 'A1', name: 'Alpha', modstamp: '2026-04-01T00:00:00Z' },
+        cursor: { systemModstamp: '2026-04-01T00:00:00Z' },
+      };
+      yield {
+        record: { external_id: 'A2', name: 'Beta', modstamp: '2026-04-02T00:00:00Z' },
+        cursor: { systemModstamp: '2026-04-02T00:00:00Z' },
+      };
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, { systemModstamp: '2026-03-31T00:00:00Z' }));
+    expect(out).toHaveLength(2);
+    expect(out[0].source).toBe('poll');
+    expect(out[0].externalId).toBe('A1');
+    expect(out[0].operation).toBe('updated');
+    expect(out[0].record.name).toBe('Alpha');
+    expect(out[0].cursor).toEqual({ systemModstamp: '2026-04-01T00:00:00Z' });
+    expect(out[1].externalId).toBe('A2');
+    expect(out[1].cursor).toEqual({ systemModstamp: '2026-04-02T00:00:00Z' });
+  });
+
+  it('forwards prior cursor by-value to the adapter context', async () => {
+    let seen: PollFetchContext | undefined;
+    const adapter: PollFetchCallback<OppRecord> = async function* (ctx) {
+      seen = ctx;
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+    });
+    const cursor = { systemModstamp: '2026-04-10T12:00:00Z' };
+    await collect(src.listChanges(subscription, cursor));
+    expect(seen!.cursor).toEqual(cursor);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter passthrough
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — filter passthrough', () => {
+  it('forwards resolved filters from DetectionConfig to the callback', async () => {
+    let seen: PollFetchContext | undefined;
+    const adapter: PollFetchCallback<OppRecord> = async function* (ctx) {
+      seen = ctx;
+    };
+    const config = makeConfig();
+    const src = new PollChangeSource<OppRecord>({ adapter, config });
+    await collect(src.listChanges(subscription, null));
+    expect(seen!.filters).toEqual([
+      { field: 'StageName', op: 'eq', value: 'Won' },
+    ]);
+  });
+
+  it('forwards an empty filter array when none are configured', async () => {
+    let seen: PollFetchContext | undefined;
+    const adapter: PollFetchCallback<OppRecord> = async function* (ctx) {
+      seen = ctx;
+    };
+    const config: DetectionConfig = {
+      mode: 'poll',
+      poll: { cursor: { kind: 'systemModstamp', field: 'modstamp' } },
+      mapping: [{ source: 'Id', target: 'external_id' }],
+      filters: [],
+    };
+    const src = new PollChangeSource<OppRecord>({ adapter, config });
+    await collect(src.listChanges(subscription, null));
+    expect(seen!.filters).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Field mapping
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — field mapping', () => {
+  it('uses the mapping target "external_id" to populate Change.externalId', async () => {
+    const adapter: PollFetchCallback<OppRecord> = async function* () {
+      yield {
+        record: { external_id: 'OPP-42', name: 'Mapped', modstamp: 't' },
+        cursor: { systemModstamp: 't' },
+      };
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+    });
+    const [change] = await collect(src.listChanges(subscription, null));
+    expect(change.externalId).toBe('OPP-42');
+  });
+
+  it('throws if the mapping declares no external_id target', () => {
+    const config = {
+      mode: 'poll' as const,
+      poll: { cursor: { kind: 'systemModstamp' as const, field: 'modstamp' } },
+      mapping: [{ source: 'Name', target: 'name' }],
+      filters: [],
+    };
+    expect(
+      () =>
+        new PollChangeSource<OppRecord>({
+          adapter: async function* () {},
+          config,
+        }),
+    ).toThrow(/external_id/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Middleware composition
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — middleware composition', () => {
+  it('composes middlewares in order: first = outermost', async () => {
+    const order: string[] = [];
+
+    const tag =
+      (label: string): ChangeMiddleware<OppRecord> =>
+      (next) =>
+      async function* (sub, cur) {
+        order.push(`${label}:enter`);
+        for await (const c of next(sub, cur)) {
+          order.push(`${label}:yield`);
+          yield c;
+        }
+        order.push(`${label}:exit`);
+      };
+
+    const adapter: PollFetchCallback<OppRecord> = async function* () {
+      yield {
+        record: { external_id: 'A', name: 'a', modstamp: 't' },
+        cursor: { systemModstamp: 't' },
+      };
+    };
+
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+      middlewares: [tag('outer'), tag('inner')],
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toHaveLength(1);
+    // outer enters first, inner enters second; on yield inner sees first then outer
+    expect(order).toEqual([
+      'outer:enter',
+      'inner:enter',
+      'inner:yield',
+      'outer:yield',
+      'inner:exit',
+      'outer:exit',
+    ]);
+  });
+
+  it('lets a middleware filter out a change', async () => {
+    const dropAll: ChangeMiddleware<OppRecord> =
+      (next) =>
+      async function* (sub, cur) {
+        for await (const _c of next(sub, cur)) {
+          // drop
+        }
+      };
+    const adapter: PollFetchCallback<OppRecord> = async function* () {
+      yield {
+        record: { external_id: 'A', name: 'a', modstamp: 't' },
+        cursor: { systemModstamp: 't' },
+      };
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+      middlewares: [dropAll],
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — adapter errors', () => {
+  it('propagates errors thrown by the callback', async () => {
+    const boom: PollFetchCallback<OppRecord> = async function* () {
+      throw new Error('upstream 503');
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter: boom,
+      config: makeConfig(),
+    });
+    await expect(
+      (async () => {
+        for await (const _c of src.listChanges(subscription, null)) {
+          // drain
+        }
+      })(),
+    ).rejects.toThrow(/upstream 503/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Label
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — label', () => {
+  it('exposes a label for run logs', () => {
+    const src = new PollChangeSource<OppRecord>({
+      adapter: async function* () {},
+      config: makeConfig(),
+      label: 'salesforce-poll-opportunity',
+    });
+    expect(src.label).toBe('salesforce-poll-opportunity');
+  });
+
+  it('falls back to a default label when not provided', () => {
+    const src = new PollChangeSource<OppRecord>({
+      adapter: async function* () {},
+      config: makeConfig(),
+    });
+    expect(typeof src.label).toBe('string');
+    expect(src.label.length).toBeGreaterThan(0);
+  });
+});
+
+// Compile-time guard: PollFetchContext must NOT include userId/tenantId.
+// This is a structural assertion via TypeScript — if the shape grows
+// these fields the line below stops compiling.
+const _shapeGuard: PollFetchContext = {
+  subscription,
+  cursor: null,
+  filters: [],
+};
+void _shapeGuard;

--- a/src/__tests__/runtime/subsystems/sync.module.spec.ts
+++ b/src/__tests__/runtime/subsystems/sync.module.spec.ts
@@ -51,7 +51,10 @@ interface CanonicalOpp extends Record<string, unknown> {
 class EmptySource implements IChangeSource<CanonicalOpp> {
   readonly label = 'test';
   // eslint-disable-next-line @typescript-eslint/require-yield
-  async *listChanges(_sub: SyncSubscriptionView): AsyncIterable<Change<CanonicalOpp>> {
+  async *listChanges(
+    _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
+  ): AsyncIterable<Change<CanonicalOpp>> {
     // yields nothing
     return;
   }
@@ -59,7 +62,10 @@ class EmptySource implements IChangeSource<CanonicalOpp> {
 
 class OneChangeSource implements IChangeSource<CanonicalOpp> {
   readonly label = 'test';
-  async *listChanges(_sub: SyncSubscriptionView): AsyncIterable<Change<CanonicalOpp>> {
+  async *listChanges(
+    _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
+  ): AsyncIterable<Change<CanonicalOpp>> {
     yield {
       externalId: 'ext-1',
       operation: 'created',


### PR DESCRIPTION
## Summary
- New `runtime/subsystems/sync/poll-change-source.ts` — generic poll-mode `IChangeSource<T>` parameterized by a parsed `DetectionConfig` + consumer-supplied `PollFetchCallback<T>`.
- Owns filter resolution (flat-AND vocabulary per Q3), field-mapping → `externalId` derivation, cursor strategy passthrough, `Change<T>.source` provenance, and middleware-chain composition (#226-1 shape).
- **`PollFetchContext = { subscription, cursor, filters }`** — locked per decision memo Q5; `userId`/`tenantId` are NOT threaded through the seam (closed over by the consumer at construction or resolved inside the callback via consumer services).
- Re-exports `PollChangeSource`, `PollChangeSourceOptions`, `PollCursor`, `PollFetchCallback`, `PollFetchContext` from `runtime/subsystems/sync/index.ts`.

Closes #230. Part of epic #226. Stacked on #235 — branch base is `feat/226-2-cursor-at-seam`; GitHub will auto-retarget when the parent merges.

## Acceptance criteria
- [x] Constructor `new PollChangeSource<T>({ adapter, config, middlewares? })` compiles cleanly.
- [x] `listChanges(subscription, cursor)` yields `Change<T>` with `source: 'poll'`.
- [x] Filter resolution applies flat-AND vocabulary (richer expressions deferred per epic open Q3).
- [x] `PollFetchContext` is exactly `{ subscription, cursor, filters }` — compile-time shape guard at end of spec.
- [x] Unit tests cover the 6 mandated cases — empty cursor, advancing cursor, filter passthrough, middleware chain composition, field-mapping, error-from-callback (12 tests total).
- [x] `just test-unit` green — 1599 pass / 0 fail.

## Test plan
- [x] `bun test src/__tests__/runtime/subsystems/poll-change-source.spec.ts` — 12 pass / 0 fail.
- [x] `just test-unit` — 1599 pass / 0 fail across 109 files.

## Deviations from brief
- Spec file lives at `src/__tests__/runtime/subsystems/poll-change-source.spec.ts` (matches existing convention; the brief acknowledges this re-routing — `runtime/subsystems/sync/__tests__/` does not exist in this repo).
- Added a `label` option (with sensible default) on `PollChangeSourceOptions<T>` to satisfy `IChangeSource<T>.label`. Two extra tests cover custom + default labels.
- Constructor rejects `DetectionConfig.mode !== 'poll'` and rejects mappings missing an `external_id` target — both with descriptive error messages.

## Out of scope (per plan §#226-3)
- CDC/webhook primitives (#226-4 / issue #231).
- Loopback factory (#226-5 / issue #232).
- Codegen emission (#226-7 / issue #233).

## Skill update (apply pre-merge)
**Skill update pending — see this section; orchestrator will apply pre-merge.**

Anchored against post-#234 state. PR #235 has its own pending skill diff that touches rules 1–2 + the L73–74 task-routing row; the edits below are independent (runtime-snapshot insertion + a new "Non-obvious rule" item). Flagging for orchestrator awareness — applying #235's diff first should not collide with these.

### Edit 1 — `.claude/skills/sync/SKILL.md` runtime snapshot

Insert a new bullet immediately after the `sync-middleware.protocol.ts` entry.

**Old:**
```
- `runtime/subsystems/sync/sync-middleware.protocol.ts` —
  `ChangeIterator<T>` + `ChangeMiddleware<T>` types; the universal
  composition seam consumed by primitives (loopback ships here in
  #226-5) (ADR-033)
- `runtime/subsystems/sync/sync-run-recorder.protocol.ts` —
```

**New:**
```
- `runtime/subsystems/sync/sync-middleware.protocol.ts` —
  `ChangeIterator<T>` + `ChangeMiddleware<T>` types; the universal
  composition seam consumed by primitives (loopback ships here in
  #226-5) (ADR-033)
- `runtime/subsystems/sync/poll-change-source.ts` —
  `PollChangeSource<T>` poll-mode primitive: parameterized by a parsed
  `DetectionConfig` + `PollFetchCallback<T>`; owns filter resolution
  (flat-AND), field-mapping → `externalId`, middleware composition,
  and `Change<T>.source` provenance (`'poll'` default; `'cdc'` opt-in
  via `poll.provenance` for Stripe-style event endpoints — #226-4)
  (#226-3 / ADR-033)
- `runtime/subsystems/sync/sync-run-recorder.protocol.ts` —
```

### Edit 2 — `.claude/skills/sync/SKILL.md` add Non-obvious rule 11

Append after rule 10 (`DetectionConfig` is the canonical filter / mapping shape).

**Old:**
```
10. **`DetectionConfig` is the canonical filter / mapping shape.** The
    per-entity `DetectionConfig` Zod schema in
    `runtime/subsystems/sync/detection-config.schema.ts` is the single
    source of truth for filter, field-mapping, and cursor-strategy
    shape across the subsystem. Runtime primitives
    (`PollChangeSource<T>` / `WebhookChangeSource<T>`) parse it at
    construction; the codegen YAML validator imports the same schema;
    the per-entity factory module emitted by Phase 2 codegen consumes
    its parsed value. Primitives and codegen factories must derive
    their behavior from `DetectionConfig` rather than inline literals
    — drift between the two sites must be a compile error, not a
    runtime mismatch. See ADR-033 (`docs/adrs/ADR-033-config-driven-change-sources.md`).

## Do not
```

**New:**
```
10. **`DetectionConfig` is the canonical filter / mapping shape.** The
    per-entity `DetectionConfig` Zod schema in
    `runtime/subsystems/sync/detection-config.schema.ts` is the single
    source of truth for filter, field-mapping, and cursor-strategy
    shape across the subsystem. Runtime primitives
    (`PollChangeSource<T>` / `WebhookChangeSource<T>`) parse it at
    construction; the codegen YAML validator imports the same schema;
    the per-entity factory module emitted by Phase 2 codegen consumes
    its parsed value. Primitives and codegen factories must derive
    their behavior from `DetectionConfig` rather than inline literals
    — drift between the two sites must be a compile error, not a
    runtime mismatch. See ADR-033 (`docs/adrs/ADR-033-config-driven-change-sources.md`).

11. **`userId` / `tenantId` are NOT in `PollFetchContext`.** The poll
    primitive's adapter callback receives exactly
    `{ subscription, cursor, filters }` (decision memo Q5). Run-scope
    identity (`userId`, `tenantId`) is closed over by the consumer at
    adapter construction (or resolved inside the callback via consumer
    services) — never threaded through the port seam. Threading it
    forces port expansion every time run-context grows, and the
    orchestrator already enforces tenancy at `execute()` entry. The
    same rule applies to `WebhookChangeSource<T>` when it lands in
    #226-4. See ADR-033 + decision memo Q5.

## Do not
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)