### PR TITLE
chore(release): 0.6.7 — auth-integrations install hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.7] — 2026-04-28
+
+Hotfix bundle for `cdp subsystem install auth-integrations`. 0.6.5 / 0.6.6 shipped the auth-integrations starter and install template, but every downstream consumer ran into four blockers on a fresh install. None of them surfaced from the source-checkout smoke (the install code resolves examples/ via the package root, which exists in dev) — they only exposed themselves through `npm install + bunx cdp subsystem install auth-integrations` against the published tarball. Surfaced by integration-patterns Wave 0b.
+
+### Fixed
+
+- **P0 — `fix(packaging)` #303** — added `examples/auth-integrations/**` to `package.json:files`. The 0.6.6 tarball did not include the starter source; `cdp subsystem install auth-integrations` therefore failed to find `node_modules/@pattern-stack/codegen/examples/auth-integrations/` and aborted the vendor copy. Narrowed to the auth-integrations subtree only — internal `examples/` (eav etc.) stay out of the published artifact. Prevention: `src/__tests__/templates/auth-integrations-files-coverage.test.ts` walks every file under `examples/auth-integrations/` and asserts it matches a `files` pattern.
+- **`fix(cli)` #303** — `cdp subsystem install auth-integrations` no longer drops `integration.yaml` at the wrong path. The scaffold-locals resolver was reading `paths.definitions` (a key that doesn't exist in the schema); switched to `paths.entities` with a fallback to legacy `paths.entities_dir`, matching the resolution order in `Context.entitiesDir` and `cdp project init`. Default location (`<cwd>/definitions/entities/integration.yaml`) is unchanged.
+- **`fix(cli)` #303** — vendored adapters under `<sharedRoot>/integrations/` no longer carry bare-package imports `from '@pattern-stack/codegen/runtime/subsystems/auth'`. Those imports both fail `tsc --noEmit` (the package's `exports` map points at compiled `dist/runtime/*` files, not deep subpaths) AND would inject against the publisher's compiled token Symbols rather than the consumer's vendored auth subsystem (duplicate-DI hazard). The install logic now rewrites every such specifier to a relative path resolving against `<subsystemsRoot>/auth` at copy time.
+- **`fix(examples)` #303** — `IntegrationsAuthModule` is now `@Global()`. `AuthController` lives inside `AuthModule`'s injector and resolves the `AUTH_INTEGRATION_*` providers exposed by `IntegrationsAuthModule`; without `@Global()`, Nest fails to boot. Same root cause as the auth-bindings module pattern in integration-patterns PR #93.
+
 ## [0.6.6] — 2026-04-27
 
 Bundled cleanup PR for the auth subsystem surfaced during integration-patterns review. Pre-1.0, so two breaking renames are taken without compatibility shims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.7] — 2026-04-28
 
-Hotfix bundle for `cdp subsystem install auth-integrations`. 0.6.5 / 0.6.6 shipped the auth-integrations starter and install template, but every downstream consumer ran into four blockers on a fresh install. None of them surfaced from the source-checkout smoke (the install code resolves examples/ via the package root, which exists in dev) — they only exposed themselves through `npm install + bunx cdp subsystem install auth-integrations` against the published tarball. Surfaced by integration-patterns Wave 0b.
+Hotfix bundle for `cdp subsystem install auth-integrations`. 0.6.5 / 0.6.6 shipped the auth-integrations starter and install template, but every downstream consumer ran into four blockers on a fresh install. None of them surfaced from the source-checkout smoke (the install code resolves examples/ via the package root, which exists in dev) — they only exposed themselves through `npm install + bunx cdp subsystem install auth-integrations` against the published tarball. Bundles a fifth fix that unifies the integrations folder layout. Surfaced by integration-patterns Wave 0b.
+
+### Changed
+
+- **BREAKING — `fix(cli)` #303 (fix #5)** — `cdp subsystem install auth-integrations` now vendors the starter under `<paths.backend_src>/modules/integrations/` (override via `paths.modules_dir`), next to the codegen-emitted `integration` entity module. Previously: `<paths.backend_src>/shared/integrations/`. The starter's runtime tree is now organized under `adapters/`, `facade/`, and `oauth/use-cases/` subfolders to avoid collision with codegen output, and `IntegrationsAuthModule` lives at the integrations folder root. Relative imports inside the vendored files (and the bare-package auth import rewriter, fix #3) target the new layout. Detection (`detectInstalledSubsystems`) checks the new vendor target first and falls back to the legacy shared/integrations location for any pre-0.6.7 install. Pre-1.0; the only downstream consumer of 0.6.5/0.6.6 is integration-patterns Wave 0b (unmerged).
 
 ### Fixed
 

--- a/examples/auth-integrations/README.md
+++ b/examples/auth-integrations/README.md
@@ -17,36 +17,48 @@ examples/auth-integrations/
     entities/
       integration.yaml                      # canonical entity (run cdp entity new)
 
-  runtime/integrations/                     # vendored to apps/api/src/shared/integrations/
-    integration-reader.adapter.ts           # IIntegrationReader impl
-    integration-token-writer.adapter.ts     # IIntegrationTokenWriter impl
-    integration-grant-sink.adapter.ts       # IIntegrationGrantSink impl
-    integrations-auth.module.ts             # binds the three AUTH_INTEGRATION_* tokens
-    integrations.service.ts                 # consumer-facing facade
-    use-cases/
-      create-or-update-from-oauth-grant.use-case.ts
-      mark-integration-requires-reauth.use-case.ts
-      disconnect-integration.use-case.ts
-      list-user-integrations.use-case.ts
+  runtime/integrations/                     # vendored next to the codegen-emitted
+                                            #   integration entity module — i.e.
+                                            #   <backend_src>/modules/integrations/
+                                            #   (override via paths.modules_dir).
+    adapters/
+      integration-reader.adapter.ts         # IIntegrationReader impl
+      integration-token-writer.adapter.ts   # IIntegrationTokenWriter impl
+      integration-grant-sink.adapter.ts     # IIntegrationGrantSink impl
+    facade/
+      integrations.service.ts               # consumer-facing facade
+    oauth/
+      use-cases/
+        create-or-update-from-oauth-grant.use-case.ts
+        mark-integration-requires-reauth.use-case.ts
+        disconnect-integration.use-case.ts
+        list-user-integrations.use-case.ts
+    integrations-auth.module.ts             # @Global() — binds the three
+                                            #   AUTH_INTEGRATION_* tokens.
 ```
 
-## How to install (manual; pending #287)
+## How to install
 
-A future `cdp subsystem install auth-integrations` command will vendor these
-files for you. Until then:
+```bash
+cdp subsystem install auth          # one-time: vendor the auth subsystem
+cdp subsystem install auth-integrations
+cdp entity new integration          # emits the entity module next to the vendor
+```
 
-1. Install + register the auth subsystem (`AuthModule.forRoot({ ... })`).
-2. Copy `definitions/entities/integration.yaml` into your project's
-   `definitions/entities/` directory.
-3. Run `cdp entity new --all` (or `cdp entity new integration`). This emits
-   `apps/api/src/modules/integrations/` (entity, repository, service, module,
-   DTOs, use cases).
-4. Copy `runtime/integrations/` into `apps/api/src/shared/integrations/`.
-5. Import `IntegrationsAuthModule` from
-   `apps/api/src/shared/integrations/integrations-auth.module.ts` in your
-   `AppModule` (or wherever you compose feature modules). Order it AFTER
-   `AuthModule.forRoot(...)` — `IntegrationsAuthModule` depends on the
-   `ENCRYPTION_KEY` provider that `AuthModule` registers.
+The `auth-integrations` install:
+- copies `definitions/entities/integration.yaml` into your configured
+  `paths.entities` (or legacy `paths.entities_dir`) directory.
+- vendors `runtime/integrations/**` under
+  `<backend_src>/modules/integrations/` (override via `paths.modules_dir`),
+  rewriting bare `@pattern-stack/codegen/runtime/subsystems/auth` imports to
+  relative paths that resolve against the vendored auth subsystem at
+  `<paths.subsystems>/auth`.
+- appends a TODO to `<backend_src>/app.module.ts` reminding you to register
+  `IntegrationsAuthModule` AFTER `AuthModule.forRoot(...)`.
+
+`IntegrationsAuthModule` is `@Global()` because `AuthController` (inside
+`AuthModule`'s injector) resolves the `AUTH_INTEGRATION_*` providers exposed
+by it.
 
 ## Two interfaces, two purposes
 

--- a/examples/auth-integrations/runtime/integrations/adapters/integration-grant-sink.adapter.ts
+++ b/examples/auth-integrations/runtime/integrations/adapters/integration-grant-sink.adapter.ts
@@ -3,7 +3,7 @@ import type {
   IIntegrationGrantSink,
   IntegrationGrantInput,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { CreateOrUpdateFromOAuthGrantUseCase } from './use-cases/create-or-update-from-oauth-grant.use-case';
+import { CreateOrUpdateFromOAuthGrantUseCase } from '../oauth/use-cases/create-or-update-from-oauth-grant.use-case';
 
 /**
  * `IIntegrationGrantSink` adapter — pass-through to

--- a/examples/auth-integrations/runtime/integrations/adapters/integration-reader.adapter.ts
+++ b/examples/auth-integrations/runtime/integrations/adapters/integration-reader.adapter.ts
@@ -5,7 +5,7 @@ import {
   type IEncryptionKey,
   type IIntegrationReader,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { IntegrationService } from '../../modules/integrations/integration.service';
+import { IntegrationService } from '../integration.service';
 
 /**
  * `IIntegrationReader` adapter — fetches the integration row by id and

--- a/examples/auth-integrations/runtime/integrations/adapters/integration-token-writer.adapter.ts
+++ b/examples/auth-integrations/runtime/integrations/adapters/integration-token-writer.adapter.ts
@@ -5,7 +5,7 @@ import {
   type IIntegrationTokenWriter,
   type IntegrationTokenUpdate,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { IntegrationService } from '../../modules/integrations/integration.service';
+import { IntegrationService } from '../integration.service';
 
 /**
  * `IIntegrationTokenWriter` adapter — encrypts the new access token

--- a/examples/auth-integrations/runtime/integrations/facade/integrations.service.ts
+++ b/examples/auth-integrations/runtime/integrations/facade/integrations.service.ts
@@ -4,12 +4,12 @@ import {
   type IEncryptionKey,
   type IntegrationGrantInput,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { IntegrationService } from '../../modules/integrations/integration.service';
-import type { Integration } from '../../modules/integrations/integration.entity';
-import { CreateOrUpdateFromOAuthGrantUseCase } from './use-cases/create-or-update-from-oauth-grant.use-case';
-import { DisconnectIntegrationUseCase } from './use-cases/disconnect-integration.use-case';
-import { ListUserIntegrationsUseCase } from './use-cases/list-user-integrations.use-case';
-import { MarkIntegrationRequiresReauthUseCase } from './use-cases/mark-integration-requires-reauth.use-case';
+import { IntegrationService } from '../integration.service';
+import type { Integration } from '../integration.entity';
+import { CreateOrUpdateFromOAuthGrantUseCase } from '../oauth/use-cases/create-or-update-from-oauth-grant.use-case';
+import { DisconnectIntegrationUseCase } from '../oauth/use-cases/disconnect-integration.use-case';
+import { ListUserIntegrationsUseCase } from '../oauth/use-cases/list-user-integrations.use-case';
+import { MarkIntegrationRequiresReauthUseCase } from '../oauth/use-cases/mark-integration-requires-reauth.use-case';
 
 /**
  * Decrypted integration shape — used by consumer code that needs to

--- a/examples/auth-integrations/runtime/integrations/integrations-auth.module.ts
+++ b/examples/auth-integrations/runtime/integrations/integrations-auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import {
   AUTH_INTEGRATION_GRANT_SINK,
   AUTH_INTEGRATION_READER,
@@ -32,7 +32,14 @@ import { MarkIntegrationRequiresReauthUseCase } from './use-cases/mark-integrati
  *   - AUTH_INTEGRATION_READER       → IntegrationReaderAdapter
  *   - AUTH_INTEGRATION_TOKEN_WRITER → IntegrationTokenWriterAdapter
  *   - AUTH_INTEGRATION_GRANT_SINK   → IntegrationGrantSinkAdapter
+ *
+ * `@Global()` is required: `AuthController` lives inside `AuthModule`'s
+ * own injector and resolves the `AUTH_INTEGRATION_*` providers exposed
+ * here. Without `@Global()`, the controller's injector cannot see these
+ * tokens and Nest fails to boot. Same pattern as the `auth-bindings`
+ * module shipped in #93.
  */
+@Global()
 @Module({
   imports: [IntegrationsModule],
   providers: [

--- a/examples/auth-integrations/runtime/integrations/integrations-auth.module.ts
+++ b/examples/auth-integrations/runtime/integrations/integrations-auth.module.ts
@@ -4,15 +4,15 @@ import {
   AUTH_INTEGRATION_READER,
   AUTH_INTEGRATION_TOKEN_WRITER,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { IntegrationsModule } from '../../modules/integrations/integrations.module';
-import { IntegrationGrantSinkAdapter } from './integration-grant-sink.adapter';
-import { IntegrationReaderAdapter } from './integration-reader.adapter';
-import { IntegrationTokenWriterAdapter } from './integration-token-writer.adapter';
-import { IntegrationsService } from './integrations.service';
-import { CreateOrUpdateFromOAuthGrantUseCase } from './use-cases/create-or-update-from-oauth-grant.use-case';
-import { DisconnectIntegrationUseCase } from './use-cases/disconnect-integration.use-case';
-import { ListUserIntegrationsUseCase } from './use-cases/list-user-integrations.use-case';
-import { MarkIntegrationRequiresReauthUseCase } from './use-cases/mark-integration-requires-reauth.use-case';
+import { IntegrationsModule } from './integrations.module';
+import { IntegrationGrantSinkAdapter } from './adapters/integration-grant-sink.adapter';
+import { IntegrationReaderAdapter } from './adapters/integration-reader.adapter';
+import { IntegrationTokenWriterAdapter } from './adapters/integration-token-writer.adapter';
+import { IntegrationsService } from './facade/integrations.service';
+import { CreateOrUpdateFromOAuthGrantUseCase } from './oauth/use-cases/create-or-update-from-oauth-grant.use-case';
+import { DisconnectIntegrationUseCase } from './oauth/use-cases/disconnect-integration.use-case';
+import { ListUserIntegrationsUseCase } from './oauth/use-cases/list-user-integrations.use-case';
+import { MarkIntegrationRequiresReauthUseCase } from './oauth/use-cases/mark-integration-requires-reauth.use-case';
 
 /**
  * `IntegrationsAuthModule` — wires the consumer-side adapters that

--- a/examples/auth-integrations/runtime/integrations/oauth/use-cases/create-or-update-from-oauth-grant.use-case.ts
+++ b/examples/auth-integrations/runtime/integrations/oauth/use-cases/create-or-update-from-oauth-grant.use-case.ts
@@ -4,8 +4,8 @@ import {
   type IEncryptionKey,
   type IntegrationGrantInput,
 } from '@pattern-stack/codegen/runtime/subsystems/auth';
-import { IntegrationService } from '../../../modules/integrations/integration.service';
-import type { Integration } from '../../../modules/integrations/integration.entity';
+import { IntegrationService } from '../../integration.service';
+import type { Integration } from '../../integration.entity';
 
 /**
  * Persists an OAuth2 grant from the authorize-code callback (initial

--- a/examples/auth-integrations/runtime/integrations/oauth/use-cases/disconnect-integration.use-case.ts
+++ b/examples/auth-integrations/runtime/integrations/oauth/use-cases/disconnect-integration.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { IntegrationService } from '../../../modules/integrations/integration.service';
-import type { Integration } from '../../../modules/integrations/integration.entity';
+import { IntegrationService } from '../../integration.service';
+import type { Integration } from '../../integration.entity';
 
 /**
  * User-initiated disconnect. Flips status to `revoked` and clears the

--- a/examples/auth-integrations/runtime/integrations/oauth/use-cases/list-user-integrations.use-case.ts
+++ b/examples/auth-integrations/runtime/integrations/oauth/use-cases/list-user-integrations.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { IntegrationService } from '../../../modules/integrations/integration.service';
-import type { Integration } from '../../../modules/integrations/integration.entity';
+import { IntegrationService } from '../../integration.service';
+import type { Integration } from '../../integration.entity';
 
 /**
  * Lists a user's integrations newest-first. Used by the settings page

--- a/examples/auth-integrations/runtime/integrations/oauth/use-cases/mark-integration-requires-reauth.use-case.ts
+++ b/examples/auth-integrations/runtime/integrations/oauth/use-cases/mark-integration-requires-reauth.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { IntegrationService } from '../../../modules/integrations/integration.service';
-import type { Integration } from '../../../modules/integrations/integration.entity';
+import { IntegrationService } from '../../integration.service';
+import type { Integration } from '../../integration.entity';
 
 /**
  * Flips an integration's status to `requires_reauth`. Called when the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",
@@ -40,6 +40,7 @@
     "dist",
     "runtime",
     "templates",
+    "examples/auth-integrations/**",
     "src/config/*.mjs",
     "src/schema/naming-config.schema.mjs",
     "src/patterns/registry.ts",

--- a/src/__tests__/cli/auth-integrations-scaffold-locals.test.ts
+++ b/src/__tests__/cli/auth-integrations-scaffold-locals.test.ts
@@ -5,6 +5,7 @@
  *   - default locals on first install
  *   - custom paths.backend_src flows into appModulePath + sharedRoot
  *   - paths.shared overrides the derived sharedRoot
+ *   - paths.modules_dir overrides the derived vendorRoot (#303 fix #5)
  *   - paths.entities (and legacy paths.entities_dir) overrides the
  *     default integration.yaml location
  *   - authModuleRegistered detection (presence + absence)
@@ -33,6 +34,7 @@ describe('resolveAuthIntegrationsScaffoldLocals', () => {
 		expect(locals.appName).toBe('auth-integrations-fixture');
 		expect(locals.appModulePath).toBe(path.resolve(CWD, 'src/app.module.ts'));
 		expect(locals.sharedRoot).toBe(path.resolve(CWD, 'src/shared'));
+		expect(locals.vendorRoot).toBe(path.resolve(CWD, 'src/modules'));
 		expect(locals.definitionsPath).toBe(
 			path.resolve(CWD, 'definitions/entities/integration.yaml'),
 		);
@@ -53,6 +55,22 @@ describe('resolveAuthIntegrationsScaffoldLocals', () => {
 		expect(locals.sharedRoot).toBe(
 			path.resolve(CWD, 'packages/api/src/shared'),
 		);
+		expect(locals.vendorRoot).toBe(
+			path.resolve(CWD, 'packages/api/src/modules'),
+		);
+	});
+
+	test('paths.modules_dir overrides the derived vendorRoot (#303 fix #5)', () => {
+		const locals = resolveAuthIntegrationsScaffoldLocals({
+			cwd: CWD,
+			config: {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				paths: { backend_src: 'apps/api/src', modules_dir: 'apps/api/src/features' },
+			} as any,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(locals.vendorRoot).toBe(path.resolve(CWD, 'apps/api/src/features'));
 	});
 
 	test('paths.shared overrides the derived sharedRoot', () => {
@@ -144,6 +162,7 @@ describe('localsToHygenArgs', () => {
 		appName: 'demo',
 		appModulePath: '/abs/src/app.module.ts',
 		sharedRoot: '/abs/src/shared',
+		vendorRoot: '/abs/src/modules',
 		definitionsPath: '/abs/definitions/entities/integration.yaml',
 		authModuleRegistered: false,
 	};
@@ -152,9 +171,11 @@ describe('localsToHygenArgs', () => {
 		const args = localsToHygenArgs(base);
 		expect(args).toContain('--appName');
 		expect(args).toContain('--appModulePath');
-		// sharedRoot and definitionsPath are consumed by subsystem.ts
-		// directly (full-file copies), not by Hygen — must NOT be forwarded.
+		// sharedRoot, vendorRoot, and definitionsPath are consumed by
+		// subsystem.ts directly (full-file copies), not by Hygen —
+		// must NOT be forwarded.
 		expect(args).not.toContain('--sharedRoot');
+		expect(args).not.toContain('--vendorRoot');
 		expect(args).not.toContain('--definitionsPath');
 	});
 

--- a/src/__tests__/cli/auth-integrations-scaffold-locals.test.ts
+++ b/src/__tests__/cli/auth-integrations-scaffold-locals.test.ts
@@ -5,7 +5,8 @@
  *   - default locals on first install
  *   - custom paths.backend_src flows into appModulePath + sharedRoot
  *   - paths.shared overrides the derived sharedRoot
- *   - paths.definitions overrides the default integration.yaml location
+ *   - paths.entities (and legacy paths.entities_dir) overrides the
+ *     default integration.yaml location
  *   - authModuleRegistered detection (presence + absence)
  *   - localsToHygenArgs forwards only the keys Hygen needs
  */
@@ -67,16 +68,44 @@ describe('resolveAuthIntegrationsScaffoldLocals', () => {
 		expect(locals.sharedRoot).toBe(path.resolve(CWD, 'custom/shared'));
 	});
 
-	test('paths.definitions overrides the default integration.yaml location', () => {
+	test('paths.entities overrides the default integration.yaml location', () => {
 		const locals = resolveAuthIntegrationsScaffoldLocals({
 			cwd: CWD,
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			config: { paths: { definitions: 'entities' } } as any,
+			config: { paths: { entities: 'definitions/entities' } } as any,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(locals.definitionsPath).toBe(
+			path.resolve(CWD, 'definitions/entities/integration.yaml'),
+		);
+	});
+
+	test('legacy paths.entities_dir is honored', () => {
+		const locals = resolveAuthIntegrationsScaffoldLocals({
+			cwd: CWD,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			config: { paths: { entities_dir: 'entities' } } as any,
 			fileExists: () => false,
 			readFile: () => null,
 		});
 		expect(locals.definitionsPath).toBe(
 			path.resolve(CWD, 'entities/integration.yaml'),
+		);
+	});
+
+	test('paths.entities wins over legacy paths.entities_dir', () => {
+		const locals = resolveAuthIntegrationsScaffoldLocals({
+			cwd: CWD,
+			config: {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				paths: { entities: 'a', entities_dir: 'b' } as any,
+			},
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(locals.definitionsPath).toBe(
+			path.resolve(CWD, 'a/integration.yaml'),
 		);
 	});
 

--- a/src/__tests__/cli/subsystem.test.ts
+++ b/src/__tests__/cli/subsystem.test.ts
@@ -353,6 +353,50 @@ describe('subsystem — install (real)', () => {
 			expect(matches.length).toBeLessThanOrEqual(1);
 		}
 	});
+	// #303: vendored adapters must NOT keep bare-package imports — those
+	// fail to resolve through the package's `exports` map and would pin
+	// against the publisher's compiled token Symbols rather than the
+	// consumer's vendored auth subsystem (duplicate-DI hazard).
+	test('auth-integrations install rewrites bare auth imports to relative paths', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'auth-integrations',
+				'--force',
+				'--cwd',
+				root,
+			]),
+		);
+
+		const integrationsDir = path.join(root, 'src/shared/integrations');
+		const files = fs
+			.readdirSync(integrationsDir, { withFileTypes: true, recursive: true })
+			.filter((d) => d.isFile() && d.name.endsWith('.ts'))
+			.map((d) =>
+				path.join(
+					(d as fs.Dirent & { parentPath?: string }).parentPath ??
+						integrationsDir,
+					d.name,
+				),
+			);
+		expect(files.length).toBeGreaterThan(0);
+		for (const file of files) {
+			const src = fs.readFileSync(file, 'utf-8');
+			expect(src).not.toContain('@pattern-stack/codegen/runtime/subsystems/auth');
+		}
+
+		// And at least one file should now import from a relative
+		// `…/subsystems/auth` path.
+		const moduleSrc = fs.readFileSync(
+			path.join(integrationsDir, 'integrations-auth.module.ts'),
+			'utf-8',
+		);
+		expect(moduleSrc).toMatch(/from\s+['"]\.\.[^'"]*subsystems\/auth['"]/);
+	});
 });
 
 describe('subsystem — detection', () => {

--- a/src/__tests__/cli/subsystem.test.ts
+++ b/src/__tests__/cli/subsystem.test.ts
@@ -372,7 +372,7 @@ describe('subsystem — install (real)', () => {
 			]),
 		);
 
-		const integrationsDir = path.join(root, 'src/shared/integrations');
+		const integrationsDir = path.join(root, 'src/modules/integrations');
 		const files = fs
 			.readdirSync(integrationsDir, { withFileTypes: true, recursive: true })
 			.filter((d) => d.isFile() && d.name.endsWith('.ts'))
@@ -396,6 +396,92 @@ describe('subsystem — install (real)', () => {
 			'utf-8',
 		);
 		expect(moduleSrc).toMatch(/from\s+['"]\.\.[^'"]*subsystems\/auth['"]/);
+	});
+
+	// #303 fix #5: vendor target lives under <modules>/integrations/, with
+	// adapters/, facade/, and oauth/use-cases/ subfolders, alongside the
+	// codegen-emitted integration entity module.
+	test('auth-integrations install vendors under <modules>/integrations with subfolder layout', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'auth-integrations',
+				'--force',
+				'--cwd',
+				root,
+			]),
+		);
+
+		const base = path.join(root, 'src/modules/integrations');
+		expect(
+			fs.existsSync(
+				path.join(base, 'adapters/integration-reader.adapter.ts'),
+			),
+		).toBe(true);
+		expect(
+			fs.existsSync(
+				path.join(base, 'adapters/integration-token-writer.adapter.ts'),
+			),
+		).toBe(true);
+		expect(
+			fs.existsSync(
+				path.join(base, 'adapters/integration-grant-sink.adapter.ts'),
+			),
+		).toBe(true);
+		expect(fs.existsSync(path.join(base, 'facade/integrations.service.ts'))).toBe(
+			true,
+		);
+		expect(
+			fs.existsSync(
+				path.join(
+					base,
+					'oauth/use-cases/create-or-update-from-oauth-grant.use-case.ts',
+				),
+			),
+		).toBe(true);
+		expect(fs.existsSync(path.join(base, 'integrations-auth.module.ts'))).toBe(
+			true,
+		);
+
+		// The legacy <shared>/integrations/ vendor target must be empty —
+		// the new layout replaces it.
+		expect(
+			fs.existsSync(path.join(root, 'src/shared/integrations')),
+		).toBe(false);
+	});
+
+	test('auth-integrations install honors paths.modules_dir override', async () => {
+		const root = mkTempProject();
+		tempDirs.push(root);
+		// Override modules_dir.
+		const configPath = path.join(root, 'codegen.config.yaml');
+		fs.writeFileSync(
+			configPath,
+			'paths:\n  subsystems: src/shared/subsystems\n  modules_dir: src/features\n',
+		);
+		const cli = buildCli();
+		await capture(() =>
+			cli.run([
+				'subsystem',
+				'install',
+				'auth-integrations',
+				'--force',
+				'--cwd',
+				root,
+			]),
+		);
+		expect(
+			fs.existsSync(
+				path.join(
+					root,
+					'src/features/integrations/integrations-auth.module.ts',
+				),
+			),
+		).toBe(true);
 	});
 });
 

--- a/src/__tests__/templates/auth-integrations-files-coverage.test.ts
+++ b/src/__tests__/templates/auth-integrations-files-coverage.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Prevention test for #303 — assert that the `examples/auth-integrations/`
+ * starter is included in the published tarball.
+ *
+ * Background: 0.6.5 / 0.6.6 shipped `cdp subsystem install auth-integrations`,
+ * which copies `examples/auth-integrations/runtime/integrations/**` and
+ * `examples/auth-integrations/definitions/entities/integration.yaml`
+ * out of `node_modules/@pattern-stack/codegen/examples/auth-integrations/`
+ * into the consumer's project. But `package.json:files` did not list
+ * `examples/auth-integrations/**`, so npm consumers ran into a missing
+ * source tree on first invocation.
+ *
+ * This test ensures every file the install logic copies is covered by
+ * the `files` manifest. It mirrors `files-manifest-coverage.test.ts`
+ * (#266) but is anchored to the explicit auth-integrations source paths
+ * referenced from `src/cli/commands/subsystem.ts`.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync, existsSync, statSync, readdirSync } from 'node:fs';
+import { resolve, relative, join } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..');
+
+function globToRegExp(pattern: string): RegExp {
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === '*' && pattern[i + 1] === '*') {
+      re += '.*';
+      i += 2;
+      if (pattern[i] === '/') i++;
+    } else if (c === '*') {
+      re += '[^/]*';
+      i++;
+    } else if (c === '?') {
+      re += '[^/]';
+      i++;
+    } else if (/[.+^$|()[\]\\]/.test(c)) {
+      re += '\\' + c;
+      i++;
+    } else {
+      re += c;
+      i++;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+function isCoveredByFiles(absPath: string, filesPatterns: string[]): boolean {
+  const rel = relative(REPO_ROOT, absPath);
+  for (const pattern of filesPatterns) {
+    const dirCandidate = resolve(REPO_ROOT, pattern);
+    if (existsSync(dirCandidate) && statSync(dirCandidate).isDirectory()) {
+      const insideRel = relative(dirCandidate, absPath);
+      if (insideRel && !insideRel.startsWith('..')) return true;
+      continue;
+    }
+    if (globToRegExp(pattern).test(rel)) return true;
+  }
+  return false;
+}
+
+function walk(root: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.isFile()) out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('package.json:files covers examples/auth-integrations/ (#303)', () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf8'),
+  );
+  const filesPatterns: string[] = pkg.files;
+  const examplesRoot = resolve(REPO_ROOT, 'examples', 'auth-integrations');
+
+  it('starter source exists on disk', () => {
+    expect(existsSync(examplesRoot)).toBe(true);
+    expect(
+      existsSync(
+        join(examplesRoot, 'runtime', 'integrations', 'integrations-auth.module.ts'),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(examplesRoot, 'definitions', 'entities', 'integration.yaml'),
+      ),
+    ).toBe(true);
+  });
+
+  it('every file under examples/auth-integrations/ is covered by `files`', () => {
+    const uncovered: string[] = [];
+    for (const file of walk(examplesRoot)) {
+      if (!isCoveredByFiles(file, filesPatterns)) {
+        uncovered.push(relative(REPO_ROOT, file));
+      }
+    }
+    if (uncovered.length > 0) {
+      throw new Error(
+        `examples/auth-integrations files not covered by package.json:files ` +
+          `(install will fail in npm consumers):\n` +
+          uncovered.map((p) => `  - ${p}`).join('\n') +
+          `\n\nFix: add "examples/auth-integrations/**" to "files".`,
+      );
+    }
+  });
+});

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -59,7 +59,10 @@ import {
 	type SubsystemBackend,
 	type InstalledSubsystem,
 } from '../shared/subsystem-detect.js';
-import { resolveSubsystemsRoot } from '../shared/subsystems-path.js';
+import {
+	resolveSubsystemsRoot,
+	resolveSubsystemsRootFromConfig,
+} from '../shared/subsystems-path.js';
 
 import { theme } from '../ui/theme.js';
 import { icons } from '../ui/icons.js';
@@ -1525,11 +1528,18 @@ interface AuthIntegrationsCopyResult {
  * Recursively copy `srcDir` → `destDir`. Idempotent: existing files are
  * skipped unless `force` is true. Returns the lists of copied vs skipped
  * absolute destination paths.
+ *
+ * Optional `transform` rewrites file contents on copy (used by the
+ * auth-integrations install to swap bare `@pattern-stack/codegen/runtime/
+ * subsystems/auth` imports for relative paths into the consumer's
+ * vendored auth subsystem). Binary files are left as-is — `transform`
+ * is only invoked for `.ts`/`.tsx` files.
  */
 function copyTreeIdempotent(
 	srcDir: string,
 	destDir: string,
 	force: boolean,
+	transform?: (content: string, destPath: string) => string,
 ): AuthIntegrationsCopyResult {
 	const written: string[] = [];
 	const skipped: string[] = [];
@@ -1550,7 +1560,14 @@ function copyTreeIdempotent(
 				continue;
 			}
 			fs.mkdirSync(path.dirname(destPath), { recursive: true });
-			fs.copyFileSync(srcPath, destPath);
+			const isTextSource =
+				transform && (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx'));
+			if (isTextSource && transform) {
+				const raw = fs.readFileSync(srcPath, 'utf-8');
+				fs.writeFileSync(destPath, transform(raw, destPath), 'utf-8');
+			} else {
+				fs.copyFileSync(srcPath, destPath);
+			}
 			written.push(destPath);
 		}
 	};
@@ -1559,6 +1576,52 @@ function copyTreeIdempotent(
 	fs.mkdirSync(destDir, { recursive: true });
 	walk(srcDir, destDir);
 	return { written, skipped };
+}
+
+/**
+ * Build a transform that rewrites every
+ * `from '@pattern-stack/codegen/runtime/subsystems/auth'` import in the
+ * vendored auth-integrations adapters to a relative path that resolves
+ * against the consumer's vendored auth subsystem at
+ * `<subsystemsRoot>/auth`.
+ *
+ * Two reasons we can't keep the bare imports:
+ *   1. The package's `exports` map exposes `./runtime/*` against
+ *      `dist/runtime/*` (compiled `.d.ts` + `.js`), not against deep
+ *      subdirectory paths — so `tsc --noEmit` fails to resolve the
+ *      sub-path in published consumers.
+ *   2. Even when types resolve, the package re-emits its own copies
+ *      of the auth tokens at runtime; injecting against those tokens
+ *      vs the consumer's vendored copy creates duplicate-DI-token
+ *      bugs (different Symbol identities).
+ *
+ * Vendoring the auth subsystem means there's exactly one set of token
+ * Symbols, owned by the consumer, and these adapters import from it
+ * directly via relative paths.
+ */
+const AUTH_BARE_IMPORT_RE =
+	/(['"])@pattern-stack\/codegen\/runtime\/subsystems\/auth\1/g;
+
+function buildAuthImportRewriter(
+	subsystemsRoot: string,
+): (content: string, destPath: string) => string {
+	const authRoot = path.join(subsystemsRoot, 'auth');
+	return (content: string, destPath: string): string => {
+		if (!AUTH_BARE_IMPORT_RE.test(content)) {
+			AUTH_BARE_IMPORT_RE.lastIndex = 0;
+			return content;
+		}
+		AUTH_BARE_IMPORT_RE.lastIndex = 0;
+		let rel = path.relative(path.dirname(destPath), authRoot);
+		if (!rel.startsWith('.')) rel = `./${rel}`;
+		// Use forward slashes regardless of platform — TS module specifiers
+		// are POSIX even on Windows.
+		const relPosix = rel.split(path.sep).join('/');
+		return content.replace(
+			AUTH_BARE_IMPORT_RE,
+			(_match, quote: string) => `${quote}${relPosix}${quote}`,
+		);
+	};
 }
 
 interface AuthIntegrationsScaffoldOutcome {
@@ -1616,11 +1679,15 @@ function runAuthIntegrationsScaffold(
 		};
 	}
 
-	// Vendor the adapters tree.
+	// Vendor the adapters tree, rewriting the bare-package auth imports
+	// to relative paths that resolve against the consumer's vendored
+	// auth subsystem (see buildAuthImportRewriter).
+	const subsystemsRoot = resolveSubsystemsRootFromConfig(cwd, config);
 	const adapterCopy = copyTreeIdempotent(
 		adaptersSrc,
 		adaptersDest,
 		opts.force,
+		buildAuthImportRewriter(subsystemsRoot),
 	);
 
 	// Vendor the integration.yaml.

--- a/src/cli/commands/subsystem.ts
+++ b/src/cli/commands/subsystem.ts
@@ -1656,7 +1656,10 @@ function runAuthIntegrationsScaffold(
 	}
 
 	const adaptersSrc = path.join(examplesRoot, 'runtime', 'integrations');
-	const adaptersDest = path.join(locals.sharedRoot, 'integrations');
+	// #303 fix #5: vendor next to the codegen-emitted entity module under
+	// `<vendorRoot>/integrations/` (default `<backendSrc>/modules/integrations/`),
+	// NOT under `<sharedRoot>/integrations/`.
+	const adaptersDest = path.join(locals.vendorRoot, 'integrations');
 	const integrationYamlSrc = path.join(
 		examplesRoot,
 		'definitions',

--- a/src/cli/shared/auth-integrations-scaffold-locals.ts
+++ b/src/cli/shared/auth-integrations-scaffold-locals.ts
@@ -41,6 +41,14 @@ const FALLBACK_BACKEND_SRC = 'src';
 const SHARED_DIR_NAME = 'shared';
 
 /**
+ * Default modules directory — where codegen emits the `integration`
+ * entity module under clean-lite-ps. The auth-integrations install
+ * vendors next to the codegen output to keep the integrations surface
+ * unified (#303 fix #5). Override via `paths.modules_dir`.
+ */
+const DEFAULT_MODULES_DIR = 'modules';
+
+/**
  * Default entity-yaml directory for the vendored `integration.yaml`.
  * Spec'd as `definitions/entities/` in #287 (the convention the
  * `examples/auth-integrations` starter ships with). Overridable via
@@ -55,10 +63,22 @@ export interface AuthIntegrationsScaffoldLocals {
 	/** Where `app-module-hook.ejs.t` appends the IntegrationsAuthModule TODO. */
 	appModulePath: string;
 	/**
-	 * Where the integrations adapters land — `<sharedRoot>/integrations/...`.
-	 * Resolves from `paths.shared` if set, else `<paths.backend_src>/shared`.
+	 * Legacy field: where `<sharedRoot>/integrations/...` would have
+	 * landed before #303 fix #5. Kept for diagnostic logging only —
+	 * vendoring now goes under `vendorRoot/integrations/` (next to the
+	 * codegen-emitted entity module).
 	 */
 	sharedRoot: string;
+	/**
+	 * Where the integrations starter is vendored — `<vendorRoot>/integrations/`.
+	 * Resolves from `paths.modules_dir` if set, else
+	 * `<paths.backend_src>/modules`. Co-locates the vendored adapters,
+	 * facade, oauth use-cases, and `IntegrationsAuthModule` with the
+	 * codegen-emitted `integration` entity module so the whole
+	 * integrations surface lives under one folder (matches dealbrain-v2
+	 * precedent; #303 fix #5).
+	 */
+	vendorRoot: string;
 	/**
 	 * Where the vendored `integration.yaml` lands. Resolves from
 	 * `paths.definitions` if set, else `<cwd>/definitions/entities/integration.yaml`.
@@ -90,8 +110,12 @@ export interface AuthIntegrationsScaffoldLocalsInput {
  * - `appModulePath` resolves to `<cwd>/<paths.backend_src>/app.module.ts`,
  *   falling back to `<cwd>/src/app.module.ts`.
  * - `sharedRoot` resolves to `<cwd>/<paths.shared>` if set, else
- *   `<cwd>/<paths.backend_src>/shared`. The integrations adapters land
- *   under `<sharedRoot>/integrations/`.
+ *   `<cwd>/<paths.backend_src>/shared`. Legacy: pre-#303-fix-#5
+ *   vendor target. Retained for diagnostics only.
+ * - `vendorRoot` resolves to `<cwd>/<paths.modules_dir>` if set, else
+ *   `<cwd>/<paths.backend_src>/modules`. The auth-integrations starter
+ *   is vendored under `<vendorRoot>/integrations/` next to the
+ *   codegen-emitted `integration` entity module (#303 fix #5).
  * - `definitionsPath` resolves to `<cwd>/<paths.entities>/integration.yaml`
  *   (or legacy `<cwd>/<paths.entities_dir>/integration.yaml`) if set,
  *   else `<cwd>/definitions/entities/integration.yaml`. (The
@@ -113,24 +137,33 @@ export function resolveAuthIntegrationsScaffoldLocals(
 			? config.paths.backend_src
 			: FALLBACK_BACKEND_SRC;
 
-	const sharedConfigured = (config?.paths as Record<string, unknown> | undefined)
-		?.shared;
+	const pathsAny = config?.paths as Record<string, unknown> | undefined;
+
+	const sharedConfigured = pathsAny?.shared;
 	const sharedRoot =
 		typeof sharedConfigured === 'string' && sharedConfigured.length > 0
 			? path.resolve(cwd, sharedConfigured)
 			: path.resolve(cwd, backendSrc, SHARED_DIR_NAME);
 
+	// #303 fix #5: vendor target lives next to the codegen-emitted
+	// integration entity module, NOT under shared/. Default mirrors the
+	// clean-lite-ps emit path (`<backendSrc>/modules/`).
+	const modulesConfigured = pathsAny?.modules_dir;
+	const vendorRoot =
+		typeof modulesConfigured === 'string' && modulesConfigured.length > 0
+			? path.resolve(cwd, modulesConfigured)
+			: path.resolve(cwd, backendSrc, DEFAULT_MODULES_DIR);
+
 	// Honor the consumer's configured entity-yaml directory. Order matches
 	// `Context.entitiesDir` resolution: `paths.entities` first, then legacy
 	// `paths.entities_dir`. (Older `paths.definitions` is NOT a real key and
 	// was a hotfix-fixed bug — #303.)
-	const pathsRaw = config?.paths as Record<string, unknown> | undefined;
 	const entitiesConfigured =
-		typeof pathsRaw?.entities === 'string' && pathsRaw.entities.length > 0
-			? pathsRaw.entities
-			: typeof pathsRaw?.entities_dir === 'string' &&
-				  pathsRaw.entities_dir.length > 0
-				? pathsRaw.entities_dir
+		typeof pathsAny?.entities === 'string' && pathsAny.entities.length > 0
+			? pathsAny.entities
+			: typeof pathsAny?.entities_dir === 'string' &&
+				  pathsAny.entities_dir.length > 0
+				? pathsAny.entities_dir
 				: null;
 	const definitionsPath =
 		entitiesConfigured !== null
@@ -149,6 +182,7 @@ export function resolveAuthIntegrationsScaffoldLocals(
 		appName: path.basename(cwd),
 		appModulePath,
 		sharedRoot,
+		vendorRoot,
 		definitionsPath,
 		authModuleRegistered,
 	};

--- a/src/cli/shared/auth-integrations-scaffold-locals.ts
+++ b/src/cli/shared/auth-integrations-scaffold-locals.ts
@@ -44,8 +44,8 @@ const SHARED_DIR_NAME = 'shared';
  * Default entity-yaml directory for the vendored `integration.yaml`.
  * Spec'd as `definitions/entities/` in #287 (the convention the
  * `examples/auth-integrations` starter ships with). Overridable via
- * `paths.definitions` in `codegen.config.yaml` if the consumer keeps their
- * yaml elsewhere.
+ * `paths.entities` (or legacy `paths.entities_dir`) in
+ * `codegen.config.yaml` if the consumer keeps their yaml elsewhere.
  */
 const DEFAULT_DEFINITIONS_DIR = 'definitions/entities';
 
@@ -92,7 +92,8 @@ export interface AuthIntegrationsScaffoldLocalsInput {
  * - `sharedRoot` resolves to `<cwd>/<paths.shared>` if set, else
  *   `<cwd>/<paths.backend_src>/shared`. The integrations adapters land
  *   under `<sharedRoot>/integrations/`.
- * - `definitionsPath` resolves to `<cwd>/<paths.definitions>` if set,
+ * - `definitionsPath` resolves to `<cwd>/<paths.entities>/integration.yaml`
+ *   (or legacy `<cwd>/<paths.entities_dir>/integration.yaml`) if set,
  *   else `<cwd>/definitions/entities/integration.yaml`. (The
  *   `examples/auth-integrations/definitions/entities/integration.yaml`
  *   convention.)
@@ -119,12 +120,21 @@ export function resolveAuthIntegrationsScaffoldLocals(
 			? path.resolve(cwd, sharedConfigured)
 			: path.resolve(cwd, backendSrc, SHARED_DIR_NAME);
 
-	const definitionsConfigured = (
-		config?.paths as Record<string, unknown> | undefined
-	)?.definitions;
+	// Honor the consumer's configured entity-yaml directory. Order matches
+	// `Context.entitiesDir` resolution: `paths.entities` first, then legacy
+	// `paths.entities_dir`. (Older `paths.definitions` is NOT a real key and
+	// was a hotfix-fixed bug — #303.)
+	const pathsRaw = config?.paths as Record<string, unknown> | undefined;
+	const entitiesConfigured =
+		typeof pathsRaw?.entities === 'string' && pathsRaw.entities.length > 0
+			? pathsRaw.entities
+			: typeof pathsRaw?.entities_dir === 'string' &&
+				  pathsRaw.entities_dir.length > 0
+				? pathsRaw.entities_dir
+				: null;
 	const definitionsPath =
-		typeof definitionsConfigured === 'string' && definitionsConfigured.length > 0
-			? path.resolve(cwd, definitionsConfigured, 'integration.yaml')
+		entitiesConfigured !== null
+			? path.resolve(cwd, entitiesConfigured, 'integration.yaml')
 			: path.resolve(cwd, DEFAULT_DEFINITIONS_DIR, 'integration.yaml');
 
 	const appModulePath = path.resolve(cwd, backendSrc, 'app.module.ts');

--- a/src/cli/shared/subsystem-detect.ts
+++ b/src/cli/shared/subsystem-detect.ts
@@ -231,31 +231,43 @@ export async function detectInstalledSubsystems(ctx: Context): Promise<Installed
 		}
 	}
 
-	// #287: detect `auth-integrations` by presence of the vendored
-	// `integrations-auth.module.ts` under the consumer's shared root. The
-	// shared root resolves the same way as in `auth-integrations-scaffold-locals.ts`:
-	// `paths.shared` (if set) else `<paths.backend_src>/shared`.
+	// #287 / #303 fix #5: detect `auth-integrations` by presence of the
+	// vendored `integrations-auth.module.ts`. The vendor target moved
+	// from `<sharedRoot>/integrations/` to `<vendorRoot>/integrations/`
+	// (default `<paths.backend_src>/modules/integrations/`, override via
+	// `paths.modules_dir`). Resolution mirrors
+	// `auth-integrations-scaffold-locals.ts`. Falls back to the legacy
+	// shared/integrations location for any pre-0.6.7 installs.
 	if (!seen.has('auth-integrations')) {
 		const backendSrc =
 			(ctx.config?.paths?.backend_src as string | undefined) ?? 'src';
-		const sharedConfigured = (
-			ctx.config?.paths as Record<string, unknown> | undefined
-		)?.shared;
+		const pathsAny = ctx.config?.paths as
+			| Record<string, unknown>
+			| undefined;
+		const modulesConfigured = pathsAny?.modules_dir;
+		const vendorRoot =
+			typeof modulesConfigured === 'string' && modulesConfigured.length > 0
+				? path.resolve(ctx.cwd, modulesConfigured)
+				: path.resolve(ctx.cwd, backendSrc, 'modules');
+		const sharedConfigured = pathsAny?.shared;
 		const sharedRoot =
 			typeof sharedConfigured === 'string' && sharedConfigured.length > 0
 				? path.resolve(ctx.cwd, sharedConfigured)
 				: path.resolve(ctx.cwd, backendSrc, 'shared');
-		const moduleFile = path.join(
-			sharedRoot,
-			'integrations',
-			'integrations-auth.module.ts',
-		);
-		if (fs.existsSync(moduleFile)) {
-			found.push({
-				name: 'auth-integrations',
-				path: path.dirname(moduleFile),
-				backend: 'drizzle',
-			});
+
+		const candidates = [
+			path.join(vendorRoot, 'integrations', 'integrations-auth.module.ts'),
+			path.join(sharedRoot, 'integrations', 'integrations-auth.module.ts'),
+		];
+		for (const moduleFile of candidates) {
+			if (fs.existsSync(moduleFile)) {
+				found.push({
+					name: 'auth-integrations',
+					path: path.dirname(moduleFile),
+					backend: 'drizzle',
+				});
+				break;
+			}
 		}
 	}
 

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -303,13 +303,56 @@ async function main(): Promise<number> {
 		//   - IntegrationsAuthModule TODO into app.module.ts.
 		run(`bun ${CLI_PATH} subsystem install auth-integrations`, tmpDir);
 
-		const integrationsAuthModulePath = path.join(
+		// #303 fix #5: vendor target is `<modules>/integrations/` with
+		// subfolders (`adapters/`, `facade/`, `oauth/use-cases/`). Assert
+		// one file from every layer plus the root module so the smoke
+		// catches any future regression in the install template's layout.
+		const integrationsRoot = path.join(tmpDir, 'src/modules/integrations');
+		const expectedVendoredFiles = [
+			'integrations-auth.module.ts',
+			'adapters/integration-reader.adapter.ts',
+			'adapters/integration-token-writer.adapter.ts',
+			'adapters/integration-grant-sink.adapter.ts',
+			'facade/integrations.service.ts',
+			'oauth/use-cases/create-or-update-from-oauth-grant.use-case.ts',
+			'oauth/use-cases/disconnect-integration.use-case.ts',
+			'oauth/use-cases/list-user-integrations.use-case.ts',
+			'oauth/use-cases/mark-integration-requires-reauth.use-case.ts',
+		];
+		for (const rel of expectedVendoredFiles) {
+			const abs = path.join(integrationsRoot, rel);
+			if (!fs.existsSync(abs)) {
+				throw new Error(
+					`expected vendored file missing after auth-integrations install: ${rel}`,
+				);
+			}
+		}
+
+		// #303 fix #3: vendored adapters must NOT carry the bare-package
+		// `@pattern-stack/codegen/runtime/subsystems/auth` import — those
+		// fail to resolve through the package's `exports` map AND would
+		// pin against publisher-side token Symbols (duplicate-DI hazard).
+		// The install rewrites them to relative paths into the consumer's
+		// vendored auth subsystem at copy time.
+		for (const rel of expectedVendoredFiles) {
+			const abs = path.join(integrationsRoot, rel);
+			const src = fs.readFileSync(abs, 'utf-8');
+			if (src.includes('@pattern-stack/codegen/runtime/subsystems/auth')) {
+				throw new Error(
+					`vendored ${rel} still imports from '@pattern-stack/codegen/runtime/subsystems/auth' — install-time rewriter regression (#303 fix #3)`,
+				);
+			}
+		}
+
+		// #303 fix #5: the legacy `<shared>/integrations/` vendor target
+		// must be empty — the new layout fully replaces it.
+		const legacySharedIntegrations = path.join(
 			tmpDir,
-			'src/modules/integrations/integrations-auth.module.ts',
+			'src/shared/integrations',
 		);
-		if (!fs.existsSync(integrationsAuthModulePath)) {
+		if (fs.existsSync(legacySharedIntegrations)) {
 			throw new Error(
-				'integrations-auth.module.ts not vendored by auth-integrations install',
+				`legacy vendor target ${legacySharedIntegrations} should not exist after auth-integrations install (#303 fix #5)`,
 			);
 		}
 		// Honor the entities_dir set by `project init` (defaults to

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -155,22 +155,21 @@ function filterConsumerErrors(output: string, tmpDir: string): string[] {
 			continue;
 		}
 
-		// #287: the vendored `auth-integrations` adapters under
-		// `src/shared/integrations/` import from
-		// `apps/api/src/modules/integrations/integration.service` (etc.) —
-		// the codegen layer that `cdp entity new integration` would emit.
-		// We don't run that step in this smoke (it would require also
-		// scaffolding a Drizzle schema for `integrations` and bundling a
-		// fixture). The adapters are deliberately vendored-with-broken-imports
-		// so the consumer can `cdp entity new integration` against their own
-		// integration entity. Filter these out — they're scope-of-consumer
-		// errors, not generator bugs.
-		//
-		// #294: revisited — running `cdp entity new integration` in smoke
-		// surfaces a separate codegen enum literal-type bug (status: text →
-		// string vs DecryptedIntegration.status's literal union). Filed as
-		// a follow-up; reinstating this filter until that's resolved.
-		if (line.includes('shared/integrations/') || line.includes('shared\\integrations\\')) {
+		// #287 / #303 fix #5: the vendored `auth-integrations` starter
+		// (under `<modules>/integrations/{adapters,facade,oauth,
+		// integrations-auth.module.ts}`) imports from the codegen-emitted
+		// integration entity module — `<modules>/integrations/integration.service`,
+		// `<modules>/integrations/integration.entity`, `<modules>/integrations/integrations.module`.
+		// We don't run `cdp entity new integration` in this smoke (it
+		// would require also scaffolding a Drizzle schema for `integrations`
+		// and bundling a fixture, AND it surfaces a separate codegen enum
+		// literal-type bug — filed as follow-up). Filter errors emitted
+		// from inside the vendored subfolders only — narrow filter so a
+		// real codegen bug in `<modules>/integrations/integration.{entity,
+		// service,...}.ts` would still surface.
+		const vendoredIntegrationsPattern =
+			/modules[/\\]integrations[/\\](?:adapters|facade|oauth|integrations-auth\.module\.ts)/;
+		if (vendoredIntegrationsPattern.test(line)) {
 			continue;
 		}
 		// Also tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
@@ -294,26 +293,31 @@ async function main(): Promise<number> {
 			throw new Error('INTEGRATION_TOKEN_ENCRYPTION_KEY missing from .env.config after auth install');
 		}
 
-		// 5.7. #287 — install the auth-integrations starter. Vendors:
+		// 5.7. #287 / #303 fix #5 — install the auth-integrations starter. Vendors:
 		//   - examples/auth-integrations/runtime/integrations/** →
-		//       <sharedRoot>/integrations/** (full-file copies, not via Hygen);
+		//       <vendorRoot>/integrations/** (full-file copies, not via Hygen).
+		//       `vendorRoot` defaults to `<paths.backend_src>/modules` per fix #5;
+		//       starter sits next to the codegen-emitted integration entity module.
 		//   - examples/auth-integrations/definitions/entities/integration.yaml →
-		//       <cwd>/definitions/entities/integration.yaml;
+		//       <paths.entities>/integration.yaml (defaults to definitions/entities/);
 		//   - IntegrationsAuthModule TODO into app.module.ts.
 		run(`bun ${CLI_PATH} subsystem install auth-integrations`, tmpDir);
 
 		const integrationsAuthModulePath = path.join(
 			tmpDir,
-			'src/shared/integrations/integrations-auth.module.ts',
+			'src/modules/integrations/integrations-auth.module.ts',
 		);
 		if (!fs.existsSync(integrationsAuthModulePath)) {
 			throw new Error(
 				'integrations-auth.module.ts not vendored by auth-integrations install',
 			);
 		}
+		// Honor the entities_dir set by `project init` (defaults to
+		// `entities/`). Fix #2 reads `paths.entities` → `paths.entities_dir`,
+		// matching `Context.entitiesDir`.
 		const integrationYamlPath = path.join(
 			tmpDir,
-			'definitions/entities/integration.yaml',
+			'entities/integration.yaml',
 		);
 		if (!fs.existsSync(integrationYamlPath)) {
 			throw new Error(


### PR DESCRIPTION
## Summary

Hotfix bundle for `cdp subsystem install auth-integrations`. 0.6.5 / 0.6.6 shipped the auth subsystem + auth-integrations starter + install templates, but every downstream consumer ran into multiple blockers on a fresh install. Surfaced by integration-patterns Wave 0b (PR #94).

### Fixes (one PR, five bundled)

1. **P0 — `examples/auth-integrations/` was missing from the published tarball.** `package.json:files` whitelist excluded it; install logic that copies from `node_modules/@pattern-stack/codegen/examples/auth-integrations/` aborted. Added a narrow `examples/auth-integrations/**` entry. Verified via `npm pack --dry-run`. Prevention test added: walks the starter and asserts every file matches a `files` pattern.
2. **`integration.yaml` landed at the wrong path.** Scaffold-locals resolver was reading `paths.definitions` (not a real key in the schema); it now reads `paths.entities` → `paths.entities_dir` → default `definitions/entities/`, matching `Context.entitiesDir` and `cdp project init`.
3. **Vendored adapters had bare-package imports** `from '@pattern-stack/codegen/runtime/subsystems/auth'`. Both fails `tsc --noEmit` (the package's `exports` map doesn't expose deep subpaths) and creates duplicate DI tokens vs. the consumer's vendored auth subsystem. The install now rewrites those specifiers at copy time to relative paths resolving against `<subsystemsRoot>/auth`.
4. **`IntegrationsAuthModule` was missing `@Global()`.** `AuthController` lives in `AuthModule`'s injector and resolves the `AUTH_INTEGRATION_*` providers exposed by `IntegrationsAuthModule`; without `@Global()`, Nest fails to boot.
5. **BREAKING — vendor target now lives next to codegen output.** The starter previously vendored to `<backend_src>/shared/integrations/` while codegen emitted the entity module at `<backend_src>/modules/integrations/` — splitting the integrations surface across two roots. Fix #5 vendors under `<backend_src>/modules/integrations/` (override via new `paths.modules_dir`), with subfolders to avoid collision with codegen output:
   ```
   <modules>/integrations/
     adapters/   integration-{reader,token-writer,grant-sink}.adapter.ts
     facade/     integrations.service.ts
     oauth/use-cases/  {create-or-update-from-oauth-grant,
                        disconnect-integration,
                        list-user-integrations,
                        mark-integration-requires-reauth}.use-case.ts
     integrations-auth.module.ts (@Global, root)
   ```
   The fix-#3 import-rewriter resolves the bare-package auth import via `path.relative(...)` so the new layout works without changes. `detectInstalledSubsystems` checks the new vendor target first; legacy `<shared>/integrations/...` is still detected as installed (pre-0.6.7 fallback). Pre-1.0; the only downstream consumer of 0.6.5/0.6.6 is integration-patterns Wave 0b (unmerged), so the BREAKING is paid once.

### Release

- Version bump 0.6.6 → 0.6.7
- CHANGELOG entry under `[0.6.7]` flagged as a hotfix; #5 is BREAKING
- `bun run test` clean; `bun run typecheck` clean; auto-merge intentionally disabled (team-lead has merge authority)

## Test plan

- [x] `bun run test` — all suites pass
- [x] `bun run typecheck` — clean
- [x] `auth-integrations-files-coverage.test.ts` asserts every starter file is covered by `package.json:files`
- [x] `subsystem.test.ts` asserts vendored adapters never carry the bare-package import, that the new subfolder layout exists, that `paths.modules_dir` is honored, and that the legacy `shared/integrations/` target is empty
- [ ] Post-publish: `npm view @pattern-stack/codegen@0.6.7 files` lists `examples/auth-integrations/**`
- [ ] Post-publish: install into a temp project + run `bunx cdp subsystem install auth-integrations` end-to-end without local-checkout copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)