### PR TITLE
chore(release): 0.6.5 — auth subsystem + auth-integrations templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.5] — 2026-04-27
+
+Auth subsystem reaches consumers. `runtime/subsystems/auth/`, the `auth-integrations` starter, and the `cdp subsystem install auth` + `auth-integrations` templates were all merged on `main` (PRs #289, #290, #292, #293, #294, #295) but the published artifact was still pinned at `0.6.4`. This release ships them.
+
+### Added
+
+- **`feat(auth)` #289** — provider-agnostic `AuthController` mounting `GET /auth/:provider/connect` and `GET /auth/:provider/callback`, plus the `IUserContext` / `IOAuthStateStore` / `IIntegrationGrantSink` ports and memory + drizzle state-store backends. `OAuth2RefreshStrategy` extracted as a template-method base class. See `runtime/subsystems/auth/`.
+- **`feat(examples)` #290** — `examples/auth-integrations/` starter: canonical `integration.yaml` entity + adapters that satisfy the three `AUTH_INTEGRATION_*` ports + `IntegrationsService` facade.
+- **`feat(cdp)` #293** — `cdp subsystem install auth` and `cdp subsystem install auth-integrations` templates. The auth template emits `auth_oauth_state` drizzle schema, appends `TOKEN_ENCRYPTION_KEY` + `AUTH_REDIRECT_URI_BASE` to `.env.config`, and drops a TODO into `app.module.ts`. `auth-integrations` vendors the starter under `apps/api/src/shared/integrations/`.
+
 ## [0.6.4] — 2026-04-27
 
 Two consumer-DX fixes surfaced by a fresh `cdp project init` run.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Ships the auth work that landed on \`main\` (PRs #289, #290, #292, #293, #294, #295) but is not yet on npm. \`integration-patterns\` INT-31 / INT-32 are blocked on this artifact existing.

## What ships

- \`runtime/subsystems/auth/\` — \`AuthController\`, \`OAuth2RefreshStrategy\`, ports (\`IUserContext\`, \`IOAuthStateStore\`, \`IIntegrationGrantSink\`, integration-store), memory + drizzle state-store backends
- \`examples/auth-integrations/\` — canonical \`integration.yaml\` entity + adapters + \`IntegrationsService\` facade
- \`cdp subsystem install auth\` + \`cdp subsystem install auth-integrations\` templates

## Test plan

- [x] Version bumped \`0.6.4\` → \`0.6.5\`
- [x] CHANGELOG entry under \`[0.6.5]\`
- [ ] After merge: \`just publish\` from local checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)