### PR TITLE
chore(release): 0.6.8 — fix enum codegen for clean-lite-ps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.8] — 2026-04-28
+
+Hotfix for enum codegen in the `clean-lite-ps` template pipeline. Surfaced during integration-patterns Wave 0b: enum-typed YAML fields emitted a Drizzle `text()` column instead of a `pgEnum`, so `InferSelectModel` resolved to `string` instead of the literal-union type and forced hand-casts in consumer code (e.g. `as DecryptedIntegrationRow['status']`).
+
+### Fixed
+
+- **`fix(codegen)` — clean-lite-ps enum emission.** `templates/entity/new/clean-lite-ps/prompt-extension.js` now produces `pgEnum` declarations + column references for any field with `choices` (or `type: enum`), matching the backend pipeline at `templates/entity/new/backend/database/schema.ejs.t:66-104`. Generated entity files now contain `export const xEnum = pgEnum('x', [...])` ahead of the `pgTable(...)` block and reference `xEnum('x').notNull()` inside the column map. `pgEnum` is added to the `drizzle-orm/pg-core` import list automatically when any enum field is present. The emitted `InferSelectModel` type now narrows to the literal union — consumers can drop `as Row['status']` casts. New unit coverage: `src/__tests__/clean-lite-ps/entity-enum-template.test.ts`.
+
+### Migration note
+
+Not a breaking change for the emitted code shape (the field's TypeScript type narrows — a strict superset of what consumer code can do). Existing Postgres databases generated against 0.6.7 or earlier will need a one-time `CREATE TYPE … AS ENUM (...)` + `ALTER TABLE … ALTER COLUMN x TYPE x_enum USING x::x_enum;` migration, since the column was previously `text`. Greenfield projects, or anyone regenerating before the first migration runs, are unaffected.
+
 ## [0.6.7] — 2026-04-28
 
 Hotfix bundle for `cdp subsystem install auth-integrations`. 0.6.5 / 0.6.6 shipped the auth-integrations starter and install template, but every downstream consumer ran into four blockers on a fresh install. None of them surfaced from the source-checkout smoke (the install code resolves examples/ via the package root, which exists in dev) — they only exposed themselves through `npm install + bunx cdp subsystem install auth-integrations` against the published tarball. Bundles a fifth fix that unifies the integrations folder layout. Surfaced by integration-patterns Wave 0b.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/clean-lite-ps/entity-enum-template.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-enum-template.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Template rendering tests for clean-lite-ps entity pgEnum emission (0.6.8 hotfix).
+ *
+ * Pre-fix: enum-typed YAML fields fell through to `text('status').notNull()`,
+ * so `InferSelectModel` returned `string` instead of the literal union and
+ * forced hand-casts in consumer code (e.g. integration-patterns
+ * apps/api/src/modules/integrations/facade/integrations.service.ts).
+ *
+ * Post-fix: enum fields emit a top-of-file `pgEnum` declaration plus a
+ * column reference to that declaration, matching the backend pipeline at
+ * templates/entity/new/backend/database/schema.ejs.t:66-104.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const ENTITY_TEMPLATE = readFileSync(
+  resolve(import.meta.dir, '../../../templates/entity/new/clean-lite-ps/entity.ejs.t'),
+  'utf8',
+);
+
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') { end = i; break; }
+  }
+  if (end === -1) return source;
+  return lines.slice(end + 1).join('\n');
+}
+
+function render(locals: Record<string, unknown>): string {
+  return ejs.render(extractBody(ENTITY_TEMPLATE), locals, { rmWhitespace: false });
+}
+
+const EMPTY_BASE_LOCALS = {};
+
+const integrationDefinition = {
+  entity: { name: 'integration', plural: 'integrations', table: 'integrations', pattern: 'Base' },
+  fields: {
+    name: { type: 'string', required: true },
+    status: { type: 'enum', choices: ['active', 'paused', 'disabled'], required: true },
+  },
+  relationships: {},
+  behaviors: ['timestamps'],
+};
+
+describe('clean-lite-ps entity template — pgEnum emission', () => {
+  it('exposes clpEnumFields with enumName, dbName, and choices', () => {
+    const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS) as any;
+    expect(locals.clpEnumFields).toEqual([
+      { enumName: 'statusEnum', dbName: 'status', choices: ['active', 'paused', 'disabled'] },
+    ]);
+  });
+
+  it('adds pgEnum to clpDrizzleImports when enum fields are present', () => {
+    const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS) as any;
+    expect(locals.clpDrizzleImports).toContain('pgEnum');
+  });
+
+  it('produces a drizzleChain referencing the enum declaration, not text()', () => {
+    const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS) as any;
+    const statusField = locals.clpProcessedFields.find((f: any) => f.name === 'status');
+    expect(statusField.drizzleChain).toBe("statusEnum('status').notNull()");
+    expect(statusField.tsType).toBe("'active' | 'paused' | 'disabled'");
+  });
+
+  it('renders pgEnum declaration above pgTable and column references it', () => {
+    const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS);
+    const out = render(locals as Record<string, unknown>);
+
+    // Top-of-file declaration
+    expect(out).toContain(
+      "export const statusEnum = pgEnum('status', ['active', 'paused', 'disabled']);",
+    );
+    // Column reference inside pgTable block
+    expect(out).toContain("status: statusEnum('status').notNull()");
+    // No text() fallback for the enum column
+    expect(out).not.toMatch(/status: text\('status'\)/);
+    // pgEnum import present
+    expect(out).toMatch(/pgEnum,/);
+  });
+
+  it('preserves text/string columns alongside enum columns', () => {
+    const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS) as any;
+    expect(locals.clpDrizzleImports).toContain('text');
+    const out = render(locals);
+    expect(out).toContain("name: text('name').notNull()");
+  });
+
+  it('omits clpEnumFields and pgEnum import when no enum fields present', () => {
+    const noEnum = {
+      entity: { name: 'task', plural: 'tasks', table: 'tasks', pattern: 'Base' },
+      fields: { title: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+    };
+    const locals = buildCleanLitePsLocals(noEnum, EMPTY_BASE_LOCALS) as any;
+    expect(locals.clpEnumFields).toEqual([]);
+    expect(locals.clpDrizzleImports).not.toContain('pgEnum');
+  });
+});

--- a/templates/entity/new/clean-lite-ps/entity.ejs.t
+++ b/templates/entity/new/clean-lite-ps/entity.ejs.t
@@ -18,6 +18,12 @@ import { type InferSelectModel } from 'drizzle-orm';
 import { <%= rel.relatedTable %> } from '<%= rel.importPath %>';
 <%_ } _%>
 <%_ }) _%>
+<%_ if (typeof clpEnumFields !== 'undefined' && clpEnumFields.length > 0) { _%>
+
+<%_ clpEnumFields.forEach(ef => { _%>
+export const <%= ef.enumName %> = pgEnum('<%= ef.dbName %>', [<%- ef.choices.map(c => `'${c}'`).join(', ') %>]);
+<%_ }) _%>
+<%_ } _%>
 
 export const <%= entityNamePlural %> = pgTable(
   '<%= entityNamePlural %>',

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -201,7 +201,7 @@ const EXTERNAL_ID_TRACKING_FIELDS = new Set([
 /**
  * Build a Drizzle column chain for a field
  */
-function buildDrizzleChain(fieldName, field, drizzleType) {
+function buildDrizzleChain(fieldName, field, drizzleType, enumName) {
   const nullable = field.nullable ?? false;
   const required = field.required ?? false;
   const hasDefault = field.default !== undefined && field.default !== null;
@@ -211,7 +211,11 @@ function buildDrizzleChain(fieldName, field, drizzleType) {
   // schemas using z.coerce.date() align with the entity type.
   // `timestamp` already defaults to Date — no mode override needed.
   let chain;
-  if (drizzleType === 'date') {
+  if (drizzleType === 'enum' && enumName) {
+    // Reference the pgEnum declaration emitted at the top of the entity file.
+    // The column name argument keeps the snake_case YAML field name.
+    chain = `${enumName}('${fieldName}')`;
+  } else if (drizzleType === 'date') {
     chain = `${drizzleType}('${fieldName}', { mode: 'date' })`;
   } else {
     chain = `${drizzleType}('${fieldName}')`;
@@ -247,7 +251,15 @@ function processFields(fields) {
     const choices = field.choices;
     const hasChoices = Array.isArray(choices) && choices.length > 0;
 
-    const drizzleType = DRIZZLE_TYPE_MAP[type] || 'text';
+    // Enum-typed fields (or any field with a `choices` list) emit a
+    // Postgres-native pgEnum declaration + column reference, so the
+    // generated `InferSelectModel` type narrows to the literal union
+    // instead of falling back to `string`. Matches the backend pipeline
+    // (templates/entity/new/backend/database/schema.ejs.t:66-104).
+    const drizzleType = hasChoices
+      ? 'enum'
+      : (DRIZZLE_TYPE_MAP[type] || 'text');
+    const enumName = hasChoices ? camelCase(fieldName) + 'Enum' : null;
     const tsType = hasChoices
       ? choices.map((c) => `'${c}'`).join(' | ')
       : (TS_TYPE_MAP[type] || 'unknown');
@@ -255,7 +267,7 @@ function processFields(fields) {
       ? `z.enum([${choices.map((c) => `'${c}'`).join(', ')}])`
       : (ZOD_TYPE_MAP[type] || 'z.unknown()');
 
-    const drizzleChain = buildDrizzleChain(fieldName, field, drizzleType);
+    const drizzleChain = buildDrizzleChain(fieldName, field, drizzleType, enumName);
 
     processed.push({
       name: fieldName,
@@ -271,6 +283,7 @@ function processFields(fields) {
       drizzleChain,
       choices,
       hasChoices,
+      enumName,
     });
   }
 
@@ -355,6 +368,12 @@ function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSof
   const imports = new Set(['pgTable', 'uuid']);
 
   for (const field of processedFields) {
+    if (field.drizzleType === 'enum') {
+      // Enum columns reference a `pgEnum` declaration emitted at the top
+      // of the entity file; the helper itself comes from drizzle-orm/pg-core.
+      imports.add('pgEnum');
+      continue;
+    }
     const importName = DRIZZLE_IMPORT_MAP[field.drizzleType];
     if (importName) imports.add(importName);
   }
@@ -783,6 +802,18 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const fkFieldNames = new Set(belongsTo.map((r) => r.field));
   const nonFkFields = processedFields.filter((f) => !fkFieldNames.has(f.name));
 
+  // Enum field declarations — surface a separate collection so the entity
+  // template can emit `export const xEnum = pgEnum('x', [...])` ahead of
+  // the `pgTable(...)` block. Both FK-filtered and unfiltered processing
+  // include the same enum fields; they're never FKs.
+  const clpEnumFields = processedFields
+    .filter((f) => f.hasChoices && f.enumName)
+    .map((f) => ({
+      enumName: f.enumName,
+      dbName: f.name,
+      choices: f.choices,
+    }));
+
   // Drizzle imports needed
   const drizzleEntityImports = collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete, hasExternalIdTracking);
   // Whether relations() import is needed
@@ -980,6 +1011,7 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     // Drizzle
     clpDrizzleImports: drizzleEntityImports,
     clpHasRelationsBlock: hasRelationsBlock,
+    clpEnumFields,
 
     // Declarative queries
     processedQueries,


### PR DESCRIPTION
## Summary

Hotfix for enum-typed YAML fields under the `clean-lite-ps` template pipeline. Surfaced during integration-patterns Wave 0b: `status: { type: enum, choices: [active, paused, disabled] }` emitted `text('status').notNull()` instead of a `pgEnum`, so `InferSelectModel` resolved to `string` and forced hand-casts (e.g. `as DecryptedIntegrationRow['status']`).

- `templates/entity/new/clean-lite-ps/prompt-extension.js`: `hasChoices` fields now produce a `pgEnum`-shaped drizzleChain (`xEnum('x')`), expose a new `clpEnumFields` collection, and add `pgEnum` to the import set.
- `templates/entity/new/clean-lite-ps/entity.ejs.t`: emits `export const xEnum = pgEnum('x', [...])` ahead of the `pgTable(...)` block. Pattern lifted from `templates/entity/new/backend/database/schema.ejs.t:66-104`.
- Bumps version 0.6.7 → 0.6.8 + CHANGELOG entry. Not breaking for the consumer surface (literal-union narrows from `string`) but existing Postgres databases need a one-time `CREATE TYPE` + `ALTER TABLE … ALTER COLUMN` — called out in CHANGELOG.

## Test plan

- [x] `bun test src/__tests__/clean-lite-ps/` — 143 pass (137 prior + 6 new in `entity-enum-template.test.ts`)
- [x] `just test-unit` — 1713 pass / 0 fail
- [x] `just test-baseline` — clean (no enum fixtures, but template typeof-guarded for backwards compat with non-CLP locals)
- [x] `just test-smoke` — green (`tsc --noEmit` + `/docs-json` shape verified)
- [ ] Post-publish: downstream verification in integration-patterns — `bunx cdp entity new --all` should emit narrowed `status` and let us drop the cast at `apps/api/src/modules/integrations/facade/integrations.service.ts:151`

🤖 Generated with [Claude Code](https://claude.com/claude-code)