### PR TITLE
feat(sync): WebhookChangeSource + CDC-as-provenance knob (#226-4)

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -87,6 +87,15 @@ meaningful.
    event_id, provider-hinted changed fields) live in `Change<T>`
    metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
    introduce mode-specific ports — we rejected that design explicitly.
+   "CDC" here means *cursor-based event endpoints* (Stripe-style
+   `events?starting_after=...`) — those map to `PollChangeSource<T>`
+   with `poll.provenance: 'cdc'` (#226-4); the primitive stamps
+   `Change<T>.source = 'cdc'` and reads `dedupKey` from
+   `poll.cursor.field`. Long-lived stream subscriptions (SFDC
+   Pub-Sub gRPC, Debezium/Kafka, Postgres logical replication) are a
+   separate primitive deferred to #226-8 — they need a different
+   substrate (`subscribe(onChange, onError)`, server-paced
+   backpressure, ack-on-yield) and shouldn't be retrofitted here.
 
 2. **Cursors are opaque at the port seam, and the orchestrator owns
    the lifecycle.** `ICursorStore.get/put` takes `unknown`. Each
@@ -227,6 +236,16 @@ Files that ship to the consumer app (not templates):
   and `Change<T>.source` provenance (`'poll'` default; `'cdc'` opt-in
   via `poll.provenance` for Stripe-style event endpoints — #226-4)
   (#226-3 / ADR-033)
+- `runtime/subsystems/sync/webhook-change-source.ts` —
+  `WebhookChangeSource<T>` webhook-mode primitive: parameterized by a
+  parsed `DetectionConfig` (`mode: 'webhook'`) + a consumer-supplied
+  `WebhookFetchCallback<T>` that iterates the consumer-owned inbound
+  staging queue. Stamps `Change<T>.source = 'webhook'`, populates
+  `dedupKey` from `webhook.eventIdField`, derives `externalId` from
+  the mapping table's `external_id` target, composes middleware via
+  the locked `ChangeMiddleware<T>` shape. Passive iterator — does NOT
+  drive the orchestrator. Inbound staging-table schema is
+  consumer-owned and deferred per ADR-0002 §Phase 4. (#226-4)
 - `runtime/subsystems/sync/sync-run-recorder.protocol.ts` —
   `ISyncRunRecorder` + `StartRunInput` / `RecordItemInput` /
   `CompleteRunInput`

--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -79,6 +79,16 @@ export {
   type PollFetchContext,
 } from './poll-change-source';
 
+// Webhook primitive (#226-4) — generic webhook-mode IChangeSource<T>
+// driven by a consumer-owned inbound staging queue iterator
+export {
+  WebhookChangeSource,
+  type WebhookChangeSourceOptions,
+  type WebhookCursor,
+  type WebhookFetchCallback,
+  type WebhookFetchContext,
+} from './webhook-change-source';
+
 // Tokens
 export {
   SYNC_CHANGE_SOURCE,

--- a/runtime/subsystems/sync/poll-change-source.ts
+++ b/runtime/subsystems/sync/poll-change-source.ts
@@ -115,6 +115,14 @@ export class PollChangeSource<T> implements IChangeSource<T> {
   private readonly filters: readonly ResolvedFilter[];
   private readonly externalIdSourceField: string;
   private readonly source: ChangeSource;
+  /**
+   * When `poll.provenance === 'cdc'`, the field on the emitted record from
+   * which `Change<T>.dedupKey` is read — sourced from `poll.cursor.field`
+   * (Stripe-style event endpoints carry the event id on the record itself
+   * and the cursor advances over the same id). `null` for default poll
+   * provenance, which does NOT populate `dedupKey`.
+   */
+  private readonly dedupKeySourceField: string | null;
   private readonly composed: ChangeIterator<T>;
 
   constructor(opts: PollChangeSourceOptions<T>) {
@@ -144,7 +152,12 @@ export class PollChangeSource<T> implements IChangeSource<T> {
     this.filters = config.filters;
     // Provenance: `mode: 'poll'` defaults to `'poll'`; opt into `'cdc'` via
     // `poll.provenance` (Stripe-style event endpoints — wired in #226-4).
-    this.source = config.poll.provenance === 'cdc' ? 'cdc' : 'poll';
+    // CDC provenance also stamps `dedupKey` from the cursor's `field`, since
+    // those endpoints surface a per-event id on each record (the same id the
+    // cursor advances over).
+    const isCdc = config.poll.provenance === 'cdc';
+    this.source = isCdc ? 'cdc' : 'poll';
+    this.dedupKeySourceField = isCdc ? config.poll.cursor.field : null;
 
     this.label =
       opts.label ?? `poll-change-source:${externalIdMapping.source}`;
@@ -186,6 +199,19 @@ export class PollChangeSource<T> implements IChangeSource<T> {
           `PollChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping target`,
         );
       }
+      let dedupKey: string | undefined;
+      if (this.dedupKeySourceField !== null) {
+        const dedupRaw = (record as Record<string, unknown>)[
+          this.dedupKeySourceField
+        ];
+        if (typeof dedupRaw !== 'string' || dedupRaw.length === 0) {
+          throw new Error(
+            `PollChangeSource: cdc-provenance record missing string '${this.dedupKeySourceField}' — when poll.provenance === 'cdc' the cursor.field must be present on each record so dedupKey can be populated`,
+          );
+        }
+        dedupKey = dedupRaw;
+      }
+
       const change: Change<T> = {
         externalId: externalIdRaw,
         // Polling cannot distinguish create vs. update vs. delete on its
@@ -198,6 +224,7 @@ export class PollChangeSource<T> implements IChangeSource<T> {
         record,
         cursor: nextCursor,
         source: this.source,
+        ...(dedupKey !== undefined ? { dedupKey } : {}),
       };
       yield change;
     }

--- a/runtime/subsystems/sync/webhook-change-source.ts
+++ b/runtime/subsystems/sync/webhook-change-source.ts
@@ -1,0 +1,213 @@
+/**
+ * Sync subsystem — `WebhookChangeSource<T>` primitive (#226-4, ADR-033).
+ *
+ * Generic webhook-mode `IChangeSource<T>` implementation parameterized by a
+ * parsed `DetectionConfig` (webhook mode) and a consumer-supplied
+ * `WebhookFetchCallback<T>` that iterates a consumer-owned inbound staging
+ * queue. The primitive owns:
+ *
+ *   - canonical `Change<T>.source = 'webhook'` stamping;
+ *   - `dedupKey` derivation from the configured `webhook.eventIdField` on
+ *     the emitted record;
+ *   - `externalId` derivation from the mapping table's `external_id` target
+ *     (mirrors `PollChangeSource`);
+ *   - middleware-chain composition via the locked `ChangeMiddleware<T>` shape
+ *     (#226-1) — same composition seam as the poll primitive.
+ *
+ * The primitive is **passive**: it iterates whatever the consumer-owned
+ * queue yields. It does NOT synchronously drive the orchestrator, does NOT
+ * own a transport, and does NOT manage acks. The inbound staging table
+ * schema is consumer-owned and deferred per ADR-0002 §Phase 4 — the
+ * `WebhookFetchCallback<T>` is the queue contract the consumer injects.
+ *
+ * Shape locks (decision memo Q5, mirrored from poll primitive):
+ *   - `WebhookFetchContext = { subscription, cursor }` — explicitly NO
+ *     `userId` / `tenantId`. Run-scope identity is closed over by the
+ *     consumer at queue construction or resolved inside the callback via
+ *     consumer services. There are no `filters` on the webhook context —
+ *     filtering is done at registration / on the staging row, not at the
+ *     port seam (the queue is already filtered by the time the primitive
+ *     iterates).
+ *
+ * Long-lived streaming CDC primitives (SFDC Pub-Sub gRPC, Debezium/Kafka,
+ * Postgres logical replication) are deferred to `#226-8` — they need a
+ * fundamentally different lifecycle (`subscribe(onChange, onError)`,
+ * server-paced backpressure, ack-on-yield) and shouldn't be retrofitted
+ * into either this primitive or the poll primitive.
+ */
+
+import type { DetectionConfig } from './detection-config.schema';
+import type {
+  Change,
+  IChangeSource,
+  SyncSubscriptionView,
+} from './sync-change-source.protocol';
+import type {
+  ChangeIterator,
+  ChangeMiddleware,
+} from './sync-middleware.protocol';
+
+// ============================================================================
+// Cursor + queue callback shapes
+// ============================================================================
+
+/**
+ * Opaque webhook cursor shape. Webhook mode typically has a cursor of
+ * `{ ts: ISO-string }` (last drained staging-row timestamp) but the
+ * primitive treats it as opaque. Consumer-owned queue iterators interpret
+ * it however the staging schema needs.
+ */
+export type WebhookCursor = unknown;
+
+/**
+ * Context the primitive forwards to the queue iterator. Locked to exactly
+ * two fields per the same Q5 reasoning that locks `PollFetchContext` — no
+ * `userId` / `tenantId`.
+ */
+export interface WebhookFetchContext {
+  readonly subscription: SyncSubscriptionView;
+  readonly cursor: WebhookCursor | null;
+}
+
+/**
+ * Consumer-supplied queue iterator. Returns an async iterable of
+ * `{ record }` pairs — the consumer drains the inbound staging queue and
+ * emits already-mapped canonical records `T`. The primitive stamps
+ * `source: 'webhook'` and `dedupKey` from the record's configured
+ * `webhook.eventIdField`; the consumer is the one who decided when a
+ * staging row is "ready" to drain.
+ *
+ * Webhook mode has no per-record cursor advance — the staging-row drain
+ * order is consumer policy (FIFO by ingestion timestamp, by event id, etc.)
+ * and is opaque to the primitive. The orchestrator's last-yielded cursor
+ * is whatever the consumer chooses to surface, if anything.
+ */
+export type WebhookFetchCallback<T> = (
+  ctx: WebhookFetchContext,
+) => AsyncIterable<{ record: T; cursor?: WebhookCursor }>;
+
+// ============================================================================
+// Constructor options
+// ============================================================================
+
+export interface WebhookChangeSourceOptions<T> {
+  /** Consumer-supplied inbound queue iterator. */
+  readonly queue: WebhookFetchCallback<T>;
+  /**
+   * Parsed detection config. MUST be `mode: 'webhook'`; the constructor
+   * throws if a poll config is supplied. Codegen-emitted factories call
+   * `DetectionConfigSchema.parse(...)` upstream so this is a safety net,
+   * not the primary validation point.
+   */
+  readonly config: DetectionConfig;
+  /**
+   * Optional middleware chain. Same shape and composition rules as
+   * `PollChangeSource` — first element is the outermost layer.
+   */
+  readonly middlewares?: ReadonlyArray<ChangeMiddleware<T>>;
+  /**
+   * Optional human label for run logs (e.g. `'stripe-webhook-charge'`).
+   * Defaults to a derived label based on the mapping at construction.
+   */
+  readonly label?: string;
+}
+
+// ============================================================================
+// WebhookChangeSource<T>
+// ============================================================================
+
+export class WebhookChangeSource<T> implements IChangeSource<T> {
+  public readonly label: string;
+
+  private readonly queue: WebhookFetchCallback<T>;
+  private readonly externalIdSourceField: string;
+  private readonly eventIdSourceField: string;
+  private readonly composed: ChangeIterator<T>;
+
+  constructor(opts: WebhookChangeSourceOptions<T>) {
+    if (opts.config.mode !== 'webhook') {
+      throw new Error(
+        `WebhookChangeSource requires DetectionConfig.mode === 'webhook'; got '${(opts.config as { mode: string }).mode}'`,
+      );
+    }
+    const config = opts.config;
+
+    // Field mapping: locate the canonical `external_id` target — mirrors the
+    // poll primitive's contract. Adapters emit records already-mapped; the
+    // primitive needs to know which key on T carries the external id so it
+    // can stamp `Change.externalId`.
+    const externalIdMapping = config.mapping.find(
+      (m) => m.target === 'external_id',
+    );
+    if (!externalIdMapping) {
+      throw new Error(
+        "WebhookChangeSource: DetectionConfig.mapping must include an entry with target 'external_id' so emitted Change<T>.externalId can be populated",
+      );
+    }
+    this.externalIdSourceField = externalIdMapping.target;
+    this.eventIdSourceField = config.webhook.eventIdField;
+
+    this.queue = opts.queue;
+
+    this.label =
+      opts.label ?? `webhook-change-source:${externalIdMapping.source}`;
+
+    // Compose middleware chain — same shape as PollChangeSource.
+    const inner: ChangeIterator<T> = (sub, cur) => this.fetch(sub, cur);
+    const middlewares = opts.middlewares ?? [];
+    this.composed = middlewares.reduceRight<ChangeIterator<T>>(
+      (next, mw) => mw(next),
+      inner,
+    );
+  }
+
+  listChanges(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>> {
+    return this.composed(subscription, cursor);
+  }
+
+  private async *fetch(
+    subscription: SyncSubscriptionView,
+    cursor: unknown | null,
+  ): AsyncIterable<Change<T>> {
+    const ctx: WebhookFetchContext = {
+      subscription,
+      cursor: cursor as WebhookCursor | null,
+    };
+
+    for await (const { record, cursor: nextCursor } of this.queue(ctx)) {
+      const externalIdRaw = (record as Record<string, unknown>)[
+        this.externalIdSourceField
+      ];
+      if (typeof externalIdRaw !== 'string' || externalIdRaw.length === 0) {
+        throw new Error(
+          `WebhookChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping target`,
+        );
+      }
+      const eventIdRaw = (record as Record<string, unknown>)[
+        this.eventIdSourceField
+      ];
+      if (typeof eventIdRaw !== 'string' || eventIdRaw.length === 0) {
+        throw new Error(
+          `WebhookChangeSource: record missing string '${this.eventIdSourceField}' — webhook records MUST carry the event id (DetectionConfig.webhook.eventIdField) so Change<T>.dedupKey can be populated`,
+        );
+      }
+
+      const change: Change<T> = {
+        externalId: externalIdRaw,
+        // Webhook mode cannot distinguish create vs. update vs. delete on
+        // its own — the orchestrator's diff stage handles classification.
+        // Tombstone / soft-delete detection is consumer-driven (same as
+        // poll mode — see ADR-033).
+        operation: 'updated',
+        record,
+        cursor: nextCursor ?? null,
+        source: 'webhook',
+        dedupKey: eventIdRaw,
+      };
+      yield change;
+    }
+  }
+}

--- a/src/__tests__/runtime/subsystems/poll-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/poll-change-source.spec.ts
@@ -324,6 +324,101 @@ describe('PollChangeSource — label', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// CDC-as-provenance (#226-4)
+// ---------------------------------------------------------------------------
+
+describe('PollChangeSource — cdc-as-provenance', () => {
+  function makeCdcConfig(): DetectionConfig {
+    return {
+      mode: 'poll',
+      poll: {
+        cursor: { kind: 'eventId', field: 'event_id' },
+        provenance: 'cdc',
+      },
+      mapping: [{ source: 'id', target: 'external_id' }],
+      filters: [],
+    };
+  }
+
+  interface CdcRecord {
+    external_id: string;
+    event_id: string;
+  }
+
+  it('stamps source: "cdc" when poll.provenance === "cdc"', async () => {
+    const adapter: PollFetchCallback<CdcRecord> = async function* () {
+      yield {
+        record: { external_id: 'X1', event_id: 'evt_001' },
+        cursor: { eventId: 'evt_001' },
+      };
+    };
+    const src = new PollChangeSource<CdcRecord>({
+      adapter,
+      config: makeCdcConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toHaveLength(1);
+    expect(out[0].source).toBe('cdc');
+  });
+
+  it('populates dedupKey from the cursor.field when provenance === "cdc"', async () => {
+    const adapter: PollFetchCallback<CdcRecord> = async function* () {
+      yield {
+        record: { external_id: 'X1', event_id: 'evt_dedup_42' },
+        cursor: { eventId: 'evt_dedup_42' },
+      };
+      yield {
+        record: { external_id: 'X2', event_id: 'evt_dedup_43' },
+        cursor: { eventId: 'evt_dedup_43' },
+      };
+    };
+    const src = new PollChangeSource<CdcRecord>({
+      adapter,
+      config: makeCdcConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out[0].dedupKey).toBe('evt_dedup_42');
+    expect(out[1].dedupKey).toBe('evt_dedup_43');
+  });
+
+  it('does NOT populate dedupKey when provenance defaults to "poll"', async () => {
+    const adapter: PollFetchCallback<OppRecord> = async function* () {
+      yield {
+        record: { external_id: 'A1', name: 'a', modstamp: 't' },
+        cursor: { systemModstamp: 't' },
+      };
+    };
+    const src = new PollChangeSource<OppRecord>({
+      adapter,
+      config: makeConfig(),
+    });
+    const [change] = await collect(src.listChanges(subscription, null));
+    expect(change.source).toBe('poll');
+    expect(change.dedupKey).toBeUndefined();
+  });
+
+  it('throws if a record is missing the configured cursor.field when provenance === "cdc"', async () => {
+    const adapter: PollFetchCallback<CdcRecord> = async function* () {
+      yield {
+        record: { external_id: 'X1' } as CdcRecord,
+        cursor: { eventId: 'evt_001' },
+      };
+    };
+    const src = new PollChangeSource<CdcRecord>({
+      adapter,
+      config: makeCdcConfig(),
+    });
+    await expect(
+      (async () => {
+        for await (const _c of src.listChanges(subscription, null)) {
+          // drain
+        }
+      })(),
+    ).rejects.toThrow(/event_id/);
+  });
+});
+
 // Compile-time guard: PollFetchContext must NOT include userId/tenantId.
 // This is a structural assertion via TypeScript — if the shape grows
 // these fields the line below stops compiling.

--- a/src/__tests__/runtime/subsystems/webhook-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/webhook-change-source.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * WebhookChangeSource<T> unit tests (#226-4)
+ *
+ * Validates the webhook-mode primitive: a `DetectionConfig`-parameterized
+ * `IChangeSource<T>` that iterates a consumer-owned inbound staging queue
+ * and emits canonical `Change<T>` records with `source: 'webhook'` and a
+ * `dedupKey` populated from the configured `webhook.eventIdField`.
+ *
+ * Key invariants under test:
+ *   - constructor accepts `{ queue, config, middlewares? }`
+ *   - `listChanges(subscription, cursor)` yields `Change<T>` with
+ *     `source: 'webhook'`, `dedupKey` from the configured event-id field
+ *   - empty-queue iteration yields nothing
+ *   - errors thrown by the queue iterator surface to the consumer
+ *   - the primitive does NOT synchronously drive the orchestrator —
+ *     it is a passive iterator over the consumer-owned queue
+ *   - middleware composition works the same shape as PollChangeSource
+ *   - constructor rejects a non-webhook config
+ */
+import { describe, expect, it } from 'bun:test';
+import {
+  WebhookChangeSource,
+  type WebhookFetchCallback,
+  type WebhookFetchContext,
+} from '../../../../runtime/subsystems/sync/webhook-change-source';
+import type { SyncSubscriptionView } from '../../../../runtime/subsystems/sync/sync-change-source.protocol';
+import type { ChangeMiddleware } from '../../../../runtime/subsystems/sync/sync-middleware.protocol';
+import type { DetectionConfig } from '../../../../runtime/subsystems/sync/detection-config.schema';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+interface WebhookRecord {
+  external_id: string;
+  name: string;
+  event_id: string;
+}
+
+const subscription: SyncSubscriptionView = {
+  id: 'sub-webhook-1',
+  domain: 'opportunity',
+  externalRef: 'sf-org-A',
+};
+
+function makeWebhookConfig(extra?: Partial<DetectionConfig>): DetectionConfig {
+  return {
+    mode: 'webhook',
+    webhook: {
+      eventIdField: 'event_id',
+    },
+    mapping: [
+      { source: 'id', target: 'external_id' },
+      { source: 'Name', target: 'name' },
+    ],
+    filters: [],
+    ...(extra as object),
+  } as DetectionConfig;
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const x of it) out.push(x);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Empty queue
+// ---------------------------------------------------------------------------
+
+describe('WebhookChangeSource — empty queue', () => {
+  it('yields no changes when the queue is empty', async () => {
+    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+      // empty
+    };
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue,
+      config: makeWebhookConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event-id dedup
+// ---------------------------------------------------------------------------
+
+describe('WebhookChangeSource — event-id dedup', () => {
+  it('populates Change.dedupKey from the configured eventIdField on the record', async () => {
+    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+      yield {
+        record: { external_id: 'A1', name: 'Alpha', event_id: 'evt_001' },
+      };
+      yield {
+        record: { external_id: 'A2', name: 'Beta', event_id: 'evt_002' },
+      };
+    };
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue,
+      config: makeWebhookConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toHaveLength(2);
+    expect(out[0].source).toBe('webhook');
+    expect(out[0].dedupKey).toBe('evt_001');
+    expect(out[0].externalId).toBe('A1');
+    expect(out[1].dedupKey).toBe('evt_002');
+  });
+
+  it('throws if a record is missing the configured eventIdField', async () => {
+    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+      yield {
+        record: { external_id: 'A1', name: 'Alpha' } as WebhookRecord,
+      };
+    };
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue,
+      config: makeWebhookConfig(),
+    });
+    await expect(
+      (async () => {
+        for await (const _c of src.listChanges(subscription, null)) {
+          // drain
+        }
+      })(),
+    ).rejects.toThrow(/event_id/);
+  });
+
+  it('forwards subscription + cursor to the queue iterator context', async () => {
+    let seen: WebhookFetchContext | undefined;
+    const queue: WebhookFetchCallback<WebhookRecord> = async function* (ctx) {
+      seen = ctx;
+    };
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue,
+      config: makeWebhookConfig(),
+    });
+    await collect(src.listChanges(subscription, { lastTs: 'x' }));
+    expect(seen).toBeDefined();
+    expect(seen!.subscription.id).toBe('sub-webhook-1');
+    expect(seen!.cursor).toEqual({ lastTs: 'x' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue errors
+// ---------------------------------------------------------------------------
+
+describe('WebhookChangeSource — queue errors', () => {
+  it('propagates errors thrown by the queue iterator', async () => {
+    const boom: WebhookFetchCallback<WebhookRecord> = async function* () {
+      throw new Error('queue offline');
+    };
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue: boom,
+      config: makeWebhookConfig(),
+    });
+    await expect(
+      (async () => {
+        for await (const _c of src.listChanges(subscription, null)) {
+          // drain
+        }
+      })(),
+    ).rejects.toThrow(/queue offline/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Middleware composition
+// ---------------------------------------------------------------------------
+
+describe('WebhookChangeSource — middleware composition', () => {
+  it('composes middlewares the same shape as PollChangeSource (first = outermost)', async () => {
+    const order: string[] = [];
+    const tag =
+      (label: string): ChangeMiddleware<WebhookRecord> =>
+      (next) =>
+      async function* (sub, cur) {
+        order.push(`${label}:enter`);
+        for await (const c of next(sub, cur)) {
+          order.push(`${label}:yield`);
+          yield c;
+        }
+        order.push(`${label}:exit`);
+      };
+    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+      yield {
+        record: { external_id: 'A', name: 'a', event_id: 'evt_1' },
+      };
+    };
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue,
+      config: makeWebhookConfig(),
+      middlewares: [tag('outer'), tag('inner')],
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toHaveLength(1);
+    expect(order).toEqual([
+      'outer:enter',
+      'inner:enter',
+      'inner:yield',
+      'outer:yield',
+      'inner:exit',
+      'outer:exit',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Construction guard
+// ---------------------------------------------------------------------------
+
+describe('WebhookChangeSource — construction', () => {
+  it('rejects a non-webhook config', () => {
+    const pollConfig: DetectionConfig = {
+      mode: 'poll',
+      poll: { cursor: { kind: 'systemModstamp', field: 'm' } },
+      mapping: [{ source: 'Id', target: 'external_id' }],
+      filters: [],
+    };
+    expect(
+      () =>
+        new WebhookChangeSource<WebhookRecord>({
+          queue: async function* () {},
+          config: pollConfig,
+        }),
+    ).toThrow(/webhook/);
+  });
+
+  it('exposes a label for run logs', () => {
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue: async function* () {},
+      config: makeWebhookConfig(),
+      label: 'stripe-webhook-charge',
+    });
+    expect(src.label).toBe('stripe-webhook-charge');
+  });
+
+  it('falls back to a default label when not provided', () => {
+    const src = new WebhookChangeSource<WebhookRecord>({
+      queue: async function* () {},
+      config: makeWebhookConfig(),
+    });
+    expect(typeof src.label).toBe('string');
+    expect(src.label.length).toBeGreaterThan(0);
+  });
+});
+
+// Compile-time guard: WebhookFetchContext must NOT include userId/tenantId.
+const _shapeGuard: WebhookFetchContext = {
+  subscription,
+  cursor: null,
+};
+void _shapeGuard;


### PR DESCRIPTION
## Summary

- Add `WebhookChangeSource<T>` primitive that mirrors the poll-primitive shape: `IChangeSource<T>` with `listChanges(subscription, cursor)`, iterates a consumer-owned inbound staging queue, stamps `Change<T>.source = 'webhook'`, populates `dedupKey` from `webhook.eventIdField`. Passive iterator — does not drive the orchestrator.
- Honor `poll.provenance: 'cdc'` on `PollChangeSource<T>`: stamps `source: 'cdc'` (already shipped via parent #237) and populates `dedupKey` from the configured `poll.cursor.field`. Default poll provenance leaves `dedupKey` unset.
- Re-export `WebhookChangeSource` + types from `runtime/subsystems/sync/index.ts`.

CDC-as-provenance is a knob on `PollChangeSource`, NOT a separate primitive. Long-lived streaming CDC (SFDC Pub-Sub, Debezium) is deferred to #226-8.

Closes #231
Part of epic #226

## Stack note

Originally drafted as stacked on `feat/226-3-poll-change-source` (PR #237). #237 has since been squash-merged to `main`, so this PR retargets `main` directly. The sole commit applies cleanly on top of `origin/main` (rebased; no conflicts).

## Acceptance

- [x] `WebhookChangeSource<T>` implements `IChangeSource<T>` with the new signature
- [x] queue is iterator source; no sync orchestrator drive
- [x] `DetectionConfigSchema` accepts `poll.provenance: 'cdc' | 'poll'` (already shipped via parent)
- [x] `PollChangeSource<T>` honors provenance — stamps `source: 'cdc'` and populates `dedupKey`
- [x] webhook event-id dedup tested
- [x] empty-queue iteration tested
- [x] queue-error surfacing tested
- [x] poll-with-cdc-provenance emits `source: 'cdc'` + correct `dedupKey` tested
- [x] `just test-unit` green (1612 pass / 0 fail locally)

**Skill update pending — see § Skill update; orchestrator will apply pre-merge.**

## Skill update (apply pre-merge)

Two edits to `.claude/skills/sync/SKILL.md`. Both anchored against the post-#234 / post-#235 / post-#237 state.

### Edit 1 — clarify rule #1 to call out CDC-as-provenance vs. streaming

```diff
@@ Non-obvious rules @@
 1. **One port for three modes.** Poll, CDC, and webhook adapters ALL
    implement `IChangeSource<T>` —
    `listChanges(subscription, cursor): AsyncIterable<Change<T>>`
    (#226-2 / ADR-033). Per-mode concerns (CDC replay_id, webhook
    event_id, provider-hinted changed fields) live in `Change<T>`
    metadata: `source`, `dedupKey`, `providerChangedFields`. Don't
    introduce mode-specific ports — we rejected that design explicitly.
+   "CDC" here means *cursor-based event endpoints* (Stripe-style
+   `events?starting_after=...`) — those map to `PollChangeSource<T>`
+   with `poll.provenance: 'cdc'` (#226-4); the primitive stamps
+   `Change<T>.source = 'cdc'` and reads `dedupKey` from
+   `poll.cursor.field`. Long-lived stream subscriptions (SFDC
+   Pub-Sub gRPC, Debezium/Kafka, Postgres logical replication) are a
+   separate primitive deferred to #226-8 — they need a different
+   substrate (`subscribe(onChange, onError)`, server-paced
+   backpressure, ack-on-yield) and shouldn't be retrofitted here.
```

### Edit 2 — add runtime-snapshot row for `webhook-change-source.ts`

Anchor: the existing `poll-change-source.ts` row added by #226-3's skill diff. Insert immediately after it.

```diff
@@ runtime snapshot @@
 - `runtime/subsystems/sync/poll-change-source.ts` —
   `PollChangeSource<T>` poll-mode primitive ...
+- `runtime/subsystems/sync/webhook-change-source.ts` —
+  `WebhookChangeSource<T>` webhook-mode primitive: parameterized by a
+  parsed `DetectionConfig` (`mode: 'webhook'`) + a consumer-supplied
+  `WebhookFetchCallback<T>` that iterates the consumer-owned inbound
+  staging queue. Stamps `Change<T>.source = 'webhook'`, populates
+  `dedupKey` from `webhook.eventIdField`, derives `externalId` from
+  the mapping table's `external_id` target, composes middleware via
+  the locked `ChangeMiddleware<T>` shape. Passive iterator — does NOT
+  drive the orchestrator. Inbound staging-table schema is
+  consumer-owned and deferred per ADR-0002 §Phase 4.
```

## Test plan

- [x] `mise exec -- bun test src/__tests__/runtime/subsystems/poll-change-source.spec.ts src/__tests__/runtime/subsystems/webhook-change-source.spec.ts` — 25 pass / 0 fail
- [x] `mise exec -- just test-unit` — 1612 pass / 0 fail (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)