### PR TITLE
chore(examples/auth-integrations): reviewer nits from #290

### DIFF
--- a/examples/auth-integrations/runtime/integrations/integration-grant-sink.adapter.ts
+++ b/examples/auth-integrations/runtime/integrations/integration-grant-sink.adapter.ts
@@ -3,24 +3,27 @@ import type {
   IIntegrationGrantSink,
   IntegrationGrantInput,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { IntegrationsService } from './integrations.service';
+import { CreateOrUpdateFromOAuthGrantUseCase } from './use-cases/create-or-update-from-oauth-grant.use-case';
 
 /**
  * `IIntegrationGrantSink` adapter — pass-through to
- * `IntegrationsService.createOrUpdateFromOAuthGrant`. The auth
- * subsystem's `AuthController.callback` invokes this after
+ * `CreateOrUpdateFromOAuthGrantUseCase`. The auth subsystem's
+ * `AuthController.callback` invokes this after
  * `ProviderStrategy.exchangeCodeForTokens`.
  *
- * This adapter is intentionally a one-line forwarder. The port and
- * the facade share the exact same `IntegrationGrantInput` shape, so
- * no field mapping is needed — encryption, upsert resolution, and
- * status handling all live inside the use case behind the facade.
+ * This adapter injects the use case directly (not the
+ * `IntegrationsService` facade) for symmetry with the reader and
+ * token-writer adapters, which also bypass the facade and talk to
+ * the codegen-emitted layer directly. The port and the use case share
+ * the exact same `IntegrationGrantInput` shape, so no field mapping is
+ * needed — encryption, upsert resolution, and status handling all live
+ * inside the use case.
  */
 @Injectable()
 export class IntegrationGrantSinkAdapter implements IIntegrationGrantSink {
-  constructor(private readonly integrations: IntegrationsService) {}
+  constructor(private readonly useCase: CreateOrUpdateFromOAuthGrantUseCase) {}
 
   async createOrUpdateFromOAuthGrant(input: IntegrationGrantInput): Promise<void> {
-    await this.integrations.createOrUpdateFromOAuthGrant(input);
+    await this.useCase.execute(input);
   }
 }

--- a/examples/auth-integrations/runtime/integrations/integrations.service.ts
+++ b/examples/auth-integrations/runtime/integrations/integrations.service.ts
@@ -84,8 +84,7 @@ export class IntegrationsService {
   async listByUser(userId: string): Promise<Array<Omit<Integration, 'accessTokenEncrypted' | 'refreshTokenEncrypted'>>> {
     const rows = await this.listUseCase.execute(userId);
     return rows.map((row) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { accessTokenEncrypted, refreshTokenEncrypted, ...safe } = row;
+      const { accessTokenEncrypted: _accessTokenEncrypted, refreshTokenEncrypted: _refreshTokenEncrypted, ...safe } = row;
       return safe;
     });
   }
@@ -125,7 +124,7 @@ export class IntegrationsService {
    * `DecryptedIntegration.accessToken`'s "empty if never granted"
    * contract.
    */
-  async decrypt(row: Integration): Promise<DecryptedIntegrationRow> {
+  private async decrypt(row: Integration): Promise<DecryptedIntegrationRow> {
     const accessToken = row.accessTokenEncrypted
       ? await this.encryption.decrypt(row.accessTokenEncrypted)
       : '';


### PR DESCRIPTION
Follow-up to #285 / PR #290 — three deferred reviewer nits.

## Changes
- **Adapter symmetry** — `IntegrationGrantSinkAdapter` now injects `CreateOrUpdateFromOAuthGrantUseCase` directly, matching the reader/writer adapters that bypass the `IntegrationsService` facade.
- **`decrypt()` is private** — only internal callers remain after the adapter change; `IntegrationsService.decrypt()` is now `private`.
- **Drop `eslint-disable`** — `listByUser`'s unused destructure bindings are now underscore-prefixed (`_accessTokenEncrypted`, `_refreshTokenEncrypted`); cosmetic.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)