### PR TITLE
chore(auth): 0.6.6 — env var rename + IProviderStrategy + OSS scrub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.6.5] — 2026-04-27
+## [0.6.6] — 2026-04-27
+
+Bundled cleanup PR for the auth subsystem surfaced during integration-patterns review. Pre-1.0, so two breaking renames are taken without compatibility shims.
+
+### Changed
+
+- **BREAKING — env var rename.** `TOKEN_ENCRYPTION_KEY` → `INTEGRATION_TOKEN_ENCRYPTION_KEY`. The auth subsystem only encrypts integration tokens; the scoped name is clearer about what the key protects and avoids colliding with other token-encryption keys a consumer might own. Read site (`runtime/subsystems/auth/backends/encryption-key/env.ts`), install template (`templates/subsystem/auth/env-config.ejs.t` + idempotency `skip_if`), CLI scaffold helpers, tests, and docs all moved together. Consumers running 0.6.5 must rename the env var and the `skip_if` line in their generated `.env.config`.
+- **BREAKING — interface rename.** `ProviderStrategy` → `IProviderStrategy` to match the rest of the auth port naming (`IIntegrationReader`, `IUserContext`, `IOAuthStateStore`, `IEncryptionKey`). Convention documented at the top of `runtime/subsystems/auth/protocols/provider-strategy.ts`: `I*` for behavioral ports, no prefix for data DTOs / template-method abstract classes. `ProviderStrategyRegistry` (a `ReadonlyMap` value-shape) keeps its name.
+- **OSS-hygiene scrub.** Removed or generalized references to the upstream extraction-source consumer across `runtime/`, `examples/`, and user-facing docs. ADRs and RFCs that document decision history retain their references intentionally.
+
+
 
 Auth subsystem reaches consumers. `runtime/subsystems/auth/`, the `auth-integrations` starter, and the `cdp subsystem install auth` + `auth-integrations` templates were all merged on `main` (PRs #289, #290, #292, #293, #294, #295) but the published artifact was still pinned at `0.6.4`. This release ships them.
 

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -909,7 +909,7 @@ Drizzle backends.
 
 ### Migration from a bespoke sync pipeline
 
-Consumers already running custom sync code (e.g. dealbrain-v2's CRM sync):
+Consumers already running custom sync code (e.g. the upstream consumer's CRM sync):
 see [docs/guides/sync-migration.md](guides/sync-migration.md) for the
 step-by-step path.
 
@@ -944,11 +944,11 @@ export class AppModule {}
 
 `AuthModule` is `global: true`. It provides `ENCRYPTION_KEY` and
 `OAUTH_STATE_STORE` tokens. Defaults: `EnvEncryptionKey` (reads
-`TOKEN_ENCRYPTION_KEY` from env) and `InMemoryOAuthStateStore`.
+`INTEGRATION_TOKEN_ENCRYPTION_KEY` from env) and `InMemoryOAuthStateStore`.
 
 ### Env vars
 
-- `TOKEN_ENCRYPTION_KEY` — 32-byte base64 string. Required when
+- `INTEGRATION_TOKEN_ENCRYPTION_KEY` — 32-byte base64 string. Required when
   `encryptionKey: 'env'`. Generate with `openssl rand -base64 32`.
 
 ### Environment setup

--- a/examples/auth-integrations/README.md
+++ b/examples/auth-integrations/README.md
@@ -84,7 +84,7 @@ change.
 ## `provider` is `string`, not `enum`
 
 Adding a new provider (`google`, `gusto`, …) should be a code change (a new
-`ProviderStrategy` registered in `STRATEGY_REGISTRY`), not a YAML/migration
+`IProviderStrategy` registered in `STRATEGY_REGISTRY`), not a YAML/migration
 change. The string column matches the strategy registry's key type and
 supports any provider slug your app cares about.
 

--- a/examples/auth-integrations/runtime/integrations/integration-grant-sink.adapter.ts
+++ b/examples/auth-integrations/runtime/integrations/integration-grant-sink.adapter.ts
@@ -9,7 +9,7 @@ import { CreateOrUpdateFromOAuthGrantUseCase } from './use-cases/create-or-updat
  * `IIntegrationGrantSink` adapter — pass-through to
  * `CreateOrUpdateFromOAuthGrantUseCase`. The auth subsystem's
  * `AuthController.callback` invokes this after
- * `ProviderStrategy.exchangeCodeForTokens`.
+ * `IProviderStrategy.exchangeCodeForTokens`.
  *
  * This adapter injects the use case directly (not the
  * `IntegrationsService` facade) for symmetry with the reader and

--- a/examples/eav/README.md
+++ b/examples/eav/README.md
@@ -24,7 +24,7 @@ The generated repositories give you typed CRUD on both tables, but **dual-write 
 - Add a `findByIdWithFields()` that joins `field_values` onto the entity row on read
 - Route between entity columns and EAV based on whether a field is declared in `field_definition`
 
-This is the same pattern `dealbrain-v2` hand-writes today in its `CrmEntityRepository<T>` + `CrmEntityService<T>` base classes.
+This is the same pattern `the upstream consumer` hand-writes today in its `CrmEntityRepository<T>` + `CrmEntityService<T>` base classes.
 
 ## TODO: promote to a first-class `EavPattern`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/auth/auth.tokens.ts
+++ b/runtime/subsystems/auth/auth.tokens.ts
@@ -23,7 +23,7 @@
  * `HUBSPOT_AUTH_STRATEGY`) by each integration module — this subsystem does
  * not mandate a single `AUTH_STRATEGY` token because an app typically has
  * many concurrent strategies, one per provider. They are dispatched through
- * `STRATEGY_REGISTRY` (a `ReadonlyMap<slug, ProviderStrategy>`), populated
+ * `STRATEGY_REGISTRY` (a `ReadonlyMap<slug, IProviderStrategy>`), populated
  * by per-provider modules via a `useFactory` provider.
  */
 export const ENCRYPTION_KEY = Symbol('ENCRYPTION_KEY');

--- a/runtime/subsystems/auth/backends/encryption-key/env.ts
+++ b/runtime/subsystems/auth/backends/encryption-key/env.ts
@@ -6,7 +6,7 @@
  * ciphertexts — prevents replay-style inference. Auth tag enforces integrity;
  * any tampering throws on decrypt.
  *
- * Key source: `TOKEN_ENCRYPTION_KEY` env var, 32 bytes base64-encoded.
+ * Key source: `INTEGRATION_TOKEN_ENCRYPTION_KEY` env var, 32 bytes base64-encoded.
  * Generate via `openssl rand -base64 32`.
  *
  * Future backend: `kms.ts` (AWS/GCP KMS) for production deployments that
@@ -18,7 +18,7 @@ import type { IEncryptionKey } from '../../protocols/encryption-key';
 export interface EnvEncryptionKeyOptions {
   /** Defaults to `process.env`. Tests inject a fixture. */
   env?: NodeJS.ProcessEnv;
-  /** Defaults to `'TOKEN_ENCRYPTION_KEY'`. */
+  /** Defaults to `'INTEGRATION_TOKEN_ENCRYPTION_KEY'`. */
   envVar?: string;
 }
 
@@ -32,7 +32,7 @@ export class EnvEncryptionKey implements IEncryptionKey {
 
   constructor(opts: EnvEncryptionKeyOptions = {}) {
     const env = opts.env ?? process.env;
-    const envVar = opts.envVar ?? 'TOKEN_ENCRYPTION_KEY';
+    const envVar = opts.envVar ?? 'INTEGRATION_TOKEN_ENCRYPTION_KEY';
     const raw = env[envVar];
     if (!raw) {
       throw new Error(

--- a/runtime/subsystems/auth/controllers/auth.controller.ts
+++ b/runtime/subsystems/auth/controllers/auth.controller.ts
@@ -9,7 +9,7 @@
  *     302-redirects to the post-connect path.
  *
  * Hexagonal seams:
- *   - `STRATEGY_REGISTRY` (ReadonlyMap<slug, ProviderStrategy>) — dispatch.
+ *   - `STRATEGY_REGISTRY` (ReadonlyMap<slug, IProviderStrategy>) — dispatch.
  *     Concrete per-provider strategies live consumer-side and contribute
  *     entries via a `useFactory` in the consumer's app module.
  *   - `AUTH_USER_CONTEXT` (IUserContext) — resolves "who is this request"
@@ -44,7 +44,7 @@ import type { AuthModuleOptions } from '../auth.module';
 import type { IOAuthStateStore } from '../protocols/oauth-state-store';
 import type { IUserContext } from '../protocols/user-context';
 import type {
-  ProviderStrategy,
+  IProviderStrategy,
   ProviderStrategyRegistry,
 } from '../protocols/provider-strategy';
 import type { IIntegrationGrantSink } from '../protocols/integration-store';
@@ -131,7 +131,7 @@ export class AuthController {
     );
   }
 
-  private requireStrategy(slug: string): ProviderStrategy {
+  private requireStrategy(slug: string): IProviderStrategy {
     const strategy = this.registry.get(slug);
     if (!strategy) {
       throw new HttpException(

--- a/runtime/subsystems/auth/index.ts
+++ b/runtime/subsystems/auth/index.ts
@@ -29,7 +29,7 @@
  *   type IIntegrationGrantSink,
  *   type IntegrationGrantInput,
  *   type IUserContext,
- *   type ProviderStrategy,
+ *   type IProviderStrategy,
  *   type ProviderStrategyRegistry,
  *   type ExchangedTokens,
  * } from '@pattern-stack/codegen/runtime/subsystems/auth';
@@ -58,7 +58,7 @@ export type {
 } from './protocols/integration-store';
 export type { IUserContext } from './protocols/user-context';
 export type {
-  ProviderStrategy,
+  IProviderStrategy,
   ProviderStrategyRegistry,
   ExchangedTokens,
 } from './protocols/provider-strategy';

--- a/runtime/subsystems/auth/protocols/auth-strategy.ts
+++ b/runtime/subsystems/auth/protocols/auth-strategy.ts
@@ -7,7 +7,7 @@
  * `OAuth2RefreshStrategy` template-method base in `../runtime/`.
  *
  * See `docs/adrs/ADR-031-auth-subsystem.md` and
- * `docs/gate-1-auth-extraction-findings.md` (inbound from dealbrain-v2) for
+ * `docs/gate-1-auth-extraction-findings.md` (extraction-source findings) for
  * the rationale.
  */
 

--- a/runtime/subsystems/auth/protocols/integration-store.ts
+++ b/runtime/subsystems/auth/protocols/integration-store.ts
@@ -6,7 +6,7 @@
  * those rows — consumers implement these narrow ports against whatever
  * `integrations` table their app uses.
  *
- * In dealbrain-v2 (the extraction source) both ports are satisfied by a
+ * In the extraction-source app both ports are satisfied by a
  * pair of thin adapters over `IntegrationService` + `RefreshIntegrationUseCase`.
  * The codegen-patterns `examples/auth-integrations/` starter (separate PR)
  * ships a canonical `integration.yaml` whose generated service + use case
@@ -70,7 +70,7 @@ export interface IIntegrationTokenWriter {
  * authorize-code callback (i.e. the user just connected a new provider, or
  * re-connected an existing one).
  *
- * `AuthController.callback` invokes this after `ProviderStrategy.exchangeCodeForTokens`.
+ * `AuthController.callback` invokes this after `IProviderStrategy.exchangeCodeForTokens`.
  * The subsystem itself never imports a concrete `IntegrationsService` — the
  * consumer's `auth-integrations` starter (or any equivalent) adapts this
  * port. Keeps the auth subsystem standalone: a non-codegen consumer can

--- a/runtime/subsystems/auth/protocols/provider-strategy.ts
+++ b/runtime/subsystems/auth/protocols/provider-strategy.ts
@@ -1,5 +1,5 @@
 /**
- * Auth subsystem — `ProviderStrategy` contract.
+ * Auth subsystem — `IProviderStrategy` contract.
  *
  * Extension of `OAuth2RefreshStrategy` (which already covers the refresh
  * path) that adds the two methods needed by the connect/callback dance:
@@ -11,11 +11,18 @@
  * stay consumer-side per ADR-031 ("every app has different combinations").
  * They typically subclass `OAuth2RefreshStrategy` for the refresh path and
  * implement these two methods structurally — that satisfies
- * `ProviderStrategy` because TS lets interfaces extend classes by type.
+ * `IProviderStrategy` because TS lets interfaces extend classes by type.
  *
  * AuthController never imports a concrete strategy — it injects the
- * `STRATEGY_REGISTRY` (a `ReadonlyMap<provider-slug, ProviderStrategy>`)
+ * `STRATEGY_REGISTRY` (a `ReadonlyMap<provider-slug, IProviderStrategy>`)
  * and dispatches by slug.
+ *
+ * **Naming convention:** interfaces that describe behavioral ports use the
+ * `I` prefix (`IProviderStrategy`, `IIntegrationReader`, `IUserContext`,
+ * `IOAuthStateStore`, `IEncryptionKey`). Plain data types / DTOs (e.g.
+ * `ExchangedTokens`, `DecryptedIntegration`, `IntegrationGrantInput`) do
+ * not. Abstract template-method classes (e.g. `OAuth2RefreshStrategy`) also
+ * do not — the `I` is for interfaces only.
  */
 import type { OAuth2RefreshStrategy } from '../runtime/oauth2-refresh.strategy';
 
@@ -29,7 +36,7 @@ export interface ExchangedTokens {
   providerMetadata?: Record<string, unknown>;
 }
 
-export interface ProviderStrategy extends OAuth2RefreshStrategy {
+export interface IProviderStrategy extends OAuth2RefreshStrategy {
   buildAuthorizeUrl(args: { state: string; redirectUri: string }): string;
   exchangeCodeForTokens(args: {
     code: string;
@@ -38,4 +45,4 @@ export interface ProviderStrategy extends OAuth2RefreshStrategy {
 }
 
 /** The DI value type behind the `STRATEGY_REGISTRY` token. */
-export type ProviderStrategyRegistry = ReadonlyMap<string, ProviderStrategy>;
+export type ProviderStrategyRegistry = ReadonlyMap<string, IProviderStrategy>;

--- a/runtime/subsystems/auth/runtime/oauth2-refresh.strategy.ts
+++ b/runtime/subsystems/auth/runtime/oauth2-refresh.strategy.ts
@@ -2,8 +2,8 @@
  * Abstract base class for OAuth2 refresh-token strategies.
  *
  * Template-method pattern: `resolve()` is concrete; four small hooks inject
- * provider specifics. Validated across two providers in dealbrain-v2
- * (SalesforceAuthStrategy, HubSpotAuthStrategy) before extraction here — see
+ * provider specifics. Validated across two providers (Salesforce, HubSpot)
+ * in the extraction-source app before being extracted here — see
  * `docs/gate-1-auth-extraction-findings.md` for the "build first, extract
  * later" evidence.
  *

--- a/runtime/subsystems/auth/runtime/session-expired.error.ts
+++ b/runtime/subsystems/auth/runtime/session-expired.error.ts
@@ -8,8 +8,8 @@
  * the `isSessionExpiredError` predicate to decide whether to force-refresh
  * and retry once.
  *
- * This discriminator replaces the SFDC-only `instanceof` check from
- * dealbrain-v2's original `withAuthRetry`. See
+ * This discriminator replaces the SFDC-only `instanceof` check from the
+ * extraction-source app's original `withAuthRetry`. See
  * `docs/gate-1-auth-extraction-findings.md` (recommendation 4).
  */
 export class SessionExpiredError extends Error {

--- a/runtime/subsystems/auth/runtime/with-auth-retry.ts
+++ b/runtime/subsystems/auth/runtime/with-auth-retry.ts
@@ -6,7 +6,7 @@
  * on the refreshed token propagates rather than looping, so transient
  * adapter bugs can't hang the caller.
  *
- * Generalisation over dealbrain's original SFDC-specific version: the
+ * Generalisation over the extraction source's SFDC-specific original: the
  * session-expired classifier is injected. Providers mark their session-
  * expired errors (via `instanceof` of a marker class, or by setting a known
  * property) and pass a classifier matching that shape.

--- a/runtime/subsystems/index.ts
+++ b/runtime/subsystems/index.ts
@@ -82,7 +82,7 @@ export type {
   IIntegrationGrantSink,
   IntegrationGrantInput,
   IUserContext,
-  ProviderStrategy,
+  IProviderStrategy,
   ProviderStrategyRegistry,
   ExchangedTokens,
   AuthCredentials,

--- a/runtime/subsystems/sync/deep-equal.differ.ts
+++ b/runtime/subsystems/sync/deep-equal.differ.ts
@@ -5,7 +5,7 @@
  * per-field diff (`{ from, to }`) for every field whose value changed.
  * Returns `'noop'` when the record is unchanged.
  *
- * Design decisions (extracted from dealbrain-v2 + HS-9 findings):
+ * Design decisions (extracted from the upstream consumer + HS-9 findings):
  *
  * 1. **Ignore list** — row metadata that sinks/services stamp unconditionally
  *    so upstream cannot reasonably disagree:

--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -41,7 +41,7 @@
  * is strictly provider-agnostic:
  *   - `entityType` is `string` throughout; no `'opportunity' | 'account' | ...`
  *     narrowing leaks into the use case
- *   - dealbrain's `SyncRunRecorderService` class injection replaced with the
+ *   - the upstream consumer's `SyncRunRecorderService` class injection replaced with the
  *     `ISyncRunRecorder` protocol (backend lands in SYNC-4)
  */
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';

--- a/runtime/subsystems/sync/sync-change-source.protocol.ts
+++ b/runtime/subsystems/sync/sync-change-source.protocol.ts
@@ -6,7 +6,7 @@
  * depend on a specific backend implementation.
  *
  * Three detection modes (poll / cdc / webhook) converge on this single port
- * per ADR-0002 (dealbrain-v2). Per-mode differences live in the
+ * per ADR-0002 (the upstream consumer). Per-mode differences live in the
  * `Change.source` / `dedupKey` / `providerChangedFields` metadata fields,
  * not in separate ports.
  *

--- a/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
+++ b/runtime/subsystems/sync/sync-cursor-store.memory-backend.ts
@@ -21,7 +21,7 @@
  * could occur. Tests that want to assert per-tenant isolation should
  * target the Drizzle backend.
  *
- * Not shipped in dealbrain-v2; this is a subsystem-first addition for the
+ * Not shipped in the upstream consumer; this is a subsystem-first addition for the
  * test surface. Consumed by:
  *   - SYNC-5 unit tests (`ExecuteSyncUseCase` against synthetic sources)
  *   - SYNC-6 module tests (`SyncModule.forRoot({ backend: 'memory' })`)

--- a/runtime/subsystems/sync/sync-loopback.protocol.ts
+++ b/runtime/subsystems/sync/sync-loopback.protocol.ts
@@ -14,10 +14,9 @@
  * a backend in Phase 1; consumers that need loopback suppression provide
  * their own (redis-hashed, memory TTL, etc.).
  *
- * `entityType` is `string` (not a union) — per dealbrain-v2's HS-9 findings
- * the CRM-specific narrowing `'opportunity' | 'account' | 'contact'` bled
- * into the port and had to be removed. Consumers narrow internally if they
- * want.
+ * `entityType` is `string` (not a union) — per HS-9 findings the
+ * CRM-specific narrowing `'opportunity' | 'account' | 'contact'` bled into
+ * the port and had to be removed. Consumers narrow internally if they want.
  */
 
 export interface ILoopbackFingerprintStore<T = unknown> {

--- a/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
+++ b/runtime/subsystems/sync/sync-run-recorder.drizzle-backend.ts
@@ -1,7 +1,7 @@
 /**
  * DrizzleSyncRunRecorder — Drizzle-backed `ISyncRunRecorder` (SYNC-4).
  *
- * Generic write path only — extracted from dealbrain-v2's
+ * Generic write path only — extracted from the source app's
  * `SyncRunRecorderService`, minus CRM-specific convenience methods. Those
  * stay consumer-owned; the subsystem ships the substrate.
  *

--- a/src/__tests__/cli/subsystem.test.ts
+++ b/src/__tests__/cli/subsystem.test.ts
@@ -288,11 +288,11 @@ describe('subsystem — install (real)', () => {
 		const parsed = JSON.parse(out);
 		expect(parsed.status).toBe('already-installed');
 
-		// Files unchanged — no duplicate auth: block, TOKEN_ENCRYPTION_KEY
+		// Files unchanged — no duplicate auth: block, INTEGRATION_TOKEN_ENCRYPTION_KEY
 		// not regenerated, no duplicate AuthModule TODO.
 		expect(fs.readFileSync(configPath, 'utf-8')).toBe(configBefore);
 		expect(fs.readFileSync(envConfigPath, 'utf-8')).toBe(envBefore);
-		const tokenLines = envBefore.match(/^TOKEN_ENCRYPTION_KEY=/gm) ?? [];
+		const tokenLines = envBefore.match(/^INTEGRATION_TOKEN_ENCRYPTION_KEY=/gm) ?? [];
 		expect(tokenLines.length).toBe(1);
 		if (fs.existsSync(appModulePath)) {
 			expect(fs.readFileSync(appModulePath, 'utf-8')).toBe(appModuleBefore);

--- a/src/__tests__/runtime/subsystems/auth/auth-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/auth-module.spec.ts
@@ -23,15 +23,15 @@ import type {
 } from '../../../../../runtime/subsystems/auth/protocols/oauth-state-store';
 
 describe('AuthModule.forRoot', () => {
-  const previousKey = process.env['TOKEN_ENCRYPTION_KEY'];
+  const previousKey = process.env['INTEGRATION_TOKEN_ENCRYPTION_KEY'];
 
   beforeAll(() => {
-    process.env['TOKEN_ENCRYPTION_KEY'] = randomBytes(32).toString('base64');
+    process.env['INTEGRATION_TOKEN_ENCRYPTION_KEY'] = randomBytes(32).toString('base64');
   });
 
   afterAll(() => {
-    if (previousKey === undefined) delete process.env['TOKEN_ENCRYPTION_KEY'];
-    else process.env['TOKEN_ENCRYPTION_KEY'] = previousKey;
+    if (previousKey === undefined) delete process.env['INTEGRATION_TOKEN_ENCRYPTION_KEY'];
+    else process.env['INTEGRATION_TOKEN_ENCRYPTION_KEY'] = previousKey;
   });
 
   it('provides defaults (EnvEncryptionKey + MemoryOAuthStateStore, no controller)', async () => {

--- a/src/__tests__/runtime/subsystems/auth/auth.controller.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/auth.controller.spec.ts
@@ -1,7 +1,7 @@
 /**
  * AuthController — round-trip the connect/callback dance with port stand-ins.
  *
- * Uses a fake `ProviderStrategy` (only the two new connect-flow methods are
+ * Uses a fake `IProviderStrategy` (only the two new connect-flow methods are
  * relevant — the refresh path is exercised by `oauth2-refresh.strategy.spec.ts`),
  * a fake `IUserContext`, the real `MemoryOAuthStateStore`, and a fake
  * `IIntegrationGrantSink` that just captures calls.
@@ -30,7 +30,7 @@ import {
 } from '../../../../../runtime/subsystems/auth/auth.tokens';
 import type {
   ExchangedTokens,
-  ProviderStrategy,
+  IProviderStrategy,
   ProviderStrategyRegistry,
 } from '../../../../../runtime/subsystems/auth/protocols/provider-strategy';
 import type { IUserContext } from '../../../../../runtime/subsystems/auth/protocols/user-context';
@@ -56,7 +56,7 @@ function makeRes() {
   return { res, captured };
 }
 
-function makeFakeStrategy(slug: string): ProviderStrategy {
+function makeFakeStrategy(slug: string): IProviderStrategy {
   const tokens: ExchangedTokens = {
     accessToken: `at-${slug}`,
     refreshToken: `rt-${slug}`,
@@ -74,7 +74,7 @@ function makeFakeStrategy(slug: string): ProviderStrategy {
     resolve: mock(async () => {
       throw new Error('not used');
     }),
-  } as unknown as ProviderStrategy;
+  } as unknown as IProviderStrategy;
 }
 
 async function makeController(opts?: {
@@ -94,7 +94,7 @@ async function makeController(opts?: {
   const strategy = makeFakeStrategy('hubspot');
   const registry: ProviderStrategyRegistry =
     opts?.registry ??
-    new Map<string, ProviderStrategy>([['hubspot', strategy]]);
+    new Map<string, IProviderStrategy>([['hubspot', strategy]]);
 
   const moduleRef = await Test.createTestingModule({
     controllers: [AuthController],
@@ -204,7 +204,7 @@ describe('AuthController', () => {
     const grantSink: IIntegrationGrantSink = {
       createOrUpdateFromOAuthGrant: async () => {},
     };
-    const registry: ProviderStrategyRegistry = new Map<string, ProviderStrategy>([
+    const registry: ProviderStrategyRegistry = new Map<string, IProviderStrategy>([
       ['hubspot', makeFakeStrategy('hubspot')],
     ]);
     const moduleRef = await Test.createTestingModule({

--- a/src/__tests__/runtime/subsystems/auth/env-encryption-key.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/env-encryption-key.spec.ts
@@ -7,7 +7,7 @@ import { EnvEncryptionKey } from '../../../../../runtime/subsystems/auth/backend
 
 function fixtureEnv(): NodeJS.ProcessEnv {
   return {
-    TOKEN_ENCRYPTION_KEY: randomBytes(32).toString('base64'),
+    INTEGRATION_TOKEN_ENCRYPTION_KEY: randomBytes(32).toString('base64'),
   };
 }
 
@@ -15,7 +15,7 @@ describe('EnvEncryptionKey', () => {
   describe('construction', () => {
     it('throws when the env var is missing', () => {
       expect(() => new EnvEncryptionKey({ env: {} })).toThrow(
-        /TOKEN_ENCRYPTION_KEY is not set/,
+        /INTEGRATION_TOKEN_ENCRYPTION_KEY is not set/,
       );
     });
 
@@ -23,7 +23,7 @@ describe('EnvEncryptionKey', () => {
       expect(
         () =>
           new EnvEncryptionKey({
-            env: { TOKEN_ENCRYPTION_KEY: Buffer.from('too short').toString('base64') },
+            env: { INTEGRATION_TOKEN_ENCRYPTION_KEY: Buffer.from('too short').toString('base64') },
           }),
       ).toThrow(/must decode to 32 bytes/);
     });

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -436,7 +436,7 @@ export class SubsystemInstallCommand extends Command {
 		// #287: auth subsystem scaffold — emits the `auth_oauth_state`
 		// drizzle schema, appends the `auth:` config block, appends the
 		// `AuthModule.forRoot` TODO to `app.module.ts`, and appends
-		// `TOKEN_ENCRYPTION_KEY` + `AUTH_REDIRECT_URI_BASE` to `.env.config`.
+		// `INTEGRATION_TOKEN_ENCRYPTION_KEY` + `AUTH_REDIRECT_URI_BASE` to `.env.config`.
 		const authScaffold =
 			desc.name === 'auth'
 				? runAuthScaffold(ctx.cwd, ctx.config, {

--- a/src/cli/shared/auth-scaffold-locals.ts
+++ b/src/cli/shared/auth-scaffold-locals.ts
@@ -19,12 +19,12 @@
  *     reserved for `project upgrade-*` flows, and a TODO comment with the
  *     full ready-to-paste snippet is friendlier than a half-correct AST
  *     patch.
- *   - `env-config.ejs.t` — appends `TOKEN_ENCRYPTION_KEY=<freshly
+ *   - `env-config.ejs.t` — appends `INTEGRATION_TOKEN_ENCRYPTION_KEY=<freshly
  *     generated 32-byte b64>` plus the `AUTH_REDIRECT_URI_BASE` knob to
  *     `.env.config`. The encryption key is generated ONCE per install (no
  *     idempotent re-run) — re-running with `--force` does not regenerate
- *     it because `skip_if: "TOKEN_ENCRYPTION_KEY"` short-circuits the
- *     inject. This is correct: rotating the key is a separate, auditable
+ *     it because `skip_if: "INTEGRATION_TOKEN_ENCRYPTION_KEY"` short-circuits
+ *     the inject. This is correct: rotating the key is a separate, auditable
  *     operation and silently regenerating it on re-install would invalidate
  *     every encrypted token in the consumer's database.
  *
@@ -59,7 +59,7 @@ export interface AuthScaffoldLocals {
 	schemaPath: string;
 	/** Where `app-module-hook.ejs.t` appends the `AuthModule.forRoot` TODO. */
 	appModulePath: string;
-	/** Where `env-config.ejs.t` appends `TOKEN_ENCRYPTION_KEY=...`. */
+	/** Where `env-config.ejs.t` appends `INTEGRATION_TOKEN_ENCRYPTION_KEY=...`. */
 	envConfigPath: string;
 	/**
 	 * Default `http://localhost:3000`; overridable via
@@ -99,7 +99,7 @@ export interface AuthScaffoldLocalsInput {
  *   against null / undefined / non-string YAML surprises).
  * - `tokenEncryptionKey` is generated via `crypto.randomBytes(32)` at
  *   resolve time. The b64 encoding is 44 chars — matches what
- *   `EnvEncryptionKey` expects from `process.env.TOKEN_ENCRYPTION_KEY`.
+ *   `EnvEncryptionKey` expects from `process.env.INTEGRATION_TOKEN_ENCRYPTION_KEY`.
  */
 export function resolveAuthScaffoldLocals(
 	input: AuthScaffoldLocalsInput,

--- a/src/schema/pipelines-config.schema.ts
+++ b/src/schema/pipelines-config.schema.ts
@@ -64,7 +64,7 @@ export const FrontendPipelineSchema = z.object({
   /**
    * Named preset that collapses the ~12 individual frontend config knobs
    * into a single opinionated bundle. Resolved elsewhere in the codegen.
-   * Examples: 'dealbrain', 'tanstack-electric'
+   * Examples: 'tanstack-electric'
    */
   preset: z.string().optional(),
 });
@@ -178,7 +178,7 @@ export type PathsConfig = z.infer<typeof PathsConfigSchema>;
  *     architecture: clean-lite-ps
  *   frontend:
  *     enabled: true
- *     preset: dealbrain
+ *     preset: tanstack-electric
  *   shared:
  *     enabled: true
  * ```

--- a/templates/subsystem/auth-config/codegen-config-auth-block.ejs.t
+++ b/templates/subsystem/auth-config/codegen-config-auth-block.ejs.t
@@ -6,7 +6,7 @@ skip_if: "auth:"
 ---
 
 auth:
-  # ── Encryption key (TOKEN_ENCRYPTION_KEY from .env.config) ──
+  # ── Encryption key (INTEGRATION_TOKEN_ENCRYPTION_KEY from .env.config) ──
   encryption_key: env
 
   # ── OAuth state store (drizzle for prod, memory for tests) ──

--- a/templates/subsystem/auth/app-module-hook.ejs.t
+++ b/templates/subsystem/auth/app-module-hook.ejs.t
@@ -17,5 +17,5 @@ skip_if: "AuthModule"
 //     redirectUriBase: process.env.AUTH_REDIRECT_URI_BASE ?? '<%= redirectUriBase %>',
 //   }),
 //
-// Requires TOKEN_ENCRYPTION_KEY in your environment (see .env.config).
+// Requires INTEGRATION_TOKEN_ENCRYPTION_KEY in your environment (see .env.config).
 // Provide an IUserContext adapter (your app's session/JWT scheme).

--- a/templates/subsystem/auth/env-config.ejs.t
+++ b/templates/subsystem/auth/env-config.ejs.t
@@ -2,19 +2,19 @@
 to: "<%= envConfigPath %>"
 inject: true
 append: true
-skip_if: "TOKEN_ENCRYPTION_KEY"
+skip_if: "INTEGRATION_TOKEN_ENCRYPTION_KEY"
 ---
 
 # OAuth integration token encryption key — 32 bytes base64 (AES-256-GCM).
 # DO NOT REUSE this dev value in prod. To regenerate locally:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 # Re-running `codegen subsystem install auth` does NOT rotate this key —
-# `skip_if: "TOKEN_ENCRYPTION_KEY"` blocks the inject intentionally, because
-# silently rotating would invalidate every encrypted token already in the
-# consumer's `integrations` table. Rotation is a separate, auditable op.
+# `skip_if: "INTEGRATION_TOKEN_ENCRYPTION_KEY"` blocks the inject intentionally,
+# because silently rotating would invalidate every encrypted token already in
+# the consumer's `integrations` table. Rotation is a separate, auditable op.
 # In production: store the key in `secrets/secrets.yaml` (or your secret
 # manager) and have your deploy pipeline materialise it into the env at
 # boot — this `.env.config` line should be a placeholder, not the source.
-TOKEN_ENCRYPTION_KEY=<%= tokenEncryptionKey %>
+INTEGRATION_TOKEN_ENCRYPTION_KEY=<%= tokenEncryptionKey %>
 # Public base URL where OAuth providers redirect back. Override in staging/prod.
 AUTH_REDIRECT_URI_BASE=<%= redirectUriBase %>

--- a/templates/subsystem/auth/prompt.js
+++ b/templates/subsystem/auth/prompt.js
@@ -21,9 +21,9 @@
  *   - `app-module-hook.ejs.t` — appends a TODO comment block to
  *     app.module.ts directing the human to register
  *     `AuthModule.forRoot({ ... })`. Same convention as observability.
- *   - `env-config.ejs.t` — appends `TOKEN_ENCRYPTION_KEY=<b64>` and
- *     `AUTH_REDIRECT_URI_BASE=<url>` to `.env.config`. Idempotent via
- *     `skip_if: "TOKEN_ENCRYPTION_KEY"` — re-running install does NOT
+ *   - `env-config.ejs.t` — appends `INTEGRATION_TOKEN_ENCRYPTION_KEY=<b64>`
+ *     and `AUTH_REDIRECT_URI_BASE=<url>` to `.env.config`. Idempotent via
+ *     `skip_if: "INTEGRATION_TOKEN_ENCRYPTION_KEY"` — re-running install does NOT
  *     regenerate the key (rotation is a separate operation).
  *
  * Auth has NO `multi_tenant` knob (see auth-scaffold-locals.ts docstring).

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -274,7 +274,7 @@ async function main(): Promise<number> {
 		//   - auth-oauth-state.schema.ts via Hygen (sole emitter);
 		//   - `auth:` block into codegen.config.yaml;
 		//   - AuthModule.forRoot TODO into app.module.ts;
-		//   - TOKEN_ENCRYPTION_KEY + AUTH_REDIRECT_URI_BASE into .env.config.
+		//   - INTEGRATION_TOKEN_ENCRYPTION_KEY + AUTH_REDIRECT_URI_BASE into .env.config.
 		run(`bun ${CLI_PATH} subsystem install auth`, tmpDir);
 
 		const configYamlAfterAuth = fs.readFileSync(configYamlPath, 'utf8');
@@ -290,8 +290,8 @@ async function main(): Promise<number> {
 			throw new Error('.env.config not created by auth install');
 		}
 		const envConfig = fs.readFileSync(envConfigPath, 'utf8');
-		if (!envConfig.includes('TOKEN_ENCRYPTION_KEY=')) {
-			throw new Error('TOKEN_ENCRYPTION_KEY missing from .env.config after auth install');
+		if (!envConfig.includes('INTEGRATION_TOKEN_ENCRYPTION_KEY=')) {
+			throw new Error('INTEGRATION_TOKEN_ENCRYPTION_KEY missing from .env.config after auth install');
 		}
 
 		// 5.7. #287 — install the auth-integrations starter. Vendors:


### PR DESCRIPTION
## Summary

Bundled cleanup PR + 0.6.6 release. Three nits surfaced during integration-patterns PR #93 review, all pre-1.0 so breaking changes are taken cleanly without compatibility shims.

### Changes

1. **BREAKING — env var rename.** `TOKEN_ENCRYPTION_KEY` → `INTEGRATION_TOKEN_ENCRYPTION_KEY`. The auth subsystem only encrypts integration tokens; the scoped name is clearer about scope and avoids colliding with other token-encryption keys. Touches the read site, install template (+ `skip_if`), CLI scaffold helpers, tests, and docs.

2. **BREAKING — interface rename.** `ProviderStrategy` → `IProviderStrategy` to match the `I*` convention used by the rest of the auth ports (`IIntegrationReader`, `IUserContext`, `IOAuthStateStore`, `IEncryptionKey`). Convention now documented at the top of `runtime/subsystems/auth/protocols/provider-strategy.ts`. `ProviderStrategyRegistry` (value-shape `ReadonlyMap`, not a port) keeps its name.

3. **OSS-hygiene scrub.** Removed/generalized references to the upstream extraction-source consumer across `runtime/`, `examples/`, and user-facing docs (`CONSUMER-SETUP.md`, `pipelines-config.schema.ts` examples). ADRs/RFCs documenting decision history retain their references intentionally.

### Release

- Bumps `0.6.5` → `0.6.6`.
- CHANGELOG entry under `[0.6.6]` calls out both BREAKING renames.
- Will run `just publish` from local checkout after merge.

## Test plan

- [x] `bun run test` — all green
- [ ] CI green
- [ ] `just publish` succeeds; `npm view @pattern-stack/codegen version` returns `0.6.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)