### PR TITLE
docs(adr): provider-keyed detection (033.1) + typed artifacts (033.2) + provider registry (034)

### DIFF
--- a/docs/adrs/ADR-033.1-provider-keyed-detection.md
+++ b/docs/adrs/ADR-033.1-provider-keyed-detection.md
@@ -1,0 +1,183 @@
+# ADR-033.1 — Provider-Keyed `detection:` Config
+
+**Status:** Accepted
+**Date:** 2026-04-26
+**Owner:** Doug
+**Related:** ADR-033 (config-driven change sources — extends), ADR-034 (provider registry — forward reference), ADR-002 (domain-first module layout), ADR-008 (subsystem architecture)
+**Extends:** ADR-033 §1 (DetectionConfig is the canonical shape) and §7 (per-entity YAML, generated factory module)
+**Tracks:** RFC #241; reference consumer [pattern-stack/sales-patterns-ts#60](https://github.com/pattern-stack/sales-patterns-ts/pull/60)
+
+## Context
+
+ADR-033 locked `DetectionConfig` as the canonical per-entity sync detection shape and committed Phase 2 to emit one `<entity>-sync-source.module.ts` per entity. The schema and template were drafted against the simplest case — *one entity, one source* — because the runtime primitives (`PollChangeSource<T>`, `WebhookChangeSource<T>`) need only one config to instantiate.
+
+That single-source assumption does not hold for any real consumer. The dogfood consumer (`dealbrain-v2`) and the canonical CRM-sync use case both sync each entity from **multiple providers concurrently** — HubSpot *and* Salesforce, not one or the other. The existing `sync.providers:` YAML block already declares this multiplicity at the entity level (`Record<string, ProviderSync>` per `src/schema/entity-definition.schema.ts:604-606`); only the `detection:` block lagged behind, treating provider as implicit.
+
+Reference consumer [sales-patterns-ts#60](https://github.com/pattern-stack/sales-patterns-ts/pull/60) hand-authored six tuples (3 entities × 2 providers) against the #226 runtime primitives, demonstrating the shape this ADR formalizes. The hand-authored modules are deleted once the codegen this ADR specifies lands.
+
+This ADR locks the schema extension and the codegen-factory shape. It does **not** define the project-wide provider registry — that belongs to ADR-034, which this ADR forward-references for tightened validation.
+
+## Decision
+
+### 1. `detection:` is provider-keyed, always
+
+The entity-YAML `detection:` field is a `Record<string, DetectionConfig>` keyed by provider name. Single-provider entities use a one-key map; multi-provider entities list each provider as a separate key. There is no scalar form. Per CLAUDE.md "no backwards compat," the codegen-patterns repo has no shipped scalar shape to preserve.
+
+```ts
+// src/schema/entity-definition.schema.ts
+detection: z.record(z.string(), DetectionConfigSchema).optional(),
+```
+
+The inner `DetectionConfigSchema` (`runtime/subsystems/sync/detection-config.schema.ts`) is **untouched**. Each provider's value is an independent `DetectionConfig` — its own `mode`, `cursor`, `mapping[]`, `filters[]`. Provider identity is structure (the YAML key), not a new schema field.
+
+```yaml
+# entities/opportunity.yaml
+detection:
+  hubspot-crm:
+    mode: poll
+    poll: { cursor: { kind: 'timestamp', field: 'hs_lastmodifieddate' } }
+    mapping: [...]
+    filters: [...]
+  salesforce-crm:
+    mode: poll
+    poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } }
+    mapping: [...]
+    filters: [...]
+```
+
+### 2. Mixed mode per provider is supported by construction
+
+Each provider's value is an independent `DetectionConfig`, so one entity can declare HubSpot as `mode: webhook` and Salesforce as `mode: poll` without any schema or orchestrator change. A `sync_subscription` is `(integration, entity)` — HubSpot's webhook subscription and Salesforce's poll subscription are already two orchestrator runs. The factory's `buildChangeSource` switches on `cfg.mode` to instantiate `PollChangeSource<T>` or `WebhookChangeSource<T>`.
+
+### 3. Filters are per-provider; no inheritance, no merging
+
+Each provider's `filters[]` is independent. There is no entity-level filter block, no overriding, no merging semantics. Shared filters across providers are expressed by copy-paste or YAML anchors (`&defaults` / `<<: *defaults`) — both already work in YAML and require no schema support.
+
+Filter inheritance is the kind of feature that is convenient for two days then confusing forever. Rejected on architectural-correctness grounds (CLAUDE.md "no half-finished implementations").
+
+### 4. Generated module: one per entity, no provider-specific symbols
+
+The Phase 2 codegen factory module emits **one module per entity**, not per `(entity, provider)` tuple. Provider names appear *only* as runtime map keys lifted from YAML — never as generated TS symbols, class names, imports, or DI tokens. Adding or removing a provider in YAML changes the configs map's contents and changes nothing in the symbol space.
+
+```ts
+// generated: src/modules/.../<entity>-sync-source.module.ts
+const OPPORTUNITY_DETECTION_CONFIGS: Record<string, DetectionConfig> = {
+  'hubspot-crm':    { mode: 'poll', poll: { cursor: { kind: 'timestamp',      field: 'hs_lastmodifieddate' } }, mapping: [...], filters: [...] },
+  'salesforce-crm': { mode: 'poll', poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp'      } }, mapping: [...], filters: [...] },
+};
+
+export const OPPORTUNITY_POLL_FETCH_REGISTRY = Symbol('OPPORTUNITY_POLL_FETCH_REGISTRY');
+export const OPPORTUNITY_CHANGE_SOURCES      = Symbol('OPPORTUNITY_CHANGE_SOURCES');
+
+@Module({
+  providers: [
+    {
+      provide: OPPORTUNITY_CHANGE_SOURCES,
+      inject:  [OPPORTUNITY_POLL_FETCH_REGISTRY /*, middleware tokens */],
+      useFactory: (
+        fetches: Record<string, PollFetchCallback<Opportunity>>,
+      ): ReadonlyMap<string, IChangeSource<Opportunity>> =>
+        new Map(
+          Object.entries(OPPORTUNITY_DETECTION_CONFIGS).map(([provider, cfg]) =>
+            [provider, buildChangeSource(cfg, fetches[provider] /*, middlewares */)],
+          ),
+        ),
+    },
+  ],
+  exports: [OPPORTUNITY_CHANGE_SOURCES],
+})
+export class OpportunitySyncSourceModule {}
+```
+
+### 5. Token shape: `<ENTITY>_CHANGE_SOURCES: ReadonlyMap`
+
+Generated tokens are entity-level only:
+
+| Token | Type | Source |
+|---|---|---|
+| `<ENTITY>_DETECTION_CONFIGS` | `Record<string, DetectionConfig>` | Internal const, not exported |
+| `<ENTITY>_POLL_FETCH_REGISTRY` | `Record<string, PollFetchCallback<T>>` | Consumer fills |
+| `<ENTITY>_CHANGE_SOURCES` | `ReadonlyMap<string, IChangeSource<T>>` | Factory output, consumer reads |
+
+`ReadonlyMap` (not `Map`) is the factory return type — the registry is built once at module construction and consumers must not mutate it. Per-tuple symbols (`<ENTITY>_HUBSPOT_CHANGE_SOURCE`, etc.) are explicitly rejected: they would force provider names back into generated symbol space, contradicting decision §4 and reintroducing the boilerplate this ADR removes.
+
+### 6. Pre-emission YAML validation: within-file cross-check
+
+`pts codegen entity validate` adds a Zod `superRefine` that fails when a `detection:` key is not also declared under that entity's `sync.providers:`. This catches typos (`hubspot-cmr`) and forgotten provider registrations at validate-time, not at codegen-time or runtime.
+
+```ts
+EntityDefinitionSchema.superRefine((entity, ctx) => {
+  if (!entity.detection) return;
+  const declared = new Set(Object.keys(entity.sync?.providers ?? {}));
+  for (const provider of Object.keys(entity.detection)) {
+    if (!declared.has(provider)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['detection', provider],
+        message: `Provider '${provider}' used in detection: but not declared in sync.providers. Known providers: ${[...declared].join(', ')}`,
+      });
+    }
+  }
+});
+```
+
+The check is intentionally **within-file only**. A second tier — cross-checking against a project-wide provider registry — is deferred to ADR-034. When ADR-034 lands, this `superRefine` extends with a second loop that validates `Object.keys(sync.providers)` against the registry. The within-file check ships in the same PR as decision §1.
+
+### 7. `EntityDefinitionSchema` stays a static export
+
+The schema remains a top-level `const` export, not a factory. An enum-of-providers shape (`z.enum([...projectProviders])`) was considered and rejected: it would require constructing the schema with project config in scope, rippling through every consumer (validator CLI, codegen pipeline, tests, fixtures). `z.record` + `superRefine` produces equivalent error UX with a clearer message ("Provider 'x' not in registry. Known: …") and preserves the static-export simplicity property.
+
+### 8. Drop the `isCleanArchitecture` gate on `sync-source.ejs.t`
+
+`templates/entity/new/backend/modules/core/sync-source.ejs.t` (added in #226-7) currently has `skip_if: <%= !hasDetection || !isCleanArchitecture %>`. The architecture predicate is wrong here — sync-source modules belong wherever modules are emitted, including the `clean-lite-ps` pipeline. The gate becomes:
+
+```
+skip_if: <%= !hasDetection %>
+```
+
+This is in scope for the same PR as decision §1; the gate's only existence reason was an ADR-033 conservatism and the file does not exist on `main` until #240 lands.
+
+### 9. Cursor disambiguation stays unchanged
+
+`sync_subscriptions.cursor` remains opaque (sync skill rule 2). The subscription row's `provider` column already disambiguates which YAML detection block parses the cursor — no need to tag the cursor itself. Provider key is the indirection.
+
+## Rationale
+
+- **§1 (provider-keyed always).** Single shape removes a branch from the template (`isMultiProvider`) and from the schema. Single-provider is just a one-key map. The reference consumer demonstrates the shape; no scalar form has shipped to preserve.
+- **§2 (mixed mode).** Falls out of §1 for free — independent `DetectionConfig` per key means independent `mode`. Worth stating explicitly because it affects how operators reason about migration paths (a webhook-first provider can coexist with a poll-first provider on the same canonical entity).
+- **§3 (no filter inheritance).** Inheritance complicates the YAML reader, the validator, and operator mental model for ambiguous gain. Copy-paste / YAML anchors cover the actual use case.
+- **§4 (no provider-specific symbols).** Provider-as-data is the load-bearing principle. The alternative (per-tuple symbols) is exactly the boilerplate the codegen layer was built to delete; reintroducing it would break the abstraction.
+- **§5 (`ReadonlyMap`).** Factory builds once; runtime mutation would silently break orchestrator semantics. `ReadonlyMap` is the smallest contract that captures this.
+- **§6 (within-file validation).** Catches the practical typo class with zero new config surface. Project-level cross-check is real value but earns its own ADR (034) because the registry serves auth/observability/audit too — not a sync concern.
+- **§7 (static schema export).** Factory-schema option ripples through every test fixture and the CLI. The error UX gain is recoverable via `superRefine` message text.
+- **§8 (drop gate).** ADR-033 conservatism that does not survive contact with `clean-lite-ps`.
+
+## Consequences
+
+**Positive:**
+- One entity = one generated module, regardless of provider count. Adding a provider to YAML is a pure data change — no symbol churn, no template branch, no module file split.
+- Provider strings appear in exactly one place per entity in generated output (the configs-map keys). Search/replace renames are mechanical.
+- Mixed-mode-per-provider is supported without orchestrator changes. The `sync_subscription` row's `(integration, entity)` shape already handles it.
+- The `superRefine` validator surfaces typos at `pts codegen entity validate`, not at runtime where the symptom is "no changes ever detected from `hubspot-cmr`."
+
+**Negative / costs:**
+- Within-file validation does not catch the case where an entity declares a provider that exists nowhere else in the project — that requires the registry from ADR-034. Mitigation: within-file is the high-value 90% case; ADR-034 tightens to 100% on a separate timeline.
+- Consumer registry maps (`Record<string, PollFetchCallback<T>>`) are stringly-typed in Part 1 — a typo in the consumer's `useFactory` registration is not caught at compile time. Mitigation: ADR-033.2 emits a typed `<EntityName>Provider` union that turns this into a TS error.
+- Storage uniqueness becomes a consumer-side concern: when two providers happen to share an `external_id`, the consumer's synced-entity table needs a composite unique on `(user_id, provider, external_id)` rather than `(user_id, external_id)`. The `external_id_tracking` behavior already supplies the `provider` column. Out of scope for this ADR; flagged for the dogfood consumer.
+
+**Out of scope:**
+- Project-wide provider registry — ADR-034.
+- Typed provider artifacts for compile-time consumer registry checks — ADR-033.2.
+- Filter vocabulary expansion (OR / NOT / nested) — RFC #241 §Out of scope; deferred per epic #226 open Q3.
+- `subscription.config` per-provider runtime overlays — RFC #241 §Out of scope; epic #226 open Q3.
+- Mode fallback semantics (CDC drops → poll resumes) — epic #226 open Q2.
+- CDC streaming primitive (`#226-8`) — separate runtime primitive, not affected.
+- Cross-tenant provider registry / dynamic provider plugins — explicit YAML keys only.
+
+## Implementation map
+
+| Issue | Lands |
+|---|---|
+| **#226-7 successor** | This ADR; `detection: z.record(...)` schema change; `superRefine` validator (within-file); generated `<entity>-sync-source.module.ts` factory shape per §4–§5; `skip_if` gate fix per §8; baseline snapshot |
+| **ADR-033.2 (parallel)** | Typed `<entity>-sync-source.providers.ts` artifact emission |
+| **ADR-034 (follow-on)** | Project-wide provider registry; tightens this ADR's `superRefine` with a second cross-check |

--- a/docs/adrs/ADR-033.2-typed-provider-artifacts.md
+++ b/docs/adrs/ADR-033.2-typed-provider-artifacts.md
@@ -1,0 +1,105 @@
+# ADR-033.2 — Typed Provider Artifacts
+
+**Status:** Accepted
+**Date:** 2026-04-26
+**Owner:** Doug
+**Related:** ADR-033 (config-driven change sources), ADR-033.1 (provider-keyed `detection:`), ADR-034 (provider registry — forward reference)
+**Tracks:** RFC #241 Part 2; reference consumer [pattern-stack/sales-patterns-ts#60](https://github.com/pattern-stack/sales-patterns-ts/pull/60)
+
+## Context
+
+ADR-033.1 keeps provider names as runtime data — map keys lifted from YAML, never generated TS symbols. That decision is correct for the module emission path: it eliminates per-tuple boilerplate and keeps adding a provider to a one-line YAML edit.
+
+It also leaves a gap. Consumer code that fills `<ENTITY>_POLL_FETCH_REGISTRY` is shaped `Record<string, PollFetchCallback<T>>` — provider keys are arbitrary strings. A typo in the consumer's `useFactory` (`'hubspot-cmr'`) compiles cleanly. A provider added to YAML but forgotten in the consumer registry compiles cleanly. A provider removed from YAML but still referenced in the consumer compiles cleanly. All three failure modes surface at runtime as silent skips ("no changes ever detected from `hubspot-cmr`"), exactly the class of bug the codegen layer was meant to make impossible.
+
+The fix is small: emit a literal-tuple type per entity that has a `detection:` block. Consumers that want type-checked registries opt in by typing their map as `Record<<EntityName>Provider, PollFetchCallback<T>>`. The codegen layer becomes the source of truth; the consumer is checked against it. dbt-style: YAML in, typed artifacts out.
+
+This artifact is emission-independent of ADR-033.1's module file. It can ship before, after, or alongside ADR-033.1 with no ordering dependency. The two share an entity-YAML pass but not an emission path.
+
+## Decision
+
+### 1. One file per entity with a `detection:` block
+
+For each entity whose YAML declares a `detection:` block, codegen emits a sibling file alongside `<entity>-sync-source.module.ts`:
+
+```ts
+// generated: src/modules/.../<entity>-sync-source.providers.ts
+export const OPPORTUNITY_PROVIDERS = ['hubspot-crm', 'salesforce-crm'] as const;
+export type OpportunityProvider = (typeof OPPORTUNITY_PROVIDERS)[number];
+```
+
+The const tuple is ordered by the YAML's `detection:` insertion order (preserved by the YAML parser). Consumers should not depend on order; it is stable across regenerations only because YAML is a flat key list.
+
+### 2. Co-location with the module file
+
+The artifact lives in the same directory as `<entity>-sync-source.module.ts`. They are a generated pair even though their emission templates are independent. Co-location avoids surprising consumers with a second output directory and matches the existing entity-codegen layout where per-entity artifacts cluster together.
+
+### 3. Separate emission template, separate Hygen file
+
+Emission is a distinct Hygen `.ejs.t` template, not an additional export inside the module file's template. Two reasons:
+
+- **Type-only consumption shouldn't drag in NestJS.** A consumer importing `OpportunityProvider` for a CLI script, a frontend type, a shared schema, or test fixtures should not transitively import `@nestjs/common` from the module file. A separate file means a pure-TS import path with zero DI graph dependency.
+- **Independent emission.** ADR-033.1 and this ADR can ship in either order or alongside each other. A folded export couples the two emission paths and contradicts the ADR-033.1 design property "module is one file per entity, not per tuple."
+
+### 4. Minimal surface: tuple + type only
+
+The emitted file exports exactly two symbols:
+
+| Symbol | Type | Purpose |
+|---|---|---|
+| `<ENTITY>_PROVIDERS` | `readonly [string, ...string[]]` (`as const` tuple) | Iteration; runtime-known provider list |
+| `<EntityName>Provider` | `(typeof <ENTITY>_PROVIDERS)[number]` | Compile-time literal-union type |
+
+Promoting the internal `<ENTITY>_DETECTION_CONFIGS` const (declared private in ADR-033.1 §4) to a third public export was considered and deferred — see Open Questions below. The shape stays minimal until a concrete consumer surfaces.
+
+### 5. Zero runtime cost
+
+`as const` produces a literal-tuple type with no runtime overhead beyond the array of strings. No classes, no decorators, no reflective metadata, no module-system side effects.
+
+### 6. Triggering condition
+
+The file is emitted iff the entity YAML contains a `detection:` block (matching ADR-033.1 §8's `skip_if: <%= !hasDetection %>`). Entities with `sync.providers:` but no `detection:` get neither the module nor the providers file — they have no codegen-able detection shape.
+
+## Rationale
+
+- **Separate file over folded.** The type-only-consumption argument is the load-bearing one. Audit-tier UIs (epic #242), `pts sync inspect` CLI, frontend status pages, and test fixtures should be able to import the type without booting NestJS. A folded export forces all of those into a heavier import path.
+- **Tuple + type only (not configs).** Promoting configs is real value (introspection, audit rendering, frontend status surfaces) but every concrete consumer is speculative today. Promoting later is a one-line codegen change; retracting once shipped is a breaking change to consumers. YAGNI applies.
+- **Literal-tuple over enum.** `as const` arrays are idiomatic for codegen-emitted artifacts: they roundtrip through `JSON.stringify`, they're inspectable at runtime without a TS compiler, and they avoid TS enum's known footguns (numeric back-mapping, `const enum` build-tool incompatibility).
+
+## Consequences
+
+**Positive:**
+- Consumer registry maps become typed:
+
+  ```ts
+  useFactory: (hs, sfdc): Record<OpportunityProvider, PollFetchCallback<Opportunity>> => ({
+    'hubspot-crm':    hs.opportunityPollFetch,
+    'salesforce-crm': sfdc.opportunityPollFetch,
+  });
+  ```
+
+  Typo (`'hubspot-cmr'`) → TS error. Adding a provider to YAML and re-running codegen → TS error on the now-incomplete consumer map. Removing a provider from YAML → TS error on the stale entry.
+- Acceptance criteria are testable end-to-end: `bun run typecheck` of the consumer is the test.
+- Independent of ADR-033.1's emission path — can land first, last, or in parallel without coordination beyond the shared YAML pass.
+- Zero runtime cost; tree-shakes to zero for consumers that only use the type.
+
+**Negative / costs:**
+- One additional generated file per entity-with-detection. Mitigation: small (~5 lines), co-located, and only emitted when `detection:` exists.
+- Type-checking enforcement is opt-in. A consumer can keep using `Record<string, PollFetchCallback<T>>` and lose the safety. Mitigation: documentation; not a correctness issue since the runtime contract still works.
+- The artifact is fully derivable from YAML — generating it is a redundant write of information already present. Mitigation: this is the dbt model — codegen redundancy buys consumer ergonomics; the YAML stays the source of truth.
+
+**Out of scope:**
+- Promoting `<ENTITY>_DETECTION_CONFIGS` to a public typed export. Deferred until a concrete consumer (likely candidates: `pts sync inspect` CLI, audit-tier #242 detection-config rendering, frontend admin status pages). Promotion is mechanical when the need surfaces.
+- Cross-entity unified provider type (`AppProvider = OpportunityProvider | ContactProvider | …`). Belongs to ADR-034's project-level registry, not this ADR.
+- Validation that a consumer registry actually covers the type (runtime exhaustiveness check). The TS compiler's exhaustiveness check is sufficient; a runtime check duplicates work the type system already does.
+
+## Open questions for future revisions
+
+1. **Promote `<ENTITY>_DETECTION_CONFIGS`?** When (not if) a consumer needs to read detection configs as data without going through DI — pretty-printing in `pts sync inspect`, rendering in audit-tier UI (epic #242), surfacing in a status page — promote the internal const to a fourth public export typed as `Readonly<Record<<EntityName>Provider, DetectionConfig>>`. Tracked here for future reference; do not preemptively emit.
+2. **`AppProvider` union.** Once ADR-034's registry lands, the registry itself becomes the source of truth for project-wide provider types and a unified `AppProvider` literal-union becomes derivable. This ADR's per-entity types remain useful for entity-scoped consumers but compose into the broader type via the registry.
+
+## Implementation map
+
+| Issue | Lands |
+|---|---|
+| **ADR-033.2 PR** | This ADR; `<entity>-sync-source.providers.ejs.t` Hygen template; trigger condition matching ADR-033.1 §8; baseline snapshot covering single-provider and multi-provider entity fixtures |

--- a/docs/adrs/ADR-034-provider-registry.md
+++ b/docs/adrs/ADR-034-provider-registry.md
@@ -1,0 +1,154 @@
+# ADR-034 — Project-Level Provider Registry
+
+**Status:** Draft
+**Date:** 2026-04-26
+**Owner:** Doug
+**Related:** ADR-033 (config-driven change sources), ADR-033.1 (provider-keyed `detection:` — tightens validation), ADR-031-auth-subsystem, ADR-025 (combiner subsystems), epic #242 (audit-tier)
+**Tracks:** RFC #241 Open Question 1 (within-file vs. project-level provider validation)
+
+## Context
+
+Multiple subsystems independently care about "what external providers is this app connected to":
+
+- **Sync** (ADR-033, ADR-033.1) — entity YAML's `sync.providers:` and `detection:` blocks are keyed by provider name; typos and forgotten registrations are the dominant validation gap (ADR-033.1 §6).
+- **Auth** (ADR-031-auth-subsystem) — OAuth provider configs, redirect URIs, token storage policy are per-provider concerns.
+- **Observability / audit-tier** (ADR-025, epic #242) — bridge metrics, audit events, and lifecycle reporters increasingly need to filter, group, and label by provider.
+- **Webhook ingestion** — inbound webhook routing assigns staging tables and signing-secret resolution per provider.
+
+Today each subsystem declares its provider list locally and there is no shared source of truth. Entity YAML's `sync.providers:` lists provider names against the entity. Auth config (consumer-side, today) lists OAuth providers against the app. Audit reporters synthesize provider lists by scanning sync runs. The information is the same; the storage is duplicated; drift is mechanical.
+
+ADR-033.1 deliberately scopes its provider-name validation to a **within-file** cross-check (entity's `detection:` keys ⊆ entity's `sync.providers:` keys). This catches the practical typo class without inventing new config surface. It does not catch the case where an entity declares a provider that exists nowhere else in the project, and it does not give other subsystems a place to look when they ask the same question.
+
+This ADR introduces a **project-level provider registry** as the single source of truth for "what is this app externally connected to." It is owned by `codegen.config.yaml`, validated at config-load time, and consumed by every subsystem that needs the answer.
+
+## Decision
+
+### 1. Registry lives in `codegen.config.yaml`
+
+A new top-level `providers:` block is added to the project config schema. The block is a `Record<string, ProviderRegistryEntry>` keyed by provider id (the same string used as map keys throughout entity YAML, sync subscriptions, and audit rows).
+
+```yaml
+# codegen.config.yaml
+providers:
+  hubspot-crm:
+    display_name: 'HubSpot CRM'
+    kind: 'crm'
+    auth: 'oauth2'
+    sandbox: false
+  salesforce-crm:
+    display_name: 'Salesforce CRM'
+    kind: 'crm'
+    auth: 'oauth2'
+    sandbox: false
+  stripe:
+    display_name: 'Stripe'
+    kind: 'billing'
+    auth: 'api-key'
+    sandbox: true
+```
+
+### 2. Minimal v1 entry shape
+
+The v1 `ProviderRegistryEntry` schema is deliberately small. Only fields with at least one concrete consumer ship in this ADR; richer metadata is added per-field by follow-on ADRs that introduce the consumer.
+
+```ts
+export const ProviderRegistryEntrySchema = z.object({
+  display_name: z.string().min(1),
+  kind: z.string().min(1),                   // free-form; e.g. 'crm', 'billing', 'comms'
+  auth: z.enum(['oauth2', 'api-key', 'webhook-secret', 'none']),
+  sandbox: z.boolean().optional().default(false),
+});
+
+export const ProviderRegistrySchema = z
+  .record(z.string().regex(/^[a-z0-9][a-z0-9-]*$/), ProviderRegistryEntrySchema);
+```
+
+Provider id format: lowercase, alphanumeric + hyphen, must start with alphanumeric. Matches the de facto shape already used in entity YAML keys.
+
+### 3. Cross-subsystem validation tightens at config-load time
+
+The codegen config loader validates the registry at load time and exposes the parsed registry through the existing `loadConfig()` API. Subsystems consume it as follows:
+
+- **Sync (ADR-033.1 tightening)** — the `superRefine` validator extends with a second loop: every key in an entity's `sync.providers:` must exist in `providers:`. Failure surfaces `pts codegen entity validate` with `Provider 'hubspot-cmr' in entity 'opportunity.sync.providers' is not declared in codegen.config.yaml#/providers`.
+- **Auth** — when ADR-031-auth-subsystem's OAuth config emission lands, OAuth provider configs must reference a registry entry with `auth: 'oauth2'`.
+- **Audit-tier (epic #242)** — provider-faceted reporters consume `Object.keys(providers)` for filter UIs and label vocabularies.
+
+Within-file checks from ADR-033.1 §6 stay in place; the project-level check is additive, not a replacement.
+
+### 4. Registry is configuration-time data, not runtime DI
+
+The registry is parsed at `loadConfig()` time and serialized into codegen output where needed. It is **not** injected as a runtime NestJS provider. Two reasons:
+
+- The registry is YAML config, not application state — the same decision shape as `codegen.config.yaml: paths`, `naming`, etc. Wiring it through NestJS DI would imply the consumer reads it at request time, which is not a use case anyone has.
+- Audit-tier and other consumers that need provider metadata at runtime get it via codegen-emitted typed artifacts (a follow-on to ADR-033.2 — see Open Questions §1), not through DI lookup.
+
+### 5. No runtime registry mutation
+
+The registry is the project's static manifest of external connections. Adding a connection is a YAML edit + regenerate step. Dynamic provider plugins (loading providers at runtime) and cross-tenant registries are explicitly out of scope. If the use case ever surfaces, it will be a separate ADR — the static registry is not the seam to bend for it.
+
+### 6. Per-provider config secrets stay out
+
+The registry holds *identity* and *type* metadata, not *configuration secrets*. OAuth client IDs, API keys, webhook signing secrets, base URLs — these stay in environment variables and are looked up at runtime by subsystem-specific code. Entries in the registry name the providers; secrets are bound by name in the consumer's deployment config.
+
+This matches the existing convention (the codebase has no notion of secrets in YAML config today) and keeps the registry safe to commit, generate from, and surface in audit UIs.
+
+### 7. Forward-references from ADR-033.1 resolve here
+
+ADR-033.1 §6 forward-references this ADR for the project-level cross-check. When this ADR's PR lands:
+
+1. The `superRefine` in `EntityDefinitionSchema` extends with the second loop described in §3.
+2. ADR-033.1 gets an inline note that the project-level check is now active.
+3. Existing entity YAMLs are checked against the new validator; any drift surfaces in `just validate-entities`.
+
+## Rationale
+
+- **Why a separate ADR (not folded into ADR-033.1).** The registry serves auth, observability, audit-tier, and webhook ingestion in addition to sync. Filing the registry under ADR-033.1 would misattribute a project-wide concern to a sync extension. A separate ADR keeps the audit trail honest: future subsystems consuming the registry cite ADR-034, not a sync ADR.
+- **Why minimal v1 entry shape.** Every metadata field the registry might carry (rate limits, retry policies, OAuth scopes, sandbox URLs, regional endpoints) has a plausible argument and zero current consumers. CLAUDE.md "no half-finished implementations" — fields land when the consumer that reads them lands.
+- **Why config-time, not runtime DI.** The registry is a static manifest, parsed once. NestJS DI is the wrong primitive for it; configuration loading is the right primitive. Codegen output bridges the static-to-runtime gap where needed.
+- **Why a record (not an enum).** Same reasoning as ADR-033.1 §7 (`z.record` over `z.enum`) — keeps the schema a static export, avoids factory-schema ripple, keeps error messages readable.
+- **Why no secrets.** Secrets in YAML is a known anti-pattern; the registry stays a manifest, not a credential store.
+
+## Consequences
+
+**Positive:**
+- Single source of truth for "what is this app connected to" — replaces three parallel implicit registries (entity YAML aggregation, auth config, audit synthesis).
+- ADR-033.1's `superRefine` tightens to catch the full provider-typo class. Entity YAML can no longer reference a provider that exists nowhere else in the project.
+- Cross-subsystem features (provider-aware audit reporting, OAuth-config codegen, webhook-secret resolution) get a manifest to consult rather than reinventing one.
+- Provides the seed for a project-wide `AppProvider` literal-union type (ADR-033.2 Open Question 2) — derivable from the registry as a single declaration.
+
+**Negative / costs:**
+- Adds new top-level config surface. Mitigation: minimal v1 schema; new fields land only when a consumer needs them.
+- Existing entity YAMLs must declare every provider in the registry to pass validation. Mitigation: `pts codegen entity validate` flags drift at validate-time; the registry is greenfield (no existing consumer ships with codegen-patterns yet) so the migration cost is zero in-tree and one-time downstream.
+- A second source of truth for provider names exists alongside the entity YAMLs that reference them. Mitigation: that's the point — entity YAMLs become *references* to the registry, not redeclarations. Validation enforces consistency.
+
+**Out of scope:**
+- Per-provider runtime config (OAuth client IDs, base URLs, rate limits) — bound at deployment, not in YAML.
+- Dynamic provider plugins / runtime registry mutation — explicitly rejected per §5.
+- Cross-tenant provider registries — single-app registry only; multi-tenant providers are a per-deployment concern.
+- Migration tooling for consumers transitioning from implicit provider lists to the registry — none ship today.
+- The provider-faceted audit reporting itself (epic #242 owns) — this ADR exposes the registry; #242 consumes it.
+
+## Open questions
+
+1. **Should the registry emit a typed artifact?** A natural follow-on to ADR-033.2 is to emit a project-wide `src/codegen/providers.ts`:
+
+   ```ts
+   export const APP_PROVIDERS = ['hubspot-crm', 'salesforce-crm', 'stripe'] as const;
+   export type AppProvider = (typeof APP_PROVIDERS)[number];
+   export const APP_PROVIDER_REGISTRY: Record<AppProvider, ProviderRegistryEntry> = { ... };
+   ```
+
+   Per-entity `<EntityName>Provider` types from ADR-033.2 would narrow `AppProvider` (`OpportunityProvider extends AppProvider`). Recommend deferring to a follow-on ADR (ADR-034.1?) once a consumer demands cross-entity typed provider access.
+
+2. **Does `kind` need an enum?** v1 is free-form (`'crm'`, `'billing'`, `'comms'`). An enum would tighten validation but pre-commits to a vocabulary. Recommend free-form for v1; tighten if/when a consumer needs the discriminator.
+
+3. **Should the registry support aliases?** Some providers ship under multiple brand names (e.g., HubSpot CRM Hub vs. HubSpot Marketing Hub) but share an OAuth app and SDK. Aliases would let one registry entry back multiple keys. Defer until a real case appears — the easy answer (separate registry entries per key) covers everything we currently see.
+
+## Implementation map
+
+| Issue | Lands |
+|---|---|
+| **ADR-034 PR** | This ADR; `ProviderRegistrySchema` in `src/config/`; `codegen.config.yaml` schema extension; `loadConfig()` returns parsed registry; ADR-033.1 `superRefine` extended with project-level cross-check; `just validate-entities` covers the new check; smoke fixture gains a `providers:` block |
+| **Follow-on (ADR-034.1?)** | Typed `src/codegen/providers.ts` artifact; `AppProvider` union; entity-scoped `<EntityName>Provider` types narrow `AppProvider` |
+| **Audit-tier (#242)** | Provider-faceted reporters consume the registry for filter vocabularies |
+| **Auth (ADR-031-auth-subsystem)** | OAuth config emission references registry entries with `auth: 'oauth2'` |


### PR DESCRIPTION
## Summary

Translates [RFC #241](https://github.com/pattern-stack/codegen-patterns/issues/241) into three locked ADRs covering provider-keyed sync detection and the project-wide provider registry.

- **ADR-033.1** (Accepted) — Provider-keyed `detection:` schema; one module per entity with `<ENTITY>_CHANGE_SOURCES: ReadonlyMap`; within-file `superRefine` validation; mixed mode per provider; drops the `isCleanArchitecture` gate on `sync-source.ejs.t`.
- **ADR-033.2** (Accepted) — `<entity>-sync-source.providers.ts` tuple+type emission; co-located, separate Hygen template, zero runtime cost; opt-in compile-time consumer registry checks.
- **ADR-034** (Draft) — Project-level provider registry in `codegen.config.yaml`; serves sync / auth / audit-tier / observability; tightens 033.1's validator with a project-level cross-check when consumed.

## Decisions captured (RFC #241 open questions)

| Q | Decision | Where |
|---|---|---|
| 1 — within-file vs project-level validation | Within-file in 033.1; project-level deferred to ADR-034 | 033.1 §6, 034 §3 |
| 2 — `z.record` vs `z.enum` for provider keys | `z.record` + `superRefine` (preserves static schema export) | 033.1 §7 |
| 3 — Token shape (Map vs per-tuple symbol) | `<ENTITY>_CHANGE_SOURCES: ReadonlyMap<string, IChangeSource<T>>` | 033.1 §5 |
| 4 — Typed artifact (separate file vs folded) | Separate co-located file; tuple + type only | 033.2 §1–§4 |

## Notes

- ADR-034 lands as **Draft** (consumer subsystems haven't exercised the registry shape yet) — promoted to Accepted when audit-tier (#242) or auth ships against it.
- 033.1 forward-references 034 for the project-level validation tightening; the `superRefine` extends with a second loop in ADR-034's PR.
- Reference consumer: [pattern-stack/sales-patterns-ts#60](https://github.com/pattern-stack/sales-patterns-ts/pull/60) (hand-authored 6 tuples = 3 entities × 2 providers; deleted in follow-up once codegen lands).

## Test plan

- [ ] ADRs render correctly on GitHub (markdown tables, code fences)
- [ ] Cross-references between 033, 033.1, 033.2, 034 resolve
- [ ] No code changes — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)