### PR TITLE
feat(sync)!: loopback-as-middleware migration (#226-5)

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -74,7 +74,7 @@ meaningful.
 | When the task involves… | Read |
 |---|---|
 | Designing a new `IChangeSource<T>` (signature `(subscription, cursor) => AsyncIterable<Change<T>>` per ADR-033) / `ISyncSink<T>` / custom `IFieldDiffer<T>` | `protocols-and-ports.md` |
-| The orchestrator's run lifecycle, cursor advance, per-item failure, loopback | `orchestrator-flow.md` |
+| The orchestrator's run lifecycle, cursor advance, per-item failure | `orchestrator-flow.md` |
 | `sync_runs` / `sync_run_items` / `sync_subscriptions` shape, `changed_fields` (ADR-0003), worked queries | `audit-model.md` |
 | Writing a feature module, migrating from bespoke sync, multi-tenancy wiring | `consumer-patterns.md` |
 
@@ -251,8 +251,15 @@ Files that ship to the consumer app (not templates):
   `DeepEqualDiffer<T>` with canonical ignore list; `providerChangedFields`
   CDC hint; Date → ISO string + decimal-string ↔ number normalizations
 - `runtime/subsystems/sync/execute-sync.use-case.ts` — the generic
-  orchestrator. `@Optional() SYNC_LOOPBACK_FINGERPRINT_STORE` +
-  `@Optional() SYNC_MULTI_TENANT`. Entry-point `assertTenantId` guard
+  orchestrator. `@Optional() SYNC_MULTI_TENANT`. Entry-point
+  `assertTenantId` guard. Loopback suppression is composed into the
+  `IChangeSource`'s middleware chain via `createLoopbackMiddleware`
+  (#226-5 / ADR-033) — no orchestrator-side branch.
+- `runtime/subsystems/sync/loopback.middleware.ts` —
+  `createLoopbackMiddleware(store)` factory; the canonical
+  `ChangeMiddleware<T>` consumers compose into their primitive's
+  middleware chain when they need to suppress echoes of their own
+  outbound writes (#226-5 / ADR-033)
 - `runtime/subsystems/sync/sync.module.ts` —
   `SyncModule.forRoot({ backend, multiTenant? })`; `global: true`
 - `runtime/subsystems/sync/sync.tokens.ts` — string-valued tokens

--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -8,22 +8,27 @@
  *
  *   1. `recorder.startRun(...)` — opens a `sync_runs` row in 'running'.
  *   2. for each change yielded by `source.listChanges(subscription, cursorBefore)`:
- *        a. if loopback store says "echo of own write" → skip, record
- *           as `status: 'skipped'`, `operation: 'noop'`, changedFields `{}`.
- *        b. differ.diff(existing, incoming) → 'noop' short-circuits to
+ *        a. differ.diff(existing, incoming) → 'noop' short-circuits to
  *           a noop audit row (no sink write).
- *        c. sink.upsertByExternalId / softDeleteByExternalId → records
+ *        b. sink.upsertByExternalId / softDeleteByExternalId → records
  *           the local id on the audit row.
- *        d. per-item try/catch — a failed item increments the failed
+ *        c. per-item try/catch — a failed item increments the failed
  *           counter and records `status: 'failed'` with `error`, but
  *           does NOT abort the run.
- *        e. advance `latestCursor = change.cursor` as the iterator moves.
+ *        d. advance `latestCursor = change.cursor` as the iterator moves.
  *   3. `cursors.put(subscription.id, latestCursor)` when the loop completes
  *      AND at least one cursor advance happened. On exceptions from the
  *      source iterator (auth expiry, network error), we persist the
  *      last-good cursor so the next run resumes from the last known
  *      successful position.
  *   4. `finally { recorder.completeRun(...) }` — always terminates the run.
+ *
+ * Loopback suppression — when a consumer's writes echo back on the next
+ * inbound poll/CDC/webhook — is composed into the source's middleware
+ * chain via `createLoopbackMiddleware(store)` (#226-5 / ADR-033). The
+ * orchestrator no longer special-cases echoes: middleware drops them
+ * before they reach this loop. Consumers that don't have outbound
+ * writeback paths simply omit the middleware.
  *
  * ## Generics
  *
@@ -36,8 +41,6 @@
  * is strictly provider-agnostic:
  *   - `entityType` is `string` throughout; no `'opportunity' | 'account' | ...`
  *     narrowing leaks into the use case
- *   - `loopback.isEchoOfOwnWrite` is typed against the same `T`, not a CRM
- *     union
  *   - dealbrain's `SyncRunRecorderService` class injection replaced with the
  *     `ISyncRunRecorder` protocol (backend lands in SYNC-4)
  */
@@ -47,13 +50,11 @@ import type { ICursorStore } from './sync-cursor-store.protocol';
 import type { IFieldDiffer, FieldDiff } from './sync-field-diff.protocol';
 import type { ISyncSink } from './sync-sink.protocol';
 import type { ISyncRunRecorder } from './sync-run-recorder.protocol';
-import type { ILoopbackFingerprintStore } from './sync-loopback.protocol';
 import { assertTenantId } from './sync-errors';
 import {
   SYNC_CHANGE_SOURCE,
   SYNC_CURSOR_STORE,
   SYNC_FIELD_DIFFER,
-  SYNC_LOOPBACK_FINGERPRINT_STORE,
   SYNC_MULTI_TENANT,
   SYNC_RUN_RECORDER,
   SYNC_SINK,
@@ -114,9 +115,6 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     @Inject(SYNC_FIELD_DIFFER) private readonly differ: IFieldDiffer<T>,
     @Inject(SYNC_SINK) private readonly sink: ISyncSink<T>,
     @Inject(SYNC_RUN_RECORDER) private readonly recorder: ISyncRunRecorder,
-    @Optional()
-    @Inject(SYNC_LOOPBACK_FINGERPRINT_STORE)
-    private readonly loopback?: ILoopbackFingerprintStore<T>,
     @Optional()
     @Inject(SYNC_MULTI_TENANT)
     private readonly multiTenant: boolean = false,
@@ -249,27 +247,6 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     input: ExecuteSyncInput<T>,
     change: Change<T>,
   ): Promise<void> {
-    // Loopback filter — skip echoes of our own outbound writes.
-    if (this.loopback) {
-      const isEcho = await this.loopback.isEchoOfOwnWrite(
-        input.subscription.domain,
-        change.externalId,
-        change.record,
-      );
-      if (isEcho) {
-        await this.recorder.recordItem({
-          syncRunId: runId,
-          entityType: input.subscription.domain,
-          externalId: change.externalId,
-          operation: 'noop',
-          status: 'skipped',
-          changedFields: {},
-          tenantId: input.tenantId,
-        });
-        return;
-      }
-    }
-
     // Deletion branch — no diff, no upsert; soft-delete via sink.
     if (change.operation === 'deleted') {
       const result = await this.sink.softDeleteByExternalId(

--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -70,6 +70,11 @@ export type {
   ComposeChangeMiddleware,
 } from './sync-middleware.protocol';
 
+// Loopback middleware factory (#226-5) — replaces the orchestrator's prior
+// `@Optional() SYNC_LOOPBACK_FINGERPRINT_STORE` branch. Consumers compose
+// `createLoopbackMiddleware(store)` into their primitive's middleware chain.
+export { createLoopbackMiddleware } from './loopback.middleware';
+
 // Poll primitive (#226-3) — generic poll-mode IChangeSource<T>
 export {
   PollChangeSource,
@@ -84,7 +89,6 @@ export {
   SYNC_CHANGE_SOURCE,
   SYNC_CURSOR_STORE,
   SYNC_FIELD_DIFFER,
-  SYNC_LOOPBACK_FINGERPRINT_STORE,
   SYNC_MODULE_OPTIONS,
   SYNC_MULTI_TENANT,
   SYNC_RUN_RECORDER,

--- a/runtime/subsystems/sync/loopback.middleware.ts
+++ b/runtime/subsystems/sync/loopback.middleware.ts
@@ -1,0 +1,62 @@
+/**
+ * Sync subsystem — loopback `ChangeMiddleware` factory (#226-5, ADR-033).
+ *
+ * Replaces the prior orchestrator-side `@Optional() SYNC_LOOPBACK_FINGERPRINT_STORE`
+ * branch. Consumers that need to suppress echoes of their own outbound
+ * writes compose `createLoopbackMiddleware(store)` into a primitive's
+ * middleware chain — typically alongside `PollChangeSource<T>` — instead
+ * of injecting a store into the orchestrator.
+ *
+ * Why middleware, not orchestrator branch:
+ *   - keeps the orchestrator port-agnostic (no per-mode special cases);
+ *   - lets primitives compose loopback with redaction / throttling /
+ *     other cross-cutting wrappers in a single chain;
+ *   - lets consumers pick per-source whether loopback is wired (some
+ *     entities have outbound writeback, others don't) without DI gymnastics.
+ *
+ * Behavior:
+ *   - For every change yielded by the inner iterator, call
+ *     `store.isEchoOfOwnWrite(subscription.domain, change.externalId, change.record)`.
+ *   - If the store returns `true`, the change is dropped (not yielded).
+ *   - Otherwise the change is passed through untouched.
+ *
+ * The middleware does not record audit rows for suppressed changes —
+ * the orchestrator no longer learns about them. This is the deliberate
+ * trade: loopback echoes are noise, not signal; their prior `skipped+noop`
+ * audit rows existed only because the orchestrator was the suppression
+ * site. Consumers wanting visibility into suppression counts can wrap
+ * their store or layer a counting middleware alongside this one.
+ */
+
+import type { Change } from './sync-change-source.protocol';
+import type {
+  ChangeIterator,
+  ChangeMiddleware,
+} from './sync-middleware.protocol';
+import type { ILoopbackFingerprintStore } from './sync-loopback.protocol';
+
+/**
+ * Build a `ChangeMiddleware<T>` that suppresses changes whose fingerprint
+ * matches a recent local write according to the supplied store.
+ *
+ * Composition — first middleware in the array is outermost. Consumers
+ * typically place loopback as the outermost layer so suppressed changes
+ * never reach downstream middleware (redaction, transforms, etc.).
+ */
+export function createLoopbackMiddleware<T>(
+  store: ILoopbackFingerprintStore<T>,
+): ChangeMiddleware<T> {
+  return (next: ChangeIterator<T>): ChangeIterator<T> => {
+    return async function* (subscription, cursor): AsyncIterable<Change<T>> {
+      for await (const change of next(subscription, cursor)) {
+        const isEcho = await store.isEchoOfOwnWrite(
+          subscription.domain,
+          change.externalId,
+          change.record,
+        );
+        if (isEcho) continue;
+        yield change;
+      }
+    };
+  };
+}

--- a/runtime/subsystems/sync/sync.module.ts
+++ b/runtime/subsystems/sync/sync.module.ts
@@ -15,12 +15,12 @@
  *
  *   - `SYNC_CHANGE_SOURCE` — per-provider per-entity; consumer binds in
  *     their feature module (e.g. `OpportunitySyncModule` provides a
- *     `SalesforceOpportunityChangeSource`).
+ *     `SalesforceOpportunityChangeSource`). Loopback suppression — when
+ *     needed — is composed into the primitive's middleware chain via
+ *     `createLoopbackMiddleware(store)` (#226-5 / ADR-033); the
+ *     orchestrator no longer accepts a fingerprint store directly.
  *   - `SYNC_SINK` — per canonical entity; consumer binds in their feature
  *     module.
- *   - `SYNC_LOOPBACK_FINGERPRINT_STORE` — optional; consumer provides
- *     only when they have outbound writeback paths. `@Optional()` at the
- *     orchestrator seam means absence is fine.
  *   - `ExecuteSyncUseCase` — registered by the feature module alongside
  *     its source + sink bindings. Providing the orchestrator here would
  *     force Nest to resolve SYNC_CHANGE_SOURCE + SYNC_SINK at module

--- a/runtime/subsystems/sync/sync.tokens.ts
+++ b/runtime/subsystems/sync/sync.tokens.ts
@@ -32,14 +32,6 @@ export const SYNC_SINK = 'SYNC_SINK' as const;
 export const SYNC_RUN_RECORDER = 'SYNC_RUN_RECORDER' as const;
 
 /**
- * Optional loopback-fingerprint store (SYNC-5). Backed by
- * `ILoopbackFingerprintStore<T>`. `ExecuteSyncUseCase` treats this as
- * `@Optional()` — consumers without outbound writeback paths don't need it.
- */
-export const SYNC_LOOPBACK_FINGERPRINT_STORE =
-  'SYNC_LOOPBACK_FINGERPRINT_STORE' as const;
-
-/**
  * Injection token for the resolved `SyncModuleOptions` object (SYNC-6).
  *
  * Backends that need to observe module configuration (e.g. `multiTenant`

--- a/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
+++ b/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
@@ -8,13 +8,17 @@
  *
  *   - created / updated / deleted happy paths
  *   - noop emission when differ returns 'noop'
- *   - loopback skip path (with in-memory fingerprint stub)
  *   - per-item failure does not fail the whole run; counts.failed increments
  *   - cursor advance on successful run
  *
  * Plus: all-failed run is marked 'failed'; empty iterable → 'no_changes';
  * source iterator throw still persists last-good cursor; deletion of a
  * missing record records as 'noop'.
+ *
+ * Loopback suppression moved out of the orchestrator in #226-5 — it now
+ * lives in `createLoopbackMiddleware(store)` and is asserted in
+ * `loopback.middleware.spec.ts`. The orchestrator no longer special-cases
+ * echoes; tests here stop covering that branch.
  */
 import { describe, it, expect, beforeEach } from 'bun:test';
 import { MemoryCursorStore } from '../../../../runtime/subsystems/sync/sync-cursor-store.memory-backend';
@@ -31,7 +35,6 @@ import type {
   RecordItemInput,
   CompleteRunInput,
 } from '../../../../runtime/subsystems/sync/sync-run-recorder.protocol';
-import type { ILoopbackFingerprintStore } from '../../../../runtime/subsystems/sync/sync-loopback.protocol';
 
 // ─── Canonical shape for tests ──────────────────────────────────────────────
 
@@ -129,26 +132,6 @@ class FakeRecorder implements ISyncRunRecorder {
   }
 }
 
-class AllowAllLoopback
-  implements ILoopbackFingerprintStore<CanonicalOpp>
-{
-  async isEchoOfOwnWrite(): Promise<boolean> {
-    return false;
-  }
-}
-
-class EchoIds
-  implements ILoopbackFingerprintStore<CanonicalOpp>
-{
-  constructor(private readonly echoed: Set<string>) {}
-  async isEchoOfOwnWrite(
-    _entityType: string,
-    externalId: string,
-  ): Promise<boolean> {
-    return this.echoed.has(externalId);
-  }
-}
-
 // ─── Shared fixtures ────────────────────────────────────────────────────────
 
 const SUB: SyncSubscriptionView = {
@@ -178,7 +161,6 @@ function makeOrchestrator(
   sink: ISyncSink<CanonicalOpp>,
   recorder: ISyncRunRecorder,
   cursors: MemoryCursorStore,
-  loopback?: ILoopbackFingerprintStore<CanonicalOpp>,
 ) {
   return new ExecuteSyncUseCase<CanonicalOpp>(
     source,
@@ -186,7 +168,6 @@ function makeOrchestrator(
     new DeepEqualDiffer<CanonicalOpp>(),
     sink,
     recorder,
-    loopback,
   );
 }
 
@@ -347,48 +328,6 @@ describe('ExecuteSyncUseCase', () => {
       // but we assert `upsertByExternalId` did not run by checking the
       // map still points to `existing`).
       expect(sink.rows.get('ext-1')).toBe(existing);
-    });
-  });
-
-  describe('loopback skip', () => {
-    it('records skipped+noop and does not call the sink', async () => {
-      const change: Change<CanonicalOpp> = {
-        externalId: 'echo-1',
-        operation: 'updated',
-        record: { external_id: 'echo-1', amount: 100 },
-        cursor: { v: 1 },
-        source: 'poll',
-      };
-      const source = new ArrayChangeSource([change]);
-      const loopback = new EchoIds(new Set(['echo-1']));
-      const orch = makeOrchestrator(source, sink, recorder, cursors, loopback);
-      await orch.execute(makeInput());
-
-      expect(recorder.items[0].operation).toBe('noop');
-      expect(recorder.items[0].status).toBe('skipped');
-      expect(sink.rows.has('echo-1')).toBe(false);
-    });
-
-    it('processes non-echoed records normally', async () => {
-      const change: Change<CanonicalOpp> = {
-        externalId: 'ext-1',
-        operation: 'created',
-        record: { external_id: 'ext-1', amount: 100 },
-        cursor: { v: 1 },
-        source: 'poll',
-      };
-      const source = new ArrayChangeSource([change]);
-      const orch = makeOrchestrator(
-        source,
-        sink,
-        recorder,
-        cursors,
-        new AllowAllLoopback(),
-      );
-      await orch.execute(makeInput());
-
-      expect(recorder.items[0].status).toBe('success');
-      expect(recorder.items[0].operation).toBe('created');
     });
   });
 

--- a/src/__tests__/runtime/subsystems/loopback.middleware.spec.ts
+++ b/src/__tests__/runtime/subsystems/loopback.middleware.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for `createLoopbackMiddleware` (#226-5).
+ *
+ * Loopback shipped as a stock `ChangeMiddleware<T>` factory replaces the
+ * orchestrator's `@Optional() SYNC_LOOPBACK_FINGERPRINT_STORE` branch.
+ * Coverage: matching fingerprint suppresses the change, missing
+ * fingerprint passes through, and the store is consulted exactly once
+ * per yielded change with the documented arguments.
+ */
+import { describe, it, expect } from 'bun:test';
+import { createLoopbackMiddleware } from '../../../../runtime/subsystems/sync/loopback.middleware';
+import type {
+  Change,
+  SyncSubscriptionView,
+} from '../../../../runtime/subsystems/sync/sync-change-source.protocol';
+import type { ChangeIterator } from '../../../../runtime/subsystems/sync/sync-middleware.protocol';
+import type { ILoopbackFingerprintStore } from '../../../../runtime/subsystems/sync/sync-loopback.protocol';
+
+interface CanonicalOpp extends Record<string, unknown> {
+  external_id: string;
+  amount?: number;
+}
+
+const SUB: SyncSubscriptionView = {
+  id: 'sub-1',
+  domain: 'opportunity',
+  externalRef: null,
+};
+
+class RecordingStore implements ILoopbackFingerprintStore<CanonicalOpp> {
+  readonly calls: Array<{
+    entityType: string;
+    externalId: string;
+    record: CanonicalOpp;
+  }> = [];
+  constructor(private readonly echoed: Set<string>) {}
+  async isEchoOfOwnWrite(
+    entityType: string,
+    externalId: string,
+    record: CanonicalOpp,
+  ): Promise<boolean> {
+    this.calls.push({ entityType, externalId, record });
+    return this.echoed.has(externalId);
+  }
+}
+
+function makeChange(externalId: string): Change<CanonicalOpp> {
+  return {
+    externalId,
+    operation: 'updated',
+    record: { external_id: externalId, amount: 100 },
+    cursor: { v: externalId },
+    source: 'poll',
+  };
+}
+
+function arrayInner(changes: Change<CanonicalOpp>[]): ChangeIterator<CanonicalOpp> {
+  return async function* (
+    _sub: SyncSubscriptionView,
+    _cursor: unknown | null,
+  ): AsyncIterable<Change<CanonicalOpp>> {
+    for (const c of changes) yield c;
+  };
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const x of it) out.push(x);
+  return out;
+}
+
+describe('createLoopbackMiddleware', () => {
+  it('suppresses changes whose fingerprint matches a recent local write', async () => {
+    const store = new RecordingStore(new Set(['echo-1']));
+    const mw = createLoopbackMiddleware<CanonicalOpp>(store);
+    const inner = arrayInner([makeChange('echo-1')]);
+
+    const wrapped = mw(inner);
+    const yielded = await collect(wrapped(SUB, null));
+
+    expect(yielded).toHaveLength(0);
+    expect(store.calls).toHaveLength(1);
+    expect(store.calls[0]).toEqual({
+      entityType: 'opportunity',
+      externalId: 'echo-1',
+      record: { external_id: 'echo-1', amount: 100 },
+    });
+  });
+
+  it('passes non-matching changes through unchanged', async () => {
+    const store = new RecordingStore(new Set());
+    const mw = createLoopbackMiddleware<CanonicalOpp>(store);
+    const change = makeChange('ext-1');
+    const inner = arrayInner([change]);
+
+    const yielded = await collect(mw(inner)(SUB, null));
+
+    expect(yielded).toHaveLength(1);
+    expect(yielded[0]).toBe(change);
+  });
+
+  it('mixes pass-through + suppression in stream order', async () => {
+    const store = new RecordingStore(new Set(['echo-1']));
+    const mw = createLoopbackMiddleware<CanonicalOpp>(store);
+    const inner = arrayInner([
+      makeChange('a'),
+      makeChange('echo-1'),
+      makeChange('b'),
+    ]);
+
+    const yielded = await collect(mw(inner)(SUB, null));
+
+    expect(yielded.map((c) => c.externalId)).toEqual(['a', 'b']);
+    // Store consulted once per yielded change in order.
+    expect(store.calls.map((c) => c.externalId)).toEqual([
+      'a',
+      'echo-1',
+      'b',
+    ]);
+  });
+
+  it('uses subscription.domain as the entityType argument to the store', async () => {
+    const store = new RecordingStore(new Set());
+    const mw = createLoopbackMiddleware<CanonicalOpp>(store);
+    const inner = arrayInner([makeChange('ext-1')]);
+
+    await collect(
+      mw(inner)({ id: 'sub-9', domain: 'account', externalRef: null }, null),
+    );
+
+    expect(store.calls[0].entityType).toBe('account');
+  });
+});


### PR DESCRIPTION
## Summary

Ship loopback suppression as a stock `ChangeMiddleware<T>` factory and delete the orchestrator's loopback branch + DI binding.

- New `runtime/subsystems/sync/loopback.middleware.ts` exporting `createLoopbackMiddleware<T>(store): ChangeMiddleware<T>`.
- Delete `SYNC_LOOPBACK_FINGERPRINT_STORE` token, the `@Optional()` injection on `ExecuteSyncUseCase`, and the orchestrator-side loopback branch.
- `ILoopbackFingerprintStore<T>` *protocol* survives at `sync-loopback.protocol.ts`; only the orchestrator's DI binding goes away.
- Re-export `createLoopbackMiddleware` from `runtime/subsystems/sync/index.ts`; update `sync.module.ts` header comment.
- Update orchestrator unit tests (drop loopback-skip describe, fakes, and constructor arg). Add unit tests for the middleware factory (4 cases — match suppresses, miss passes through, mixed stream order, `subscription.domain` → `entityType`).

Closes #232. Part of epic #226. Originally stacked on #237 (now merged) → rebased onto `main`.

## BREAKING CHANGE

`SYNC_LOOPBACK_FINGERPRINT_STORE` token is removed. The `ExecuteSyncUseCase` constructor no longer accepts an `@Optional() ILoopbackFingerprintStore<T>` argument. Consumers wire loopback by composing `createLoopbackMiddleware(store)` into their `PollChangeSource` (or other `IChangeSource`) middleware chain. Per CLAUDE.md "no backwards compat" — no shims, no `@Optional()` retained, no parallel paths.

## Acceptance

- [x] `SYNC_LOOPBACK_FINGERPRINT_STORE` token gone from `sync.tokens.ts` — `grep -r SYNC_LOOPBACK_FINGERPRINT_STORE runtime/ src/` returns only docstring mentions, zero token references.
- [x] Orchestrator no longer references `loopback`; flow tests still pass.
- [x] `createLoopbackMiddleware` unit tests cover matching fingerprint, missing fingerprint, store interaction (4/4 green).
- [x] `just test-unit` (1601/1601) and `just test-baseline` green locally.

## Skill update (apply pre-merge)

Per plan §#226-5, the orchestrator should apply these `.claude/skills/sync/SKILL.md` edits before merge. Anchored by literal text content, not line number.

**Edit 1 — orchestrator-flow row in the routing table.** Anchor:

\`\`\`
| The orchestrator's run lifecycle, cursor advance, per-item failure, loopback | \`orchestrator-flow.md\` |
\`\`\`

Replace with:

\`\`\`
| The orchestrator's run lifecycle, cursor advance, per-item failure | \`orchestrator-flow.md\` |
\`\`\`

**Edit 2 — Current runtime snapshot, orchestrator entry.** Anchor:

\`\`\`
- \`runtime/subsystems/sync/execute-sync.use-case.ts\` — the generic
  orchestrator. \`@Optional() SYNC_LOOPBACK_FINGERPRINT_STORE\` +
  \`@Optional() SYNC_MULTI_TENANT\`. Entry-point \`assertTenantId\` guard
\`\`\`

Replace with:

\`\`\`
- \`runtime/subsystems/sync/execute-sync.use-case.ts\` — the generic
  orchestrator. \`@Optional() SYNC_MULTI_TENANT\`. Entry-point
  \`assertTenantId\` guard. Loopback suppression is composed into the
  \`IChangeSource\`'s middleware chain via \`createLoopbackMiddleware\`
  (#226-5 / ADR-033) — no orchestrator-side branch.
- \`runtime/subsystems/sync/loopback.middleware.ts\` —
  \`createLoopbackMiddleware(store)\` factory; the canonical
  \`ChangeMiddleware<T>\` consumers compose into their primitive's
  middleware chain when they need to suppress echoes of their own
  outbound writes (#226-5 / ADR-033)
\`\`\`

(Keep the existing \`sync-loopback.protocol.ts\` runtime snapshot entry — only the protocol's *DI binding* into the orchestrator goes away.)

**Edit 3 — \`orchestrator-flow.md\` (L1).** The flow diagram and prose currently include a \`loopback.isEchoOfOwnWrite\` branch; orchestrator-side detection no longer happens. Drop the loopback paragraph (line ~115 onwards) and remove the \`if loopback.isEchoOfOwnWrite(…)\` line in the flow (line ~21). Anchor by literal text.

**Skill update pending — see § Skill update; orchestrator will apply pre-merge.**

### Coordination with #235's pending skill diff

#235 also rewrites rules 1, 2, and the L73-74 row. The L80-82 row (orchestrator-flow router entry) and Current runtime snapshot orchestrator block here are independent — anchored on literal "loopback" text rather than line numbers. No conflict expected.

## Test plan

- [x] \`just test-unit\` green locally
- [x] \`just test-baseline\` green locally
- [ ] Apply pre-merge skill edits per § Skill update
- [ ] CI passes on \`main\` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)