### PR TITLE
feat(patterns): Junction pattern definition + BaseJunctionFields + schema + registry

### DIFF
--- a/.ai-docs/stacks/codegen-app-patterns/specs/58.md
+++ b/.ai-docs/stacks/codegen-app-patterns/specs/58.md
@@ -1,0 +1,250 @@
+---
+issue: pattern-stack/dealbrain-integrations#58
+status: awaiting-strategy-review
+related:
+  - .ai-docs/plans/codegen-app-patterns.yaml  # epic plan, leaf `junction-pattern-definition`
+  - docs/adrs/ADR-031-app-defined-patterns.md
+  - docs/RFC-app-defined-patterns.md
+  - docs/specs/app-defined-patterns-implementation.md
+  - src/patterns/pattern-definition.ts        # contract
+  - src/patterns/registry.ts                  # LIBRARY_PATTERNS store + library barrel hook
+  - src/patterns/library/activity.pattern.ts  # structural reference (simple definition)
+  - src/patterns/library/synced.pattern.ts    # structural reference (definition + impliedBehaviors)
+  - src/schema/relationship-definition.schema.ts  # precedent for parallel top-level schema
+  - src/utils/yaml-loader.ts                  # `detectYamlType` dispatch + `loadRelationshipFromYaml`
+upstream_repo: pattern-stack/codegen-patterns
+tracker_repo: pattern-stack/dealbrain-integrations
+stack: codegen-app-patterns
+plan_leaf_key: junction-pattern-definition
+---
+
+# Junction pattern: definition + BaseJunctionFields + schema + registry
+
+## Goal
+
+Land the **definition-layer** half of the Junction pattern in `pattern-stack/codegen-patterns` as a single PR. Scope is everything that the downstream Hygen-template, association-codegen, and fixture leaves need to consume — but no code generation, no templates, no association methods. After this issue merges, the registry knows what `pattern: Junction` means and the YAML parser accepts and validates it; nothing downstream yet emits.
+
+Concretely: a new `JunctionPattern` `PatternDefinition`, a shared `BaseJunctionFields` shape, a parallel top-level YAML schema for `pattern: Junction` declarations (siblings to the existing `relationship-definition.schema.ts`), registry wiring through `LIBRARY_PATTERNS`, and a YAML-loader dispatch tweak so `detectYamlType` recognises junction files. Coexistence with the existing `relationships:` block on the same entity is mandatory.
+
+## Approach
+
+**Treat Junction like Relationship, not like a domain family.** Relationship is the obvious precedent — both are typed, temporal, sourced association definitions emitted from a top-level YAML key. Junction differs along three axes that the design must handle explicitly:
+
+1. **`between: [<entity>, <entity>]`** — exactly two endpoints (Relationship's `from`/`to` is the precedent shape; Junction calls them `between` to signal symmetric pairing semantics, but the underlying topology is identical to a two-endpoint cross-type relationship).
+2. **Per-pairing role enum, declared in the consumer YAML, never shared across pairings.** This is the load-bearing constraint from `CLAUDE.md` ("Explicit junctions"). The schema MUST reject any attempt to reference a role enum defined on a different pairing — meaning the role enum lives inside the junction YAML, not at the registry layer, and the schema validates locality at parse time.
+3. **`BaseJunctionFields` shared shape.** Six fields — `is_primary` (bool), `started_at` (timestamp, nullable), `ended_at` (timestamp, nullable), `sourced_from` (text, nullable), `confidence` (numeric/decimal, nullable), `matched_at` (timestamp, nullable). Exposed as a TS const, importable by both the schema (for collision checks) and downstream template generation (next leaf).
+
+**Routing.** Three storage decisions:
+
+- **Where does the `JunctionPattern` `PatternDefinition` live?** In `src/patterns/library/junction.pattern.ts`, registered via `src/patterns/library/index.ts`'s barrel — the same path every existing library pattern follows. It is a thin record (name, description, impliedBehaviors if any, `configSchema` for the `pattern: Junction`-attached config block). It does **not** carry the `repositoryClass` / `serviceClass` fields that `Activity`/`Synced`/`Metadata` carry — Junction's emitted artifact is a junction *table* with its own repo class, not a base class an entity extends. (Compare: Junction is to Relationship as Activity is to a regular entity.)
+- **Where does the top-level `pattern: Junction` YAML schema live?** A new file `src/schema/junction-definition.schema.ts` parallel to `relationship-definition.schema.ts`. Junction is its own top-level YAML shape — a junction file's top-level key is `pattern: Junction` (or `junction:` — see Open Questions Q1), not `entity:`. This keeps validation atomic and reuses the proven Relationship pattern of "one Zod schema per top-level YAML form."
+- **How does the loader find it?** Extend `detectYamlType()` in `src/utils/yaml-loader.ts` to return `'junction'` when the parsed YAML carries the junction discriminator, and add a `loadJunctionFromYaml()` companion mirroring `loadRelationshipFromYaml()`. This keeps the dispatcher pattern consistent and avoids a second schema growing inside the existing two.
+
+**Coexistence with `relationships:`.** Per the plan's acceptance criteria and Gate 0 decision: an entity YAML must be able to carry BOTH `pattern: Junction` (the new top-level shape) AND a `relationships:` block (the existing per-entity relationship declarations) without conflict. The schema enforces this **by virtue of living on disjoint top-level keys** — entity YAML stays in `EntityDefinitionSchema` (whose `relationships:` field is unchanged), and junction YAML stays in `JunctionDefinitionSchema`. The "coexistence test" is therefore a fixture-level test: load an entity YAML that carries `relationships:`, then load a junction YAML that pairs that entity — assert both parse and the resulting `DomainGraph` representations don't collide on names. (The graph-builder integration is OUT of scope for this leaf; see "Out of scope". The coexistence test for THIS leaf is schema-level only: both schemas accept their respective inputs cleanly and the registry surfaces both contributions.)
+
+**Diagram — discriminator routing.**
+
+```mermaid
+flowchart LR
+  yaml[YAML file] --> detect[detectYamlType]
+  detect -->|entity:| entitySchema[EntityDefinitionSchema]
+  detect -->|relationship:| relSchema[RelationshipDefinitionSchema]
+  detect -->|pattern: Junction| junctionSchema[JunctionDefinitionSchema  *new*]
+  detect -->|other| unknown[(unknown)]
+  junctionSchema --> registryLookup[getPattern&#40;'Junction'&#41;]
+  registryLookup --> libPatterns[(LIBRARY_PATTERNS)]
+  libPatterns -. seeded by .-> junctionLibFile[src/patterns/library/junction.pattern.ts]
+```
+
+**Reject-paths the schema must enforce** (encoded in Zod refinements):
+
+- `between` MUST be a two-element array of entity-name strings (lowercase snake_case). Reject length 1 or 3+.
+- Role enum (whatever it's named per pairing) MUST be declared inside the junction YAML's `fields:` block. The schema rejects references to enums declared in other junction files — i.e., the schema cannot statically verify *another file's* enum, but it MUST reject any indirection construct (e.g. `role_enum_ref: <other-pairing-name>`) that would let a pairing inherit another's role enum. The simplest enforcement: the `fields:` block validates `role` (or `<pairing>_role`) as a self-contained enum field, no enum-import syntax. See Open Questions Q2 for the exact field-naming rule.
+- `BaseJunctionFields` column names MUST NOT be redeclared in the junction's `fields:` block — collisions are hard errors (precedent: `relationship-definition.schema.ts` already does this against its temporal/FK columns).
+- `pattern: Junction` is a literal — the schema doesn't accept the `pattern:`/`patterns:` indirection used on entities. Junction is the discriminator, not a contribution toggle.
+
+## File-level plan
+
+### Create
+- `src/patterns/library/junction.pattern.ts` — `JunctionPattern` `PatternDefinition`. Carries `name: 'Junction'`, `description`, optional `configSchema` (Zod schema for the YAML-side `pattern: Junction` config block; see Interfaces). No `repositoryClass`/`serviceClass` — Junction does not contribute a base class to an entity; it is the top-level discriminator for a junction-shaped YAML file.
+- `src/patterns/library/base-junction-fields.ts` — exported `BaseJunctionFields` const, a `PatternColumnContribution[]` with the six fields listed in Goal. Imported by `junction.pattern.ts` and by `src/schema/junction-definition.schema.ts`. Also re-exported from the library barrel.
+- `src/schema/junction-definition.schema.ts` — Zod `JunctionDefinitionSchema` for the top-level `pattern: Junction` YAML. Mirrors `relationship-definition.schema.ts` structure: top-level config block (`between`, optional `temporal`, optional `sourced`), `fields:` block (reuse `FieldDefinition` from entity schema), `queries:` block (reuse `QueryDeclaration`), Zod `.strict()` + reserved-column-collision refinements against `BaseJunctionFields`.
+- `src/__tests__/patterns/junction-pattern.test.ts` — registry-level tests: `JunctionPattern` is reachable via `getPattern('Junction')`, present in `getLibraryPatternNames()`, exported from the library barrel.
+- `src/__tests__/schema/junction-definition.test.ts` — schema-level tests modelled on `src/__tests__/schema/relationship-definition.test.ts` (363+ lines of precedent). Covers: valid intra-domain pair, valid cross-domain pair, rejection of wrong-arity `between`, rejection of `BaseJunctionFields` column collisions, rejection of role-enum-sharing attempts, coexistence of `pattern: Junction` YAML with an entity YAML that carries `relationships:` (load both, assert both parse).
+- `test/fixtures/junctions/opportunity_contact.yaml` — minimal valid intra-domain fixture used by the schema test. Lives in `test/fixtures/junctions/` (parallel to `test/fixtures/relationships/`).
+- `test/fixtures/junctions/opportunity_activity.yaml` — minimal valid cross-domain fixture (Opportunity from CRM, Activity from interactions or wherever wave-1 CRM places it). Used by the schema test for the cross-domain assertion.
+- `test/fixtures/junctions/invalid/`  — small set of negative fixtures: `bad-between-arity.yaml`, `collides-base-field.yaml`, `shared-role-enum-ref.yaml`. Loaded by the schema test's failure cases.
+
+### Modify
+- `src/patterns/library/index.ts` — import `JunctionPattern`, call `registerLibraryPattern(JunctionPattern)`, add it to the barrel exports. Also re-export `BaseJunctionFields` from `./base-junction-fields.js`.
+- `src/utils/yaml-loader.ts` — (1) add `loadJunctionFromYaml()` mirroring `loadRelationshipFromYaml()` (validate against `JunctionDefinitionSchema`); (2) extend `detectYamlType()` to recognise the junction discriminator and return `'junction'`; (3) export `LoadJunctionResult` types in the same shape as the relationship counterparts. Update the return-type union of `detectYamlType()` from `'entity' | 'relationship' | 'unknown'` to include `'junction'`.
+- `src/index.ts` — re-export `JunctionPattern`, `BaseJunctionFields`, `JunctionDefinitionSchema`, `JunctionDefinition` (the inferred type), and the new `loadJunctionFromYaml` helper.
+
+Out of `Modify`: graph-builder, parser pipeline (`src/parser/load-entities.ts`), and any analyzer integration are intentionally deferred to subsequent leaves so this PR stays definitional. `LIBRARY_PATTERNS`'s `assertHasContribution()` will fail for a pattern that declares neither columns nor repo/service classes — see Open Questions Q3 for whether `JunctionPattern` needs a sentinel `columns: BaseJunctionFields` or a contribution-check carve-out.
+
+## Interfaces
+
+```typescript
+// src/patterns/library/base-junction-fields.ts
+import type { PatternColumnContribution } from '../pattern-definition.js';
+
+/**
+ * Shared columns every junction table carries. Per-pairing role columns
+ * and pairing-specific fields are declared in the consumer YAML's
+ * `fields:` block and are NOT part of this shape.
+ */
+export const BaseJunctionFields: ReadonlyArray<PatternColumnContribution> = [
+  { name: 'is_primary',   type: 'boolean' },           // nullable: false, default false
+  { name: 'started_at',   type: 'timestamp' },         // nullable: true
+  { name: 'ended_at',     type: 'timestamp' },         // nullable: true
+  { name: 'sourced_from', type: 'text' },              // nullable: true — provenance hint
+  { name: 'confidence',   type: 'numeric(5,4)' },      // nullable: true — 0.0000..1.0000
+  { name: 'matched_at',   type: 'timestamp' },         // nullable: true
+] as const;
+
+export const BASE_JUNCTION_FIELD_NAMES: ReadonlySet<string> =
+  new Set(BaseJunctionFields.map((c) => c.name));
+
+// src/patterns/library/junction.pattern.ts
+import { definePattern } from '../pattern-definition.js';
+import { z } from 'zod';
+
+/**
+ * The `pattern: Junction`-attached config block (validated against the
+ * entity-side `config:` map for keys that match this pattern's name).
+ * Surface is intentionally thin in this leaf — extensions land in
+ * later leaves (templates, association-codegen).
+ */
+const JunctionPatternConfigSchema = z
+  .object({
+    // Reserved for downstream leaves. Empty in v1 to keep the surface tight.
+  })
+  .strict();
+
+export const JunctionPattern = definePattern({
+  name: 'Junction',
+  description:
+    'Explicit many-to-many junction with role + temporal + sourcing metadata',
+  // No repositoryClass/serviceClass: Junction is a top-level shape, not a
+  // contribution toggle for a normal entity. The downstream template leaf
+  // emits a dedicated junction repo/service.
+  configSchema: JunctionPatternConfigSchema,
+});
+
+// src/schema/junction-definition.schema.ts
+import { z } from 'zod';
+import {
+  FieldDefinitionSchema,
+  // existing field schema re-used verbatim
+} from './entity-definition.schema.js';
+import { BASE_JUNCTION_FIELD_NAMES } from '../patterns/library/base-junction-fields.js';
+
+const EntityNameSchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9_]*$/, 'Entity reference must be snake_case');
+
+/**
+ * Top-level junction YAML shape.
+ *
+ *   pattern: Junction
+ *   between: [opportunity, contact]
+ *   temporal: true        # optional, default true
+ *   sourced: true         # optional, default true
+ *   fields:
+ *     role:
+ *       type: enum
+ *       values: [champion, decision_maker, influencer]
+ *   queries: ...
+ */
+export const JunctionDefinitionSchema = z
+  .object({
+    pattern: z.literal('Junction'),
+    between: z.tuple([EntityNameSchema, EntityNameSchema]),
+    temporal: z.boolean().optional().default(true),
+    sourced: z.boolean().optional().default(true),
+    fields: z.record(z.string(), FieldDefinitionSchema).optional(),
+    queries: z.array(z.unknown()).optional(), // reuse QueryDeclaration in impl
+  })
+  .strict()
+  .refine(
+    (d) => d.between[0] !== d.between[1],
+    { message: '`between` endpoints must be distinct' },
+  )
+  .refine(
+    (d) => {
+      const fieldNames = Object.keys(d.fields ?? {});
+      return !fieldNames.some((n) => BASE_JUNCTION_FIELD_NAMES.has(n));
+    },
+    {
+      message:
+        '`fields:` block redeclares a reserved BaseJunctionFields column ' +
+        '(is_primary, started_at, ended_at, sourced_from, confidence, matched_at)',
+    },
+  );
+
+export type JunctionDefinition = z.infer<typeof JunctionDefinitionSchema>;
+
+// src/utils/yaml-loader.ts — additions
+
+export interface JunctionLoadResult {
+  success: true;
+  definition: JunctionDefinition;
+  filePath: string;
+}
+export interface JunctionLoadError {
+  success: false;
+  error: string;
+  details?: string[];
+  filePath: string;
+}
+export type LoadJunctionResult = JunctionLoadResult | JunctionLoadError;
+
+export function loadJunctionFromYaml(filePath: string): LoadJunctionResult;
+
+// updated signature:
+export function detectYamlType(
+  filePath: string,
+): 'entity' | 'relationship' | 'junction' | 'unknown';
+```
+
+## Tests
+
+Bun test runner, file layout mirrors existing `src/__tests__/{schema,patterns}/` trees.
+
+**`src/__tests__/patterns/junction-pattern.test.ts`** — registry / barrel surface:
+- `JunctionPattern` resolves via `getPattern('Junction')` after the library barrel loads.
+- `JunctionPattern.name === 'Junction'`.
+- `getLibraryPatternNames()` contains `'Junction'`.
+- `BaseJunctionFields` exports all six expected column names in the documented order; `BASE_JUNCTION_FIELD_NAMES` has the matching set.
+- The pattern survives `_resetRegistryForTests({ includeLibrary: true })` followed by a re-import of the library barrel (determinism check, matches existing registry test style).
+
+**`src/__tests__/schema/junction-definition.test.ts`** — schema acceptance/rejection, modelled on `relationship-definition.test.ts`:
+- *Fixtures pass:* `test/fixtures/junctions/opportunity_contact.yaml` (intra-domain) and `test/fixtures/junctions/opportunity_activity.yaml` (cross-domain) both parse to `JunctionDefinition` without errors.
+- *Wrong arity rejected:* `between: [a]` and `between: [a, b, c]` fail validation with a clear message.
+- *Same-endpoint rejected:* `between: [contact, contact]` fails.
+- *BaseJunctionFields collision rejected:* a fixture that redeclares `is_primary` (or any of the six) under `fields:` is rejected with a message naming the offending column.
+- *Role-enum sharing rejected:* a fixture that tries to indirect a role enum (e.g. `role_enum_ref: opportunity_contact`) is rejected. Concretely: the schema has no syntax for cross-pairing enum references, so the negative fixture exercises `.strict()` rejecting an unknown key.
+- *Coexistence:* loading an entity YAML carrying a `relationships:` block (use one of the existing `test/fixtures/relationships/` neighbours OR a tiny new entity fixture) followed by `loadJunctionFromYaml()` on `opportunity_contact.yaml` produces two independent definitions; assert no shared mutable state, no name collision raised by the registry.
+
+**`detectYamlType` extension** — covered inline in `junction-definition.test.ts` or in `src/__tests__/utils/yaml-loader.test.ts` if that file exists; a junction fixture returns `'junction'`, an entity fixture still returns `'entity'`, a relationship fixture still returns `'relationship'`.
+
+No integration tests touch templates, codegen, or the DomainGraph in this leaf — those land downstream (`junction-hygen-templates`, `junction-association-codegen`, `junction-test-fixtures`).
+
+CI sanity: `just test-unit` must remain under its ~200ms budget (this PR adds schema + registry tests, all in-memory).
+
+## Out of scope
+
+- Hygen templates that emit junction tables/repos/services — owned by `junction-hygen-templates` leaf.
+- Association methods on canonical ports (`OpportunityPort.contacts.attach(...)` etc.) — owned by `junction-association-codegen` leaf, which reuses Relationship's cross-entity emission mechanism (to be documented by `relationship-verification` and read from there).
+- End-to-end fixtures producing compiling Drizzle/NestJS code — owned by `junction-test-fixtures` leaf.
+- DomainGraph integration (analyzer): registering junction definitions onto `DomainGraph.junctionDefinitions` or similar. This issue is purely definitional; the analyzer extension happens when there's an artifact for it to produce.
+- The `pattern:` / `patterns:` entity field is not modified. Junction is a top-level YAML shape, not a value an entity declares under `pattern:`. Touching `EntityConfigSchema` would conflate the two surfaces.
+- Tracker hygiene on `pattern-stack/dealbrain-integrations` (#13/#14/#15) — owned by `tracker-hygiene-close-stale` leaf, runs only after every code leaf merges.
+
+## Open questions
+
+- **Q1 — Top-level discriminator key.** Should the junction YAML's top-level key be `pattern: Junction` (mirroring how entities declare `pattern:`) or `junction:` (mirroring how `relationship:` is the discriminator on relationship YAML)? The plan and CLAUDE.md both write "`pattern: Junction`" so the schema above uses `pattern: z.literal('Junction')`. The Relationship precedent argues for `junction:` as a sibling top-level key. Default: ship `pattern: Junction` per the plan text; flag for the reviewer.
+- **Q2 — Role-field naming convention.** Is the role column always named `role` (single key under `fields:`), or `<pairing>_role` (e.g. `opportunity_contact_role`)? Implementation choice affects the column-collision check and downstream template rendering. Recommend: single `role` field, since the table name already encodes the pairing and prefixing the column buys nothing. Flag for reviewer.
+- **Q3 — `assertHasContribution()` for `JunctionPattern`.** The current registry insists every pattern contribute at least one of `columns`, `repositoryClass`, or `serviceClass`. `JunctionPattern` has none of these in its current shape. Two clean fixes: (a) set `JunctionPattern.columns = BaseJunctionFields` so the contribution check passes structurally — this also makes the field set discoverable through the pattern, which is arguably useful for the downstream template leaf; or (b) loosen `assertHasContribution()` to accept a `configSchema`-only pattern as a "discriminator pattern" with no contribution. Recommend (a) — it doubles as the registry-side declaration of the `BaseJunctionFields` shape, keeps the contribution check intact, and aligns with how `Metadata`/`Activity` already pre-declare their contributions.
+- **Q4 — `temporal` / `sourced` defaults.** Relationship's schema defaults both to `true`. Junction's `BaseJunctionFields` always carries `started_at`/`ended_at`/`sourced_from` etc., so the toggles arguably duplicate intent. Options: (a) drop `temporal`/`sourced` from the junction schema (always on, columns always emitted); (b) keep them as opt-outs that suppress the corresponding `BaseJunctionFields` columns. The schema above keeps them as opt-outs for parity with Relationship — confirm with reviewer.
+- **Q5 — Cross-domain entity-name validation.** `between: [opportunity, activity]` references entities that may live in different domain YAML directories. The schema validates the *shape* of the name but not its existence — existence is a job for the analyzer/graph-builder in a later leaf. Confirm this layering decision is acceptable; the alternative is to validate against a resolved entity index here, which would mean dragging the parser pipeline into this leaf.

--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -384,6 +384,7 @@ import { z } from 'zod';
 import {
   ActivityPattern,
   BasePattern,
+  JunctionPattern,
   KnowledgePattern,
   MetadataPattern,
   SyncedPattern,
@@ -573,4 +574,5 @@ _afterAllForCleanup(() => {
   registerLibraryPattern(ActivityPattern);
   registerLibraryPattern(KnowledgePattern);
   registerLibraryPattern(MetadataPattern);
+  registerLibraryPattern(JunctionPattern);
 });

--- a/src/__tests__/patterns/junction-pattern.test.ts
+++ b/src/__tests__/patterns/junction-pattern.test.ts
@@ -1,0 +1,87 @@
+/**
+ * JunctionPattern registry-surface tests.
+ *
+ * Confirms the pattern is reachable through the library barrel, the
+ * column contribution is intact, and the BaseJunctionFields shape is
+ * stable.
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+// Importing the barrel pre-registers the 6 library patterns as a side effect
+// (Base / Synced / Activity / Knowledge / Metadata / Junction).
+import '../../patterns/index.ts';
+
+import {
+	getPattern,
+	getLibraryPatternNames,
+} from '../../patterns/registry.ts';
+import {
+	JunctionPattern,
+	BaseJunctionFields,
+	BASE_JUNCTION_FIELD_NAMES,
+} from '../../patterns/library/index.ts';
+
+describe('JunctionPattern', () => {
+	test('is registered under the name "Junction"', () => {
+		const def = getPattern('Junction');
+		expect(def).toBeDefined();
+		expect(def?.name).toBe('Junction');
+	});
+
+	test('appears in getLibraryPatternNames()', () => {
+		expect(getLibraryPatternNames()).toContain('Junction');
+	});
+
+	test('declares no base class (junction emits its own repo/service)', () => {
+		expect(JunctionPattern.repositoryClass).toBeUndefined();
+		expect(JunctionPattern.serviceClass).toBeUndefined();
+	});
+
+	test('contributes BaseJunctionFields as columns', () => {
+		expect(JunctionPattern.columns).toBeDefined();
+		const got = (JunctionPattern.columns ?? []).map((c) => c.name);
+		expect(got).toEqual([
+			'is_primary',
+			'started_at',
+			'ended_at',
+			'sourced_from',
+			'confidence',
+			'matched_at',
+		]);
+	});
+
+	test('exposes a configSchema (thin in v1; reserved for downstream leaves)', () => {
+		expect(JunctionPattern.configSchema).toBeDefined();
+	});
+});
+
+describe('BaseJunctionFields', () => {
+	test('exports the six expected columns in documented order', () => {
+		expect(BaseJunctionFields.map((c) => c.name)).toEqual([
+			'is_primary',
+			'started_at',
+			'ended_at',
+			'sourced_from',
+			'confidence',
+			'matched_at',
+		]);
+	});
+
+	test('column types match the spec', () => {
+		const byName = new Map(BaseJunctionFields.map((c) => [c.name, c.type]));
+		expect(byName.get('is_primary')).toBe('boolean');
+		expect(byName.get('started_at')).toBe('timestamp');
+		expect(byName.get('ended_at')).toBe('timestamp');
+		expect(byName.get('sourced_from')).toBe('text');
+		expect(byName.get('confidence')).toBe('numeric(5,4)');
+		expect(byName.get('matched_at')).toBe('timestamp');
+	});
+
+	test('BASE_JUNCTION_FIELD_NAMES is the matching set', () => {
+		expect(BASE_JUNCTION_FIELD_NAMES.size).toBe(BaseJunctionFields.length);
+		for (const col of BaseJunctionFields) {
+			expect(BASE_JUNCTION_FIELD_NAMES.has(col.name)).toBe(true);
+		}
+	});
+});

--- a/src/__tests__/patterns/validate-composition.test.ts
+++ b/src/__tests__/patterns/validate-composition.test.ts
@@ -31,6 +31,7 @@ import '../../patterns/index.ts';
 import {
 	ActivityPattern,
 	BasePattern,
+	JunctionPattern,
 	KnowledgePattern,
 	MetadataPattern,
 	SyncedPattern,
@@ -43,6 +44,7 @@ afterAll(() => {
 	registerLibraryPattern(ActivityPattern);
 	registerLibraryPattern(KnowledgePattern);
 	registerLibraryPattern(MetadataPattern);
+	registerLibraryPattern(JunctionPattern);
 });
 
 // ============================================================================

--- a/src/__tests__/patterns/validate-orchestration.test.ts
+++ b/src/__tests__/patterns/validate-orchestration.test.ts
@@ -32,6 +32,7 @@ import '../../patterns/index.ts';
 import {
 	ActivityPattern,
 	BasePattern,
+	JunctionPattern,
 	KnowledgePattern,
 	MetadataPattern,
 	SyncedPattern,
@@ -46,6 +47,7 @@ afterAll(() => {
 	registerLibraryPattern(ActivityPattern);
 	registerLibraryPattern(KnowledgePattern);
 	registerLibraryPattern(MetadataPattern);
+	registerLibraryPattern(JunctionPattern);
 });
 
 // ============================================================================

--- a/src/__tests__/schema/junction-definition.test.ts
+++ b/src/__tests__/schema/junction-definition.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Junction Definition Schema tests.
+ *
+ * Validates the junction YAML contract against the Zod schema and the
+ * `detectYamlType` discriminator. Uses fixtures under
+ * `test/fixtures/junctions/`.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+import {
+	JunctionDefinitionSchema,
+	safeValidateJunctionDefinition,
+} from '../../schema/junction-definition.schema';
+import { detectYamlType, loadJunctionFromYaml } from '../../utils/yaml-loader';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const FIXTURE_ROOT = resolve(__dirname, '../../../test/fixtures/junctions');
+
+function loadFixture(name: string): unknown {
+	const filePath = resolve(FIXTURE_ROOT, name);
+	const content = readFileSync(filePath, 'utf-8');
+	return parseYaml(content);
+}
+
+function fixturePath(name: string): string {
+	return resolve(FIXTURE_ROOT, name);
+}
+
+// ============================================================================
+// Valid fixtures
+// ============================================================================
+
+describe('junction fixtures validate against schema', () => {
+	const fixtures = ['opportunity_contact.yaml', 'opportunity_activity.yaml'];
+
+	for (const fixture of fixtures) {
+		it(`validates ${fixture}`, () => {
+			const data = loadFixture(fixture);
+			const result = JunctionDefinitionSchema.safeParse(data);
+			if (!result.success) {
+				console.error(`Validation errors for ${fixture}:`, result.error.errors);
+			}
+			expect(result.success).toBe(true);
+		});
+	}
+
+	it('intra-domain pair (opportunity, contact) parses to the documented shape', () => {
+		const data = loadFixture('opportunity_contact.yaml');
+		const parsed = JunctionDefinitionSchema.parse(data);
+		expect(parsed.pattern).toBe('Junction');
+		expect(parsed.between).toEqual(['opportunity', 'contact']);
+		expect(parsed.temporal).toBe(true);
+		expect(parsed.sourced).toBe(true);
+		expect(parsed.fields).toBeDefined();
+	});
+
+	it('cross-domain pair (opportunity, activity) parses cleanly', () => {
+		const data = loadFixture('opportunity_activity.yaml');
+		const parsed = JunctionDefinitionSchema.parse(data);
+		expect(parsed.between).toEqual(['opportunity', 'activity']);
+	});
+});
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+describe('junction schema defaults', () => {
+	const minimal = {
+		pattern: 'Junction' as const,
+		between: ['opportunity', 'contact'] as [string, string],
+	};
+
+	it('accepts minimal definition (no fields, no queries)', () => {
+		const result = JunctionDefinitionSchema.safeParse(minimal);
+		expect(result.success).toBe(true);
+	});
+
+	it('defaults temporal to true', () => {
+		const parsed = JunctionDefinitionSchema.parse(minimal);
+		expect(parsed.temporal).toBe(true);
+	});
+
+	it('defaults sourced to true', () => {
+		const parsed = JunctionDefinitionSchema.parse(minimal);
+		expect(parsed.sourced).toBe(true);
+	});
+
+	it('preserves explicit temporal: false', () => {
+		const parsed = JunctionDefinitionSchema.parse({ ...minimal, temporal: false });
+		expect(parsed.temporal).toBe(false);
+	});
+
+	it('preserves explicit sourced: false', () => {
+		const parsed = JunctionDefinitionSchema.parse({ ...minimal, sourced: false });
+		expect(parsed.sourced).toBe(false);
+	});
+});
+
+// ============================================================================
+// Reject paths
+// ============================================================================
+
+describe('junction schema rejects malformed input', () => {
+	it('rejects pattern value other than "Junction"', () => {
+		const result = JunctionDefinitionSchema.safeParse({
+			pattern: 'Synced',
+			between: ['opportunity', 'contact'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects between of length 1', () => {
+		const result = JunctionDefinitionSchema.safeParse({
+			pattern: 'Junction',
+			between: ['opportunity'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects between of length 3 (fixture)', () => {
+		const data = loadFixture('invalid/bad-between-arity.yaml');
+		const result = JunctionDefinitionSchema.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects non-snake_case entity names in between', () => {
+		const result = JunctionDefinitionSchema.safeParse({
+			pattern: 'Junction',
+			between: ['Opportunity', 'contact'],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects same-endpoint pair (fixture)', () => {
+		const data = loadFixture('invalid/same-endpoint.yaml');
+		const result = JunctionDefinitionSchema.safeParse(data);
+		expect(result.success).toBe(false);
+		const messages = result.success
+			? []
+			: result.error.errors.map((e) => e.message).join(' | ');
+		expect(messages).toMatch(/distinct/);
+	});
+
+	it('rejects fields: that redeclare a BaseJunctionFields column (fixture)', () => {
+		const data = loadFixture('invalid/collides-base-field.yaml');
+		const result = JunctionDefinitionSchema.safeParse(data);
+		expect(result.success).toBe(false);
+		const messages = result.success
+			? []
+			: result.error.errors.map((e) => e.message).join(' | ');
+		expect(messages).toMatch(/BaseJunctionFields/);
+	});
+
+	it('rejects unknown top-level keys (role_enum_ref indirection, fixture)', () => {
+		// The "shared role enum" reject-path: there is no syntax for
+		// cross-pairing enum reuse. `.strict()` rejects the unknown key.
+		const data = loadFixture('invalid/shared-role-enum-ref.yaml');
+		const result = JunctionDefinitionSchema.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects unknown top-level keys (strict object)', () => {
+		const result = JunctionDefinitionSchema.safeParse({
+			pattern: 'Junction',
+			between: ['opportunity', 'contact'],
+			arbitrary_extension: true,
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+// ============================================================================
+// safeValidateJunctionDefinition helper
+// ============================================================================
+
+describe('safeValidateJunctionDefinition', () => {
+	it('returns success=true for a valid definition', () => {
+		const data = loadFixture('opportunity_contact.yaml');
+		const result = safeValidateJunctionDefinition(data);
+		expect(result.success).toBe(true);
+		expect(result.data?.between).toEqual(['opportunity', 'contact']);
+	});
+
+	it('returns success=false for an invalid definition', () => {
+		const data = loadFixture('invalid/bad-between-arity.yaml');
+		const result = safeValidateJunctionDefinition(data);
+		expect(result.success).toBe(false);
+		expect(result.error).toBeDefined();
+	});
+});
+
+// ============================================================================
+// detectYamlType / loadJunctionFromYaml
+// ============================================================================
+
+describe('detectYamlType', () => {
+	it('returns "junction" for a junction fixture', () => {
+		expect(detectYamlType(fixturePath('opportunity_contact.yaml'))).toBe(
+			'junction',
+		);
+	});
+
+	it('returns "entity" for an entity fixture (unaffected by junction routing)', () => {
+		const entityFixture = resolve(
+			__dirname,
+			'../../../test/fixtures/opportunity.yaml',
+		);
+		expect(detectYamlType(entityFixture)).toBe('entity');
+	});
+
+	it('returns "relationship" for a relationship fixture (unaffected by junction routing)', () => {
+		const relFixture = resolve(
+			__dirname,
+			'../../../test/fixtures/relationships/person_organization.yaml',
+		);
+		expect(detectYamlType(relFixture)).toBe('relationship');
+	});
+});
+
+describe('loadJunctionFromYaml', () => {
+	it('loads + validates a junction file end-to-end', () => {
+		const result = loadJunctionFromYaml(fixturePath('opportunity_contact.yaml'));
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.definition.between).toEqual(['opportunity', 'contact']);
+			expect(result.filePath).toBe(fixturePath('opportunity_contact.yaml'));
+		}
+	});
+
+	it('reports a structured failure for an invalid junction file', () => {
+		const result = loadJunctionFromYaml(
+			fixturePath('invalid/bad-between-arity.yaml'),
+		);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.details?.length ?? 0).toBeGreaterThan(0);
+		}
+	});
+
+	it('reports file-not-found as a structured failure', () => {
+		const result = loadJunctionFromYaml(fixturePath('does-not-exist.yaml'));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toMatch(/File not found/);
+		}
+	});
+});
+
+// ============================================================================
+// Coexistence with relationships:
+// ============================================================================
+
+describe('coexistence with the existing relationships: block', () => {
+	it('a junction file and a relationship file load to independent definitions', () => {
+		// Loads an existing relationship fixture (person_organization) and a
+		// junction fixture (opportunity_contact). Both must parse cleanly
+		// against their own schemas — the registry-side coexistence point
+		// is that the two surfaces live on disjoint top-level keys, so
+		// neither schema's `.strict()` rejects the other's shape.
+		const junctionPath = fixturePath('opportunity_contact.yaml');
+		const relPath = resolve(
+			__dirname,
+			'../../../test/fixtures/relationships/person_organization.yaml',
+		);
+
+		const junctionResult = loadJunctionFromYaml(junctionPath);
+		expect(junctionResult.success).toBe(true);
+
+		const relRaw = parseYaml(readFileSync(relPath, 'utf-8'));
+		// Don't import the relationship schema directly — go through
+		// `detectYamlType` to assert the discriminators don't collide.
+		expect(detectYamlType(relPath)).toBe('relationship');
+		expect(detectYamlType(junctionPath)).toBe('junction');
+		expect(typeof relRaw).toBe('object');
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,15 @@ export function validateEntities(entitiesDir: string): {
 export * from './analyzer/types';
 
 // Re-export parser utilities
-export { loadEntities, loadRelationships, loadEntityFromYaml, loadRelationshipFromYaml } from './parser';
+export { loadEntities, loadRelationships, loadEntityFromYaml, loadRelationshipFromYaml, loadJunctionFromYaml } from './parser';
+
+// Re-export junction definition schema surface
+export {
+	JunctionDefinitionSchema,
+	validateJunctionDefinition,
+	safeValidateJunctionDefinition,
+	type JunctionDefinition,
+} from './schema/junction-definition.schema';
 
 // Re-export analyzer utilities
 export {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -11,6 +11,7 @@ export {
 	resolveRelationshipReferences,
 	loadEntityFromYaml,
 	loadRelationshipFromYaml,
+	loadJunctionFromYaml,
 	type LoadEntitiesResult,
 	type LoadRelationshipsResult,
 } from './load-entities';

--- a/src/parser/load-entities.ts
+++ b/src/parser/load-entities.ts
@@ -537,3 +537,4 @@ export function resolveRelationshipReferences(
 
 export { loadEntityFromYaml } from '../utils/yaml-loader';
 export { loadRelationshipFromYaml } from '../utils/yaml-loader';
+export { loadJunctionFromYaml } from '../utils/yaml-loader';

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -53,7 +53,15 @@ export {
 export {
 	ActivityPattern,
 	BasePattern,
+	JunctionPattern,
 	KnowledgePattern,
 	MetadataPattern,
 	SyncedPattern,
+} from './library/index.js';
+
+// BaseJunctionFields — re-exported for downstream template / codegen leaves
+// that need to reason about the shared junction shape.
+export {
+	BaseJunctionFields,
+	BASE_JUNCTION_FIELD_NAMES,
 } from './library/index.js';

--- a/src/patterns/library/base-junction-fields.ts
+++ b/src/patterns/library/base-junction-fields.ts
@@ -1,0 +1,32 @@
+/**
+ * BaseJunctionFields — shared column shape every junction table carries.
+ *
+ * Per-pairing role columns and pairing-specific fields are declared in the
+ * consumer YAML's `fields:` block and are NOT part of this shape.
+ *
+ * Exposed as a TS const so two consumers can import it:
+ *   - `junction.pattern.ts`              — registers it as the pattern's
+ *                                          column contribution so the
+ *                                          registry's `assertHasContribution()`
+ *                                          check passes structurally.
+ *   - `junction-definition.schema.ts`    — uses the name set for the
+ *                                          reserved-column collision check
+ *                                          on the consumer's `fields:` block.
+ *
+ * See ADR-031 and `.ai-docs/stacks/codegen-app-patterns/specs/58.md`.
+ */
+
+import type { PatternColumnContribution } from '../pattern-definition.js';
+
+export const BaseJunctionFields: readonly PatternColumnContribution[] = [
+	{ name: 'is_primary', type: 'boolean' },
+	{ name: 'started_at', type: 'timestamp' },
+	{ name: 'ended_at', type: 'timestamp' },
+	{ name: 'sourced_from', type: 'text' },
+	{ name: 'confidence', type: 'numeric(5,4)' },
+	{ name: 'matched_at', type: 'timestamp' },
+] as const;
+
+export const BASE_JUNCTION_FIELD_NAMES: ReadonlySet<string> = new Set(
+	BaseJunctionFields.map((c) => c.name),
+);

--- a/src/patterns/library/index.ts
+++ b/src/patterns/library/index.ts
@@ -11,6 +11,7 @@
 import { registerLibraryPattern } from '../registry.js';
 import { ActivityPattern } from './activity.pattern.js';
 import { BasePattern } from './base.pattern.js';
+import { JunctionPattern } from './junction.pattern.js';
 import { KnowledgePattern } from './knowledge.pattern.js';
 import { MetadataPattern } from './metadata.pattern.js';
 import { SyncedPattern } from './synced.pattern.js';
@@ -20,11 +21,17 @@ registerLibraryPattern(SyncedPattern);
 registerLibraryPattern(ActivityPattern);
 registerLibraryPattern(KnowledgePattern);
 registerLibraryPattern(MetadataPattern);
+registerLibraryPattern(JunctionPattern);
 
 export {
 	ActivityPattern,
 	BasePattern,
+	JunctionPattern,
 	KnowledgePattern,
 	MetadataPattern,
 	SyncedPattern,
 };
+export {
+	BaseJunctionFields,
+	BASE_JUNCTION_FIELD_NAMES,
+} from './base-junction-fields.js';

--- a/src/patterns/library/junction.pattern.ts
+++ b/src/patterns/library/junction.pattern.ts
@@ -1,0 +1,41 @@
+/**
+ * JunctionPattern — top-level discriminator for explicit many-to-many
+ * junction YAML files.
+ *
+ * Unlike `Activity` / `Synced` / `Metadata` (which attach to an entity via
+ * `pattern:` / `patterns:`), `Junction` IS the top-level YAML shape — a
+ * junction file's discriminator is `pattern: Junction`, not `entity:`.
+ * It therefore does not declare `repositoryClass` / `serviceClass`: the
+ * downstream Hygen-template leaf emits a dedicated junction repo/service
+ * per pairing.
+ *
+ * `columns` is set to `BaseJunctionFields` for two reasons:
+ *   1. Registry-side declaration of the shared shape — discoverable through
+ *      `getPattern('Junction').columns` by the downstream template leaf.
+ *   2. Satisfies the registry's `assertHasContribution()` check, which
+ *      insists every pattern contribute at least one of columns / repo /
+ *      service class. (See spec §"Open Questions Q3"; recommendation (a).)
+ *
+ * See `.ai-docs/stacks/codegen-app-patterns/specs/58.md`.
+ */
+
+import { z } from 'zod';
+import { definePattern } from '../pattern-definition.js';
+import { BaseJunctionFields } from './base-junction-fields.js';
+
+/**
+ * The `pattern: Junction`-attached config block, validated at parse time.
+ *
+ * Surface is intentionally thin in this leaf — extensions land in later
+ * leaves (templates, association-codegen). `.strict()` rejects unknown
+ * keys so consumers who misspell a flag fail loudly.
+ */
+const JunctionPatternConfigSchema = z.object({}).strict();
+
+export const JunctionPattern = definePattern({
+	name: 'Junction',
+	description:
+		'Explicit many-to-many junction with role + temporal + sourcing metadata',
+	columns: [...BaseJunctionFields],
+	configSchema: JunctionPatternConfigSchema,
+});

--- a/src/schema/junction-definition.schema.ts
+++ b/src/schema/junction-definition.schema.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import { BASE_JUNCTION_FIELD_NAMES } from '../patterns/library/base-junction-fields.js';
+
+/**
+ * Junction Definition Schema
+ *
+ * Top-level YAML contract for explicit many-to-many junctions between two
+ * entities. Sibling to `relationship-definition.schema.ts`: same authoring
+ * model (typed, temporal, sourced association), different topology.
+ *
+ * A junction file's top-level discriminator is `pattern: Junction` (not
+ * `entity:` or `relationship:`). The pairing endpoints live in
+ * `between: [<entity>, <entity>]` — both intra-domain (e.g.
+ * `[opportunity, contact]`) and cross-domain (e.g. `[opportunity, activity]`)
+ * are accepted; existence of the named entities is verified by the
+ * analyzer in a later leaf, not by this schema.
+ *
+ * Per-pairing role enums + pairing-specific fields are declared inside the
+ * consumer YAML's `fields:` block. They are NEVER shared across pairings
+ * (CLAUDE.md "Explicit junctions"); the schema enforces locality by
+ * rejecting indirection syntax via `.strict()`.
+ *
+ * See: docs/adrs/ADR-031-app-defined-patterns.md
+ * See: .ai-docs/stacks/codegen-app-patterns/specs/58.md
+ * See: test/fixtures/junctions/ for examples
+ */
+
+// ============================================================================
+// Entity Name
+// ============================================================================
+
+const EntityNameSchema = z
+	.string()
+	.regex(/^[a-z][a-z0-9_]*$/, 'Entity reference must be snake_case');
+
+// ============================================================================
+// Junction Definition
+// ============================================================================
+
+/**
+ * Top-level junction YAML shape.
+ *
+ *   pattern: Junction
+ *   between: [opportunity, contact]
+ *   temporal: true        # optional, default true
+ *   sourced: true         # optional, default true
+ *   fields:
+ *     role:
+ *       type: enum
+ *       values: [champion, decision_maker, influencer]
+ *   queries:
+ *     - by: [opportunity_id]
+ *
+ * Fields use the same shape as entity fields — validated downstream by the
+ * template / codegen layer using the existing `FieldDefinitionSchema`.
+ * This schema accepts the shape loosely (`z.any()`) and applies only the
+ * reserved-column collision check; matches the relationship-schema
+ * precedent (`relationship-definition.schema.ts` line ~250).
+ */
+export const JunctionDefinitionSchema = z
+	.object({
+		/** Discriminator literal — `pattern: Junction`. */
+		pattern: z.literal('Junction'),
+
+		/**
+		 * Exactly two endpoint entity names. Both intra- and cross-domain
+		 * pairings are accepted; entity existence is validated by the
+		 * analyzer in a later leaf.
+		 */
+		between: z.tuple([EntityNameSchema, EntityNameSchema]),
+
+		/**
+		 * Emit BaseJunctionFields temporal columns (`started_at`, `ended_at`,
+		 * `matched_at`). Default true. Matches Relationship's `temporal` toggle.
+		 */
+		temporal: z.boolean().optional().default(true),
+
+		/**
+		 * Emit BaseJunctionFields sourcing columns (`sourced_from`,
+		 * `confidence`). Default true. Matches Relationship's `sourced` toggle.
+		 */
+		sourced: z.boolean().optional().default(true),
+
+		/**
+		 * Junction-specific fields beyond `BaseJunctionFields`. Includes the
+		 * per-pairing role enum (declared inline; never shared across
+		 * pairings). Shape is validated downstream by the codegen layer
+		 * using the existing entity FieldDefinitionSchema.
+		 */
+		fields: z.record(z.string(), z.any()).optional(),
+
+		/**
+		 * Declarative queries — same syntax as entity queries. Shape is
+		 * validated downstream by the codegen layer.
+		 */
+		queries: z.array(z.any()).optional(),
+	})
+	.strict()
+	.refine((d) => d.between[0] !== d.between[1], {
+		message: '`between` endpoints must be distinct',
+		path: ['between'],
+	})
+	.refine(
+		(d) => {
+			const fieldNames = Object.keys(d.fields ?? {});
+			return !fieldNames.some((n) => BASE_JUNCTION_FIELD_NAMES.has(n));
+		},
+		{
+			message:
+				'`fields:` block redeclares a reserved BaseJunctionFields column ' +
+				'(is_primary, started_at, ended_at, sourced_from, confidence, matched_at)',
+			path: ['fields'],
+		},
+	);
+
+export type JunctionDefinition = z.infer<typeof JunctionDefinitionSchema>;
+
+// ============================================================================
+// Validation Helpers
+// ============================================================================
+
+export function validateJunctionDefinition(data: unknown): JunctionDefinition {
+	return JunctionDefinitionSchema.parse(data);
+}
+
+export function safeValidateJunctionDefinition(data: unknown): {
+	success: boolean;
+	data?: JunctionDefinition;
+	error?: z.ZodError;
+} {
+	const result = JunctionDefinitionSchema.safeParse(data);
+	if (result.success) {
+		return { success: true, data: result.data };
+	}
+	return { success: false, error: result.error };
+}

--- a/src/utils/yaml-loader.ts
+++ b/src/utils/yaml-loader.ts
@@ -13,6 +13,10 @@ import {
 	type RelationshipDefinition,
 	RelationshipDefinitionSchema,
 } from '../schema/relationship-definition.schema';
+import {
+	type JunctionDefinition,
+	JunctionDefinitionSchema,
+} from '../schema/junction-definition.schema';
 
 export interface LoadResult {
 	success: true;
@@ -308,19 +312,127 @@ export function loadEventFromYaml(filePath: string): LoadEventResult {
 	};
 }
 
+// ============================================================================
+// Junction YAML Loading
+// ============================================================================
+
+export interface JunctionLoadResult {
+	success: true;
+	definition: JunctionDefinition;
+	filePath: string;
+}
+
+export interface JunctionLoadError {
+	success: false;
+	error: string;
+	details?: string[];
+	filePath: string;
+}
+
+export type LoadJunctionResult = JunctionLoadResult | JunctionLoadError;
+
 /**
- * Detect whether a YAML file is an entity or relationship definition.
+ * Load and validate a junction definition from a YAML file.
+ *
+ * Mirrors {@link loadRelationshipFromYaml}: existence check → readFileSync →
+ * parseYaml → `JunctionDefinitionSchema.safeParse`. Returns a discriminated
+ * result; callers are expected to aggregate into `AnalysisIssue`s rather
+ * than throw.
+ */
+export function loadJunctionFromYaml(filePath: string): LoadJunctionResult {
+	if (!existsSync(filePath)) {
+		return {
+			success: false,
+			error: `File not found: ${filePath}`,
+			filePath,
+		};
+	}
+
+	let content: string;
+	try {
+		content = readFileSync(filePath, 'utf-8');
+	} catch (err) {
+		return {
+			success: false,
+			error: `Failed to read file: ${filePath}`,
+			details: [err instanceof Error ? err.message : String(err)],
+			filePath,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = parseYaml(content);
+	} catch (err) {
+		return {
+			success: false,
+			error: `Invalid YAML syntax in ${filePath}`,
+			details: [err instanceof Error ? err.message : String(err)],
+			filePath,
+		};
+	}
+
+	const result = JunctionDefinitionSchema.safeParse(parsed);
+	if (!result.success) {
+		return {
+			success: false,
+			error: `Validation failed for ${filePath}`,
+			details: formatZodErrors(result.error),
+			filePath,
+		};
+	}
+
+	return {
+		success: true,
+		definition: result.data,
+		filePath,
+	};
+}
+
+/**
+ * Load multiple junction files.
+ */
+export function loadJunctionsFromYaml(filePaths: string[]): {
+	successes: JunctionLoadResult[];
+	failures: JunctionLoadError[];
+} {
+	const successes: JunctionLoadResult[] = [];
+	const failures: JunctionLoadError[] = [];
+
+	for (const filePath of filePaths) {
+		const result = loadJunctionFromYaml(filePath);
+		if (result.success) {
+			successes.push(result);
+		} else {
+			failures.push(result);
+		}
+	}
+
+	return { successes, failures };
+}
+
+/**
+ * Detect whether a YAML file is an entity, relationship, or junction definition.
  * Checks for the top-level discriminator key.
+ *
+ * Junctions are discriminated by `pattern: Junction` (a literal value, not
+ * just key presence) so an entity YAML that happens to carry `pattern:
+ * Synced` is NOT mistaken for a junction file.
  */
 export function detectYamlType(
 	filePath: string,
-): 'entity' | 'relationship' | 'unknown' {
+): 'entity' | 'relationship' | 'junction' | 'unknown' {
 	if (!existsSync(filePath)) return 'unknown';
 
 	try {
 		const content = readFileSync(filePath, 'utf-8');
 		const parsed = parseYaml(content) as Record<string, unknown>;
 		if (parsed && typeof parsed === 'object') {
+			// Junction discriminator is value-sensitive (must be exactly the
+			// literal 'Junction'). Check BEFORE 'entity' so we don't mistake
+			// a top-level junction file for an entity simply because both
+			// schemas could in principle nest a `pattern:` key.
+			if (parsed.pattern === 'Junction') return 'junction';
 			if ('entity' in parsed) return 'entity';
 			if ('relationship' in parsed) return 'relationship';
 		}

--- a/test/fixtures/junctions/invalid/bad-between-arity.yaml
+++ b/test/fixtures/junctions/invalid/bad-between-arity.yaml
@@ -1,0 +1,8 @@
+# `between` MUST be exactly two endpoints — this fixture has three.
+pattern: Junction
+between: [opportunity, contact, activity]
+
+fields:
+  role:
+    type: enum
+    values: [a, b]

--- a/test/fixtures/junctions/invalid/collides-base-field.yaml
+++ b/test/fixtures/junctions/invalid/collides-base-field.yaml
@@ -1,0 +1,12 @@
+# `fields:` redeclares `is_primary`, which is reserved by BaseJunctionFields.
+# The schema must reject this with a message naming the offending column.
+pattern: Junction
+between: [opportunity, contact]
+
+fields:
+  is_primary:
+    type: boolean
+    nullable: false
+  role:
+    type: enum
+    values: [champion, end_user]

--- a/test/fixtures/junctions/invalid/same-endpoint.yaml
+++ b/test/fixtures/junctions/invalid/same-endpoint.yaml
@@ -1,0 +1,8 @@
+# `between` endpoints must be distinct — this names the same entity twice.
+pattern: Junction
+between: [contact, contact]
+
+fields:
+  role:
+    type: enum
+    values: [a, b]

--- a/test/fixtures/junctions/invalid/shared-role-enum-ref.yaml
+++ b/test/fixtures/junctions/invalid/shared-role-enum-ref.yaml
@@ -1,0 +1,7 @@
+# Attempts to indirect this junction's role enum to another pairing's
+# definition. There is no syntax for cross-pairing enum reuse — the role
+# enum lives inside this file or not at all. `.strict()` rejects the
+# unknown `role_enum_ref` key.
+pattern: Junction
+between: [opportunity, contact]
+role_enum_ref: opportunity_account

--- a/test/fixtures/junctions/opportunity_activity.yaml
+++ b/test/fixtures/junctions/opportunity_activity.yaml
@@ -1,0 +1,20 @@
+# Opportunity ↔ Activity junction (cross-domain).
+#
+# Opportunity lives in the CRM domain; Activity lives in the interactions
+# domain. The schema accepts both intra- and cross-domain pairings; entity
+# existence is resolved by the analyzer in a later leaf, not here.
+
+pattern: Junction
+between: [opportunity, activity]
+temporal: true
+sourced: true
+
+fields:
+  role:
+    type: enum
+    values: [primary_engagement, supporting_touch]
+    nullable: true
+
+queries:
+  - by: [opportunity_id]
+  - by: [activity_id]

--- a/test/fixtures/junctions/opportunity_contact.yaml
+++ b/test/fixtures/junctions/opportunity_contact.yaml
@@ -1,0 +1,21 @@
+# Opportunity ↔ Contact junction (intra-domain).
+#
+# Explicit many-to-many between two CRM entities. The `role` enum is
+# declared inline — never imported from another pairing. This is the
+# canonical "valid intra-domain" fixture for src/__tests__/schema/.
+
+pattern: Junction
+between: [opportunity, contact]
+temporal: true
+sourced: true
+
+fields:
+  role:
+    type: enum
+    values: [champion, decision_maker, influencer, blocker, end_user]
+    nullable: false
+
+queries:
+  - by: [opportunity_id]
+  - by: [contact_id]
+  - by: [opportunity_id, is_primary]


### PR DESCRIPTION
## Summary

Lands the **definition-layer** half of the Junction pattern. Downstream template / association-codegen / fixture leaves consume from here; this PR itself emits no code and adds no association methods.

After merge: the registry knows what `pattern: Junction` means, the YAML loader recognises and validates junction files, and the shared `BaseJunctionFields` shape is importable by the next leaf.

- **Pattern**: `JunctionPattern` registered through `src/patterns/library/index.ts`. Carries `columns = BaseJunctionFields` (satisfies `assertHasContribution()` + makes the shape discoverable). No `repositoryClass` / `serviceClass` — the downstream template leaf emits a dedicated repo/service per pairing.
- **Shape**: `BaseJunctionFields` (`is_primary`, `started_at`, `ended_at`, `sourced_from`, `confidence`, `matched_at`).
- **Schema**: `JunctionDefinitionSchema` (sibling to `relationship-definition.schema.ts`). Enforces two-element `between`, distinct endpoints, no `BaseJunctionFields` collisions, `.strict()` to reject role-enum-sharing indirection.
- **Loader**: `detectYamlType` now returns `'junction'` for files whose top-level `pattern:` literal is `Junction`; `loadJunctionFromYaml()` plumbed through `src/parser/` and the top-level `src/index.ts`.
- **Fixtures**: 2 valid (`opportunity_contact`, `opportunity_activity`) + 4 invalid (`bad-between-arity`, `same-endpoint`, `collides-base-field`, `shared-role-enum-ref`).
- **Tests**: 34 new (junction registry + schema + loader). Full unit suite green at **1747 / 1747**.

Spec: [`.ai-docs/stacks/codegen-app-patterns/specs/58.md`](https://github.com/pattern-stack/codegen-patterns/blob/doug/58-junction-pattern-definition/.ai-docs/stacks/codegen-app-patterns/specs/58.md) (already on the branch from `afba1cf`).

Closes pattern-stack/dealbrain-integrations#58.

## Open-question resolutions (from spec §Open Questions)

- **Q1**: Top-level discriminator is `pattern: Junction` (literal value), matching the plan + CLAUDE.md.
- **Q2**: Role field is named `role` (single key under `fields:`); pairing is encoded in the table name.
- **Q3**: `JunctionPattern.columns = [...BaseJunctionFields]` — recommendation (a). `assertHasContribution()` passes structurally and the registry surfaces the shared shape for the downstream template leaf.
- **Q4**: Kept `temporal` / `sourced` as opt-outs (default `true`) for parity with the Relationship schema.
- **Q5**: Schema validates the shape of entity names but not their existence — existence resolution is deferred to the analyzer in a later leaf.

## Out of scope (per spec)

- Hygen templates that emit junction tables/repos/services (owned by `junction-hygen-templates` leaf)
- Association methods on canonical ports (owned by `junction-association-codegen` leaf)
- DomainGraph integration (owned by a later analyzer leaf)
- Entity-side `pattern:` / `patterns:` field — left untouched

## Test plan

- [x] `just test-unit` — 1747 tests pass, including 34 new junction tests
- [x] `JunctionPattern` resolves via `getPattern('Junction')`
- [x] Intra-domain pair (`[opportunity, contact]`) validates
- [x] Cross-domain pair (`[opportunity, activity]`) validates
- [x] Wrong-arity `between` rejected (length 1 and 3)
- [x] Same-endpoint pair rejected
- [x] `fields:` collision against `BaseJunctionFields` rejected with message naming the collision
- [x] Unknown key (e.g. `role_enum_ref`) rejected via `.strict()`
- [x] `detectYamlType` returns `'junction'` for the new fixtures and continues to return `'entity'` / `'relationship'` for existing ones
- [ ] Downstream consumer (next stack leaf) reviews the discoverability of `BaseJunctionFields` via `getPattern('Junction').columns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)