### PR TITLE
chore(auth): install template nits + smoke gap close (#294)

### DIFF
--- a/src/__tests__/cli/auth-scaffold-locals.test.ts
+++ b/src/__tests__/cli/auth-scaffold-locals.test.ts
@@ -26,7 +26,6 @@ describe('resolveAuthScaffoldLocals', () => {
 		const locals = resolveAuthScaffoldLocals({
 			cwd: CWD,
 			config: null,
-			fileExists: () => false,
 		});
 
 		expect(locals.appName).toBe('auth-fixture');
@@ -47,7 +46,6 @@ describe('resolveAuthScaffoldLocals', () => {
 			cwd: CWD,
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			config: { auth: { redirect_uri_base: 'https://api.example.com' } } as any,
-			fileExists: () => false,
 		});
 		expect(locals.redirectUriBase).toBe('https://api.example.com');
 	});
@@ -69,7 +67,6 @@ describe('resolveAuthScaffoldLocals', () => {
 			cwd: CWD,
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			config: { paths: { backend_src: 'packages/api/src' } } as any,
-			fileExists: () => false,
 		});
 		expect(locals.appModulePath).toBe(
 			path.resolve(CWD, 'packages/api/src/app.module.ts'),
@@ -92,7 +89,6 @@ describe('resolveAuthScaffoldLocals', () => {
 				},
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} as any,
-			fileExists: () => false,
 		});
 		expect(locals.schemaPath).toBe(
 			path.resolve(CWD, 'custom/subsystems/auth/auth-oauth-state.schema.ts'),
@@ -103,7 +99,6 @@ describe('resolveAuthScaffoldLocals', () => {
 		const locals = resolveAuthScaffoldLocals({
 			cwd: CWD,
 			config: null,
-			fileExists: () => false,
 		});
 		// 32 bytes encoded as base64 = 44 ascii chars (with one '=' pad).
 		expect(locals.tokenEncryptionKey.length).toBe(44);
@@ -120,27 +115,14 @@ describe('resolveAuthScaffoldLocals', () => {
 		const a = resolveAuthScaffoldLocals({
 			cwd: CWD,
 			config: null,
-			fileExists: () => false,
 		});
 		const b = resolveAuthScaffoldLocals({
 			cwd: CWD,
 			config: null,
-			fileExists: () => false,
 		});
 		expect(a.tokenEncryptionKey).not.toBe(b.tokenEncryptionKey);
 	});
 
-	test('fileExists probe is permitted to be unused', () => {
-		expect(() =>
-			resolveAuthScaffoldLocals({
-				cwd: CWD,
-				config: null,
-				fileExists: () => {
-					throw new Error('should not be called');
-				},
-			}),
-		).not.toThrow();
-	});
 });
 
 describe('localsToHygenArgs', () => {

--- a/src/__tests__/cli/subsystem.test.ts
+++ b/src/__tests__/cli/subsystem.test.ts
@@ -258,6 +258,101 @@ describe('subsystem — install (real)', () => {
 		const parsed = JSON.parse(out);
 		expect(parsed.status).toBe('already-installed');
 	});
+
+	// #294: mirror the events idempotency check for `auth` and
+	// `auth-integrations`. Confirms second-run no-op behaviour survives
+	// future template changes — no duplicate config blocks, no duplicate
+	// env vars, no duplicate app.module.ts imports.
+	test('second auth install is idempotent without --force', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run(['subsystem', 'install', 'auth', '--force', '--cwd', root]),
+		);
+
+		const configPath = path.join(root, 'codegen.config.yaml');
+		const envConfigPath = path.join(root, '.env.config');
+		const appModulePath = path.join(root, 'src/app.module.ts');
+		const configBefore = fs.readFileSync(configPath, 'utf-8');
+		const envBefore = fs.readFileSync(envConfigPath, 'utf-8');
+		const appModuleBefore = fs.existsSync(appModulePath)
+			? fs.readFileSync(appModulePath, 'utf-8')
+			: '';
+
+		// Second run — no --force.
+		const { result, out } = await capture(() =>
+			cli.run(['subsystem', 'install', 'auth', '--json', '--cwd', root]),
+		);
+		expect(result).toBe(0);
+		const parsed = JSON.parse(out);
+		expect(parsed.status).toBe('already-installed');
+
+		// Files unchanged — no duplicate auth: block, TOKEN_ENCRYPTION_KEY
+		// not regenerated, no duplicate AuthModule TODO.
+		expect(fs.readFileSync(configPath, 'utf-8')).toBe(configBefore);
+		expect(fs.readFileSync(envConfigPath, 'utf-8')).toBe(envBefore);
+		const tokenLines = envBefore.match(/^TOKEN_ENCRYPTION_KEY=/gm) ?? [];
+		expect(tokenLines.length).toBe(1);
+		if (fs.existsSync(appModulePath)) {
+			expect(fs.readFileSync(appModulePath, 'utf-8')).toBe(appModuleBefore);
+		}
+	});
+
+	test('second auth-integrations install is idempotent without --force', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'auth-integrations',
+				'--force',
+				'--cwd',
+				root,
+			]),
+		);
+
+		const appModulePath = path.join(root, 'src/app.module.ts');
+		const integrationYamlPath = path.join(
+			root,
+			'definitions/entities/integration.yaml',
+		);
+		const appModuleBefore = fs.existsSync(appModulePath)
+			? fs.readFileSync(appModulePath, 'utf-8')
+			: '';
+		const yamlBefore = fs.existsSync(integrationYamlPath)
+			? fs.readFileSync(integrationYamlPath, 'utf-8')
+			: '';
+
+		const { result, out } = await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'auth-integrations',
+				'--json',
+				'--cwd',
+				root,
+			]),
+		);
+		expect(result).toBe(0);
+		const parsed = JSON.parse(out);
+		expect(parsed.status).toBe('already-installed');
+
+		// Vendored YAML + app.module.ts unchanged on second run; no duplicate
+		// IntegrationsAuthModule TODO appended.
+		if (fs.existsSync(integrationYamlPath)) {
+			expect(fs.readFileSync(integrationYamlPath, 'utf-8')).toBe(yamlBefore);
+		}
+		if (fs.existsSync(appModulePath)) {
+			const after = fs.readFileSync(appModulePath, 'utf-8');
+			expect(after).toBe(appModuleBefore);
+			const matches = after.match(/IntegrationsAuthModule/g) ?? [];
+			// At most one occurrence (the TODO from first install).
+			expect(matches.length).toBeLessThanOrEqual(1);
+		}
+	});
 });
 
 describe('subsystem — detection', () => {

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -1425,7 +1425,6 @@ function runAuthScaffold(
 	const locals = resolveAuthScaffoldLocals({
 		cwd,
 		config,
-		fileExists: (p: string) => fs.existsSync(p),
 	});
 
 	// Files the auth templates will target (used by --dry-run output and

--- a/src/cli/shared/auth-scaffold-locals.ts
+++ b/src/cli/shared/auth-scaffold-locals.ts
@@ -33,9 +33,10 @@
  * `generated/` dir (no codegen artifacts; the runtime ports + adapters are
  * directly importable).
  *
- * This module is filesystem-unaware except via injected probes — callers
- * pass `fileExists(p)` rather than us reaching for `node:fs` directly. That
- * keeps the unit test suite pure (see cli/auth-scaffold-locals.test.ts).
+ * This module is filesystem-unaware — the resolver is pure (config + cwd).
+ * The CLI's `runAuthScaffold` handles the `.env.config` touch externally
+ * before invoking Hygen (subsystem.ts:1460-1463), so no fs probe is needed
+ * here. Keeps the unit test suite pure (see cli/auth-scaffold-locals.test.ts).
  */
 import crypto from 'node:crypto';
 import path from 'node:path';
@@ -81,8 +82,6 @@ export interface AuthScaffoldLocalsInput {
 	cwd: string;
 	/** Parsed codegen.config.yaml (may be null on a brand-new init). */
 	config: CodegenConfig | null;
-	/** Injected fs probe. Implementations: `(p) => fs.existsSync(p)`. */
-	fileExists: (absolutePath: string) => boolean;
 }
 
 /**
@@ -106,7 +105,6 @@ export function resolveAuthScaffoldLocals(
 	input: AuthScaffoldLocalsInput,
 ): AuthScaffoldLocals {
 	const { cwd, config } = input;
-	void input.fileExists;
 
 	const backendSrc =
 		typeof config?.paths?.backend_src === 'string' &&

--- a/templates/subsystem/auth/auth-oauth-state.schema.ejs.t
+++ b/templates/subsystem/auth/auth-oauth-state.schema.ejs.t
@@ -2,6 +2,7 @@
 to: "<%= schemaPath %>"
 force: true
 ---
+// Schema barrel append tracked in #284 — same gap as events/jobs/sync today.
 /**
  * Drizzle schema for the `auth_oauth_state` table — backs the
  * `DrizzleOAuthStateStore` (`state-store.drizzle-backend.ts`).

--- a/templates/subsystem/auth/env-config.ejs.t
+++ b/templates/subsystem/auth/env-config.ejs.t
@@ -5,7 +5,16 @@ append: true
 skip_if: "TOKEN_ENCRYPTION_KEY"
 ---
 
-# OAuth integration token encryption key — 32 bytes b64 — DO NOT REUSE in prod
+# OAuth integration token encryption key — 32 bytes base64 (AES-256-GCM).
+# DO NOT REUSE this dev value in prod. To regenerate locally:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+# Re-running `codegen subsystem install auth` does NOT rotate this key —
+# `skip_if: "TOKEN_ENCRYPTION_KEY"` blocks the inject intentionally, because
+# silently rotating would invalidate every encrypted token already in the
+# consumer's `integrations` table. Rotation is a separate, auditable op.
+# In production: store the key in `secrets/secrets.yaml` (or your secret
+# manager) and have your deploy pipeline materialise it into the env at
+# boot — this `.env.config` line should be a placeholder, not the source.
 TOKEN_ENCRYPTION_KEY=<%= tokenEncryptionKey %>
 # Public base URL where OAuth providers redirect back. Override in staging/prod.
 AUTH_REDIRECT_URI_BASE=<%= redirectUriBase %>

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -155,13 +155,25 @@ function filterConsumerErrors(output: string, tmpDir: string): string[] {
 			continue;
 		}
 
-		// #294: the `shared/integrations/` filter has been removed — smoke
-		// now runs `cdp entity new integration` after the auth-integrations
-		// install (the integration.yaml is vendored by the install template),
-		// so the adapter imports it depends on are real codegen output. If
-		// new errors surface here, fix them — don't re-add the filter.
-
-		// Tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
+		// #287: the vendored `auth-integrations` adapters under
+		// `src/shared/integrations/` import from
+		// `apps/api/src/modules/integrations/integration.service` (etc.) —
+		// the codegen layer that `cdp entity new integration` would emit.
+		// We don't run that step in this smoke (it would require also
+		// scaffolding a Drizzle schema for `integrations` and bundling a
+		// fixture). The adapters are deliberately vendored-with-broken-imports
+		// so the consumer can `cdp entity new integration` against their own
+		// integration entity. Filter these out — they're scope-of-consumer
+		// errors, not generator bugs.
+		//
+		// #294: revisited — running `cdp entity new integration` in smoke
+		// surfaces a separate codegen enum literal-type bug (status: text →
+		// string vs DecryptedIntegration.status's literal union). Filed as
+		// a follow-up; reinstating this filter until that's resolved.
+		if (line.includes('shared/integrations/') || line.includes('shared\\integrations\\')) {
+			continue;
+		}
+		// Also tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
 		// barrel import — the smoke project doesn't `bun add` the package.
 		if (line.includes("'@pattern-stack/codegen/")) {
 			continue;
@@ -314,22 +326,6 @@ async function main(): Promise<number> {
 				'IntegrationsAuthModule TODO hint missing from app.module.ts after auth-integrations install',
 			);
 		}
-
-		// 5.8. #294 — generate the `integration` entity from the vendored
-		// YAML the auth-integrations install just dropped at
-		// `definitions/entities/integration.yaml`. The vendored adapters
-		// under `src/shared/integrations/` import from this codegen output,
-		// so without this step they would dangle (and previously the smoke
-		// filtered the resulting tsc errors instead of resolving them).
-		// Generating against the real entity closes the validation loop.
-		// `entity new` takes a YAML path (not a bare entity name); the
-		// auth-integrations install ships the yaml under `definitions/entities/`
-		// rather than the project's `entities_dir`, so we point at it
-		// explicitly rather than rely on `--all` discovery.
-		run(
-			`bun ${CLI_PATH} entity new definitions/entities/integration.yaml --force`,
-			tmpDir,
-		);
 
 		// 6. Syntax-check the scaffolded project.
 		//

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -155,20 +155,13 @@ function filterConsumerErrors(output: string, tmpDir: string): string[] {
 			continue;
 		}
 
-		// #287: the vendored `auth-integrations` adapters under
-		// `src/shared/integrations/` import from
-		// `apps/api/src/modules/integrations/integration.service` (etc.) —
-		// the codegen layer that `cdp entity new integration` would emit.
-		// We don't run that step in this smoke (it would require also
-		// scaffolding a Drizzle schema for `integrations` and bundling a
-		// fixture). The adapters are deliberately vendored-with-broken-imports
-		// so the consumer can `cdp entity new integration` against their own
-		// integration entity. Filter these out — they're scope-of-consumer
-		// errors, not generator bugs.
-		if (line.includes('shared/integrations/') || line.includes('shared\\integrations\\')) {
-			continue;
-		}
-		// Also tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
+		// #294: the `shared/integrations/` filter has been removed — smoke
+		// now runs `cdp entity new integration` after the auth-integrations
+		// install (the integration.yaml is vendored by the install template),
+		// so the adapter imports it depends on are real codegen output. If
+		// new errors surface here, fix them — don't re-add the filter.
+
+		// Tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
 		// barrel import — the smoke project doesn't `bun add` the package.
 		if (line.includes("'@pattern-stack/codegen/")) {
 			continue;
@@ -321,6 +314,22 @@ async function main(): Promise<number> {
 				'IntegrationsAuthModule TODO hint missing from app.module.ts after auth-integrations install',
 			);
 		}
+
+		// 5.8. #294 — generate the `integration` entity from the vendored
+		// YAML the auth-integrations install just dropped at
+		// `definitions/entities/integration.yaml`. The vendored adapters
+		// under `src/shared/integrations/` import from this codegen output,
+		// so without this step they would dangle (and previously the smoke
+		// filtered the resulting tsc errors instead of resolving them).
+		// Generating against the real entity closes the validation loop.
+		// `entity new` takes a YAML path (not a bare entity name); the
+		// auth-integrations install ships the yaml under `definitions/entities/`
+		// rather than the project's `entities_dir`, so we point at it
+		// explicitly rather than rely on `--all` discovery.
+		run(
+			`bun ${CLI_PATH} entity new definitions/entities/integration.yaml --force`,
+			tmpDir,
+		);
 
 		// 6. Syntax-check the scaffolded project.
 		//


### PR DESCRIPTION
## Summary

Four follow-ups from #287 / #293 review. (Item 5 split off — see note below.)

## Acceptance (#294)

- [x] **env-config.ejs.t** comments expanded — rotation command, dev/prod trade-off, why `skip_if` blocks re-run rotation (would invalidate encrypted-token rows), pointer to `secrets/secrets.yaml`.
- [x] **subsystem.test.ts** has idempotency cases for both `auth` and `auth-integrations` — mirrors the existing events case at `:246-260`. Verifies second-run no-op (no duplicate config blocks, env vars, or app.module.ts imports).
- [x] **dead-load removed from auth-scaffold-locals.ts** — dropped `fileExists` from `AuthScaffoldLocalsInput`, the resolver, the CLI caller, and the unit-test fixtures. The CLI's `runAuthScaffold` already does the `.env.config` touch externally (subsystem.ts:1460-1463).
- [x] **schema template references #284** — one-line breadcrumb on `auth-oauth-state.schema.ejs.t`.
- [ ] ~~run-smoke.ts runs `entity new` against vendored YAML and drops the filter~~ — **split into a separate issue.** Running `cdp entity new integration` surfaces a separate codegen enum literal-type bug (`integrations.service.ts:145` — `status: text → string` vs `DecryptedIntegration.status`'s literal union). Need to fix that codegen gap first; reinstating the `shared/integrations/` filter for now. Lead is filing the follow-up.

## Test plan

- [x] `bun test src/__tests__/cli/` — 327 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `just test-smoke` — PASS (with the filter restored)

## Out of scope

- #284 (schema barrel append gap) — breadcrumb only
- #190 (post-publish smoke gap) — separate
- Item 5 — separate follow-up (codegen enum literal-type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)