### PR TITLE
chore(release): add `just publish` recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -125,6 +125,39 @@ release:
     git push origin "v${version}"
     echo "Tagged and pushed v${version}"
 
+# Publish current origin/main to npm (clean worktree, no branch-state assumptions)
+publish:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    git fetch origin main
+
+    version=$(git show origin/main:package.json | jq -r .version)
+    is_private=$(git show origin/main:package.json | jq -r '.private // false')
+
+    if [ "$is_private" = "true" ]; then
+        echo "ERROR: package.json on origin/main has private:true — refusing to publish."
+        echo "Remove the field, tag a new release, then retry."
+        exit 1
+    fi
+
+    workdir="/tmp/codegen-publish-${version}-$$"
+    echo "Publishing @pattern-stack/codegen@${version} from origin/main"
+    echo "Worktree: ${workdir}"
+
+    trap 'cd /; git worktree remove --force "${workdir}" 2>/dev/null || true' EXIT
+
+    git worktree add "${workdir}" origin/main
+    cd "${workdir}"
+
+    mise trust >/dev/null 2>&1 || true
+    mise install >/dev/null 2>&1 || true
+
+    bun install
+    npm publish
+
+    echo "✓ Published @pattern-stack/codegen@${version}"
+
 # ─── Install Skill ────────────────────────────────────────────────────────────
 
 # Install the codegen Claude Code skill into a target project


### PR DESCRIPTION
Adds `just publish` — wraps the post-tag publish flow into a single command.

## What it does

1. `git fetch origin main`
2. Reads version from `origin/main:package.json`
3. **Pre-flight check**: refuses to publish if `package.json` has `"private": true` (the 0.6.2 → 0.6.3 republish gotcha — caught by trial-and-error this session, now caught at the recipe layer)
4. Creates a clean worktree at `/tmp/codegen-publish-<version>-<pid>`
5. `mise trust` + `mise install` to bootstrap toolchain (node + bun from `.mise.toml`)
6. `bun install`
7. `npm publish` (the package's own `prepublishOnly` runs `bun run build`)
8. Cleans up the worktree on exit (trap)

## Why

The publish dance was hand-typed each time (`mise trust`, `asdf set`, `bun install`, `npm publish`, manual worktree cleanup). Multiple steps, easy to skip one. `just publish` makes it idempotent + adds the `private: true` gate that would have caught 0.6.2's republish need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)