### PR TITLE
feat(codegen): clean-lite-ps sync-source paths + ADR-033.1 entity-type clarification (#267, closes #268)

### DIFF
--- a/docs/adrs/ADR-033-config-driven-change-sources.md
+++ b/docs/adrs/ADR-033-config-driven-change-sources.md
@@ -112,6 +112,8 @@ type PollFetchContext = {
 
 `userId` / `tenantId` are *run-scoped* (they arrive on `ExecuteSyncUseCase.execute(input)`, not on the source). Threading them through the port forces signature expansion every time run context grows. Adapter closures own provider auth lookup — the consumer registers a `PollFetchCallback<T>` against a token, and that callback closes over whatever services it needs.
 
+`T` in `PollFetchCallback<T>` is the entity/domain type — the persisted Drizzle row's TS type. Wire-format conversions (ISO-string → Date, decimal-string → number, etc.) happen via `DetectionConfig.mapping[].transform` before the callback's record reaches `Change<T>`; consumers do not maintain a parallel canonical TS type. See ADR-033.1 §10 for the full rationale.
+
 ### 7. Per-entity YAML, generated factory module
 
 The `detection:` block lives in per-entity YAML (`entities/<entity>.yaml`). `codegen.config.yaml: sync:` keeps subsystem-wide settings only (backend, multiTenant, schema/config paths). The per-entity factory module emitted by Phase 2 codegen looks like:
@@ -135,6 +137,8 @@ export class OpportunitySyncSourceModule {}
 ```
 
 Adapter-callback tokens (`OPPORTUNITY_POLL_ADAPTER` here) are consumer-registered. The codegen factory composes the locked middleware list and binds to `SYNC_CHANGE_SOURCE`.
+
+`Opportunity` here (and the `T` parameter generally) is the entity type. `mapping[].transform` is the seat for any wire→entity field conversion the consumer needs — the change-source primitive applies the mapping before yielding `Change<T>` to the orchestrator. See ADR-033.1 §10.
 
 ## Rationale (Q1–Q6 cross-reference)
 

--- a/docs/adrs/ADR-033.1-provider-keyed-detection.md
+++ b/docs/adrs/ADR-033.1-provider-keyed-detection.md
@@ -89,6 +89,8 @@ export const OPPORTUNITY_CHANGE_SOURCES      = Symbol('OPPORTUNITY_CHANGE_SOURCE
 export class OpportunitySyncSourceModule {}
 ```
 
+**`T` is the entity/domain type uniformly.** `T` in `PollFetchCallback<T>`, `IChangeSource<T>`, and (downstream) `ISyncSink<T>` is the entity class — the persisted Drizzle row's TS type, the same type the rest of the app reasons about. There is no separate "canonical wire type" per entity. Wire-format conversions (ISO-string → Date, decimal-string → number, etc.) happen declaratively via `DetectionConfig.mapping[].transform` (`runtime/subsystems/sync/detection-config.schema.ts`); the change-source primitive applies them before yielding `Change<T>`. See §10 below for the rationale.
+
 ### 5. Token shape: `<ENTITY>_CHANGE_SOURCES: ReadonlyMap`
 
 Generated tokens are entity-level only:
@@ -137,9 +139,24 @@ skip_if: <%= !hasDetection %>
 
 This is in scope for the same PR as decision §1; the gate's only existence reason was an ADR-033 conservatism and the file does not exist on `main` until #240 lands.
 
+Dropping the gate is necessary but not sufficient for clean-lite-ps support. The template's emit `to:` and entity-import paths must route through the architecture-specific override seam. clean-lite-ps's `prompt-extension.js` provides this override (`clpOutputPaths.syncSourceModule`, `clpOutputPaths.syncSourceProviders`, `clpImports.syncSourceToEntity`); the clean pipeline uses `${basePaths.backendSrc}/${paths.modules}/...` and `imports.moduleToDomain` (the existing `getImportPaths()` helper that resolves to the domain barrel). Both pipelines now emit sync-source modules at consumer-appropriate paths. (Closes #267.)
+
 ### 9. Cursor disambiguation stays unchanged
 
 `sync_subscriptions.cursor` remains opaque (sync skill rule 2). The subscription row's `provider` column already disambiguates which YAML detection block parses the cursor — no need to tag the cursor itself. Provider key is the indirection.
+
+### 10. `T` is the entity type; no canonical wire type
+
+The sync seam's type parameter `T` is uniformly the entity/domain type — the persisted Drizzle row's TS type, the same type domain services reason about. There is no separate canonical wire type per entity, and `DetectionConfig.mapping[]` is sufficient to express provider→entity field translation declaratively (rename via `target`, type conversion via `transform`).
+
+A previously-considered alternative — adding a `sync.canonical_type` YAML knob that lets consumers parameterize `T` with a provider-agnostic canonical TS type (`CanonicalAccount`, etc.) — is rejected. Rationale:
+
+- **`mapping[].transform` is the declarative seat for wire-format conversion.** Pushing that work into a parallel TS type forks the source of truth.
+- **The cited motivation for canonical types — "the app does too much, decouple the wire layer" — is solved upstream**, by separating data-shape entities from behavior-laden services. Clean entity layouts (Drizzle row + service) admit direct sync-to-entity flow with no intermediate type.
+- **`Change<T>.providerMetadata` already carries provider-only fields** that don't belong on the entity. Wire fields can pass through without polluting the domain model.
+- **Two-layer mapping is duplicate work** when one declarative layer (`mapping[]`) is already canonical for sync. A second hand-coded layer (canonical→entity in the sink) doubles maintenance with no architectural gain.
+
+**Note on `ISyncSink<TCanonical>`'s parameter name.** The protocol's parameter is `TCanonical` for historical reasons (the original sink design assumed a canonical layer). With this decision, `TCanonical` is functionally the entity type. The protocol's name stays for now — renaming it touches every sink implementation across consumers and the rename adds no semantic clarity. A future ADR may rename it to `TEntity` once consumers have migrated; flagged as cosmetic. (Closes #268.)
 
 ## Rationale
 

--- a/src/__tests__/templates/sync-source-clean-lite-ps.test.ts
+++ b/src/__tests__/templates/sync-source-clean-lite-ps.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Issue #267 + ADR-033.1 §8 — clean-lite-ps sync-source emission.
+ *
+ * The sync-source.ejs.t template's `to:` and entity-import paths must route
+ * through clean-lite-ps overrides when the architecture is `clean-lite-ps`:
+ *   - module emit path: src/modules/<plural>/<entity>-sync-source.module.ts
+ *     (co-located with the entity file, NOT under infrastructure/modules/)
+ *   - entity import: ./<entity>.entity (sibling import, matches the
+ *     entity-file location in the same feature folder)
+ *
+ * Both are sourced from `clpOutputPaths.syncSourceModule` and
+ * `clpImports.syncSourceToEntity` populated by the clean-lite-ps
+ * prompt-extension.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const MODULE_TEMPLATE = resolve(
+  import.meta.dir,
+  '../../../templates/entity/new/backend/modules/core/sync-source.ejs.t',
+);
+const PROVIDERS_TEMPLATE = resolve(
+  import.meta.dir,
+  '../../../templates/entity/new/backend/modules/core/sync-source.providers.ejs.t',
+);
+
+function readFrontmatter(source: string): { frontmatter: string; body: string } {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return { frontmatter: '', body: source };
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return { frontmatter: '', body: source };
+  return {
+    frontmatter: lines.slice(1, end).join('\n'),
+    body: lines.slice(end + 1).join('\n'),
+  };
+}
+
+const opportunityDefinition = {
+  entity: { name: 'opportunity', plural: 'opportunities', table: 'opportunities', pattern: 'Synced' },
+  fields: {
+    user_id: { type: 'uuid', required: true },
+    name: { type: 'string', required: true },
+    amount: { type: 'decimal', nullable: true },
+  },
+  relationships: {
+    user: { type: 'belongs_to', target: 'user', foreign_key: 'user_id', nullable: false },
+  },
+  behaviors: ['timestamps'],
+};
+
+describe('sync-source emission (clean-lite-ps) — #267', () => {
+  it('clean-lite-ps locals expose syncSourceModule + syncSourceProviders + clpImports.syncSourceToEntity', () => {
+    const locals = buildCleanLitePsLocals(opportunityDefinition, { backendSrc: 'src' });
+
+    expect(locals.clpOutputPaths.syncSourceModule).toBe(
+      'src/modules/opportunities/opportunity-sync-source.module.ts',
+    );
+    expect(locals.clpOutputPaths.syncSourceProviders).toBe(
+      'src/modules/opportunities/opportunity-sync-source.providers.ts',
+    );
+    expect(locals.clpImports.syncSourceToEntity).toBe('./opportunity.entity');
+  });
+
+  it('module template `to:` resolves to the CLP path when isCleanLitePs is true', () => {
+    const locals = buildCleanLitePsLocals(opportunityDefinition, { backendSrc: 'src' });
+    const { frontmatter } = readFrontmatter(readFileSync(MODULE_TEMPLATE, 'utf8'));
+    // Render the frontmatter as EJS so the conditional ternary evaluates.
+    const rendered = ejs.render(frontmatter, {
+      hasDetection: true,
+      isCleanLitePs: true,
+      clpOutputPaths: locals.clpOutputPaths,
+      basePaths: { backendSrc: 'unused' },
+      paths: { modules: 'unused' },
+      name: 'opportunity',
+    });
+    expect(rendered).toContain('src/modules/opportunities/opportunity-sync-source.module.ts');
+    expect(rendered).not.toContain('unused');
+  });
+
+  it('providers template `to:` resolves to the CLP path when isCleanLitePs is true', () => {
+    const locals = buildCleanLitePsLocals(opportunityDefinition, { backendSrc: 'src' });
+    const { frontmatter } = readFrontmatter(readFileSync(PROVIDERS_TEMPLATE, 'utf8'));
+    const rendered = ejs.render(frontmatter, {
+      hasDetection: true,
+      isCleanLitePs: true,
+      clpOutputPaths: locals.clpOutputPaths,
+      basePaths: { backendSrc: 'unused' },
+      paths: { modules: 'unused' },
+      name: 'opportunity',
+    });
+    expect(rendered).toContain('src/modules/opportunities/opportunity-sync-source.providers.ts');
+    expect(rendered).not.toContain('unused');
+  });
+
+  it('module body imports the entity sibling-style under clean-lite-ps', () => {
+    const locals = buildCleanLitePsLocals(opportunityDefinition, { backendSrc: 'src' });
+    const { body } = readFrontmatter(readFileSync(MODULE_TEMPLATE, 'utf8'));
+    const rendered = ejs.render(body, {
+      name: 'opportunity',
+      className: 'Opportunity',
+      hasDetection: true,
+      detectionConfigsLiteral: '{}',
+      isCleanLitePs: true,
+      clpImports: locals.clpImports,
+      imports: { moduleToDomain: '../../domain' },
+    });
+    expect(rendered).toContain("import type { Opportunity } from './opportunity.entity';");
+    expect(rendered).not.toContain("from '../../domain'");
+  });
+
+  it('clean-architecture path still uses imports.moduleToDomain (regression guard)', () => {
+    const { body } = readFrontmatter(readFileSync(MODULE_TEMPLATE, 'utf8'));
+    const rendered = ejs.render(body, {
+      name: 'opportunity',
+      className: 'Opportunity',
+      hasDetection: true,
+      detectionConfigsLiteral: '{}',
+      isCleanLitePs: false,
+      clpImports: undefined,
+      imports: { moduleToDomain: '../domain' },
+    });
+    expect(rendered).toContain("import type { Opportunity } from '../domain';");
+  });
+});

--- a/src/__tests__/templates/sync-source-rendering.test.ts
+++ b/src/__tests__/templates/sync-source-rendering.test.ts
@@ -49,6 +49,9 @@ function renderModule(detectionBlock: Record<string, unknown>): string {
     hasDetection: Object.keys(detectionBlock).length > 0,
     detectionConfigsLiteral: JSON.stringify(detectionBlock, null, 2),
     imports: { moduleToDomain: '../domain' },
+    isCleanLitePs: false,
+    clpOutputPaths: undefined,
+    clpImports: undefined,
   });
 }
 

--- a/templates/entity/new/backend/modules/core/sync-source.ejs.t
+++ b/templates/entity/new/backend/modules/core/sync-source.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= hasDetection ? `${basePaths.backendSrc}/${paths.modules}/${name}-sync-source.module.ts` : null %>"
+to: "<%= hasDetection ? (isCleanLitePs ? clpOutputPaths.syncSourceModule : `${basePaths.backendSrc}/${paths.modules}/${name}-sync-source.module.ts`) : null %>"
 skip_if: <%= !hasDetection %>
 force: true
 ---
@@ -10,7 +10,7 @@ import type {
   IChangeSource,
   PollFetchCallback,
 } from '@shared/subsystems/sync';
-import type { <%= className %> } from '<%= imports.moduleToDomain %>';
+import type { <%= className %> } from '<%= isCleanLitePs ? clpImports.syncSourceToEntity : imports.moduleToDomain %>';
 
 const <%= name.toUpperCase() %>_DETECTION_CONFIGS: Record<string, DetectionConfig> = <%- detectionConfigsLiteral %>;
 

--- a/templates/entity/new/backend/modules/core/sync-source.providers.ejs.t
+++ b/templates/entity/new/backend/modules/core/sync-source.providers.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: "<%= hasDetection ? `${basePaths.backendSrc}/${paths.modules}/${name}-sync-source.providers.ts` : null %>"
+to: "<%= hasDetection ? (isCleanLitePs ? clpOutputPaths.syncSourceProviders : `${basePaths.backendSrc}/${paths.modules}/${name}-sync-source.providers.ts`) : null %>"
 skip_if: <%= !hasDetection %>
 force: true
 ---

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -825,6 +825,17 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     declarativeQueries: hasDeclarativeQueries
       ? `${srcRoot}/modules/${entityNamePlural}/use-cases/declarative-queries.ts`
       : null,
+    // ADR-033.1 §8 — sync-source module emission for clean-lite-ps. Co-located
+    // with the entity feature module under src/modules/<plural>/. Closes #267.
+    syncSourceModule: `${srcRoot}/modules/${entityNamePlural}/${entityName}-sync-source.module.ts`,
+    syncSourceProviders: `${srcRoot}/modules/${entityNamePlural}/${entityName}-sync-source.providers.ts`,
+  };
+
+  // Architecture-specific imports for clean-lite-ps. The sync-source module
+  // imports the entity type sibling-style (`./<entity>.entity`) since the
+  // module file lives next to the entity file in the same feature folder.
+  const clpImports = {
+    syncSourceToEntity: `./${entityName}.entity`,
   };
 
   // Class names
@@ -952,6 +963,9 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
 
     // Output paths
     clpOutputPaths: outputPaths,
+
+    // Architecture-specific imports (ADR-033.1 §8 — sync-source closes #267)
+    clpImports,
 
     // Class names
     classNames,

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -1644,6 +1644,7 @@ export default {
       const _p = definition.entity?.plural || _n + 's';
       Object.assign(locals, {
         clpOutputPaths: undefined,
+        clpImports: undefined,
         entityName: _n,
         entityNamePlural: _p,
         entityNamePascal: _n,


### PR DESCRIPTION
## Summary

- **Fix #267**: clean-lite-ps consumers can now emit sync-source modules at the right path (`src/modules/<plural>/<entity>-sync-source.module.ts`) and import the entity sibling-style (`./<entity>.entity`) via the new `clpOutputPaths.syncSourceModule`/`syncSourceProviders` and `clpImports.syncSourceToEntity` overrides.
- **Closes #268** ("won't fix"): Decision locked — `T` in `IChangeSource<T>` / `PollFetchCallback<T>` / `ISyncSink<T>` is uniformly the entity/domain type. Wire→entity conversion is `DetectionConfig.mapping[].transform`'s job. No `sync.canonical_type` YAML knob; no parallel canonical TS type per entity.
- **ADR-033.1 amended**: §4 clarifies `T` = entity; §8 extends with architecture-aware emission; new §10 records the canonical-type rejection rationale and notes `ISyncSink<TCanonical>`'s parameter name stays as a cosmetic-rename-later flag. ADR-033 §6/§7 add cross-reference notes.

## Discovery notes

Issue #267 claimed `imports.moduleToDomain` was missing from `getImportPaths()`. **It already exists** at `src/config/paths.mjs:499` and resolves to `'../domain'` for the clean architecture — the baseline emission was already correct. The actual gap was that `clean-lite-ps`'s `prompt-extension.js` had no override seam for the sync-source template's `to:` and entity import. Fix is scoped accordingly: only CLP gets new locals; the clean pipeline is untouched.

## Test plan

- [x] `just test-unit` — 1670 pass (5 new in `sync-source-clean-lite-ps.test.ts`)
- [x] `just test-baseline` — green; no clean-architecture baseline diffs (regression guard)
- [x] `just test-smoke` — green
- [x] New CLP render test asserts emit path = `src/modules/opportunities/opportunity-sync-source.module.ts` and entity import = `./opportunity.entity`
- [x] Regression guard verifies clean-architecture path still imports from `../domain`

## Architectural decision (closes #268)

The canonical-type concept in sales-patterns-ts was a workaround for app-side overreach (entities with too much behavior). The right fix is cleaner domain models — Drizzle row + service — not a parallel TS type. `mapping[].transform` is already the declarative seat for wire-format conversion; layering a hand-coded canonical→entity step in the sink would double the maintenance with no architectural gain. `Change<T>.providerMetadata` carries provider-only fields without polluting `T`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)