### PR TITLE
feat(bridge): audit-tier guard at top of processEvent (#247)

### DIFF
--- a/.claude/skills/bridge/SKILL.md
+++ b/.claude/skills/bridge/SKILL.md
@@ -72,6 +72,18 @@ Reserved `events_*` pools get high concurrency (default 32) — they host cheap 
 
 Default configuration gives parallelism, not ordering. For per-aggregate ordering, prefer `concurrency_key` on the user `@JobHandler` (granular, parallel across aggregates) over `pool.concurrency = 1` (blunt, serializes all wrappers in that direction).
 
+### Audit-tier guard (defense-in-depth)
+
+`tier:audit` events (lifecycle / observability — `crm_sync_started`, etc.) are **not bridge-eligible**. The codegen-side validator (AUDIT-2) blocks the registry from listing them as triggers, so the registry is the **primary** enforcement. `BridgeOutboxDrainHook.processEvent` adds a **defense-in-depth** runtime guard at the very top of the method:
+
+- If `event.metadata.tier === 'audit'`, the hook short-circuits, writes no `bridge_delivery` rows, and returns `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }`.
+- A WARN log fires once per `(event_type, process)` via a `Set<string>` (`warnedAuditTypes`) — finer-grained than the once-per-process `warnedNullDirection` flag, so drift in a specific event type surfaces without flooding logs across many types.
+- Reaching the guard is a drift signal: an out-of-band `bridge_trigger` row exists, or there's version skew during deploy. The `auditBlocked` count on `BridgeOutboxDrainResult` rides on every per-event drain return so observability layers can aggregate without a new protocol method.
+
+Spec reference: `ai-docs/specs/issue-242/plan.md` §AUDIT-4.
+
+There is **no** `IObservability` read for audit-blocks today — see plan §AUDIT-4 "Why no `IObservability` read in this PR." Two clean follow-up paths if a consumer asks: a `getBridgeAuditBlocks(windowHours)` read on the bridge port + observability composer, or a self-published `bridge.audit_blocked` audit-tier event surfaced by the AUDIT-5 viewer.
+
 ### Multi-tenancy
 
 When `multiTenant=true`, three enforcement sites need `assertTenantId` on entry:

--- a/docs/adrs/ADR-023-event-to-job-bridge.md
+++ b/docs/adrs/ADR-023-event-to-job-bridge.md
@@ -7,6 +7,22 @@
 **Depends on:** ADR-024 Phase 1 (shipped via EVT-1..EVT-8) — typed event registry, `TypedEventBus`, direction-routed outbox
 **Unblocks:** ADR-026 (JobEvent Observability — selective job lifecycle → events broadcast)
 
+## 2026-04-26 Revision Note — Audit-tier guard (AUDIT-4)
+
+The bridge outbox drain hook (`runtime/subsystems/bridge/bridge-outbox-drain-hook.ts`) gains a top-of-`processEvent` guard for `tier:audit` events. This is a **defense-in-depth** addition; the codegen-side validator from AUDIT-2 (which hard-errors on a job declaring `triggers: [<audit_event>]`) remains the **primary** enforcement.
+
+Behaviour:
+
+- If `event.metadata.tier === 'audit'`, the hook returns `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }` immediately — no `bridge_delivery` row is written, no wrapper `job_run` is spawned.
+- A WARN fires once per `(event_type, process)` via a private `Set<string>` (`warnedAuditTypes`). Finer-grained than the once-per-process `warnedNullDirection` flag; drift in a specific event type surfaces without flooding logs across many types.
+- `BridgeOutboxDrainResult` gains `auditBlocked: number`. `0` on every non-audit return path; `1` when the guard fires. Per-event observability data that rides on the existing return shape — no new protocol method, no new state on the hook.
+
+Why a runtime guard at all when codegen already errors: catches drift the codegen path cannot — out-of-band `bridge_trigger` inserts (manual ops, recovery scripts, faulty migrations) and version skew during rolling deploys (old generator, new bus). Reaching the guard is by definition unexpected; the WARN is the operator-facing surface and `auditBlocked` is the machine-readable surface.
+
+No `IObservability` read for audit-blocks ships in this PR. Two clean follow-up paths exist if production needs aggregate visibility — `getBridgeAuditBlocks(windowHours)` on the bridge port + observability composer, or self-published `bridge.audit_blocked` audit-tier events surfaced by the AUDIT-5 viewer. File AUDIT-6 if a real consumer asks.
+
+Spec: `ai-docs/specs/issue-242/plan.md` §AUDIT-4. Sequenced after AUDIT-3 (the bus stamps `metadata.tier` so the guard has something to read).
+
 ## 2026-04-21 Revision Notes
 
 This ADR was reviewed on 2026-04-21 against the draft shipped in PR #9cca553. Refinements below are **additions**, not rewrites — every original decision stands.

--- a/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
+++ b/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
@@ -58,6 +58,7 @@ const POOL_BY_DIRECTION: Record<string, string> = {
 export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
   private readonly logger = new Logger(BridgeOutboxDrainHook.name);
   private warnedNullDirection = false;
+  private readonly warnedAuditTypes = new Set<string>();
 
   constructor(
     @Optional()
@@ -69,9 +70,29 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
     event: DomainEvent,
     tx: DrizzleTransaction,
   ): Promise<BridgeOutboxDrainResult> {
+    // Audit-tier guard (defense-in-depth — AUDIT-4). Audit events are not
+    // bridge-eligible: the codegen-side validator (AUDIT-2) blocks the
+    // registry from listing them as triggers. Reaching this branch means
+    // registry/runtime drift — an out-of-band `bridge_trigger` insert, or
+    // version skew during deploy. Refuse fanout, surface drift via WARN.
+    if (event.metadata?.['tier'] === 'audit') {
+      this.warnAuditBlockedOnce(event);
+      return {
+        delivered: 0,
+        dedupSkips: 0,
+        triggerCount: 0,
+        auditBlocked: 1,
+      };
+    }
+
     const triggers = this.lookupTriggers(event.type);
     if (triggers.length === 0) {
-      return { delivered: 0, dedupSkips: 0, triggerCount: 0 };
+      return {
+        delivered: 0,
+        dedupSkips: 0,
+        triggerCount: 0,
+        auditBlocked: 0,
+      };
     }
 
     const direction =
@@ -95,7 +116,12 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
             `outbox row.`,
         );
       }
-      return { delivered: 0, dedupSkips: 0, triggerCount: triggers.length };
+      return {
+        delivered: 0,
+        dedupSkips: 0,
+        triggerCount: triggers.length,
+        auditBlocked: 0,
+      };
     }
 
     let delivered = 0;
@@ -163,7 +189,22 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
       delivered++;
     }
 
-    return { delivered, dedupSkips, triggerCount: triggers.length };
+    return {
+      delivered,
+      dedupSkips,
+      triggerCount: triggers.length,
+      auditBlocked: 0,
+    };
+  }
+
+  private warnAuditBlockedOnce(event: DomainEvent): void {
+    if (this.warnedAuditTypes.has(event.type)) return;
+    this.warnedAuditTypes.add(event.type);
+    this.logger.warn(
+      `Bridge guard blocked audit-tier event '${event.type}' (event.id=${event.id}). ` +
+        `Registry says this event is not bridge-eligible; a bridge_trigger row exists ` +
+        `out-of-band. Investigate registry/runtime drift.`,
+    );
   }
 
   private lookupTriggers(

--- a/runtime/subsystems/bridge/bridge.protocol.ts
+++ b/runtime/subsystems/bridge/bridge.protocol.ts
@@ -333,11 +333,21 @@ export type BridgeRegistry = {
  *
  * `triggerCount`: total triggers matched in the registry for this event;
  * `triggerCount === delivered + dedupSkips`.
+ *
+ * `auditBlocked`: number of events the dispatcher refused to fan out
+ * because their `metadata.tier === 'audit'`. Audit-tier events are not
+ * bridge-eligible; codegen errors block the registry from listing them
+ * as triggers, so a non-zero value here indicates registry/runtime drift
+ * (an out-of-band `bridge_trigger` insert, version skew during deploy).
+ * Per-event: `0` when the guard does not fire, `1` when it does. Add it
+ * to per-batch logging if your drain caller aggregates results. See
+ * ai-docs/specs/issue-242/plan.md §AUDIT-4.
  */
 export interface BridgeOutboxDrainResult {
   delivered: number;
   dedupSkips: number;
   triggerCount: number;
+  auditBlocked: number;
 }
 
 /**
@@ -366,9 +376,18 @@ export interface IBridgeOutboxDrainHook {
    * job_run` row pairs for every matched trigger via the supplied `tx`.
    *
    * Behaviour:
+   *   0. **Audit-tier guard (defense-in-depth).** If
+   *      `event.metadata.tier === 'audit'`, returns
+   *      `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }`
+   *      immediately and logs a per-`(event_type, process)` WARN. The
+   *      codegen-side validator (AUDIT-2) is the primary enforcement;
+   *      this guard catches out-of-band `bridge_trigger` inserts and
+   *      version skew during deploy. See
+   *      ai-docs/specs/issue-242/plan.md §AUDIT-4.
    *   1. Looks up `bridgeRegistry[event.type]`. No matches → returns
-   *      `{ delivered: 0, dedupSkips: 0, triggerCount: 0 }`; the drain
-   *      proceeds to dispatch user subscribers + stamp `processed_at`.
+   *      `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 0 }`;
+   *      the drain proceeds to dispatch user subscribers + stamp
+   *      `processed_at`.
    *   2. For each matched trigger:
    *      - `INSERT INTO bridge_delivery (event_id, trigger_id, status,
    *        wrapper_run_id, tenant_id, ...) VALUES (...) ON CONFLICT

--- a/src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts
@@ -11,7 +11,8 @@
  *     that trigger; sibling triggers still fire
  *   - tenant_id propagation
  */
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { Logger } from '@nestjs/common';
 
 import {
   BridgeOutboxDrainHook,
@@ -113,7 +114,12 @@ describe('BridgeOutboxDrainHook — registry lookup', () => {
     const hook = new BridgeOutboxDrainHook({} as BridgeRegistry);
     const { tx, calls } = makeTx([]);
     const result = await hook.processEvent(event(), tx as never);
-    expect(result).toEqual({ delivered: 0, dedupSkips: 0, triggerCount: 0 });
+    expect(result).toEqual({
+      delivered: 0,
+      dedupSkips: 0,
+      triggerCount: 0,
+      auditBlocked: 0,
+    });
     expect(calls).toHaveLength(0);
   });
 });
@@ -130,6 +136,7 @@ describe('BridgeOutboxDrainHook — null direction tolerance', () => {
       delivered: 0,
       dedupSkips: 0,
       triggerCount: 2, // matched but un-routable
+      auditBlocked: 0,
     });
     expect(calls).toHaveLength(0);
   });
@@ -147,6 +154,7 @@ describe('BridgeOutboxDrainHook — happy path', () => {
       delivered: 2,
       dedupSkips: 0,
       triggerCount: 2,
+      auditBlocked: 0,
     });
 
     // Expect 4 inserts: 2 delivery + 2 wrapper, interleaved.
@@ -208,6 +216,7 @@ describe('BridgeOutboxDrainHook — Case B / replay dedup', () => {
       delivered: 1,
       dedupSkips: 1,
       triggerCount: 2,
+      auditBlocked: 0,
     });
 
     // 1 dedup-skipped delivery insert + 1 successful delivery insert + 1
@@ -229,6 +238,7 @@ describe('BridgeOutboxDrainHook — Case B / replay dedup', () => {
       delivered: 0,
       dedupSkips: 2,
       triggerCount: 2,
+      auditBlocked: 0,
     });
     expect(calls.filter((c) => c.table === 'job_run')).toHaveLength(0);
   });
@@ -277,5 +287,117 @@ describe('BridgeOutboxDrainHook — tenant propagation', () => {
     const wrapper = calls.find((c) => c.table === 'job_run')!;
     expect(delivery.values['tenantId']).toBeNull();
     expect(wrapper.values['tenantId']).toBeNull();
+  });
+});
+
+// ─── Audit-tier guard (AUDIT-4) ──────────────────────────────────────────────
+
+describe('BridgeOutboxDrainHook — audit-tier guard', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Spy on the NestJS Logger prototype since the hook constructs its own
+    // private Logger instance. Reset between tests so per-test WARN counts
+    // are isolated. (`spyOn` returns a persistent spy across tests; clear
+    // the call log per test.)
+    warnSpy = spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    warnSpy.mockClear();
+  });
+
+  function auditEvent(overrides: Partial<DomainEvent> = {}): DomainEvent {
+    return event({
+      id: 'audit-evt-1',
+      type: 'crm_sync_started',
+      metadata: { tier: 'audit', pool: null, direction: null },
+      ...overrides,
+    });
+  }
+
+  it('blocks fanout when an audit event reaches an out-of-band trigger', async () => {
+    // Out-of-band: registry has a trigger registered for an audit event
+    // type (codegen-side AUDIT-2 should have prevented this — simulating
+    // registry/runtime drift).
+    const hook = new BridgeOutboxDrainHook({
+      crm_sync_started: [
+        {
+          triggerId: 'side_effect_job#0',
+          jobType: 'side_effect_job',
+          map: () => ({}),
+        },
+      ],
+    } as unknown as BridgeRegistry);
+    const { tx, calls } = makeTx([]);
+
+    const result = await hook.processEvent(auditEvent(), tx as never);
+
+    expect(result).toEqual({
+      delivered: 0,
+      dedupSkips: 0,
+      triggerCount: 0,
+      auditBlocked: 1,
+    });
+    expect(calls).toHaveLength(0); // no bridge_delivery rows written
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]![0]);
+    expect(message).toContain(
+      "Bridge guard blocked audit-tier event 'crm_sync_started'",
+    );
+    expect(message).toContain('event.id=audit-evt-1');
+    expect(message).toContain('Investigate registry/runtime drift.');
+  });
+
+  it('dedups WARN per event type within a single process', async () => {
+    const hook = new BridgeOutboxDrainHook({} as BridgeRegistry);
+
+    const a = await hook.processEvent(auditEvent(), makeTx([]).tx as never);
+    const b = await hook.processEvent(
+      auditEvent({ id: 'audit-evt-2' }),
+      makeTx([]).tx as never,
+    );
+
+    expect(a.auditBlocked).toBe(1);
+    expect(b.auditBlocked).toBe(1);
+    // Same event type → WARN only once across the two calls.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits a fresh WARN when a different audit event type is seen', async () => {
+    const hook = new BridgeOutboxDrainHook({} as BridgeRegistry);
+
+    await hook.processEvent(auditEvent(), makeTx([]).tx as never);
+    await hook.processEvent(
+      auditEvent({ id: 'audit-evt-2', type: 'crm_sync_completed' }),
+      makeTx([]).tx as never,
+    );
+
+    // Two distinct event types → WARN fires once per type.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(String(warnSpy.mock.calls[0]![0])).toContain(
+      "'crm_sync_started'",
+    );
+    expect(String(warnSpy.mock.calls[1]![0])).toContain(
+      "'crm_sync_completed'",
+    );
+  });
+
+  it('does not fire on domain events with valid triggers', async () => {
+    const hook = new BridgeOutboxDrainHook(REGISTRY_TWO_TRIGGERS);
+    const { tx } = makeTx([['del-1'], ['del-2']]);
+    const result = await hook.processEvent(event(), tx as never);
+    expect(result.auditBlocked).toBe(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not fire on domain events with no triggers', async () => {
+    const hook = new BridgeOutboxDrainHook({} as BridgeRegistry);
+    const { tx } = makeTx([]);
+    const result = await hook.processEvent(event(), tx as never);
+    expect(result).toEqual({
+      delivered: 0,
+      dedupSkips: 0,
+      triggerCount: 0,
+      auditBlocked: 0,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/runtime/subsystems/event-bus.spec.ts
+++ b/src/__tests__/runtime/subsystems/event-bus.spec.ts
@@ -822,7 +822,7 @@ describe('DrizzleEventBus — BRIDGE-4 drain modification', () => {
     const hook = {
       processEvent: mock(async (event: DomainEvent, tx: unknown) => {
         hookCalls.push({ event, tx });
-        return { delivered: 0, dedupSkips: 0, triggerCount: 0 };
+        return { delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 0 };
       }),
     };
     const bus = new DrizzleEventBus(


### PR DESCRIPTION
## Summary

AUDIT-4 of epic #242 — defense-in-depth runtime guard.

- `BridgeOutboxDrainHook.processEvent`: top-of-method guard returns `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }` when `event.metadata.tier === 'audit'`, BEFORE the trigger lookup.
- Per-`(event_type, process)` WARN dedup via `warnedAuditTypes: Set<string>` — surfaces drift in specific event types without flooding logs.
- WARN message: `Bridge guard blocked audit-tier event '<type>' (event.id=<id>). Registry says this event is not bridge-eligible; a bridge_trigger row exists out-of-band. Investigate registry/runtime drift.`
- `BridgeOutboxDrainResult` gains `auditBlocked: number`. All existing non-audit return paths now include `auditBlocked: 0`.
- `DrizzleEventBus.processBatch` unchanged — drain caller does not log per-batch aggregates today; spec says don't add now.

Codegen errors from AUDIT-2 are the primary enforcement; this guard catches **registry/runtime drift** (out-of-band `bridge_trigger` inserts, version skew during deploy).

Living docs:
- `.claude/skills/bridge/SKILL.md` — audit-tier guard section.
- `docs/adrs/ADR-023-event-to-job-bridge.md` — dated revision note (2026-04-26).

Refs: `ai-docs/specs/issue-242/plan.md` §AUDIT-4

Closes #247

## Test plan

- [x] `just test-unit` — 1663 pass / 0 fail
- [x] `just test-baseline` — pass; diff scope empty (purely runtime)
- [x] `just test-smoke` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)