### PR TITLE
fix(release)!: 0.6.1 hotfix — ship template-referenced src files (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-04-26
+
+Critical hotfix for #266. `0.6.0` shipped with a broken `entity new` command for every npm consumer: `templates/entity/new/prompt.js` and `templates/entity/new/clean-lite-ps/prompt-extension.js` import runtime helpers from `../../../src/config/*.mjs` and `../../../src/patterns/registry.js`, but the `package.json:files` manifest excluded `src/`. Every published-tarball invocation died with `ResolveMessage: Cannot find module '../../../src/config/paths.mjs'`. The repo's smoke + baseline tests didn't catch this because they run from the source checkout, where the relative paths resolve directly.
+
+### Fixed
+
+- **`fix(release)` #266** — extend `package.json:files` with the narrow set of `src/` paths that templates reach for at runtime: `src/config/*.mjs`, `src/schema/naming-config.schema.mjs`, `src/patterns/registry.ts`, `src/patterns/pattern-definition.ts`, `src/patterns/library/*.ts`. Narrow paths (not a broad `src/` entry) so test files and CLI source stay out of the tarball. Verified by `npm pack && npm install ./pack.tgz && entity new` against a real fixture entity — generation now succeeds end-to-end.
+
+### Added
+
+- **Prevention test** at `src/__tests__/templates/files-manifest-coverage.test.ts`: statically scans every `templates/**/*.{js,mjs,cjs}` for relative imports that escape the `templates/` tree, resolves each against the source layout (with `.js → .ts` rewrite for Bun TS-aware ESM), and asserts the resolved path matches at least one entry in `package.json:files`. Fails CI when a future template adds a cross-package import without updating the manifest. Closes the hole identified in #190 (post-publish smoke proposal).
+
 ## [0.6.0] — 2026-04-26
 
 Sync subsystem Phase 2: configurable change sources land. Detection mode is now declarative — entity YAML carries a `detection:` block parsed into a typed `DetectionConfig`, and codegen emits a per-entity Map factory module that wires consumer-supplied adapter callbacks to the right primitive. Plus audit-tier event classification (epic #242 phases 1–4).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",
@@ -37,6 +37,11 @@
     "dist",
     "runtime",
     "templates",
+    "src/config/*.mjs",
+    "src/schema/naming-config.schema.mjs",
+    "src/patterns/registry.ts",
+    "src/patterns/pattern-definition.ts",
+    "src/patterns/library/*.ts",
     "CHANGELOG.md",
     "README.md",
     "LICENSE"

--- a/src/__tests__/templates/files-manifest-coverage.test.ts
+++ b/src/__tests__/templates/files-manifest-coverage.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Prevention test for issue #266 — assert that every cross-package import
+ * from a template (`templates/**\/*.{js,mjs,cjs}` reaching into `../**\/src/...`)
+ * resolves to a file that the published `package.json:files` manifest will
+ * include in the npm tarball.
+ *
+ * Background: 0.6.0 shipped `templates/entity/new/prompt.js` which imports
+ * `../../../src/config/paths.mjs` at runtime, but the `files` manifest
+ * only listed `["dist", "runtime", "templates", ...]`. Every consumer's
+ * `entity new` invocation died with `Cannot find module '../../../src/config/paths.mjs'`.
+ *
+ * The smoke + baseline tests didn't catch this because they run from the
+ * source checkout, where `../../../src/config/paths.mjs` resolves directly.
+ * Only `npm pack && npm install ./pack.tgz && entity new` exposes the gap.
+ *
+ * This test enumerates the imports statically and proves each touched path
+ * matches at least one entry in `files`. A new template that adds a
+ * cross-package import without updating `files` will fail here pre-publish.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { glob } from 'glob';
+import { resolve, relative, dirname, join } from 'node:path';
+
+/**
+ * Tiny glob → RegExp converter sufficient for `package.json:files` patterns.
+ * Supports:
+ *   *       — match anything except `/`
+ *   **      — match across path separators
+ *   ?       — single non-`/` char
+ *   {a,b}   — alternation
+ * No extglob, no character classes — none of those appear in `files`.
+ */
+function globToRegExp(pattern: string): RegExp {
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === '*' && pattern[i + 1] === '*') {
+      re += '.*';
+      i += 2;
+      if (pattern[i] === '/') i++;
+    } else if (c === '*') {
+      re += '[^/]*';
+      i++;
+    } else if (c === '?') {
+      re += '[^/]';
+      i++;
+    } else if (c === '{') {
+      const end = pattern.indexOf('}', i);
+      const alts = pattern.slice(i + 1, end).split(',').map((a) => a.replace(/[.+^$|()[\]\\]/g, '\\$&'));
+      re += `(?:${alts.join('|')})`;
+      i = end + 1;
+    } else if (/[.+^$|()[\]\\]/.test(c)) {
+      re += '\\' + c;
+      i++;
+    } else {
+      re += c;
+      i++;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..');
+
+interface CrossPackageImport {
+  templateFile: string; // absolute path
+  importSpecifier: string; // e.g. '../../../src/config/paths.mjs'
+  resolvedAbsolute: string; // absolute path the specifier resolves to
+}
+
+/**
+ * Extract every import/from "..." or import("...") with a relative
+ * specifier that escapes the `templates/` tree (i.e. resolves outside it).
+ */
+function findCrossPackageImports(): CrossPackageImport[] {
+  const templatesDir = resolve(REPO_ROOT, 'templates');
+  const files = glob.sync('**/*.{js,mjs,cjs}', {
+    cwd: templatesDir,
+    absolute: true,
+  });
+
+  const out: CrossPackageImport[] = [];
+  // Match `from "..."`, `from '...'`, `import "..."`, `import '...'`,
+  // and `require("...")`. Only relative specifiers (start with '.').
+  const importRegex = /(?:from|import|require)\s*\(?\s*["'](\.\.?\/[^"']+)["']\)?/g;
+
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    let m: RegExpExecArray | null;
+    while ((m = importRegex.exec(src)) !== null) {
+      const spec = m[1];
+      // Resolve relative to the template file's directory.
+      let resolved = resolve(dirname(file), spec);
+
+      // The specifier may use a `.js` extension that refers to a `.ts`
+      // sibling (Bun's TS-aware ESM resolution). Normalize by checking
+      // the common rewrites.
+      if (!existsSync(resolved)) {
+        const candidates = [
+          resolved.replace(/\.js$/, '.ts'),
+          resolved.replace(/\.mjs$/, '.mts'),
+        ];
+        for (const c of candidates) {
+          if (existsSync(c)) {
+            resolved = c;
+            break;
+          }
+        }
+      }
+
+      // Skip imports that resolve back inside templates/ — those are
+      // intra-package and don't depend on the files manifest.
+      const rel = relative(templatesDir, resolved);
+      if (!rel.startsWith('..')) continue;
+
+      out.push({
+        templateFile: file,
+        importSpecifier: spec,
+        resolvedAbsolute: resolved,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Approximate `npm pack`'s behavior for the `files` field. We don't
+ * implement the full ignore-rules cascade; instead, for each pattern we
+ * resolve it against the repo root using `minimatch` (with directory
+ * patterns expanding to all descendants) and assert that the candidate
+ * path falls inside the resulting set.
+ *
+ * This is a conservative shape — patterns like "dist" cover everything
+ * under `dist/`, while patterns like "src/config/*.mjs" cover only the
+ * matching glob.
+ */
+function isCoveredByFiles(absPath: string, filesPatterns: string[]): boolean {
+  const rel = relative(REPO_ROOT, absPath);
+  for (const pattern of filesPatterns) {
+    // Bare directory entry: matches anything under that directory.
+    const dirCandidate = resolve(REPO_ROOT, pattern);
+    if (existsSync(dirCandidate) && statSync(dirCandidate).isDirectory()) {
+      const insideRel = relative(dirCandidate, absPath);
+      if (insideRel && !insideRel.startsWith('..')) return true;
+      continue;
+    }
+    // Glob pattern.
+    if (globToRegExp(pattern).test(rel)) return true;
+    // Pattern with directory prefix (e.g. "src/patterns/library/*.ts")
+    // and absPath being the same — minimatch handles this above. Done.
+  }
+  return false;
+}
+
+describe('package.json:files covers all cross-package template imports (#266)', () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
+  );
+  const filesPatterns: string[] = pkg.files;
+
+  const imports = findCrossPackageImports();
+
+  it('finds at least the known #266 cross-package imports', () => {
+    // Sanity: if we ever get to zero, the regex broke. The known offenders
+    // from #266 (prompt.js + clean-lite-ps prompt-extension.js) ensure a
+    // non-zero floor today.
+    expect(imports.length).toBeGreaterThan(0);
+  });
+
+  it('every cross-package import resolves to a file shipped by `files`', () => {
+    const uncovered: { spec: string; from: string; resolved: string }[] = [];
+    for (const imp of imports) {
+      // The resolution may map to a file that doesn't exist on disk if
+      // the import is dead — flag those too.
+      if (!existsSync(imp.resolvedAbsolute)) {
+        uncovered.push({
+          spec: imp.importSpecifier,
+          from: relative(REPO_ROOT, imp.templateFile),
+          resolved: '<does not exist>: ' + relative(REPO_ROOT, imp.resolvedAbsolute),
+        });
+        continue;
+      }
+      if (!isCoveredByFiles(imp.resolvedAbsolute, filesPatterns)) {
+        uncovered.push({
+          spec: imp.importSpecifier,
+          from: relative(REPO_ROOT, imp.templateFile),
+          resolved: relative(REPO_ROOT, imp.resolvedAbsolute),
+        });
+      }
+    }
+
+    if (uncovered.length > 0) {
+      const lines = uncovered.map(
+        (u) => `  - ${u.from}\n      imports "${u.spec}"\n      → ${u.resolved}`,
+      );
+      throw new Error(
+        `Templates import paths not covered by package.json:files (will break npm consumers):\n` +
+          lines.join('\n') +
+          `\n\nFix: add narrow paths to "files" in package.json. See #266.`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Critical hotfix for #266. `@pattern-stack/codegen@0.6.0` is unrunnable for every npm consumer — every `entity new` invocation dies with `ResolveMessage: Cannot find module '../../../src/config/paths.mjs'`. Repo's smoke + baseline tests didn't catch this because they run from the source checkout, where `../../../src/...` resolves directly to the live tree.

- Extend `package.json:files` with the narrow set of `src/` paths the templates reach for at runtime.
- Add a prevention test that statically asserts every template cross-package import resolves to a file shipped by the manifest. This catches future occurrences pre-publish.
- Bump `0.6.0 → 0.6.1`, CHANGELOG entry citing the fix and the prevention test.

## Audit findings

`grep -rn "from [\"']\.\..*src/" templates/` surfaces 6 imports across 2 files (3 unique targets):

| Template file | Specifier | Resolves to |
|---|---|---|
| `templates/entity/new/prompt.js:25` | `../../../src/config/paths.mjs` | `src/config/paths.mjs` |
| `templates/entity/new/prompt.js:26` | `../../../src/config/naming-config.mjs` | `src/config/naming-config.mjs` |
| `templates/entity/new/prompt.js` (also) | `../../../src/patterns/registry.js` | `src/patterns/registry.ts` (Bun TS-aware ESM) |
| `templates/entity/new/prompt.js` (also) | `../../../src/patterns/library/index.js` | `src/patterns/library/index.ts` |
| `templates/entity/new/clean-lite-ps/prompt-extension.js:14` | `../../../../src/patterns/registry.js` | `src/patterns/registry.ts` |
| `templates/entity/new/clean-lite-ps/prompt-extension.js:15` | `../../../../src/patterns/library/index.js` | `src/patterns/library/index.ts` |

Transitive closure (followed `import` graphs):

- **`src/config/`** — `paths.mjs` → `config-loader.mjs`, `naming-config.mjs`, `case-converters.mjs`, `locations.mjs`, `../schema/naming-config.schema.mjs`. All five `.mjs` files plus the schema file are reachable.
- **`src/patterns/`** — `registry.ts` → `pattern-definition.ts`. `library/index.ts` → `*.pattern.ts` (5 files) → `pattern-definition.ts`. The `validate-*.ts` files reach into `analyzer/` and `behaviors/` but are **not** imported by what the templates touch — so they stay out of the tarball.

Conclusion: ship `src/config/*.mjs`, `src/schema/naming-config.schema.mjs`, `src/patterns/registry.ts`, `src/patterns/pattern-definition.ts`, `src/patterns/library/*.ts`. Narrow paths only — broad `src/` would ship test fixtures + CLI source unnecessarily.

## Verification (npm-pack-and-install, mandatory per #266)

Reproduced the failure pre-fix and confirmed the fix end-to-end:

```bash
# in worktree:
npm pack
mkdir /tmp/verify-266 && cd /tmp/verify-266
npm init -y
mkdir entities && cp <repo>/test/fixtures/user.yaml entities/test.yaml
npm install <worktree>/pattern-stack-codegen-0.6.0.tgz
bun node_modules/@pattern-stack/codegen/dist/src/cli/index.js entity new entities/test.yaml --force
```

**Pre-fix output:**
```
[INFO] generating user
ResolveMessage: Cannot find module '../../../src/config/paths.mjs' from
  '/private/tmp/verify-266/node_modules/@pattern-stack/codegen/templates/entity/new/prompt.js'
[FAIL] user — Command failed
[WARN] 1 entities · 0 succeeded · 1 failed
```

**Post-fix output (after re-packing with the manifest fix):**
```
[OK] user
[OK] 1 entities · 1 succeeded
[INFO] barrels regenerated (1 entities)
```

Tarball contents now include the 14 newly-shipped files under `package/src/{config,patterns,schema}/`.

## Prevention test

Added `src/__tests__/templates/files-manifest-coverage.test.ts`:

- Globs `templates/**/*.{js,mjs,cjs}`, regex-matches every relative `import`/`from`/`require` specifier.
- Resolves each spec against the template's directory; falls back to `.js → .ts` rewrite (Bun TS-aware ESM).
- Skips imports that resolve back inside `templates/` (intra-package).
- Asserts each remaining (cross-package) target matches at least one entry in `package.json:files` via a tiny glob → RegExp matcher.
- Today: detects 6 imports across 2 templates, all 6 covered. Sanity-checked: removing the new `files` entries makes the test fail with all 6 imports listed — so it catches the exact #266 regression.

## Test plan

- [x] Unit tests pass: `just test-unit` — 1665 pass, 0 fail (includes the new test).
- [x] Manual repro: `npm pack && npm install ./pack.tgz && entity new` against `test/fixtures/user.yaml` succeeds.
- [x] Pre-fix sanity check: stashing `package.json` and re-running the prevention test surfaces all 6 cross-package imports as uncovered.
- [ ] CI green (auto-run on push).

## Why this slipped

Third occurrence of the post-publish-tarball-mismatch class. See #190 (post-publish smoke proposal — still open). The prevention test added here closes the gap statically; #190 remains a worthwhile dynamic verification step but is out of scope for this hotfix.

## Out of scope

- Long-term refactor (issue #266 option 2/3): bundle template runtime deps into `dist/templates-runtime/`, or eliminate cross-package imports from templates entirely. Both are real architectural improvements, neither blocks the 0.6.1 hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)