### PR TITLE
feat(schema): provider-keyed detection (#233 / ADR-033.1 a)

### DIFF
--- a/src/__tests__/schema/detection-block.test.ts
+++ b/src/__tests__/schema/detection-block.test.ts
@@ -1,10 +1,12 @@
 /**
- * Tests for the entity-YAML `detection:` block (#226-6).
+ * Tests for the entity-YAML `detection:` block (ADR-033.1).
  *
- * Validates that `EntityDefinitionSchema` accepts an optional `detection`
- * field, parsed by the canonical `DetectionConfigSchema` re-exported from
- * `runtime/subsystems/sync`. No template/codegen emission yet — schema
- * validation only.
+ * `detection:` is a Record<provider, DetectionConfig>. The inner config
+ * shape is owned by `runtime/subsystems/sync/detection-config.schema.ts`
+ * (covered by its own tests). This file covers:
+ *   - the record wrapper accepts single- and multi-provider maps,
+ *   - the within-file superRefine cross-checks `detection:` keys against
+ *     `sync.providers` keys per ADR-033.1 §6.
  */
 
 import { describe, it, expect } from 'bun:test';
@@ -12,158 +14,109 @@ import { EntityDefinitionSchema } from '../../schema/entity-definition.schema';
 import { loadEntityFromYaml } from '../../utils/yaml-loader';
 import { resolve } from 'path';
 
-describe('detection block (#226-6)', () => {
-	const base = {
-		entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities' },
-		fields: { name: { type: 'string', required: true } },
-	};
+const base = {
+	entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities' },
+	fields: { name: { type: 'string', required: true } },
+};
 
+const hubspotDetection = {
+	mode: 'poll' as const,
+	poll: { cursor: { kind: 'timestamp' as const, field: 'hs_lastmodifieddate' } },
+	mapping: [{ source: 'dealname', target: 'name' }],
+	filters: [{ field: 'pipeline', op: 'neq' as const, value: 'archived' }],
+};
+
+const salesforceDetection = {
+	mode: 'poll' as const,
+	poll: { cursor: { kind: 'systemModstamp' as const, field: 'SystemModstamp' } },
+	mapping: [{ source: 'Name', target: 'name' }],
+	filters: [{ field: 'IsDeleted', op: 'eq' as const, value: false }],
+};
+
+const providers = {
+	'hubspot-crm': { remote_entity: 'deal', direction: 'inbound' as const },
+	'salesforce-crm': { remote_entity: 'Opportunity', direction: 'inbound' as const },
+};
+
+describe('detection block (ADR-033.1)', () => {
 	it('detection is optional', () => {
 		const result = EntityDefinitionSchema.safeParse(base);
 		expect(result.success).toBe(true);
 		expect(result.data!.detection).toBeUndefined();
 	});
 
-	it('accepts a minimal poll-mode detection block', () => {
+	it('accepts a single-provider one-key map', () => {
 		const result = EntityDefinitionSchema.safeParse({
 			...base,
-			detection: {
-				mode: 'poll',
-				poll: {
-					cursor: { kind: 'systemModstamp', field: 'SystemModstamp' },
-				},
-				mapping: [{ source: 'Name', target: 'name' }],
-			},
+			sync: { providers: { 'hubspot-crm': providers['hubspot-crm'] } },
+			detection: { 'hubspot-crm': hubspotDetection },
 		});
 		expect(result.success).toBe(true);
-		expect(result.data!.detection!.mode).toBe('poll');
+		expect(Object.keys(result.data!.detection!)).toEqual(['hubspot-crm']);
+		expect(result.data!.detection!['hubspot-crm']!.mode).toBe('poll');
 	});
 
-	it('accepts poll mode with provenance: cdc and filters', () => {
+	it('accepts a multi-provider map with independent configs', () => {
 		const result = EntityDefinitionSchema.safeParse({
 			...base,
+			sync: { providers },
 			detection: {
-				mode: 'poll',
-				poll: {
-					cursor: { kind: 'eventId', field: 'id' },
-					provenance: 'cdc',
-				},
-				mapping: [
-					{ source: 'Name', target: 'name' },
-					{ source: 'Amount', target: 'amount', transform: 'decimal-string' },
-				],
-				filters: [
-					{ field: 'StageName', op: 'neq', value: 'Closed Lost' },
-					{ field: 'OwnerId', op: 'in', value: ['a', 'b'] },
-				],
+				'hubspot-crm': hubspotDetection,
+				'salesforce-crm': salesforceDetection,
 			},
 		});
 		expect(result.success).toBe(true);
 		const detection = result.data!.detection!;
-		expect(detection.mode).toBe('poll');
-		if (detection.mode === 'poll') {
-			expect(detection.poll.provenance).toBe('cdc');
-			expect(detection.filters).toHaveLength(2);
-		}
+		expect(Object.keys(detection).sort()).toEqual(['hubspot-crm', 'salesforce-crm']);
+		const hub = detection['hubspot-crm']!;
+		const sf = detection['salesforce-crm']!;
+		if (hub.mode === 'poll') expect(hub.poll.cursor.kind).toBe('timestamp');
+		if (sf.mode === 'poll') expect(sf.poll.cursor.kind).toBe('systemModstamp');
 	});
 
-	it('accepts a webhook-mode detection block', () => {
+	it('rejects a detection key that is not declared in sync.providers', () => {
 		const result = EntityDefinitionSchema.safeParse({
 			...base,
-			detection: {
-				mode: 'webhook',
-				webhook: { eventIdField: 'event_id' },
-				mapping: [{ source: 'name', target: 'name' }],
-			},
-		});
-		expect(result.success).toBe(true);
-		expect(result.data!.detection!.mode).toBe('webhook');
-	});
-
-	it('rejects an unknown detection mode', () => {
-		const result = EntityDefinitionSchema.safeParse({
-			...base,
-			detection: {
-				mode: 'cdc',
-				mapping: [{ source: 'Name', target: 'name' }],
-			},
+			sync: { providers: { 'hubspot-crm': providers['hubspot-crm'] } },
+			detection: { 'hubspot-cmr': hubspotDetection },
 		});
 		expect(result.success).toBe(false);
+		if (result.success) return;
+		const issue = result.error.issues.find((i) => i.path.join('.') === 'detection.hubspot-cmr');
+		expect(issue).toBeDefined();
+		expect(issue!.path).toEqual(['detection', 'hubspot-cmr']);
+		expect(issue!.message).toBe(
+			"Provider 'hubspot-cmr' used in detection: but not declared in sync.providers. Known providers: hubspot-crm",
+		);
 	});
 
-	it('rejects a poll block missing the cursor strategy', () => {
+	it('rejects detection when sync.providers is missing entirely', () => {
 		const result = EntityDefinitionSchema.safeParse({
 			...base,
-			detection: {
-				mode: 'poll',
-				poll: {},
-				mapping: [{ source: 'Name', target: 'name' }],
-			},
+			detection: { 'hubspot-crm': hubspotDetection },
 		});
 		expect(result.success).toBe(false);
+		if (result.success) return;
+		const issue = result.error.issues.find((i) => i.path.join('.') === 'detection.hubspot-crm');
+		expect(issue).toBeDefined();
+		expect(issue!.message).toBe(
+			"Provider 'hubspot-crm' used in detection: but not declared in sync.providers. Known providers: ",
+		);
 	});
 
-	it('rejects an unknown cursor kind', () => {
-		const result = EntityDefinitionSchema.safeParse({
-			...base,
-			detection: {
-				mode: 'poll',
-				poll: { cursor: { kind: 'bogus', field: 'x' } },
-				mapping: [{ source: 'Name', target: 'name' }],
-			},
-		});
-		expect(result.success).toBe(false);
-	});
-
-	it('rejects an empty mapping array', () => {
-		const result = EntityDefinitionSchema.safeParse({
-			...base,
-			detection: {
-				mode: 'poll',
-				poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } },
-				mapping: [],
-			},
-		});
-		expect(result.success).toBe(false);
-	});
-
-	it('rejects a filter with an unknown op', () => {
-		const result = EntityDefinitionSchema.safeParse({
-			...base,
-			detection: {
-				mode: 'poll',
-				poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } },
-				mapping: [{ source: 'Name', target: 'name' }],
-				filters: [{ field: 'x', op: 'like', value: 'y' }],
-			},
-		});
-		expect(result.success).toBe(false);
-	});
-
-	it('rejects webhook mode without eventIdField', () => {
-		const result = EntityDefinitionSchema.safeParse({
-			...base,
-			detection: {
-				mode: 'webhook',
-				webhook: {},
-				mapping: [{ source: 'name', target: 'name' }],
-			},
-		});
-		expect(result.success).toBe(false);
-	});
-
-	it('parses the opportunity fixture YAML containing a detection block', () => {
+	it('parses the opportunity fixture YAML with a multi-provider detection block', () => {
 		const yamlPath = resolve(__dirname, '../../../test/fixtures/opportunity.yaml');
 		const result = loadEntityFromYaml(yamlPath);
 		expect(result.success).toBe(true);
 		if (!result.success) return;
 		const definition = result.definition;
 		expect(definition.detection).toBeDefined();
-		expect(definition.detection!.mode).toBe('poll');
-		if (definition.detection!.mode === 'poll') {
-			expect(definition.detection!.poll.cursor.kind).toBe('systemModstamp');
-			expect(definition.detection!.mapping.length).toBeGreaterThan(0);
-			expect(definition.detection!.filters.length).toBeGreaterThan(0);
+		expect(Object.keys(definition.detection!).sort()).toEqual(['hubspot-crm', 'salesforce-crm']);
+		const sf = definition.detection!['salesforce-crm']!;
+		if (sf.mode === 'poll') {
+			expect(sf.poll.cursor.kind).toBe('systemModstamp');
+			expect(sf.mapping.length).toBeGreaterThan(0);
+			expect(sf.filters.length).toBeGreaterThan(0);
 		}
 	});
 });

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -793,18 +793,19 @@ export const EntityDefinitionSchema = z
     // Electric SQL + provider sync (Salesforce, HubSpot, etc.)
     sync: SyncConfigSchema.optional(),
 
-    // #226-6: Config-driven change-source detection (ADR-033).
+    // ADR-033.1: Provider-keyed change-source detection.
     //
-    // Declarative detection config consumed by the runtime change-source
-    // primitives (`PollChangeSource<T>` / `WebhookChangeSource<T>`) and by
-    // the per-entity factory module emitted by Phase 2 codegen (#226-7).
-    // The Zod schema is the canonical source of filter / mapping / cursor
-    // shape and is imported from `runtime/subsystems/sync` so this
-    // validator and the runtime parser stay in lockstep — drift between
-    // the two sites must be a compile error, not a runtime mismatch.
+    // Map of provider name → DetectionConfig. Single-provider entities use
+    // a one-key map; multi-provider entities list each provider as a
+    // separate key. Each value is an independent `DetectionConfig` (its
+    // own mode/cursor/mapping/filters) sourced from the canonical schema
+    // in `runtime/subsystems/sync` so this validator and the runtime
+    // parser stay in lockstep.
     //
-    // Optional and additive: existing entity YAMLs are unaffected.
-    detection: DetectionConfigSchema.optional(),
+    // Within-file cross-check (ADR-033.1 §6): every key here must also
+    // appear in `sync.providers` — see the superRefine on
+    // `EntityDefinitionSchema` below.
+    detection: z.record(z.string(), DetectionConfigSchema).optional(),
 
     // v2: Domain event declarations (CODEGEN-EVOLUTION-PLAN Phase 2)
     // Generates typed event classes, handlers, and queue registration
@@ -842,7 +843,20 @@ export const EntityDefinitionSchema = z
         "(e.g. `eav_definition_table: 'field_definition'`).",
       path: ['eav_definition_table'],
     },
-  );
+  )
+  .superRefine((entity, ctx) => {
+    if (!entity.detection) return;
+    const declared = new Set(Object.keys(entity.sync?.providers ?? {}));
+    for (const provider of Object.keys(entity.detection)) {
+      if (!declared.has(provider)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['detection', provider],
+          message: `Provider '${provider}' used in detection: but not declared in sync.providers. Known providers: ${[...declared].join(', ')}`,
+        });
+      }
+    }
+  });
 
 export type EntityDefinition = z.infer<typeof EntityDefinitionSchema>;
 

--- a/test/fixtures/opportunity.yaml
+++ b/test/fixtures/opportunity.yaml
@@ -75,30 +75,62 @@ relationships:
     target: deal_state
     foreign_key: state_id
 
-# Config-driven change-source detection (#226-6, ADR-033).
-# Schema-validated by the canonical DetectionConfigSchema from
-# runtime/subsystems/sync. No codegen emission yet — that lands in #226-7.
+sync:
+  providers:
+    hubspot-crm:
+      remote_entity: deal
+      direction: inbound
+    salesforce-crm:
+      remote_entity: Opportunity
+      direction: inbound
+
+# Provider-keyed change-source detection (ADR-033.1).
+# Each provider is an independent DetectionConfig. Cross-checked against
+# sync.providers above by EntityDefinitionSchema.superRefine.
 detection:
-  mode: poll
-  poll:
-    cursor:
-      kind: systemModstamp
-      field: SystemModstamp
-  mapping:
-    - source: Name
-      target: name
-    - source: Amount
-      target: amount
-      transform: decimal-string
-    - source: CloseDate
-      target: expected_close_date
-      transform: date-iso
-    - source: OwnerId
-      target: owner_id
-  filters:
-    - field: IsDeleted
-      op: eq
-      value: false
-    - field: StageName
-      op: neq
-      value: "Closed Lost"
+  hubspot-crm:
+    mode: poll
+    poll:
+      cursor:
+        kind: timestamp
+        field: hs_lastmodifieddate
+    mapping:
+      - source: dealname
+        target: name
+      - source: amount
+        target: amount
+        transform: decimal-string
+      - source: closedate
+        target: expected_close_date
+        transform: date-iso
+      - source: hubspot_owner_id
+        target: owner_id
+    filters:
+      - field: pipeline
+        op: neq
+        value: archived
+
+  salesforce-crm:
+    mode: poll
+    poll:
+      cursor:
+        kind: systemModstamp
+        field: SystemModstamp
+    mapping:
+      - source: Name
+        target: name
+      - source: Amount
+        target: amount
+        transform: decimal-string
+      - source: CloseDate
+        target: expected_close_date
+        transform: date-iso
+      - source: OwnerId
+        target: owner_id
+    filters:
+      - field: IsDeleted
+        op: eq
+        value: false
+      - field: StageName
+        op: neq
+        value: "Closed Lost"


### PR DESCRIPTION
Implements ADR-033.1 part (a): provider-keyed `detection:` schema + within-file validator. First mergeable slice of epic #254.

Closes #233. References ADR-033.1, RFC #241.

## Summary
- `detection:` is now `z.record(z.string(), DetectionConfigSchema).optional()` (was a single `DetectionConfigSchema`). The inner schema in `runtime/subsystems/sync/detection-config.schema.ts` is untouched — provider identity is YAML-key structure, not a new field.
- New `EntityDefinitionSchema.superRefine` enforces `detection:` keys ⊆ `sync.providers` keys per ADR-033.1 §6, with the spec'd message format.
- `test/fixtures/opportunity.yaml` rewritten to a realistic multi-provider shape (`hubspot-crm` + `salesforce-crm`) with matching `sync.providers` — feeds the downstream baseline work in #251 / #252.

Per CLAUDE.md "no backwards compat," the previous scalar `detection:` shape is deleted, not preserved in parallel.

## Test plan
- [x] `bun test src/__tests__/schema/detection-block.test.ts` — 6 tests pass
  - single-provider one-key map parses
  - multi-provider map parses with independent `mode`/`cursor`/`mapping`/`filters` per provider
  - `superRefine` rejects `detection.hubspot-cmr` against `sync.providers.hubspot-crm` with `path: ['detection', 'hubspot-cmr']` and the exact ADR message
  - `superRefine` rejects when `sync.providers` is missing entirely (empty known-list)
  - `opportunity.yaml` fixture loads with both providers under `detection`
- [x] `just test-unit` (full suite) green; one observed flake in `cli/subsystem.test.ts` (temp-dir race in sync-install test) reproduces on rerun-pass and is unrelated to schema work.
- [x] `bun run src/cli/index.ts entity validate test/fixtures/` — `opportunity` validates cleanly; pre-existing failures are unrelated `codegen.config.*.yaml` files in the fixture dir.

## Out of scope (deferred)
- Runtime `buildChangeSource()` factory (#251 / NEW-A)
- Codegen template emission (#252 / NEW-B)
- Project-wide provider registry cross-check (NEW-D / ADR-034)
- Typed provider artifacts (NEW-C / ADR-033.2)