### PR TITLE
fix(init): typed modules barrel + codegen bin alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     }
   },
   "bin": {
+    "codegen": "dist/src/cli/index.js",
     "cdp": "dist/src/cli/index.js"
   },
   "files": [

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -383,7 +383,10 @@ function emptyModulesBarrel(): string {
 	return `// AUTO-GENERATED — DO NOT EDIT.
 // Regenerated on every \`codegen entity new\` / \`codegen entity new --all\`.
 // See ADR-017.
-export const GENERATED_MODULES: unknown[] = [];
+import type { DynamicModule, ForwardReference, Type } from '@nestjs/common';
+export const GENERATED_MODULES: Array<
+	Type | DynamicModule | Promise<DynamicModule> | ForwardReference
+> = [];
 `;
 }
 


### PR DESCRIPTION
Two small fixes reported by a fresh `cdp project init` run.

## Fix 1 — Empty `GENERATED_MODULES` barrel fails typecheck

The init scaffold emitted `src/generated/modules.ts` typed as `unknown[]`:

```ts
export const GENERATED_MODULES: unknown[] = [];
```

The same scaffold's `src/app.module.ts` spreads that into NestJS's `imports:`:

```ts
imports: [DatabaseModule, OpenApiModule, ...GENERATED_MODULES]
```

On a freshly-init'd project (no entities yet), `tsc --noEmit` fails:

```
src/app.module.ts: error TS2322: Type 'unknown' is not assignable to type 'Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference<any>'.
```

Every consumer hits this on day one. Fixed by typing the empty barrel with NestJS's actual import-type union:

```ts
import type { DynamicModule, ForwardReference, Type } from '@nestjs/common';
export const GENERATED_MODULES: Array<
  Type | DynamicModule | Promise<DynamicModule> | ForwardReference
> = [];
```

The entity-populated barrel emitted by `barrel-generator.ts` (`as const` array of NestJS module classes) still satisfies this type when spread — a class is a `Type`.

## Fix 2 — Bin name `cdp` collides with an unrelated npm package

`package.json` previously declared only `"bin": { "cdp": "..." }`. There's an unrelated package on npm also named `cdp` (a configs.json check-in tool). When a consumer runs `bunx cdp project init` without first installing `@pattern-stack/codegen` locally, npm resolves and runs the wrong package — silently. The CLI banner, README, and downstream docs already refer to the binary as `codegen <command>`.

Added `codegen` as the primary bin. Kept `cdp` as an alias so existing consumers don't break:

```json
"bin": {
  "codegen": "dist/src/cli/index.js",
  "cdp": "dist/src/cli/index.js"
}
```

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (full suite)
- [ ] Spot-check on a fresh `codegen project init` that the emitted `src/generated/modules.ts` typechecks against `app.module.ts`

No version bump, no CHANGELOG entry — those are release concerns.

Reported by an integration-patterns consumer.