### PR TITLE
feat(events): codegen emits tier; audit-trigger codegen error (#245)

### DIFF
--- a/.claude/skills/events/event-codegen.md
+++ b/.claude/skills/events/event-codegen.md
@@ -114,7 +114,15 @@ payload:
 
 **What the generator stamps for audit events:** registry entry has `pool: null, direction: null`. Typed facade writes `metadata.pool = null, metadata.direction = null`. First-class columns (when shipped) land as NULL. Observability viewer renders no pool chip — correct, because there is no pool.
 
-**Bridge enforcement:** a job YAML that declares `triggers: [crm_sync_completed]` when `crm_sync_completed` is `tier: audit` MUST fail codegen. Error: `Job 'xyz' triggers on audit-tier event 'crm_sync_completed'. Audit events are not bridge-eligible. Use a domain event, or remove the trigger.`
+**Codegen errors (AUDIT-2 — three hard-error paths):**
+
+1. `tier: 'audit'` + `pool: <X>` →
+   `Event '<type>' is tier:audit; pool MUST be omitted (got '<X>'). Audit events have no pool. See ai-docs/specs/issue-242/plan.md §AUDIT-2.`
+   Source: `EventDefinitionSchema` superRefine in `src/schema/event-definition.schema.ts`.
+2. `tier: 'audit'` + `direction: <X>` → analogous wording for `direction`.
+3. A `@JobHandler('<jobType>', { triggers: [...] })` that points at an audit-tier event →
+   `AuditEventTriggerError: @JobHandler('<jobType>') trigger '<triggerId>' references audit-tier event '<eventType>'. Audit events are not bridge-eligible. Use a domain event, or remove the trigger.`
+   Source: `validateNoAuditTriggers` in `src/cli/shared/bridge-registry-generator.ts`. Reads `tier` from the emitted events `registry.ts`; runs after `validateAgainstEventRegistry`.
 
 **Use when:**
 - Polling/sync lifecycle events (`*_sync_started`, `*_sync_completed`, `*_sync_failed`)

--- a/docs/specs/EVT-3.md
+++ b/docs/specs/EVT-3.md
@@ -214,3 +214,16 @@ All resolved 2026-04-20 — see `docs/specs/EVT-phase-1-issues.md` §Resolved Qu
 - `docs/specs/events-codegen-plan.md` §2 — original artifact designs (superseded by ADR-024)
 - `docs/specs/JOB-7.md` — `ScopeEntityType` generator as a simpler analog
 - `runtime/subsystems/events/event-bus.protocol.ts` — `DomainEvent` shape imported by generated types
+
+## Revision — 2026-04-26 (AUDIT-2)
+
+The codegen contract gains **audit-tier validation**. Generator and bridge-generator now surface three hard errors with templated messages (see `ai-docs/specs/issue-242/plan.md` §AUDIT-2):
+
+1. `tier: 'audit'` with a `pool` field — `EventDefinitionSchema` rejects with
+   `Event '<type>' is tier:audit; pool MUST be omitted (got '<X>'). Audit events have no pool. See ai-docs/specs/issue-242/plan.md §AUDIT-2.`
+2. `tier: 'audit'` with a `direction` field — analogous wording.
+3. `@JobHandler('<jobType>')` trigger referencing an audit-tier event — `bridge-registry-generator` raises `AuditEventTriggerError`.
+
+The emitted `registry.ts` interface widens accordingly: every entry has `tier: 'domain' | 'audit'`; `direction` and `pool` are now `... | null` to accommodate audit entries whose registry rows are emitted as `direction: null, pool: null`. Domain entries are unchanged in shape (string literals).
+
+Implementation: `src/cli/shared/event-codegen-generator.ts` (`buildRegistryContent`, `REGISTRY_INTERFACE`), `src/cli/shared/bridge-registry-generator.ts` (`AuditEventTriggerError`, `readEventTiers`, `validateNoAuditTriggers`), `src/schema/event-definition.schema.ts` (refinement messages).

--- a/runtime/subsystems/events/generated/registry.ts
+++ b/runtime/subsystems/events/generated/registry.ts
@@ -6,8 +6,9 @@ import type { EventTypeName } from './types';
 
 export interface EventMetadata {
 	type: EventTypeName;
-	direction: 'inbound' | 'change' | 'outbound';
-	pool: 'events_inbound' | 'events_change' | 'events_outbound';
+	tier: 'domain' | 'audit';
+	direction: 'inbound' | 'change' | 'outbound' | null;
+	pool: 'events_inbound' | 'events_change' | 'events_outbound' | null;
 	aggregate?: string;
 	source?: string;
 	destination?: string;
@@ -18,6 +19,7 @@ export interface EventMetadata {
 export const eventRegistry = {
 	'contact_created': {
 		type: 'contact_created',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'contact',
@@ -26,6 +28,7 @@ export const eventRegistry = {
 	},
 	'contact_marked_champion': {
 		type: 'contact_marked_champion',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'contact',
@@ -34,14 +37,24 @@ export const eventRegistry = {
 	},
 	'contact_merged': {
 		type: 'contact_merged',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'contact',
 		version: 1,
 		retry: { attempts: 3, backoff: 'exponential' },
 	},
+	'crm_sync_started': {
+		type: 'crm_sync_started',
+		tier: 'audit',
+		direction: null,
+		pool: null,
+		version: 1,
+		retry: { attempts: 3, backoff: 'exponential' },
+	},
 	'deal_created': {
 		type: 'deal_created',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'deal',
@@ -50,6 +63,7 @@ export const eventRegistry = {
 	},
 	'deal_stage_changed': {
 		type: 'deal_stage_changed',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'deal',
@@ -58,6 +72,7 @@ export const eventRegistry = {
 	},
 	'stripe_payment_received': {
 		type: 'stripe_payment_received',
+		tier: 'domain',
 		direction: 'inbound',
 		pool: 'events_inbound',
 		source: 'stripe',
@@ -66,6 +81,7 @@ export const eventRegistry = {
 	},
 	'webhook_outbound_contact_sync': {
 		type: 'webhook_outbound_contact_sync',
+		tier: 'domain',
 		direction: 'outbound',
 		pool: 'events_outbound',
 		aggregate: 'contact',

--- a/runtime/subsystems/events/generated/schemas.ts
+++ b/runtime/subsystems/events/generated/schemas.ts
@@ -22,6 +22,11 @@ export const contactMergedPayloadSchema = z.object({
 	targetId: z.string().uuid(),
 }).strict();
 
+export const crmSyncStartedPayloadSchema = z.object({
+	runId: z.string().uuid(),
+	source: z.string(),
+}).strict();
+
 export const dealCreatedPayloadSchema = z.object({
 	accountId: z.string().uuid(),
 	dealId: z.string().uuid(),
@@ -52,6 +57,7 @@ export const eventPayloadSchemas = {
 	'contact_created': contactCreatedPayloadSchema,
 	'contact_marked_champion': contactMarkedChampionPayloadSchema,
 	'contact_merged': contactMergedPayloadSchema,
+	'crm_sync_started': crmSyncStartedPayloadSchema,
 	'deal_created': dealCreatedPayloadSchema,
 	'deal_stage_changed': dealStageChangedPayloadSchema,
 	'stripe_payment_received': stripePaymentReceivedPayloadSchema,

--- a/runtime/subsystems/events/generated/types.ts
+++ b/runtime/subsystems/events/generated/types.ts
@@ -34,6 +34,16 @@ export interface ContactMergedEvent extends DomainEvent {
 	};
 }
 
+/** A CRM sync run kicked off (audit/observational, not bridge-eligible). */
+export interface CrmSyncStartedEvent extends DomainEvent {
+	readonly type: 'crm_sync_started';
+	readonly aggregateType: 'crm_sync_started';
+	readonly payload: {
+		runId: string;
+		source: string;
+	};
+}
+
 export interface DealCreatedEvent extends DomainEvent {
 	readonly type: 'deal_created';
 	readonly aggregateType: 'deal';
@@ -84,6 +94,7 @@ export type AppDomainEvent =
 	| ContactCreatedEvent
 	| ContactMarkedChampionEvent
 	| ContactMergedEvent
+	| CrmSyncStartedEvent
 	| DealCreatedEvent
 	| DealStageChangedEvent
 	| StripePaymentReceivedEvent

--- a/src/__tests__/cli/bridge-registry-generator.test.ts
+++ b/src/__tests__/cli/bridge-registry-generator.test.ts
@@ -17,9 +17,12 @@ import {
   generateBridgeRegistry,
   readKnownEventTypes,
   scanHandlerFiles,
+  AuditEventTriggerError,
   DuplicateTriggerError,
   UnknownTriggerEventError,
+  readEventTiers,
   validateAgainstEventRegistry,
+  validateNoAuditTriggers,
   validateNoDuplicateTriggers,
   type ScannedTrigger,
 } from '../../cli/shared/bridge-registry-generator';
@@ -38,14 +41,21 @@ function writeHandler(dir: string, file: string, content: string): string {
   return full;
 }
 
-function writeEventsRegistry(dir: string, eventTypes: string[]): string {
+function writeEventsRegistry(
+  dir: string,
+  eventTypes: Array<string | { type: string; tier: 'domain' | 'audit' }>,
+): string {
   const generatedDir = path.join(dir, 'events/generated');
   fs.mkdirSync(generatedDir, { recursive: true });
+  const entries = eventTypes.map((e) => {
+    const obj = typeof e === 'string' ? { type: e, tier: 'domain' as const } : e;
+    return `\t'${obj.type}': {\n\t\ttype: '${obj.type}',\n\t\ttier: '${obj.tier}',\n\t},`;
+  });
   const lines: string[] = [
     "// AUTO-GENERATED",
     "import type { EventTypeName } from './types';",
     'export const eventRegistry = {',
-    ...eventTypes.map((t) => `\t'${t}': {\n\t\ttype: '${t}',\n\t},`),
+    ...entries,
     '} as const satisfies Record<EventTypeName, unknown>;',
   ];
   fs.writeFileSync(path.join(generatedDir, 'registry.ts'), lines.join('\n'));
@@ -271,6 +281,92 @@ describe('validateAgainstEventRegistry', () => {
   });
 });
 
+describe('readEventTiers', () => {
+  it('parses tier per event from the generated registry', () => {
+    const root = makeTmpDir('tiers');
+    const generatedDir = writeEventsRegistry(root, [
+      'contact_created',
+      { type: 'crm_sync_started', tier: 'audit' },
+    ]);
+    const tiers = readEventTiers(generatedDir);
+    expect(tiers.get('contact_created')).toBe('domain');
+    expect(tiers.get('crm_sync_started')).toBe('audit');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns empty map when registry missing', () => {
+    expect(readEventTiers()).toEqual(new Map());
+    expect(readEventTiers('/nope/does/not/exist')).toEqual(new Map());
+  });
+});
+
+describe('validateNoAuditTriggers (AUDIT-2)', () => {
+  it('throws AuditEventTriggerError when a trigger references an audit event', () => {
+    const triggers: ScannedTrigger[] = [
+      {
+        jobType: 'log_sync_start',
+        triggerId: 'log_sync_start#0',
+        event: 'crm_sync_started',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/log.ts',
+        sourceLine: 5,
+      },
+    ];
+    const tiers = new Map<string, 'domain' | 'audit'>([
+      ['crm_sync_started', 'audit'],
+    ]);
+    let caught: unknown;
+    try {
+      validateNoAuditTriggers(triggers, tiers);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AuditEventTriggerError);
+    const err = caught as AuditEventTriggerError;
+    expect(err.event).toBe('crm_sync_started');
+    expect(err.jobType).toBe('log_sync_start');
+    expect(err.triggerId).toBe('log_sync_start#0');
+    expect(err.message).toContain(
+      "@JobHandler('log_sync_start') trigger 'log_sync_start#0' references audit-tier event 'crm_sync_started'",
+    );
+    expect(err.message).toContain('Audit events are not bridge-eligible');
+    expect(err.message).toContain('§AUDIT-2');
+  });
+
+  it('does not throw for domain-tier triggers', () => {
+    const triggers: ScannedTrigger[] = [
+      {
+        jobType: 'send_welcome',
+        triggerId: 'send_welcome#0',
+        event: 'contact_created',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/x.ts',
+        sourceLine: 1,
+      },
+    ];
+    const tiers = new Map<string, 'domain' | 'audit'>([
+      ['contact_created', 'domain'],
+    ]);
+    expect(() => validateNoAuditTriggers(triggers, tiers)).not.toThrow();
+  });
+
+  it('skips validation when tier map is empty', () => {
+    const triggers: ScannedTrigger[] = [
+      {
+        jobType: 'x',
+        triggerId: 'x#0',
+        event: 'whatever',
+        mapSource: '() => ({})',
+        sourceFile: '/tmp/x.ts',
+        sourceLine: 1,
+      },
+    ];
+    expect(() =>
+      validateNoAuditTriggers(triggers, new Map()),
+    ).not.toThrow();
+  });
+});
+
 describe('buildBridgeRegistryContent', () => {
   it('emits empty registry when no triggers', () => {
     const out = buildBridgeRegistryContent([]);
@@ -388,6 +484,24 @@ describe('generateBridgeRegistry — orchestration', () => {
     expect(out).toContain("'send_welcome_email#0'");
     expect(out).toContain("'sync_contact_to_hubspot#0'");
     expect(out).toContain("'sync_contact_to_hubspot#1'");
+  });
+
+  it('throws AuditEventTriggerError when a handler triggers on an audit-tier event', async () => {
+    writeHandler(handlersDir, 'audit-trigger.ts', HANDLER_TEMPLATE('log_sync_start', `
+  triggers: [
+    { event: 'crm_sync_started', map: (e) => ({}) },
+  ],
+`));
+    const eventsGeneratedDir = writeEventsRegistry(root, [
+      { type: 'crm_sync_started', tier: 'audit' },
+    ]);
+    expect(
+      generateBridgeRegistry({
+        handlersDir,
+        eventsGeneratedDir,
+        outputDir,
+      }),
+    ).rejects.toBeInstanceOf(AuditEventTriggerError);
   });
 
   it('throws UnknownTriggerEventError when handler references unknown event', async () => {

--- a/src/__tests__/cli/event-codegen-generator.test.ts
+++ b/src/__tests__/cli/event-codegen-generator.test.ts
@@ -114,6 +114,23 @@ const webhookOutboundContactSync: EventDefinition = {
 	pool: 'events_outbound',
 };
 
+/**
+ * Audit-tier fixture (AUDIT-2). No `direction`, no `pool`, no
+ * `aggregate`/`source`/`destination`. The Zod schema enforces this
+ * shape; the generator must emit `tier: 'audit'`, `direction: null`,
+ * `pool: null`.
+ */
+const crmSyncStarted = {
+	type: 'crm_sync_started',
+	tier: 'audit',
+	version: 1,
+	description: 'A CRM sync run kicked off (audit/observational).',
+	payload: {
+		run_id: { type: 'uuid', nullable: false },
+	},
+	retry: { attempts: 3, backoff: 'exponential' },
+} as unknown as EventDefinition;
+
 // ---------------------------------------------------------------------------
 // Case helpers
 // ---------------------------------------------------------------------------
@@ -444,6 +461,36 @@ describe('buildRegistryContent — non-empty', () => {
 		expect(content).toContain('version: 1,');
 		expect(content).toContain(
 			"retry: { attempts: 5, backoff: 'exponential' },",
+		);
+	});
+
+	test('emits tier on every entry; domain entries keep direction/pool string literals', () => {
+		const content = buildRegistryContent([contactCreated]);
+		expect(content).toContain("tier: 'domain',");
+		expect(content).toContain("direction: 'change',");
+		expect(content).toContain("pool: 'events_change',");
+	});
+
+	test('audit events emit tier:audit with direction:null and pool:null', () => {
+		const content = buildRegistryContent([crmSyncStarted]);
+		expect(content).toContain("'crm_sync_started': {");
+		expect(content).toContain("tier: 'audit',");
+		expect(content).toContain('direction: null,');
+		expect(content).toContain('pool: null,');
+		// Audit entries have no aggregate/source/destination by construction.
+		expect(content).not.toContain("aggregate: '");
+		expect(content).not.toContain("source: '");
+		expect(content).not.toContain("destination: '");
+	});
+
+	test('EventMetadata interface widens direction/pool to nullable and adds tier', () => {
+		const content = buildRegistryContent([]);
+		expect(content).toContain("tier: 'domain' | 'audit';");
+		expect(content).toContain(
+			"direction: 'inbound' | 'change' | 'outbound' | null;",
+		);
+		expect(content).toContain(
+			"pool: 'events_inbound' | 'events_change' | 'events_outbound' | null;",
 		);
 	});
 

--- a/src/__tests__/parser/load-events.test.ts
+++ b/src/__tests__/parser/load-events.test.ts
@@ -24,11 +24,11 @@ const FIXTURE_DIR = resolve(__dirname, '../../../test/fixtures/events');
 // ----------------------------------------------------------------------------
 
 describe('loadEvents — happy path against checked-in fixtures', () => {
-	it('loads three valid event YAMLs with zero error issues', () => {
+	it('loads four valid event YAMLs (3 domain + 1 audit) with zero error issues', () => {
 		const result = loadEvents(FIXTURE_DIR, ['contact']);
 		const errorIssues = result.issues.filter((i) => i.severity === 'error');
 		expect(errorIssues).toEqual([]);
-		expect(result.events).toHaveLength(3);
+		expect(result.events).toHaveLength(4);
 	});
 
 	it('returns events sorted alphabetically by filename', () => {
@@ -36,15 +36,21 @@ describe('loadEvents — happy path against checked-in fixtures', () => {
 		const types = result.events.map((e) => e.type);
 		expect(types).toEqual([
 			'contact_created',
+			'crm_sync_started',
 			'stripe_payment_received',
 			'webhook_outbound_contact_sync',
 		]);
 	});
 
-	it('populates pool on every returned event (derived or explicit)', () => {
+	it('populates pool on every domain-tier event (derived or explicit); audit events have no pool', () => {
 		const result = loadEvents(FIXTURE_DIR, ['contact']);
 		for (const ev of result.events) {
-			expect(ev.pool).toMatch(/^events_(inbound|change|outbound)$/);
+			if (ev.tier === 'audit') {
+				expect(ev.pool).toBeUndefined();
+				expect(ev.direction).toBeUndefined();
+			} else {
+				expect(ev.pool).toMatch(/^events_(inbound|change|outbound)$/);
+			}
 		}
 	});
 });

--- a/src/__tests__/schema/event-definition.schema.test.ts
+++ b/src/__tests__/schema/event-definition.schema.test.ts
@@ -383,7 +383,7 @@ describe('EventDefinitionSchema — tier', () => {
 			);
 			expect(issue).toBeDefined();
 			expect(issue?.message).toBe(
-				"'pool' must be omitted when tier is 'audit' (got 'events_change'). Audit events have no pool.",
+				"Event 'crm_sync_started' is tier:audit; pool MUST be omitted (got 'events_change'). Audit events have no pool. See ai-docs/specs/issue-242/plan.md §AUDIT-2.",
 			);
 		}
 	});
@@ -401,7 +401,7 @@ describe('EventDefinitionSchema — tier', () => {
 			);
 			expect(issue).toBeDefined();
 			expect(issue?.message).toBe(
-				"'direction' must be omitted when tier is 'audit' (got 'change'). Audit events have no direction.",
+				"Event 'crm_sync_started' is tier:audit; direction MUST be omitted (got 'change'). Audit events have no direction. See ai-docs/specs/issue-242/plan.md §AUDIT-2.",
 			);
 		}
 	});

--- a/src/cli/shared/bridge-registry-generator.ts
+++ b/src/cli/shared/bridge-registry-generator.ts
@@ -165,6 +165,30 @@ export class DuplicateTriggerError extends Error {
   }
 }
 
+/**
+ * Thrown when a `@JobHandler` trigger references an event whose registry
+ * entry has `tier: 'audit'`. Audit events are observational and not
+ * bridge-eligible by design (AUDIT-2). See
+ * `ai-docs/specs/issue-242/plan.md` §AUDIT-2.
+ */
+export class AuditEventTriggerError extends Error {
+  override readonly name = 'AuditEventTriggerError';
+  constructor(
+    public readonly event: string,
+    public readonly jobType: string,
+    public readonly triggerId: string,
+    public readonly sourceFile: string,
+    public readonly sourceLine: number,
+  ) {
+    super(
+      `AuditEventTriggerError: @JobHandler('${jobType}') trigger '${triggerId}' ` +
+        `references audit-tier event '${event}'. Audit events are not ` +
+        `bridge-eligible. Use a domain event, or remove the trigger. ` +
+        `Source: ${sourceFile}:${sourceLine}. See ai-docs/specs/issue-242/plan.md §AUDIT-2.`,
+    );
+  }
+}
+
 export class UnknownTriggerEventError extends Error {
   override readonly name = 'UnknownTriggerEventError';
   constructor(
@@ -351,6 +375,62 @@ export function readKnownEventTypes(eventsGeneratedDir?: string): string[] {
 }
 
 /**
+ * Read the generated `events/registry.ts` file and extract the `tier`
+ * field for each event entry. Returns a Map keyed by event type. Events
+ * without a `tier` field (older registries pre-AUDIT-2) are reported as
+ * `domain` for safety.
+ *
+ * Lightweight regex scan — same approach as `readKnownEventTypes`. The
+ * file is codegen-stable and machine-emitted.
+ */
+export function readEventTiers(
+  eventsGeneratedDir?: string,
+): Map<string, 'domain' | 'audit'> {
+  const out = new Map<string, 'domain' | 'audit'>();
+  if (!eventsGeneratedDir) return out;
+  const registryPath = path.join(eventsGeneratedDir, 'registry.ts');
+  if (!fs.existsSync(registryPath)) return out;
+  const text = fs.readFileSync(registryPath, 'utf8');
+  // Match each entry block:
+  //   'event_type': {
+  //     type: 'event_type',
+  //     tier: 'audit',
+  //     ...
+  //   },
+  // The tier line, when present, is the first or second line after the key.
+  const re =
+    /'([a-zA-Z0-9_.-]+)':\s*\{[^}]*?tier:\s*'(domain|audit)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.set(m[1]!, m[2] as 'domain' | 'audit');
+  }
+  return out;
+}
+
+/**
+ * Throws `AuditEventTriggerError` on the first trigger whose event has
+ * `tier: 'audit'` in the events registry. AUDIT-2: audit events are not
+ * bridge-eligible.
+ */
+export function validateNoAuditTriggers(
+  triggers: ScannedTrigger[],
+  eventTiers: Map<string, 'domain' | 'audit'>,
+): void {
+  if (eventTiers.size === 0) return;
+  for (const t of triggers) {
+    if (eventTiers.get(t.event) === 'audit') {
+      throw new AuditEventTriggerError(
+        t.event,
+        t.jobType,
+        t.triggerId,
+        t.sourceFile,
+        t.sourceLine,
+      );
+    }
+  }
+}
+
+/**
  * Throws `UnknownTriggerEventError` on first unknown trigger event.
  * Skips validation when `knownEventTypes` is empty (no registry to
  * validate against).
@@ -501,6 +581,11 @@ export async function generateBridgeRegistry(
   // 2b. Validate against eventRegistry (no-op if registry not present).
   const knownEventTypes = readKnownEventTypes(eventsGeneratedDir);
   validateAgainstEventRegistry(triggers, knownEventTypes);
+
+  // 2c. Reject triggers on audit-tier events (AUDIT-2). Audit events
+  //     are observational and not bridge-eligible by design.
+  const eventTiers = readEventTiers(eventsGeneratedDir);
+  validateNoAuditTriggers(triggers, eventTiers);
 
   // 3. Build content.
   const content = buildBridgeRegistryContent(triggers);

--- a/src/cli/shared/event-codegen-generator.ts
+++ b/src/cli/shared/event-codegen-generator.ts
@@ -447,8 +447,9 @@ export function buildSchemasContent(events: EventDefinition[]): string {
 const REGISTRY_INTERFACE = [
 	'export interface EventMetadata {',
 	'\ttype: EventTypeName;',
-	"\tdirection: 'inbound' | 'change' | 'outbound';",
-	"\tpool: 'events_inbound' | 'events_change' | 'events_outbound';",
+	"\ttier: 'domain' | 'audit';",
+	"\tdirection: 'inbound' | 'change' | 'outbound' | null;",
+	"\tpool: 'events_inbound' | 'events_change' | 'events_outbound' | null;",
 	'\taggregate?: string;',
 	'\tsource?: string;',
 	'\tdestination?: string;',
@@ -495,10 +496,18 @@ export function buildRegistryContent(events: EventDefinition[]): string {
 
 	chunks.push(`export const eventRegistry = {`);
 	for (const ev of sorted) {
+		const tier = ev.tier ?? 'domain';
 		chunks.push(`\t'${ev.type}': {`);
 		chunks.push(`\t\ttype: '${ev.type}',`);
-		chunks.push(`\t\tdirection: '${ev.direction}',`);
-		chunks.push(`\t\tpool: '${ev.pool}',`);
+		chunks.push(`\t\ttier: '${tier}',`);
+		if (tier === 'audit') {
+			// Audit events have no routing fields (AUDIT-1/AUDIT-2 invariant).
+			chunks.push(`\t\tdirection: null,`);
+			chunks.push(`\t\tpool: null,`);
+		} else {
+			chunks.push(`\t\tdirection: '${ev.direction}',`);
+			chunks.push(`\t\tpool: '${ev.pool}',`);
+		}
 		if (ev.aggregate !== undefined) {
 			chunks.push(`\t\taggregate: '${ev.aggregate}',`);
 		}

--- a/src/schema/event-definition.schema.ts
+++ b/src/schema/event-definition.schema.ts
@@ -201,14 +201,14 @@ const EventDefinitionSchemaRefined = EventDefinitionSchemaCore.superRefine(
 			if (data.pool !== undefined) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
-					message: `'pool' must be omitted when tier is 'audit' (got '${data.pool}'). Audit events have no pool.`,
+					message: `Event '${data.type}' is tier:audit; pool MUST be omitted (got '${data.pool}'). Audit events have no pool. See ai-docs/specs/issue-242/plan.md §AUDIT-2.`,
 					path: ["pool"],
 				});
 			}
 			if (data.direction !== undefined) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
-					message: `'direction' must be omitted when tier is 'audit' (got '${data.direction}'). Audit events have no direction.`,
+					message: `Event '${data.type}' is tier:audit; direction MUST be omitted (got '${data.direction}'). Audit events have no direction. See ai-docs/specs/issue-242/plan.md §AUDIT-2.`,
 					path: ["direction"],
 				});
 			}

--- a/test/baseline/runtime/subsystems/events/generated/registry.ts
+++ b/test/baseline/runtime/subsystems/events/generated/registry.ts
@@ -6,8 +6,9 @@ import type { EventTypeName } from './types';
 
 export interface EventMetadata {
 	type: EventTypeName;
-	direction: 'inbound' | 'change' | 'outbound';
-	pool: 'events_inbound' | 'events_change' | 'events_outbound';
+	tier: 'domain' | 'audit';
+	direction: 'inbound' | 'change' | 'outbound' | null;
+	pool: 'events_inbound' | 'events_change' | 'events_outbound' | null;
 	aggregate?: string;
 	source?: string;
 	destination?: string;
@@ -18,6 +19,7 @@ export interface EventMetadata {
 export const eventRegistry = {
 	'contact_created': {
 		type: 'contact_created',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'contact',
@@ -26,6 +28,7 @@ export const eventRegistry = {
 	},
 	'contact_marked_champion': {
 		type: 'contact_marked_champion',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'contact',
@@ -34,14 +37,24 @@ export const eventRegistry = {
 	},
 	'contact_merged': {
 		type: 'contact_merged',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'contact',
 		version: 1,
 		retry: { attempts: 3, backoff: 'exponential' },
 	},
+	'crm_sync_started': {
+		type: 'crm_sync_started',
+		tier: 'audit',
+		direction: null,
+		pool: null,
+		version: 1,
+		retry: { attempts: 3, backoff: 'exponential' },
+	},
 	'deal_created': {
 		type: 'deal_created',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'deal',
@@ -50,6 +63,7 @@ export const eventRegistry = {
 	},
 	'deal_stage_changed': {
 		type: 'deal_stage_changed',
+		tier: 'domain',
 		direction: 'change',
 		pool: 'events_change',
 		aggregate: 'deal',
@@ -58,6 +72,7 @@ export const eventRegistry = {
 	},
 	'stripe_payment_received': {
 		type: 'stripe_payment_received',
+		tier: 'domain',
 		direction: 'inbound',
 		pool: 'events_inbound',
 		source: 'stripe',
@@ -66,6 +81,7 @@ export const eventRegistry = {
 	},
 	'webhook_outbound_contact_sync': {
 		type: 'webhook_outbound_contact_sync',
+		tier: 'domain',
 		direction: 'outbound',
 		pool: 'events_outbound',
 		aggregate: 'contact',

--- a/test/baseline/runtime/subsystems/events/generated/schemas.ts
+++ b/test/baseline/runtime/subsystems/events/generated/schemas.ts
@@ -22,6 +22,11 @@ export const contactMergedPayloadSchema = z.object({
 	targetId: z.string().uuid(),
 }).strict();
 
+export const crmSyncStartedPayloadSchema = z.object({
+	runId: z.string().uuid(),
+	source: z.string(),
+}).strict();
+
 export const dealCreatedPayloadSchema = z.object({
 	accountId: z.string().uuid(),
 	dealId: z.string().uuid(),
@@ -52,6 +57,7 @@ export const eventPayloadSchemas = {
 	'contact_created': contactCreatedPayloadSchema,
 	'contact_marked_champion': contactMarkedChampionPayloadSchema,
 	'contact_merged': contactMergedPayloadSchema,
+	'crm_sync_started': crmSyncStartedPayloadSchema,
 	'deal_created': dealCreatedPayloadSchema,
 	'deal_stage_changed': dealStageChangedPayloadSchema,
 	'stripe_payment_received': stripePaymentReceivedPayloadSchema,

--- a/test/baseline/runtime/subsystems/events/generated/types.ts
+++ b/test/baseline/runtime/subsystems/events/generated/types.ts
@@ -34,6 +34,16 @@ export interface ContactMergedEvent extends DomainEvent {
 	};
 }
 
+/** A CRM sync run kicked off (audit/observational, not bridge-eligible). */
+export interface CrmSyncStartedEvent extends DomainEvent {
+	readonly type: 'crm_sync_started';
+	readonly aggregateType: 'crm_sync_started';
+	readonly payload: {
+		runId: string;
+		source: string;
+	};
+}
+
 export interface DealCreatedEvent extends DomainEvent {
 	readonly type: 'deal_created';
 	readonly aggregateType: 'deal';
@@ -84,6 +94,7 @@ export type AppDomainEvent =
 	| ContactCreatedEvent
 	| ContactMarkedChampionEvent
 	| ContactMergedEvent
+	| CrmSyncStartedEvent
 	| DealCreatedEvent
 	| DealStageChangedEvent
 	| StripePaymentReceivedEvent

--- a/test/fixtures/events/crm_sync_started.yaml
+++ b/test/fixtures/events/crm_sync_started.yaml
@@ -1,0 +1,9 @@
+type: crm_sync_started
+tier: audit
+version: 1
+description: A CRM sync run kicked off (audit/observational, not bridge-eligible).
+payload:
+  run_id:
+    type: uuid
+  source:
+    type: string


### PR DESCRIPTION
## Summary

AUDIT-2 of epic #242 — generator + codegen-side enforcement.

- `buildRegistryContent`: emits `tier` on every registry entry; audit entries emit `direction: null, pool: null`. `EventMetadata` interface widened: `tier: 'domain' | 'audit'` added; `direction` / `pool` become `| null`.
- `EventDefinitionSchema`: refinement messages rewritten to spec wording — `Event '<type>' is tier:audit; pool MUST be omitted (got '<X>'). Audit events have no pool. See ai-docs/specs/issue-242/plan.md §AUDIT-2.` (and analogous for direction). Single source of truth — no post-processing in the loader.
- `bridge-registry-generator`: new `AuditEventTriggerError` fires when a `@JobHandler` trigger references an audit-tier event. Integrates into the existing pipeline after the unknown-event check.
- New audit fixture `test/fixtures/events/crm_sync_started.yaml` matching the motivating CRM-sync use case.
- Baseline refresh: every existing registry entry gains `tier: 'domain'`; interface updated; new audit entry added. Diff scope verified — only the three `events/generated/` files plus the new fixture.

Living docs:
- `.claude/skills/events/event-codegen.md` — three codegen errors documented with exact wording.
- `docs/specs/EVT-3.md` — dated revision note (2026-04-26 / AUDIT-2).

Refs: `ai-docs/specs/issue-242/plan.md` §AUDIT-2

Closes #245

## Test plan

- [x] `just test-unit` — 1644 pass / 0 fail
- [x] `just test-baseline` — pass; diff scope: only `events/generated/{registry,schemas,types}.ts` + new fixture
- [x] `just test-smoke` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)