### PR TITLE
feat(sync): buildChangeSource() factory (#250 / ADR-033.1 b)

### DIFF
--- a/runtime/subsystems/sync/build-change-source.ts
+++ b/runtime/subsystems/sync/build-change-source.ts
@@ -1,0 +1,42 @@
+/**
+ * Sync subsystem — `buildChangeSource()` runtime factory (#250, ADR-033.1 b).
+ *
+ * Mode-dispatching constructor for `IChangeSource<T>`. Codegen-emitted
+ * provider modules call this from `useFactory` once they've resolved the
+ * provider-keyed `fetches[provider]` callback and parsed the per-entity
+ * `DetectionConfig`. Switching is on `cfg.mode` so the option-bag shape
+ * difference between primitives (`adapter` vs. `queue`) stays internal —
+ * consumers pass one fetch callback regardless of mode.
+ */
+import type { DetectionConfig } from './detection-config.schema';
+import type { IChangeSource } from './sync-change-source.protocol';
+import type { ChangeMiddleware } from './sync-middleware.protocol';
+import {
+  PollChangeSource,
+  type PollFetchCallback,
+} from './poll-change-source';
+import {
+  WebhookChangeSource,
+  type WebhookFetchCallback,
+} from './webhook-change-source';
+
+export function buildChangeSource<T>(
+  cfg: DetectionConfig,
+  fetch: PollFetchCallback<T> | WebhookFetchCallback<T>,
+  middlewares: ReadonlyArray<ChangeMiddleware<T>> = [],
+): IChangeSource<T> {
+  switch (cfg.mode) {
+    case 'poll':
+      return new PollChangeSource<T>({
+        adapter: fetch as PollFetchCallback<T>,
+        config: cfg,
+        middlewares,
+      });
+    case 'webhook':
+      return new WebhookChangeSource<T>({
+        queue: fetch as WebhookFetchCallback<T>,
+        config: cfg,
+        middlewares,
+      });
+  }
+}

--- a/runtime/subsystems/sync/index.ts
+++ b/runtime/subsystems/sync/index.ts
@@ -94,6 +94,10 @@ export {
   type WebhookFetchContext,
 } from './webhook-change-source';
 
+// buildChangeSource (#250, ADR-033.1 b) — mode-dispatching factory consumed
+// by codegen-emitted provider modules' `useFactory` wiring
+export { buildChangeSource } from './build-change-source';
+
 // Tokens
 export {
   SYNC_CHANGE_SOURCE,

--- a/src/__tests__/runtime/subsystems/build-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/build-change-source.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * buildChangeSource() unit tests (#250, ADR-033.1 b)
+ *
+ * Validates the mode-dispatching factory:
+ *   - poll cfg → instanceof PollChangeSource
+ *   - webhook cfg → instanceof WebhookChangeSource
+ *   - middlewares array threaded into the constructed primitive
+ *   - default empty middlewares is fine
+ *   - import resolves via the sync barrel (no deep path)
+ */
+import { describe, expect, it } from 'bun:test';
+import {
+  buildChangeSource,
+  PollChangeSource,
+  WebhookChangeSource,
+  type ChangeMiddleware,
+  type DetectionConfig,
+  type PollFetchCallback,
+  type WebhookFetchCallback,
+} from '../../../../runtime/subsystems/sync';
+import type {
+  Change,
+  SyncSubscriptionView,
+} from '../../../../runtime/subsystems/sync/sync-change-source.protocol';
+
+interface PollRecord {
+  external_id: string;
+  modstamp: string;
+}
+
+interface WebhookRecord {
+  external_id: string;
+  event_id: string;
+}
+
+const subscription: SyncSubscriptionView = {
+  id: 'sub-1',
+  domain: 'opportunity',
+  externalRef: 'sf-org-A',
+};
+
+function pollConfig(): DetectionConfig {
+  return {
+    mode: 'poll',
+    poll: { cursor: { kind: 'systemModstamp', field: 'modstamp' } },
+    mapping: [{ source: 'Id', target: 'external_id' }],
+    filters: [],
+  } as DetectionConfig;
+}
+
+function webhookConfig(): DetectionConfig {
+  return {
+    mode: 'webhook',
+    webhook: { eventIdField: 'event_id' },
+    mapping: [{ source: 'id', target: 'external_id' }],
+    filters: [],
+  } as DetectionConfig;
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const x of it) out.push(x);
+  return out;
+}
+
+describe('buildChangeSource — mode dispatch', () => {
+  it('returns a PollChangeSource for mode: poll', () => {
+    const fetch: PollFetchCallback<PollRecord> = async function* () {
+      // empty
+    };
+    const src = buildChangeSource<PollRecord>(pollConfig(), fetch);
+    expect(src).toBeInstanceOf(PollChangeSource);
+  });
+
+  it('returns a WebhookChangeSource for mode: webhook', () => {
+    const fetch: WebhookFetchCallback<WebhookRecord> = async function* () {
+      // empty
+    };
+    const src = buildChangeSource<WebhookRecord>(webhookConfig(), fetch);
+    expect(src).toBeInstanceOf(WebhookChangeSource);
+  });
+
+  it('accepts a default empty middlewares array', async () => {
+    const fetch: PollFetchCallback<PollRecord> = async function* () {
+      yield {
+        record: { external_id: 'opp-1', modstamp: '2025-01-01T00:00:00Z' },
+        cursor: { ts: '2025-01-01T00:00:00Z' },
+      };
+    };
+    const src = buildChangeSource<PollRecord>(pollConfig(), fetch);
+    const changes = await collect(src.listChanges(subscription, null));
+    expect(changes).toHaveLength(1);
+    expect(changes[0]!.externalId).toBe('opp-1');
+  });
+});
+
+describe('buildChangeSource — middleware threading', () => {
+  it('threads middlewares into the poll primitive (observed via stream)', async () => {
+    const calls: string[] = [];
+    const tagging: ChangeMiddleware<PollRecord> = (next) =>
+      async function* (sub, cur) {
+        calls.push('mw-in');
+        for await (const change of next(sub, cur)) {
+          calls.push('mw-out');
+          yield change;
+        }
+      };
+    const fetch: PollFetchCallback<PollRecord> = async function* () {
+      yield {
+        record: { external_id: 'opp-1', modstamp: '2025-01-01T00:00:00Z' },
+        cursor: { ts: '2025-01-01T00:00:00Z' },
+      };
+    };
+    const src = buildChangeSource<PollRecord>(pollConfig(), fetch, [tagging]);
+    const changes = await collect(src.listChanges(subscription, null));
+    expect(changes).toHaveLength(1);
+    expect(calls).toEqual(['mw-in', 'mw-out']);
+  });
+
+  it('threads middlewares into the webhook primitive (observed via stream)', async () => {
+    const calls: string[] = [];
+    const filtering: ChangeMiddleware<WebhookRecord> = (next) =>
+      async function* (sub, cur) {
+        calls.push('mw-in');
+        for await (const change of next(sub, cur)) {
+          calls.push('mw-out');
+          yield change;
+        }
+      };
+    const fetch: WebhookFetchCallback<WebhookRecord> = async function* () {
+      yield {
+        record: { external_id: 'opp-1', event_id: 'evt-1' },
+      };
+    };
+    const src = buildChangeSource<WebhookRecord>(webhookConfig(), fetch, [
+      filtering,
+    ]);
+    const changes = await collect(src.listChanges(subscription, null));
+    expect(changes).toHaveLength(1);
+    expect(changes[0]!.dedupKey).toBe('evt-1');
+    expect(calls).toEqual(['mw-in', 'mw-out']);
+  });
+
+  it('composes multiple middlewares outermost-first', async () => {
+    const order: string[] = [];
+    const a: ChangeMiddleware<PollRecord> = (next) =>
+      async function* (sub, cur) {
+        order.push('a-in');
+        yield* next(sub, cur);
+      };
+    const b: ChangeMiddleware<PollRecord> = (next) =>
+      async function* (sub, cur) {
+        order.push('b-in');
+        yield* next(sub, cur);
+      };
+    const fetch: PollFetchCallback<PollRecord> = async function* () {
+      // empty
+    };
+    const src = buildChangeSource<PollRecord>(pollConfig(), fetch, [a, b]);
+    await collect(src.listChanges(subscription, null));
+    expect(order).toEqual(['a-in', 'b-in']);
+  });
+});


### PR DESCRIPTION
## Summary

- New `buildChangeSource<T>(cfg, fetch, middlewares?)` runtime factory that dispatches on `cfg.mode` and constructs the appropriate `IChangeSource<T>` primitive (`PollChangeSource` for `'poll'`, `WebhookChangeSource` for `'webhook'`), forwarding the consumer-supplied fetch callback to each primitive's option-bag (`adapter` for poll, `queue` for webhook) and threading the middleware chain through unchanged.
- Barrel-exported from `runtime/subsystems/sync` so codegen-emitted provider modules can consume it from a single import in their `useFactory` wiring per ADR-033.1 §4.
- No changes to `PollChangeSource` / `WebhookChangeSource` themselves.

Closes #250. Part of epic #254 (ADR-033.1 — provider-keyed detection).

## Test plan

- [x] `mise exec -- bun test src/__tests__/runtime/subsystems/build-change-source.spec.ts` — 6/6 pass
- [x] `mise exec -- bun test src/__tests__/` — 1631/1631 pass
- [x] `instanceof PollChangeSource` for `mode: 'poll'`
- [x] `instanceof WebhookChangeSource` for `mode: 'webhook'`
- [x] middlewares array threaded into both primitives (verified by behavior — `mw-in` / `mw-out` markers fire when the iterator drains)
- [x] default empty middlewares works (no middleware-related errors when omitted)
- [x] tests import via the sync barrel (no deep path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)