### PR TITLE
test(junction): snapshot tests + smoke-helper extraction (CGP-61 PR A)

### DIFF
--- a/.ai-docs/stacks/codegen-app-patterns/specs/61.md
+++ b/.ai-docs/stacks/codegen-app-patterns/specs/61.md
@@ -216,7 +216,7 @@ test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-
 
 The `-clean` recipes (`test-smoke-junction-clean`, `test-smoke-junction-cross-domain-clean`) exist but are **not** in `test-all`. Confirmed against CI run 25770873094 — only the two clean-lite-ps variants ran in `main`'s most recent green build.
 
-This contradicts §Risks #2 ("Implementer must run `just test-smoke-junction{,-cross-domain}{,-clean}` after the extraction"). The actual gate is two variants, not four. PR A runs the two clean-lite-ps variants as the gate; the two `-clean` variants are documented broken (see #2 below) and out of scope.
+This contradicts §Risks #2 ("Implementer must run `just test-smoke-junction{,-cross-domain}{,-clean}` after the extraction"). The actual gate is two variants, not four. PR A runs the two clean-lite-ps variants as the gate; the two `-clean` variants are documented broken (see #2 below) and out of scope. **Known gap, not tracked separately** — per user direction (2026-05-12), the clean architecture may be rebuilt from clean-lite-ps, at which point the gap resolves; filing a tracker would just be churn.
 
 ### 2. Clean-arch junction emission is broken on `main`
 
@@ -226,11 +226,11 @@ Both `-clean` smoke variants fail with 17 typecheck errors against a freshly-boo
 - **`@repo/db/server/schema`** — entity repository templates (`src/infrastructure/persistence/repositories/<ent>.repository.ts`) import from a monorepo alias `@repo/db/server/schema`. The smoke tmp project has no such alias and no such package; tsconfig declares `@shared/*`, `@modules/*`, `@generated/*` only.
 - **Junction repo import path mismatch** — `src/infrastructure/persistence/drizzle/opportunity-contacts.repository.ts` imports `./opportunity_contact.entity`, but in the clean-arch layout the entity is emitted to `src/domain/opportunity_contacts/opportunity_contact.entity.ts`. The relative path is wrong.
 
-These are pre-existing on `main`. Verified by reverting `test/smoke/run-smoke-junction.ts` to `origin/main` and re-running — same 17 errors. Not introduced by this leaf.
+These are pre-existing on `main`. Verified by reverting `test/smoke/run-smoke-junction.ts` to `origin/main` and re-running — same 17 errors. Not introduced by this leaf. Documented here as a record for anyone who later chooses to fix clean-arch in place; otherwise they resolve when clean-arch is rebuilt from clean-lite-ps.
 
 ### 3. Stack-wide scope adjustment — clean-lite-ps only (PR A + PR B)
 
-User-confirmed (2026-05-12): clean-arch is scoped out of **both** PR A and PR B until the smoke gap + emission bugs in the follow-up issue are resolved. Consequences:
+User-confirmed (2026-05-12): clean-arch is scoped out of **both** PR A and PR B. Consequences:
 
 - **Smoke gate for PR A**: the two clean-lite-ps variants (`test-smoke-junction`, `test-smoke-junction-cross-domain`). Helper extraction verified against both.
 - **Snapshot coverage for PR A**: clean-lite-ps only (already the spec's intent in §"What each test does", reinforced by the smoke-gap finding).
@@ -238,4 +238,4 @@ User-confirmed (2026-05-12): clean-arch is scoped out of **both** PR A and PR B 
 - **Snapshot coverage for PR B**: clean-lite-ps only.
 - **Acceptance**: "`just test-all` green" remains the bar — `test-all` does not include `-clean`, so the bar is reachable.
 
-Re-introduce clean-arch coverage (smoke + snapshots) only after the follow-up issue lands. This is the post-implementation truth for the entire `codegen-app-patterns:junction-test-fixtures` leaf.
+The clean-arch gap is **not tracked as a separate issue** — per user direction, the clean architecture may be rebuilt from clean-lite-ps, at which point both the smoke gap and the three emission bugs in §2 resolve. If anyone later chooses to fix clean-arch in place instead, the three root causes in §2 above are the starting point. This is the post-implementation truth for the entire `codegen-app-patterns:junction-test-fixtures` leaf.

--- a/.ai-docs/stacks/codegen-app-patterns/specs/61.md
+++ b/.ai-docs/stacks/codegen-app-patterns/specs/61.md
@@ -1,0 +1,240 @@
+---
+issue: pattern-stack/dealbrain-integrations#61
+status: awaiting-strategy-review
+related:
+  - .ai-docs/plans/codegen-app-patterns.yaml                   # epic plan, leaf `junction-test-fixtures`
+  - .ai-docs/stacks/codegen-app-patterns/specs/58.md           # JunctionDefinition + BaseJunctionFields (merged as #360)
+  - .ai-docs/stacks/codegen-app-patterns/specs/59.md           # Junction Hygen templates (merged as #359)
+  - .ai-docs/stacks/codegen-app-patterns/specs/cgp-62.md       # Relationship pattern audit + smoke (merged as #361)
+  - test/smoke/run-smoke-junction.ts                           # existing junction smoke harness — reuse, do not duplicate
+  - test/smoke/fixtures-junction/                              # existing intra-domain smoke fixture (opportunity × contact)
+  - test/smoke/fixtures-junction-cross-domain/                 # existing cross-domain smoke fixture (opportunity × activity)
+  - test/fixtures/junctions/                                   # existing parser-test fixtures
+  - src/__tests__/                                             # bun:test snapshot convention (this is the project's framework)
+  - codegen-patterns#358                                       # relationships service-method emission — PR B stacks on this
+upstream_repo: pattern-stack/codegen-patterns
+tracker_repo: pattern-stack/dealbrain-integrations
+stack: codegen-app-patterns
+plan_leaf_key: junction-test-fixtures
+depends_on:
+  - pattern-stack/dealbrain-integrations#59                    # Hygen templates — merged (#359)
+  - pattern-stack/dealbrain-integrations#60                    # association codegen — see "Scope note vs plan leaf"
+external_depends_on:
+  - pattern-stack/codegen-patterns#358                         # PR B (coexistence) only; PR A is independent
+---
+
+# Junction pattern: test fixtures
+
+## Goal
+
+Lock the emitted output of the Junction codegen pipeline against drift, and prove that Junction + `relationships:` codegen paths coexist on the same parent entity without stomping each other.
+
+Ships as **two stacked PRs**:
+
+- **PR A — Snapshot tests** for the two existing scenarios (`opportunity_contact`, `opportunity_activity`). Independent of #358; can land immediately.
+- **PR B — Coexistence fixture + test** (parent entity carrying both `pattern: Junction` participation **and** a `relationships:` block targeting a third entity). Stacks on codegen-patterns#358.
+
+## Scope note vs plan leaf
+
+The plan leaf `junction-test-fixtures` (lines 239–261 of the plan) was authored before #359/#360/#361 landed. Substantial scope has already shipped:
+
+- ✅ Both YAML fixtures exist (`test/fixtures/junctions/opportunity_contact.yaml`, `opportunity_activity.yaml`)
+- ✅ Smoke fixtures exist (`test/smoke/fixtures-junction{,-cross-domain}/`)
+- ✅ End-to-end compile gate exists (`just test-smoke-junction{,-cross-domain}{,-clean}` — 4 variants, all in `test-all`)
+- ✅ Invalid-fixture validation exists (`src/__tests__/schema/junction-definition.test.ts`)
+- ✅ Plan leaf's `depends_on: junction-association-codegen` (#60) is **only relevant for PR B** — PR A asserts the structural output already shipped by #59.
+
+What this leaf still owes:
+
+1. **Snapshot tests** locking the emitted schema/repo/service/association-accessor output. The smoke harness only does compile + grep; template formatting drift goes undetected.
+2. **Coexistence fixture** (Junction + `relationships:` on same entity) — explicitly called out in the plan leaf's acceptance criteria, not yet implemented.
+
+Everything else listed in the plan leaf is satisfied by predecessors.
+
+## PR A — Snapshot tests
+
+### Files (new)
+
+```
+test/junction/
+  _helpers.ts                       # shared tmp-project bootstrap (extracted from run-smoke-junction.ts)
+  opportunity-contact.test.ts       # intra-domain snapshot test
+  opportunity-activity.test.ts      # cross-domain snapshot test
+  __snapshots__/                    # committed
+    opportunity-contact.test.ts.snap
+    opportunity-activity.test.ts.snap
+```
+
+### Test framework
+
+**bun:test** — matches `src/__tests__/` precedent (`bun test` is the runner). Use `toMatchSnapshot()` for full-file snapshots. Update via `bun test --update-snapshots`.
+
+### What each test does
+
+For each scenario:
+
+1. Bootstrap a tmp project using the helper extracted from `run-smoke-junction.ts` (init, install pinned deps, `codegen project init`, copy entities, `codegen entity new --all --force`, copy junctions, `codegen junction new --all --force`).
+2. Read the 5 emitted artifacts:
+   - **Junction:** `<junction>.entity.ts`, `<junction>.repository.ts`, `<junction>.service.ts`
+   - **Parent services (both sides):** `<left>.service.ts`, `<right>.service.ts` — covers two-sided association accessors emitted by #60
+3. Assert each via `toMatchSnapshot()` (full-file). Snapshots are committed.
+
+Run for `clean-lite-ps` architecture only in PR A (matches the default smoke run). Add `clean` architecture variants only if drift signals are needed — defer to follow-up to avoid 10 snapshots per template tweak.
+
+### Helper extraction (mandatory — do not duplicate)
+
+`run-smoke-junction.ts` already contains the tmp-project bootstrap. Extract to `test/junction/_helpers.ts`:
+
+```ts
+export interface BootstrapResult {
+  projectDir: string;
+  emittedFile(relPath: string): string;  // returns file contents
+  cleanup(): void;                       // unless KEEP_SMOKE_DIR=1
+}
+
+export async function bootstrapJunctionProject(opts: {
+  scenario: 'junction' | 'junction-cross-domain' | 'junction-coexistence';  // 'junction-coexistence' added in PR B
+  architecture: 'clean-lite-ps' | 'clean';
+}): Promise<BootstrapResult>;
+```
+
+After extraction, `run-smoke-junction.ts` becomes a thin CLI wrapper around the helper. Snapshot tests import the helper directly. The smoke harness must continue to pass — that's the implementer's first checkpoint.
+
+### Justfile
+
+Add `test-junction` recipe; include in `test-all`:
+
+```just
+test-junction:
+    bun test test/junction/
+
+test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-junction test-smoke-junction-cross-domain test-junction
+```
+
+### Acceptance (PR A)
+
+- `just test-junction` green
+- `just test-all` green (smoke harness still works post-extraction)
+- Snapshots committed under `test/junction/__snapshots__/`
+- Snapshots visibly contain pairing-aware finders (`findByOpportunityId`, `findByContactId`) and the canonical `WithAnalytics(BaseService<...>)` shape
+
+## PR B — Coexistence fixture (stacks on #358)
+
+### Why this stacks on #358
+
+The coexistence fixture only has a point once `relationships:` actually emits service methods. Before #358, the `relationships:` block on `opportunity` would parse but emit no `findAccount()` method onto `OpportunityService`, so there is nothing to coexist with the junction accessor. PR B must wait for #358 to merge.
+
+### Fixture shape — Option B (orthogonal targets)
+
+The coexistence test proves the *file-level* merge of two independent codegen paths is clean. The two paths target **different** entities:
+
+- `opportunity` has a plain FK to `account` declared via `relationships:` block (handled by #358).
+- `opportunity` participates in `opportunity_contact` junction with `contact` (handled by #59/#60).
+
+The resulting `OpportunityService` carries **both** `findAccount()` (from #358) **and** the junction accessor (from #60). The two emitters write into the same service file; if either stomps the other's imports or method declarations, the test fails.
+
+We deliberately do **not** test "junction-as-relationship" (e.g. `relationships: { contacts: { has_many: contact, via: opportunity_contact } }`). That is a feature interaction for a `via:` keyword which may not exist. File separately if wanted.
+
+### Files (new)
+
+```
+test/smoke/fixtures-junction-coexistence/
+  entities/
+    opportunity.yaml      # SyncedEntity with relationships: { account: belongs_to: account } + plain FK account_id
+    account.yaml          # minimal SyncedEntity (relationship target)
+    contact.yaml          # minimal SyncedEntity (junction target)
+  junctions/
+    opportunity_contact.yaml   # same shape as the existing fixture; opportunity participates here too
+
+test/junction/
+  coexistence.test.ts          # snapshot opportunity.service.ts; assert both accessor methods present + no duplicate imports
+  __snapshots__/coexistence.test.ts.snap
+```
+
+### Smoke runner extension
+
+Extend `test/smoke/run-smoke-junction.ts` with a new `--scenario junction-coexistence` value (mirrors the existing `--scenario` switch). Add fixture-dir + scenario-meta entries to the two maps near the top of that file. The smoke runner must invoke **both** `codegen entity new --all --force` (which now also emits the relationship into `opportunity.service.ts` thanks to #358) **and** `codegen junction new --all --force` (which adds the junction accessor onto the same file).
+
+If the file-level merge requires anything beyond what each emitter currently does, that is a **#60 or #358 bug** — surface it as a halt against the right issue, do not paper over in the fixture.
+
+### Justfile
+
+```just
+test-smoke-junction-coexistence:
+    bun test/smoke/run-smoke-junction.ts --scenario junction-coexistence --architecture clean-lite-ps
+
+test-smoke-junction-coexistence-clean:
+    bun test/smoke/run-smoke-junction.ts --scenario junction-coexistence --architecture clean
+
+test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-junction test-smoke-junction-cross-domain test-smoke-junction-coexistence test-junction
+```
+
+### Acceptance (PR B)
+
+- `just test-smoke-junction-coexistence` and `-clean` both green
+- `just test-junction` green (incl. new `coexistence.test.ts`)
+- Coexistence snapshot of `opportunity.service.ts` contains BOTH:
+  - `findAccount` (from `relationships:` / #358)
+  - the junction accessor for `contact` (from `pattern: Junction` / #60)
+- No duplicate import statements; no two methods of the same name
+- `just test-all` green
+
+## Out of scope
+
+- `via:` keyword on `relationships:` (junction-as-relationship)
+- DTO / controller assertions on emitted output (covered by #347 and adjacent issues)
+- `clean` architecture snapshots for the two non-coexistence scenarios (defer unless needed)
+- Doc updates beyond the justfile recipes
+- Updating the plan leaf YAML — the plan documents intent at write time; the implementer should not retroactively re-author it (this spec is the post-implementation truth, per CLAUDE.md "specs as living documentation")
+
+## Open questions
+
+1. **Snapshot framework — confirmed bun:test.** Closed by user; matches `src/__tests__/` precedent.
+2. **Helper extraction risk.** Pulling tmp-project bootstrap out of `run-smoke-junction.ts` could regress the smoke harness. Mitigation: implementer must run `just test-smoke-junction{,-cross-domain}{,-clean}` after the extraction and before adding snapshot tests. If any of those four break, halt and surface.
+3. **Coexistence depends on #358's exact emission shape.** PR B can only be specified concretely once #358's PR is open and the emitted `findAccount()` signature is known. The fixture YAML may need a tweak (e.g. `belongs_to` vs `has_one` naming). Defer the final YAML to PR B's author after rebasing onto #358.
+
+## Risks
+
+- **Snapshot churn during the rest of the wave.** Snapshots will break on every template tweak. That's the point — we're trading dev friction for drift detection. Regen flow (`bun test --update-snapshots`) is documented in the test file's header comment.
+- **Helper extraction touches the smoke harness.** The smoke harness is currently the only end-to-end junction signal; breaking it during extraction is the highest-risk move in PR A. Implementer runs the four smoke variants first, snapshot tests second.
+- **Cross-repo PR tracking.** The PR lands in `pattern-stack/codegen-patterns`; the tracker issue lives in `pattern-stack/dealbrain-integrations`. When PR A and PR B merge, paste their URLs into closing comments on #61.
+
+## Branches
+
+- PR A: `doug/cgp-61-junction-snapshot-tests` off `pattern-stack/codegen-patterns:main`
+- PR B: `doug/cgp-61-junction-coexistence` stacked on `doug/cgp-358-relationships-service-composition` (do not rebase onto `main` until #358 merges)
+
+## Discoveries (PR A implementation, 2026-05-12)
+
+Surfacing facts discovered during PR A that invalidate two assumptions in this spec. Per CLAUDE.md "specs as living documentation."
+
+### 1. `just test-all` only runs 2 of 4 junction smoke variants
+
+`Justfile` line 91 wires:
+```
+test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-junction test-smoke-junction-cross-domain
+```
+
+The `-clean` recipes (`test-smoke-junction-clean`, `test-smoke-junction-cross-domain-clean`) exist but are **not** in `test-all`. Confirmed against CI run 25770873094 — only the two clean-lite-ps variants ran in `main`'s most recent green build.
+
+This contradicts §Risks #2 ("Implementer must run `just test-smoke-junction{,-cross-domain}{,-clean}` after the extraction"). The actual gate is two variants, not four. PR A runs the two clean-lite-ps variants as the gate; the two `-clean` variants are documented broken (see #2 below) and out of scope.
+
+### 2. Clean-arch junction emission is broken on `main`
+
+Both `-clean` smoke variants fail with 17 typecheck errors against a freshly-bootstrapped tmp project. Three independent root causes:
+
+- **`@mguay/nestjs-trpc`** — entity templates emit `src/presentation/trpc/<plural>.router.ts` files that import this package; it is not in `RUNTIME_DEPS` of the smoke harness.
+- **`@repo/db/server/schema`** — entity repository templates (`src/infrastructure/persistence/repositories/<ent>.repository.ts`) import from a monorepo alias `@repo/db/server/schema`. The smoke tmp project has no such alias and no such package; tsconfig declares `@shared/*`, `@modules/*`, `@generated/*` only.
+- **Junction repo import path mismatch** — `src/infrastructure/persistence/drizzle/opportunity-contacts.repository.ts` imports `./opportunity_contact.entity`, but in the clean-arch layout the entity is emitted to `src/domain/opportunity_contacts/opportunity_contact.entity.ts`. The relative path is wrong.
+
+These are pre-existing on `main`. Verified by reverting `test/smoke/run-smoke-junction.ts` to `origin/main` and re-running — same 17 errors. Not introduced by this leaf.
+
+### 3. PR A scope adjustment
+
+Both consequences of the above:
+
+- **Smoke gate for PR A**: the two clean-lite-ps variants (`test-smoke-junction`, `test-smoke-junction-cross-domain`). Helper extraction verified against both.
+- **Snapshot coverage for PR A**: clean-lite-ps only (already the spec's intent in §"What each test does", reinforced by the smoke-gap finding).
+- **Acceptance**: "`just test-all` green" remains the bar — `test-all` does not include `-clean`, so the bar is reachable.
+
+Follow-up issue tracks the clean-arch breakage and the question of whether to fix it before or after gating `-clean` in `test-all`.

--- a/.ai-docs/stacks/codegen-app-patterns/specs/61.md
+++ b/.ai-docs/stacks/codegen-app-patterns/specs/61.md
@@ -79,7 +79,7 @@ For each scenario:
    - **Parent services (both sides):** `<left>.service.ts`, `<right>.service.ts` — covers two-sided association accessors emitted by #60
 3. Assert each via `toMatchSnapshot()` (full-file). Snapshots are committed.
 
-Run for `clean-lite-ps` architecture only in PR A (matches the default smoke run). Add `clean` architecture variants only if drift signals are needed — defer to follow-up to avoid 10 snapshots per template tweak.
+Run for `clean-lite-ps` architecture only in PR A (matches the default smoke run). The `clean` architecture variants are out of scope (see §Discoveries — clean-lite-ps is the indefinite default scope for this leaf).
 
 ### Helper extraction (mandatory — do not duplicate)
 
@@ -216,7 +216,9 @@ test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-
 
 The `-clean` recipes (`test-smoke-junction-clean`, `test-smoke-junction-cross-domain-clean`) exist but are **not** in `test-all`. Confirmed against CI run 25770873094 — only the two clean-lite-ps variants ran in `main`'s most recent green build.
 
-This contradicts §Risks #2 ("Implementer must run `just test-smoke-junction{,-cross-domain}{,-clean}` after the extraction"). The actual gate is two variants, not four. PR A runs the two clean-lite-ps variants as the gate; the two `-clean` variants are documented broken (see #2 below) and out of scope. **Known gap, not tracked separately** — per user direction (2026-05-12), the clean architecture may be rebuilt from clean-lite-ps, at which point the gap resolves; filing a tracker would just be churn.
+This contradicts §Risks #2 ("Implementer must run `just test-smoke-junction{,-cross-domain}{,-clean}` after the extraction"). The actual gate is two variants, not four. PR A runs the two clean-lite-ps variants as the gate; the two `-clean` variants are documented broken (see #2 below) and out of scope.
+
+**Known gap (not tracked separately).** Per user direction, the clean-arch breakage is not filed as its own issue — the clean architecture may be rebuilt from clean-lite-ps, at which point the breakage resolves. The three root causes are documented in §2 below as a record only.
 
 ### 2. Clean-arch junction emission is broken on `main`
 
@@ -226,7 +228,7 @@ Both `-clean` smoke variants fail with 17 typecheck errors against a freshly-boo
 - **`@repo/db/server/schema`** — entity repository templates (`src/infrastructure/persistence/repositories/<ent>.repository.ts`) import from a monorepo alias `@repo/db/server/schema`. The smoke tmp project has no such alias and no such package; tsconfig declares `@shared/*`, `@modules/*`, `@generated/*` only.
 - **Junction repo import path mismatch** — `src/infrastructure/persistence/drizzle/opportunity-contacts.repository.ts` imports `./opportunity_contact.entity`, but in the clean-arch layout the entity is emitted to `src/domain/opportunity_contacts/opportunity_contact.entity.ts`. The relative path is wrong.
 
-These are pre-existing on `main`. Verified by reverting `test/smoke/run-smoke-junction.ts` to `origin/main` and re-running — same 17 errors. Not introduced by this leaf. Documented here as a record for anyone who later chooses to fix clean-arch in place; otherwise they resolve when clean-arch is rebuilt from clean-lite-ps.
+These are pre-existing on `main`. Verified by reverting `test/smoke/run-smoke-junction.ts` to `origin/main` and re-running — same 17 errors. Not introduced by this leaf. Documented as a record only.
 
 ### 3. Stack-wide scope adjustment — clean-lite-ps only (PR A + PR B)
 
@@ -238,4 +240,4 @@ User-confirmed (2026-05-12): clean-arch is scoped out of **both** PR A and PR B.
 - **Snapshot coverage for PR B**: clean-lite-ps only.
 - **Acceptance**: "`just test-all` green" remains the bar — `test-all` does not include `-clean`, so the bar is reachable.
 
-The clean-arch gap is **not tracked as a separate issue** — per user direction, the clean architecture may be rebuilt from clean-lite-ps, at which point both the smoke gap and the three emission bugs in §2 resolve. If anyone later chooses to fix clean-arch in place instead, the three root causes in §2 above are the starting point. This is the post-implementation truth for the entire `codegen-app-patterns:junction-test-fixtures` leaf.
+The clean-lite-ps scope is the **indefinite default** for this leaf. This is the post-implementation truth for `codegen-app-patterns:junction-test-fixtures`.

--- a/.ai-docs/stacks/codegen-app-patterns/specs/61.md
+++ b/.ai-docs/stacks/codegen-app-patterns/specs/61.md
@@ -118,9 +118,15 @@ test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-
 - Snapshots committed under `test/junction/__snapshots__/`
 - Snapshots visibly contain pairing-aware finders (`findByOpportunityId`, `findByContactId`) and the canonical `WithAnalytics(BaseService<...>)` shape
 
-## PR B — Coexistence fixture (stacks on #358)
+## PR B — Coexistence fixture (stacks on #358) — status: partially subsumed
 
-### Why this stacks on #358
+**Status update (2026-05-12, post-rebase of PR A):** #358 merged as codegen-patterns#362 mid-flight. The PR A intra-domain fixture (`opportunity_contact` / `contact` carries `relationships: { account: belongs_to }`) **already exercises half the coexistence story** — its snapshot of `contact.service.ts` now contains the `account()` relationship-composition method emitted by #358/#362, alongside the inherited synced-entity surface.
+
+The other half (junction accessor method on the same parent service) still requires #60 to land. Until then there is no second emitter writing into the parent service file, so the file-level merge that PR B was designed to test cannot exist yet. PR A snapshots will pick up that emission automatically once #60 ships — at which point a dedicated PR B fixture may be redundant.
+
+If PR B is still wanted as an explicit coverage step, the design below stands. If not, close PR B against this leaf when #60 lands and verify the PR A snapshots show both methods on `contact.service.ts`.
+
+### Why this stacks on #358 (historical — #358 has merged)
 
 The coexistence fixture only has a point once `relationships:` actually emits service methods. Before #358, the `relationships:` block on `opportunity` would parse but emit no `findAccount()` method onto `OpportunityService`, so there is nothing to coexist with the junction accessor. PR B must wait for #358 to merge.
 
@@ -241,3 +247,11 @@ User-confirmed (2026-05-12): clean-arch is scoped out of **both** PR A and PR B.
 - **Acceptance**: "`just test-all` green" remains the bar — `test-all` does not include `-clean`, so the bar is reachable.
 
 The clean-lite-ps scope is the **indefinite default** for this leaf. This is the post-implementation truth for `codegen-app-patterns:junction-test-fixtures`.
+
+### 4. #358 / #362 merged mid-flight; PR A snapshots picked it up post-rebase
+
+CGP-358's service-layer relationship composition (PR #362) merged to `main` at 2026-05-12 21:59:51, **after** this branch was cut. The first PR-A push captured snapshots generated against the pre-#362 `main` and CI then failed because CI's `main` had #362.
+
+Resolution: rebase onto current `main`, regenerate snapshots. The new `contact.service.ts` snapshot now contains the `account()` relationship-composition method (`AccountRepository` injection, two-query find pattern, "CGP-358b / CGP-62" comment block) — `contact.yaml` is the only fixture entity carrying a `relationships:` block, so it is the only parent service whose snapshot picked up emission changes.
+
+**Knock-on effect on PR B.** With #358 merged, PR A's intra-domain snapshot incidentally covers half of the coexistence story (relationship-emitter output on `contact.service.ts`). The other half (junction-accessor emission onto the same parent service) is still gated on #60. Once #60 lands, PR A's snapshots will pick up both emitters' output on `contact.service.ts` automatically — at which point a dedicated PR B fixture may be redundant. See the PR B section header for the updated status note.

--- a/.ai-docs/stacks/codegen-app-patterns/specs/61.md
+++ b/.ai-docs/stacks/codegen-app-patterns/specs/61.md
@@ -159,19 +159,18 @@ If the file-level merge requires anything beyond what each emitter currently doe
 
 ### Justfile
 
+clean-lite-ps only (see §Discoveries — clean-arch scope-back applies stack-wide):
+
 ```just
 test-smoke-junction-coexistence:
     bun test/smoke/run-smoke-junction.ts --scenario junction-coexistence --architecture clean-lite-ps
-
-test-smoke-junction-coexistence-clean:
-    bun test/smoke/run-smoke-junction.ts --scenario junction-coexistence --architecture clean
 
 test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-junction test-smoke-junction-cross-domain test-smoke-junction-coexistence test-junction
 ```
 
 ### Acceptance (PR B)
 
-- `just test-smoke-junction-coexistence` and `-clean` both green
+- `just test-smoke-junction-coexistence` green (clean-lite-ps)
 - `just test-junction` green (incl. new `coexistence.test.ts`)
 - Coexistence snapshot of `opportunity.service.ts` contains BOTH:
   - `findAccount` (from `relationships:` / #358)
@@ -229,12 +228,14 @@ Both `-clean` smoke variants fail with 17 typecheck errors against a freshly-boo
 
 These are pre-existing on `main`. Verified by reverting `test/smoke/run-smoke-junction.ts` to `origin/main` and re-running — same 17 errors. Not introduced by this leaf.
 
-### 3. PR A scope adjustment
+### 3. Stack-wide scope adjustment — clean-lite-ps only (PR A + PR B)
 
-Both consequences of the above:
+User-confirmed (2026-05-12): clean-arch is scoped out of **both** PR A and PR B until the smoke gap + emission bugs in the follow-up issue are resolved. Consequences:
 
 - **Smoke gate for PR A**: the two clean-lite-ps variants (`test-smoke-junction`, `test-smoke-junction-cross-domain`). Helper extraction verified against both.
 - **Snapshot coverage for PR A**: clean-lite-ps only (already the spec's intent in §"What each test does", reinforced by the smoke-gap finding).
+- **Smoke gate for PR B**: `test-smoke-junction-coexistence` (clean-lite-ps) only. The `-clean` variant is not authored in PR B's justfile section — see updated snippet in PR B's Justfile section above.
+- **Snapshot coverage for PR B**: clean-lite-ps only.
 - **Acceptance**: "`just test-all` green" remains the bar — `test-all` does not include `-clean`, so the bar is reachable.
 
-Follow-up issue tracks the clean-arch breakage and the question of whether to fix it before or after gating `-clean` in `test-all`.
+Re-introduce clean-arch coverage (smoke + snapshots) only after the follow-up issue lands. This is the post-implementation truth for the entire `codegen-app-patterns:junction-test-fixtures` leaf.

--- a/justfile
+++ b/justfile
@@ -53,6 +53,11 @@ test-smoke-junction-cross-domain:
 test-smoke-junction-cross-domain-clean:
     bun test/smoke/run-smoke-junction.ts --scenario junction-cross-domain --architecture clean
 
+# Junction snapshot tests — locks emitted output of junction codegen against drift.
+# Regenerate after intentional template changes: bun test --update-snapshots test/junction/
+test-junction:
+    bun test test/junction/
+
 # Run the relationship-scenario smoke (CGP-62): self-ref + cross-entity
 # belongs_to + has_many against the CRM fixture set. Verifies the
 # clean-lite-ps Drizzle relations() emission shape. ~60-120s.
@@ -94,7 +99,7 @@ validate:
     bash test/scaffold/validate.sh
 
 # Run all tests
-test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-junction test-smoke-junction-cross-domain
+test-all: test-unit test-baseline test-smoke test-smoke-relationship test-smoke-junction test-smoke-junction-cross-domain test-junction
 
 # ─── Domain Analysis ──────────────────────────────────────────────────────────
 

--- a/test/junction/__snapshots__/opportunity-activity.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-activity.test.ts.snap
@@ -147,6 +147,21 @@ import { EVENT_BUS } from '@shared/constants/tokens';
 import { BaseService } from '@shared/base-classes/base-service';
 import { OpportunityActivityRepository } from './opportunity_activity.repository';
 import type { OpportunityActivity } from './opportunity_activity.entity';
+import { OpportunityRepository } from '../opportunities/opportunity.repository';
+import type { Opportunity } from '../opportunities/opportunity.entity';
+import { ActivityRepository } from '../activities/activity.repository';
+import type { Activity } from '../activities/activity.entity';
+
+/**
+ * Pick of the link-side mutable fields that callers may supply when
+ * attaching. Subset of \`OpportunityActivity\` minus the two FK columns
+ * (those come from the method args).
+ */
+export type OpportunityActivityLinkInput = Partial<
+  Pick<OpportunityActivity,
+    'isPrimary' | 'startedAt' | 'endedAt' | 'sourcedFrom' | 'confidence' | 'matchedAt'
+  >
+>;
 
 @Injectable()
 export class OpportunityActivityService extends WithAnalytics(
@@ -158,7 +173,11 @@ export class OpportunityActivityService extends WithAnalytics(
   @Optional() @Inject(EVENT_BUS)
   protected override eventBus: any = undefined;
 
-  constructor(protected override readonly repository: OpportunityActivityRepository) {
+  constructor(
+    protected override readonly repository: OpportunityActivityRepository,
+    private readonly opportunityRepo: OpportunityRepository,
+    private readonly activityRepo: ActivityRepository,
+  ) {
     super(repository);
   }
 
@@ -168,8 +187,6 @@ export class OpportunityActivityService extends WithAnalytics(
 
   /**
    * Fetch all junction rows for a given opportunity_id.
-   *
-   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
    */
   async findByOpportunityId(
     opportunityId: string,
@@ -180,8 +197,6 @@ export class OpportunityActivityService extends WithAnalytics(
 
   /**
    * Fetch all junction rows for a given activity_id.
-   *
-   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
    */
   async findByActivityId(
     activityId: string,
@@ -190,19 +205,108 @@ export class OpportunityActivityService extends WithAnalytics(
     return this.repository.findByActivityId(activityId, opts);
   }
 
-  // ─────────────────────────────────────────────────────────────────────────
-  // Fan-out association methods (attach/detach/list/setPrimary) are NOT
-  // emitted here. They land via junction-association-codegen
-  // (pattern-stack/dealbrain-integrations#60) once
-  // pattern-stack/codegen-patterns#358 establishes the service-method
-  // emission machinery.
-  //
-  // Until #60 lands, consumers hand-write fan-out methods in their own
-  // service files against the canonical shape documented in
-  // .ai-docs/stacks/codegen-app-patterns/specs/cgp-62.md (see
-  // architectural_notes.cross_entity_access.canonical_shape in the stack
-  // plan). The hand-written methods are the executable spec for #60.
-  // ─────────────────────────────────────────────────────────────────────────
+  // ═══════════════════════════════════════════════════════════════════════
+  // CGP-60 — canonical fan-out methods
+  // Mirrored, paginated, composed \`{ entity, link }\` shape. Always emitted
+  // on the junction service; parent-side \`attach<Right>\` / \`addTo<Left>\` /
+  // etc. inject templates delegate here. \`list\` is implemented with two
+  // single-table queries (no Drizzle \`with:\`).
+  // ═══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Create a junction row linking a opportunity and a activity.
+   * Returns the persisted row.
+   *
+   * **Idempotency:** NOT idempotent at the service layer in v1. A duplicate
+   * pair raises the DB-level composite-PK unique-constraint error from the
+   * underlying repository's \`create\`. Callers requiring idempotency should
+   * either check existence via \`findByOpportunityId\` + filter,
+   * or wrap the call in try/catch on the unique-violation error. A future
+   * leaf may add a transactional check-then-create here if a consumer
+   * surfaces the need (track as a follow-up if so).
+   */
+  async attach(
+    opportunityId: string,
+    activityId: string,
+    link?: OpportunityActivityLinkInput,
+  ): Promise<OpportunityActivity> {
+    return this.create({
+      opportunityId: opportunityId,
+      activityId: activityId,
+      ...(link ?? {}),
+    } as unknown as Partial<OpportunityActivity>);
+  }
+
+  /**
+   * Remove the junction row linking \`opportunityId\` and
+   * \`activityId\`. No-op if no row exists.
+   */
+  async detach(
+    opportunityId: string,
+    activityId: string,
+  ): Promise<void> {
+    const links = await this.repository.findByOpportunityId(opportunityId);
+    const match = links.find(
+      (l) => (l as any).activityId === activityId,
+    );
+    if (match) {
+      await this.delete((match as any).id ?? \`\${opportunityId}:\${activityId}\`);
+    }
+  }
+
+  /**
+   * List the targets associated with one side of the junction, composed as
+   * \`{ entity, link }\`. Implementation: one repo call for the links, one
+   * \`findByIds\` call for the targets — no SQL JOIN. Cursor pagination by
+   * right-entity \`id\` (matches CGP-358 has_many shape; time-ordered cursor
+   * is deferred per spec Open Q3).
+   */
+  async listAssoc(
+    side: 'left' | 'right',
+    anchorId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<Array<{ entity: Opportunity | Activity; link: OpportunityActivity }>> {
+    if (side === 'left') {
+      const links = await this.repository.findByOpportunityId(anchorId, opts);
+      const targetIds = links.map((l) => (l as any).activityId as string);
+      const targets = await this.activityRepo.findByIds(targetIds);
+      const byId = new Map(targets.map((t) => [(t as any).id, t]));
+      return links.map((link) => ({
+        entity: byId.get((link as any).activityId)! as Activity,
+        link,
+      }));
+    } else {
+      const links = await this.repository.findByActivityId(anchorId, opts);
+      const targetIds = links.map((l) => (l as any).opportunityId as string);
+      const targets = await this.opportunityRepo.findByIds(targetIds);
+      const byId = new Map(targets.map((t) => [(t as any).id, t]));
+      return links.map((link) => ({
+        entity: byId.get((link as any).opportunityId)! as Opportunity,
+        link,
+      }));
+    }
+  }
+
+  /**
+   * Mark the (\`opportunityId\`, \`activityId\`) row
+   * as \`is_primary: true\`. Demoting other rows on the same side is the
+   * caller's concern in v1; future leaves may add transactional demotion.
+   */
+  async setPrimary(
+    opportunityId: string,
+    activityId: string,
+  ): Promise<void> {
+    const links = await this.repository.findByOpportunityId(opportunityId);
+    const match = links.find(
+      (l) => (l as any).activityId === activityId,
+    );
+    if (match) {
+      await this.update(
+        (match as any).id ?? \`\${opportunityId}:\${activityId}\`,
+        { isPrimary: true } as unknown as Partial<OpportunityActivity>,
+      );
+    }
+  }
 
   // Inherited from BaseService:
   //   findById, findByIds, list, count, exists, create, update, delete
@@ -212,6 +316,12 @@ export class OpportunityActivityService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits opportunity.service.ts (left parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
+// CGP-60 — junction service + types (forwardRef resolves circular module dep)
+import { forwardRef } from '@nestjs/common';
+import { OpportunityActivityService, OpportunityActivityLinkInput } from '../opportunity_activities/opportunity_activity.service';
+import type { OpportunityActivity } from '../opportunity_activities/opportunity_activity.entity';
+import type { Activity } from '../activities/activity.entity';
+
 import { WithAnalytics } from '@shared/base-classes/with-analytics';
 import { EVENT_BUS } from '@shared/constants/tokens';
 import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
@@ -237,6 +347,51 @@ export class OpportunityService extends WithAnalytics(
   // Lifecycle events (created/updated/deleted + per-field changes) are emitted
   // automatically by BaseService when the events subsystem is installed.
   //
+  // ═══════════════════════════════════════════════════════════════════════
+  // CGP-60 — fan-out to Activity (junction: opportunity_activity)
+  // Delegates to OpportunityActivityService. Per-junction marker keeps
+  // idempotency; multiple junctions on the same parent each emit their own
+  // block. \`forwardRef\` resolves the circular module import (parent module
+  // imports junction module; junction module imports parent modules for
+  // repo DI).
+  // ═══════════════════════════════════════════════════════════════════════
+  // junction:opportunity_activity:left-fan-out
+
+  @Inject(forwardRef(() => OpportunityActivityService))
+  private readonly opportunityActivityService!: OpportunityActivityService;
+
+  async attachActivity(
+    opportunityId: string,
+    activityId: string,
+    link?: OpportunityActivityLinkInput,
+  ): Promise<OpportunityActivity> {
+    return this.opportunityActivityService.attach(opportunityId, activityId, link);
+  }
+
+  async detachActivity(
+    opportunityId: string,
+    activityId: string,
+  ): Promise<void> {
+    return this.opportunityActivityService.detach(opportunityId, activityId);
+  }
+
+  async activitiesList(
+    opportunityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<Array<{ entity: Activity; link: OpportunityActivity }>> {
+    return this.opportunityActivityService.listAssoc('left', opportunityId, opts) as Promise<
+      Array<{ entity: Activity; link: OpportunityActivity }>
+    >;
+  }
+
+  async activitiesSetPrimary(
+    opportunityId: string,
+    activityId: string,
+  ): Promise<void> {
+    return this.opportunityActivityService.setPrimary(opportunityId, activityId);
+  }
+
+
   // Inherited from SyncedEntityService:
   //   findById, findByIds, list, count, exists, create, update, delete
   //   findByExternalId, findAllByUserId, findVisibleByUserId
@@ -249,6 +404,12 @@ export class OpportunityService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits activity.service.ts (right parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
+// CGP-60 — junction service + types (forwardRef resolves circular module dep)
+import { forwardRef } from '@nestjs/common';
+import { OpportunityActivityService, OpportunityActivityLinkInput } from '../opportunity_activities/opportunity_activity.service';
+import type { OpportunityActivity } from '../opportunity_activities/opportunity_activity.entity';
+import type { Opportunity } from '../opportunities/opportunity.entity';
+
 import { WithAnalytics } from '@shared/base-classes/with-analytics';
 import { EVENT_BUS } from '@shared/constants/tokens';
 import { ActivityEntityService } from '@shared/base-classes/activity-entity-service';
@@ -274,6 +435,48 @@ export class ActivityService extends WithAnalytics(
   // Lifecycle events (created/updated/deleted + per-field changes) are emitted
   // automatically by BaseService when the events subsystem is installed.
   //
+  // ═══════════════════════════════════════════════════════════════════════
+  // CGP-60 — fan-out to Opportunity (junction: opportunity_activity)
+  // Delegates to OpportunityActivityService. See left-side block for the
+  // forwardRef + per-junction marker rationale.
+  // ═══════════════════════════════════════════════════════════════════════
+  // junction:opportunity_activity:right-fan-out
+
+  @Inject(forwardRef(() => OpportunityActivityService))
+  private readonly opportunityActivityService!: OpportunityActivityService;
+
+  async addToOpportunity(
+    activityId: string,
+    opportunityId: string,
+    link?: OpportunityActivityLinkInput,
+  ): Promise<OpportunityActivity> {
+    return this.opportunityActivityService.attach(opportunityId, activityId, link);
+  }
+
+  async removeFromOpportunity(
+    activityId: string,
+    opportunityId: string,
+  ): Promise<void> {
+    return this.opportunityActivityService.detach(opportunityId, activityId);
+  }
+
+  async opportunitiesList(
+    activityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<Array<{ entity: Opportunity; link: OpportunityActivity }>> {
+    return this.opportunityActivityService.listAssoc('right', activityId, opts) as Promise<
+      Array<{ entity: Opportunity; link: OpportunityActivity }>
+    >;
+  }
+
+  async opportunitiesSetPrimary(
+    activityId: string,
+    opportunityId: string,
+  ): Promise<void> {
+    return this.opportunityActivityService.setPrimary(opportunityId, activityId);
+  }
+
+
   // Inherited from ActivityEntityService:
   //   findById, findByIds, list, count, exists, create, update, delete
   //   findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId

--- a/test/junction/__snapshots__/opportunity-activity.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-activity.test.ts.snap
@@ -1,0 +1,285 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits opportunity_activity.entity.ts 1`] = `
+"import {
+  boolean,
+  numeric,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { relations, type InferSelectModel } from 'drizzle-orm';
+import { opportunities } from '../opportunities/opportunity.entity';
+import { activities } from '../activities/activity.entity';
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+// ============================================================================
+// Table
+// ============================================================================
+
+export const opportunityActivities = pgTable(
+  'opportunity_activities',
+  {
+    // FK columns — composite primary key (no surrogate id: Q4 resolution)
+    opportunityId: uuid('opportunity_id').notNull().references(() => opportunities.id, { onDelete: 'restrict' }),
+    activityId: uuid('activity_id').notNull().references(() => activities.id, { onDelete: 'restrict' }),
+
+    // BaseJunctionFields — is_primary is always emitted
+    isPrimary: boolean('is_primary').notNull().default(false),
+
+    // Temporal window (temporal: true, default)
+    startedAt: timestamp('started_at'),
+    endedAt: timestamp('ended_at'),
+
+    // Provenance (sourced: true, default)
+    sourcedFrom: text('sourced_from'),
+    confidence: numeric('confidence', { precision: 5, scale: 4 }),
+    matchedAt: timestamp('matched_at'),
+
+    // Timestamps
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    // Composite primary key on the two FK columns (Q4 resolution: no surrogate id)
+    primaryKey({ columns: [table.opportunityId, table.activityId] }),
+  ],
+);
+
+export type OpportunityActivity = InferSelectModel<typeof opportunityActivities>;
+export type OpportunityActivityInsert = typeof opportunityActivities.$inferInsert;
+
+// ============================================================================
+// Relations — extension-path metadata for db.query.X.findMany({ with: ... })
+// Generated code does NOT consume these; they exist for hand-written admin
+// queries and for #60's fan-out methods once they land.
+// ============================================================================
+
+export const opportunityActivitiesRelations = relations(opportunityActivities, ({ one }) => ({
+  opportunity: one(opportunities, {
+    fields: [opportunityActivities.opportunityId],
+    references: [opportunities.id],
+  }),
+  activity: one(activities, {
+    fields: [opportunityActivities.activityId],
+    references: [activities.id],
+  }),
+}));
+"
+`;
+
+exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits opportunity_activity.repository.ts 1`] = `
+"import { Injectable, Inject } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
+import { BaseRepository } from '@shared/base-classes/base-repository';
+import { opportunityActivities, type OpportunityActivity } from './opportunity_activity.entity';
+
+@Injectable()
+export class OpportunityActivityRepository extends BaseRepository<OpportunityActivity> {
+  readonly table = opportunityActivities;
+
+  // Junctions track temporal validity via started_at / ended_at, NOT via
+  // deleted_at. is_primary flips replace soft-delete semantics (Q5 resolution).
+  protected override readonly behaviors = {
+    timestamps: true,
+    softDelete: false,
+    userTracking: false,
+  };
+
+  constructor(@Inject(DRIZZLE) db: DrizzleClient) {
+    super(db);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Pairing-aware finders — hardcoded in v1 (Q2 resolution: no declarative
+  // queries block on junctions; every junction needs exactly these two methods).
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch all junction rows where opportunity_id matches.
+   *
+   * Pagination shape: { cursor?, limit? } — canonical per cgp-62 r4.
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByOpportunityId(
+    opportunityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityActivity[]> {
+    const rows = await this.baseQuery()
+      .where(eq(this.table.opportunityId, opportunityId))
+      .limit(opts?.limit ?? 100);
+    return rows as OpportunityActivity[];
+  }
+
+  /**
+   * Fetch all junction rows where activity_id matches.
+   *
+   * Pagination shape: { cursor?, limit? } — canonical per cgp-62 r4.
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByActivityId(
+    activityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityActivity[]> {
+    const rows = await this.baseQuery()
+      .where(eq(this.table.activityId, activityId))
+      .limit(opts?.limit ?? 100);
+    return rows as OpportunityActivity[];
+  }
+
+  // Inherited from BaseRepository:
+  //   findById, findByIds, list, count, exists, create, update, delete, upsertMany
+}
+"
+`;
+
+exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits opportunity_activity.service.ts 1`] = `
+"import { Injectable, Inject, Optional } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
+import { EVENT_BUS } from '@shared/constants/tokens';
+import { BaseService } from '@shared/base-classes/base-service';
+import { OpportunityActivityRepository } from './opportunity_activity.repository';
+import type { OpportunityActivity } from './opportunity_activity.entity';
+
+@Injectable()
+export class OpportunityActivityService extends WithAnalytics(
+  BaseService<OpportunityActivityRepository, OpportunityActivity>,
+) {
+  protected override readonly entityName = 'opportunity_activity';
+
+  /** Injected by NestJS when EventsModule is registered. */
+  @Optional() @Inject(EVENT_BUS)
+  protected override eventBus: any = undefined;
+
+  constructor(protected override readonly repository: OpportunityActivityRepository) {
+    super(repository);
+  }
+
+  // Pairing-aware pass-throughs — mirror the repo's two finders so use-cases
+  // and #60's fan-out methods both delegate through the service layer, keeping
+  // analytics/events instrumentation uniform (per relationship's service.ejs.t).
+
+  /**
+   * Fetch all junction rows for a given opportunity_id.
+   *
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByOpportunityId(
+    opportunityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityActivity[]> {
+    return this.repository.findByOpportunityId(opportunityId, opts);
+  }
+
+  /**
+   * Fetch all junction rows for a given activity_id.
+   *
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByActivityId(
+    activityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityActivity[]> {
+    return this.repository.findByActivityId(activityId, opts);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Fan-out association methods (attach/detach/list/setPrimary) are NOT
+  // emitted here. They land via junction-association-codegen
+  // (pattern-stack/dealbrain-integrations#60) once
+  // pattern-stack/codegen-patterns#358 establishes the service-method
+  // emission machinery.
+  //
+  // Until #60 lands, consumers hand-write fan-out methods in their own
+  // service files against the canonical shape documented in
+  // .ai-docs/stacks/codegen-app-patterns/specs/cgp-62.md (see
+  // architectural_notes.cross_entity_access.canonical_shape in the stack
+  // plan). The hand-written methods are the executable spec for #60.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  // Inherited from BaseService:
+  //   findById, findByIds, list, count, exists, create, update, delete
+}
+"
+`;
+
+exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits opportunity.service.ts (left parent — junction accessor) 1`] = `
+"import { Injectable, Inject, Optional } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
+import { EVENT_BUS } from '@shared/constants/tokens';
+import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
+import { OpportunityRepository } from './opportunity.repository';
+import type { Opportunity } from './opportunity.entity';
+
+@Injectable()
+export class OpportunityService extends WithAnalytics(
+  SyncedEntityService<OpportunityRepository, Opportunity>,
+) {
+  protected override readonly entityName = 'opportunity';
+
+  /** Injected by NestJS when EventsModule is registered. */
+  @Optional() @Inject(EVENT_BUS)
+  protected override eventBus: any = undefined;
+
+  constructor(
+    protected override readonly repository: OpportunityRepository,
+  ) {
+    super(repository);
+  }
+
+  // Lifecycle events (created/updated/deleted + per-field changes) are emitted
+  // automatically by BaseService when the events subsystem is installed.
+  //
+  // Inherited from SyncedEntityService:
+  //   findById, findByIds, list, count, exists, create, update, delete
+  //   findByExternalId, findAllByUserId, findVisibleByUserId
+
+
+
+}
+"
+`;
+
+exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits activity.service.ts (right parent — junction accessor) 1`] = `
+"import { Injectable, Inject, Optional } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
+import { EVENT_BUS } from '@shared/constants/tokens';
+import { ActivityEntityService } from '@shared/base-classes/activity-entity-service';
+import { ActivityRepository } from './activity.repository';
+import type { Activity } from './activity.entity';
+
+@Injectable()
+export class ActivityService extends WithAnalytics(
+  ActivityEntityService<ActivityRepository, Activity>,
+) {
+  protected override readonly entityName = 'activity';
+
+  /** Injected by NestJS when EventsModule is registered. */
+  @Optional() @Inject(EVENT_BUS)
+  protected override eventBus: any = undefined;
+
+  constructor(
+    protected override readonly repository: ActivityRepository,
+  ) {
+    super(repository);
+  }
+
+  // Lifecycle events (created/updated/deleted + per-field changes) are emitted
+  // automatically by BaseService when the events subsystem is installed.
+  //
+  // Inherited from ActivityEntityService:
+  //   findById, findByIds, list, count, exists, create, update, delete
+  //   findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId
+
+
+
+}
+"
+`;

--- a/test/junction/__snapshots__/opportunity-contact.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-contact.test.ts.snap
@@ -264,6 +264,8 @@ import { EVENT_BUS } from '@shared/constants/tokens';
 import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
 import { ContactRepository } from './contact.repository';
 import type { Contact } from './contact.entity';
+import { AccountRepository } from '../accounts/account.repository';
+import type { Account } from '../accounts/account.entity';
 
 @Injectable()
 export class ContactService extends WithAnalytics(
@@ -277,6 +279,7 @@ export class ContactService extends WithAnalytics(
 
   constructor(
     protected override readonly repository: ContactRepository,
+    private readonly accountRepo: AccountRepository,
   ) {
     super(repository);
   }
@@ -288,6 +291,21 @@ export class ContactService extends WithAnalytics(
   //   findById, findByIds, list, count, exists, create, update, delete
   //   findByExternalId, findAllByUserId, findVisibleByUserId
 
+  // ═══════════════════════════════════════════════════════════════════════
+  // Relationship composition methods (CGP-358b / CGP-62)
+  // Two queries, no SQL JOIN. Core-contract path; relations() const stays
+  // as opt-in extension for hand-written Drizzle queries.
+  // ═══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch the Account parent for this Contact.
+   * Two repo calls: find self by id → find target by FK.
+   */
+  async account(contactId: string): Promise<Account | null> {
+    const entity = await this.repository.findById(contactId);
+    if (!entity) return null;
+    return entity.accountId ? this.accountRepo.findById(entity.accountId) : null;
+  }
 
 
 }

--- a/test/junction/__snapshots__/opportunity-contact.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-contact.test.ts.snap
@@ -157,6 +157,21 @@ import { EVENT_BUS } from '@shared/constants/tokens';
 import { BaseService } from '@shared/base-classes/base-service';
 import { OpportunityContactRepository } from './opportunity_contact.repository';
 import type { OpportunityContact } from './opportunity_contact.entity';
+import { OpportunityRepository } from '../opportunities/opportunity.repository';
+import type { Opportunity } from '../opportunities/opportunity.entity';
+import { ContactRepository } from '../contacts/contact.repository';
+import type { Contact } from '../contacts/contact.entity';
+
+/**
+ * Pick of the link-side mutable fields that callers may supply when
+ * attaching. Subset of \`OpportunityContact\` minus the two FK columns
+ * (those come from the method args).
+ */
+export type OpportunityContactLinkInput = Partial<
+  Pick<OpportunityContact,
+    'isPrimary' | 'startedAt' | 'endedAt' | 'sourcedFrom' | 'confidence' | 'matchedAt' | 'role'
+  >
+>;
 
 @Injectable()
 export class OpportunityContactService extends WithAnalytics(
@@ -168,7 +183,11 @@ export class OpportunityContactService extends WithAnalytics(
   @Optional() @Inject(EVENT_BUS)
   protected override eventBus: any = undefined;
 
-  constructor(protected override readonly repository: OpportunityContactRepository) {
+  constructor(
+    protected override readonly repository: OpportunityContactRepository,
+    private readonly opportunityRepo: OpportunityRepository,
+    private readonly contactRepo: ContactRepository,
+  ) {
     super(repository);
   }
 
@@ -178,8 +197,6 @@ export class OpportunityContactService extends WithAnalytics(
 
   /**
    * Fetch all junction rows for a given opportunity_id.
-   *
-   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
    */
   async findByOpportunityId(
     opportunityId: string,
@@ -190,8 +207,6 @@ export class OpportunityContactService extends WithAnalytics(
 
   /**
    * Fetch all junction rows for a given contact_id.
-   *
-   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
    */
   async findByContactId(
     contactId: string,
@@ -200,19 +215,108 @@ export class OpportunityContactService extends WithAnalytics(
     return this.repository.findByContactId(contactId, opts);
   }
 
-  // ─────────────────────────────────────────────────────────────────────────
-  // Fan-out association methods (attach/detach/list/setPrimary) are NOT
-  // emitted here. They land via junction-association-codegen
-  // (pattern-stack/dealbrain-integrations#60) once
-  // pattern-stack/codegen-patterns#358 establishes the service-method
-  // emission machinery.
-  //
-  // Until #60 lands, consumers hand-write fan-out methods in their own
-  // service files against the canonical shape documented in
-  // .ai-docs/stacks/codegen-app-patterns/specs/cgp-62.md (see
-  // architectural_notes.cross_entity_access.canonical_shape in the stack
-  // plan). The hand-written methods are the executable spec for #60.
-  // ─────────────────────────────────────────────────────────────────────────
+  // ═══════════════════════════════════════════════════════════════════════
+  // CGP-60 — canonical fan-out methods
+  // Mirrored, paginated, composed \`{ entity, link }\` shape. Always emitted
+  // on the junction service; parent-side \`attach<Right>\` / \`addTo<Left>\` /
+  // etc. inject templates delegate here. \`list\` is implemented with two
+  // single-table queries (no Drizzle \`with:\`).
+  // ═══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Create a junction row linking a opportunity and a contact.
+   * Returns the persisted row.
+   *
+   * **Idempotency:** NOT idempotent at the service layer in v1. A duplicate
+   * pair raises the DB-level composite-PK unique-constraint error from the
+   * underlying repository's \`create\`. Callers requiring idempotency should
+   * either check existence via \`findByOpportunityId\` + filter,
+   * or wrap the call in try/catch on the unique-violation error. A future
+   * leaf may add a transactional check-then-create here if a consumer
+   * surfaces the need (track as a follow-up if so).
+   */
+  async attach(
+    opportunityId: string,
+    contactId: string,
+    link?: OpportunityContactLinkInput,
+  ): Promise<OpportunityContact> {
+    return this.create({
+      opportunityId: opportunityId,
+      contactId: contactId,
+      ...(link ?? {}),
+    } as unknown as Partial<OpportunityContact>);
+  }
+
+  /**
+   * Remove the junction row linking \`opportunityId\` and
+   * \`contactId\`. No-op if no row exists.
+   */
+  async detach(
+    opportunityId: string,
+    contactId: string,
+  ): Promise<void> {
+    const links = await this.repository.findByOpportunityId(opportunityId);
+    const match = links.find(
+      (l) => (l as any).contactId === contactId,
+    );
+    if (match) {
+      await this.delete((match as any).id ?? \`\${opportunityId}:\${contactId}\`);
+    }
+  }
+
+  /**
+   * List the targets associated with one side of the junction, composed as
+   * \`{ entity, link }\`. Implementation: one repo call for the links, one
+   * \`findByIds\` call for the targets — no SQL JOIN. Cursor pagination by
+   * right-entity \`id\` (matches CGP-358 has_many shape; time-ordered cursor
+   * is deferred per spec Open Q3).
+   */
+  async listAssoc(
+    side: 'left' | 'right',
+    anchorId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<Array<{ entity: Opportunity | Contact; link: OpportunityContact }>> {
+    if (side === 'left') {
+      const links = await this.repository.findByOpportunityId(anchorId, opts);
+      const targetIds = links.map((l) => (l as any).contactId as string);
+      const targets = await this.contactRepo.findByIds(targetIds);
+      const byId = new Map(targets.map((t) => [(t as any).id, t]));
+      return links.map((link) => ({
+        entity: byId.get((link as any).contactId)! as Contact,
+        link,
+      }));
+    } else {
+      const links = await this.repository.findByContactId(anchorId, opts);
+      const targetIds = links.map((l) => (l as any).opportunityId as string);
+      const targets = await this.opportunityRepo.findByIds(targetIds);
+      const byId = new Map(targets.map((t) => [(t as any).id, t]));
+      return links.map((link) => ({
+        entity: byId.get((link as any).opportunityId)! as Opportunity,
+        link,
+      }));
+    }
+  }
+
+  /**
+   * Mark the (\`opportunityId\`, \`contactId\`) row
+   * as \`is_primary: true\`. Demoting other rows on the same side is the
+   * caller's concern in v1; future leaves may add transactional demotion.
+   */
+  async setPrimary(
+    opportunityId: string,
+    contactId: string,
+  ): Promise<void> {
+    const links = await this.repository.findByOpportunityId(opportunityId);
+    const match = links.find(
+      (l) => (l as any).contactId === contactId,
+    );
+    if (match) {
+      await this.update(
+        (match as any).id ?? \`\${opportunityId}:\${contactId}\`,
+        { isPrimary: true } as unknown as Partial<OpportunityContact>,
+      );
+    }
+  }
 
   // Inherited from BaseService:
   //   findById, findByIds, list, count, exists, create, update, delete
@@ -222,6 +326,12 @@ export class OpportunityContactService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits opportunity.service.ts (left parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
+// CGP-60 — junction service + types (forwardRef resolves circular module dep)
+import { forwardRef } from '@nestjs/common';
+import { OpportunityContactService, OpportunityContactLinkInput } from '../opportunity_contacts/opportunity_contact.service';
+import type { OpportunityContact } from '../opportunity_contacts/opportunity_contact.entity';
+import type { Contact } from '../contacts/contact.entity';
+
 import { WithAnalytics } from '@shared/base-classes/with-analytics';
 import { EVENT_BUS } from '@shared/constants/tokens';
 import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
@@ -247,6 +357,51 @@ export class OpportunityService extends WithAnalytics(
   // Lifecycle events (created/updated/deleted + per-field changes) are emitted
   // automatically by BaseService when the events subsystem is installed.
   //
+  // ═══════════════════════════════════════════════════════════════════════
+  // CGP-60 — fan-out to Contact (junction: opportunity_contact)
+  // Delegates to OpportunityContactService. Per-junction marker keeps
+  // idempotency; multiple junctions on the same parent each emit their own
+  // block. \`forwardRef\` resolves the circular module import (parent module
+  // imports junction module; junction module imports parent modules for
+  // repo DI).
+  // ═══════════════════════════════════════════════════════════════════════
+  // junction:opportunity_contact:left-fan-out
+
+  @Inject(forwardRef(() => OpportunityContactService))
+  private readonly opportunityContactService!: OpportunityContactService;
+
+  async attachContact(
+    opportunityId: string,
+    contactId: string,
+    link?: OpportunityContactLinkInput,
+  ): Promise<OpportunityContact> {
+    return this.opportunityContactService.attach(opportunityId, contactId, link);
+  }
+
+  async detachContact(
+    opportunityId: string,
+    contactId: string,
+  ): Promise<void> {
+    return this.opportunityContactService.detach(opportunityId, contactId);
+  }
+
+  async contactsList(
+    opportunityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<Array<{ entity: Contact; link: OpportunityContact }>> {
+    return this.opportunityContactService.listAssoc('left', opportunityId, opts) as Promise<
+      Array<{ entity: Contact; link: OpportunityContact }>
+    >;
+  }
+
+  async contactsSetPrimary(
+    opportunityId: string,
+    contactId: string,
+  ): Promise<void> {
+    return this.opportunityContactService.setPrimary(opportunityId, contactId);
+  }
+
+
   // Inherited from SyncedEntityService:
   //   findById, findByIds, list, count, exists, create, update, delete
   //   findByExternalId, findAllByUserId, findVisibleByUserId
@@ -259,6 +414,12 @@ export class OpportunityService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits contact.service.ts (right parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
+// CGP-60 — junction service + types (forwardRef resolves circular module dep)
+import { forwardRef } from '@nestjs/common';
+import { OpportunityContactService, OpportunityContactLinkInput } from '../opportunity_contacts/opportunity_contact.service';
+import type { OpportunityContact } from '../opportunity_contacts/opportunity_contact.entity';
+import type { Opportunity } from '../opportunities/opportunity.entity';
+
 import { WithAnalytics } from '@shared/base-classes/with-analytics';
 import { EVENT_BUS } from '@shared/constants/tokens';
 import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
@@ -287,6 +448,48 @@ export class ContactService extends WithAnalytics(
   // Lifecycle events (created/updated/deleted + per-field changes) are emitted
   // automatically by BaseService when the events subsystem is installed.
   //
+  // ═══════════════════════════════════════════════════════════════════════
+  // CGP-60 — fan-out to Opportunity (junction: opportunity_contact)
+  // Delegates to OpportunityContactService. See left-side block for the
+  // forwardRef + per-junction marker rationale.
+  // ═══════════════════════════════════════════════════════════════════════
+  // junction:opportunity_contact:right-fan-out
+
+  @Inject(forwardRef(() => OpportunityContactService))
+  private readonly opportunityContactService!: OpportunityContactService;
+
+  async addToOpportunity(
+    contactId: string,
+    opportunityId: string,
+    link?: OpportunityContactLinkInput,
+  ): Promise<OpportunityContact> {
+    return this.opportunityContactService.attach(opportunityId, contactId, link);
+  }
+
+  async removeFromOpportunity(
+    contactId: string,
+    opportunityId: string,
+  ): Promise<void> {
+    return this.opportunityContactService.detach(opportunityId, contactId);
+  }
+
+  async opportunitiesList(
+    contactId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<Array<{ entity: Opportunity; link: OpportunityContact }>> {
+    return this.opportunityContactService.listAssoc('right', contactId, opts) as Promise<
+      Array<{ entity: Opportunity; link: OpportunityContact }>
+    >;
+  }
+
+  async opportunitiesSetPrimary(
+    contactId: string,
+    opportunityId: string,
+  ): Promise<void> {
+    return this.opportunityContactService.setPrimary(opportunityId, contactId);
+  }
+
+
   // Inherited from SyncedEntityService:
   //   findById, findByIds, list, count, exists, create, update, delete
   //   findByExternalId, findAllByUserId, findVisibleByUserId

--- a/test/junction/__snapshots__/opportunity-contact.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-contact.test.ts.snap
@@ -1,0 +1,295 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits opportunity_contact.entity.ts 1`] = `
+"import {
+  boolean,
+  numeric,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { relations, type InferSelectModel } from 'drizzle-orm';
+import { opportunities } from '../opportunities/opportunity.entity';
+import { contacts } from '../contacts/contact.entity';
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+export const opportunityContactRoleEnum = pgEnum('opportunity_contact_role', [
+  'champion',
+  'decision_maker',
+  'influencer',
+]);
+
+// ============================================================================
+// Table
+// ============================================================================
+
+export const opportunityContacts = pgTable(
+  'opportunity_contacts',
+  {
+    // FK columns — composite primary key (no surrogate id: Q4 resolution)
+    opportunityId: uuid('opportunity_id').notNull().references(() => opportunities.id, { onDelete: 'restrict' }),
+    contactId: uuid('contact_id').notNull().references(() => contacts.id, { onDelete: 'restrict' }),
+
+    // Role enum (per-pairing; declared in junction YAML's fields.role.choices)
+    role: opportunityContactRoleEnum('role'),
+
+    // BaseJunctionFields — is_primary is always emitted
+    isPrimary: boolean('is_primary').notNull().default(false),
+
+    // Temporal window (temporal: true, default)
+    startedAt: timestamp('started_at'),
+    endedAt: timestamp('ended_at'),
+
+    // Provenance (sourced: true, default)
+    sourcedFrom: text('sourced_from'),
+    confidence: numeric('confidence', { precision: 5, scale: 4 }),
+    matchedAt: timestamp('matched_at'),
+
+    // Timestamps
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => [
+    // Composite primary key on the two FK columns (Q4 resolution: no surrogate id)
+    primaryKey({ columns: [table.opportunityId, table.contactId] }),
+  ],
+);
+
+export type OpportunityContact = InferSelectModel<typeof opportunityContacts>;
+export type OpportunityContactInsert = typeof opportunityContacts.$inferInsert;
+
+// ============================================================================
+// Relations — extension-path metadata for db.query.X.findMany({ with: ... })
+// Generated code does NOT consume these; they exist for hand-written admin
+// queries and for #60's fan-out methods once they land.
+// ============================================================================
+
+export const opportunityContactsRelations = relations(opportunityContacts, ({ one }) => ({
+  opportunity: one(opportunities, {
+    fields: [opportunityContacts.opportunityId],
+    references: [opportunities.id],
+  }),
+  contact: one(contacts, {
+    fields: [opportunityContacts.contactId],
+    references: [contacts.id],
+  }),
+}));
+"
+`;
+
+exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits opportunity_contact.repository.ts 1`] = `
+"import { Injectable, Inject } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { DRIZZLE } from '@shared/constants/tokens';
+import type { DrizzleClient } from '@shared/types/drizzle';
+import { BaseRepository } from '@shared/base-classes/base-repository';
+import { opportunityContacts, type OpportunityContact } from './opportunity_contact.entity';
+
+@Injectable()
+export class OpportunityContactRepository extends BaseRepository<OpportunityContact> {
+  readonly table = opportunityContacts;
+
+  // Junctions track temporal validity via started_at / ended_at, NOT via
+  // deleted_at. is_primary flips replace soft-delete semantics (Q5 resolution).
+  protected override readonly behaviors = {
+    timestamps: true,
+    softDelete: false,
+    userTracking: false,
+  };
+
+  constructor(@Inject(DRIZZLE) db: DrizzleClient) {
+    super(db);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Pairing-aware finders — hardcoded in v1 (Q2 resolution: no declarative
+  // queries block on junctions; every junction needs exactly these two methods).
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch all junction rows where opportunity_id matches.
+   *
+   * Pagination shape: { cursor?, limit? } — canonical per cgp-62 r4.
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByOpportunityId(
+    opportunityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityContact[]> {
+    const rows = await this.baseQuery()
+      .where(eq(this.table.opportunityId, opportunityId))
+      .limit(opts?.limit ?? 100);
+    return rows as OpportunityContact[];
+  }
+
+  /**
+   * Fetch all junction rows where contact_id matches.
+   *
+   * Pagination shape: { cursor?, limit? } — canonical per cgp-62 r4.
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByContactId(
+    contactId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityContact[]> {
+    const rows = await this.baseQuery()
+      .where(eq(this.table.contactId, contactId))
+      .limit(opts?.limit ?? 100);
+    return rows as OpportunityContact[];
+  }
+
+  // Inherited from BaseRepository:
+  //   findById, findByIds, list, count, exists, create, update, delete, upsertMany
+}
+"
+`;
+
+exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits opportunity_contact.service.ts 1`] = `
+"import { Injectable, Inject, Optional } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
+import { EVENT_BUS } from '@shared/constants/tokens';
+import { BaseService } from '@shared/base-classes/base-service';
+import { OpportunityContactRepository } from './opportunity_contact.repository';
+import type { OpportunityContact } from './opportunity_contact.entity';
+
+@Injectable()
+export class OpportunityContactService extends WithAnalytics(
+  BaseService<OpportunityContactRepository, OpportunityContact>,
+) {
+  protected override readonly entityName = 'opportunity_contact';
+
+  /** Injected by NestJS when EventsModule is registered. */
+  @Optional() @Inject(EVENT_BUS)
+  protected override eventBus: any = undefined;
+
+  constructor(protected override readonly repository: OpportunityContactRepository) {
+    super(repository);
+  }
+
+  // Pairing-aware pass-throughs — mirror the repo's two finders so use-cases
+  // and #60's fan-out methods both delegate through the service layer, keeping
+  // analytics/events instrumentation uniform (per relationship's service.ejs.t).
+
+  /**
+   * Fetch all junction rows for a given opportunity_id.
+   *
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByOpportunityId(
+    opportunityId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityContact[]> {
+    return this.repository.findByOpportunityId(opportunityId, opts);
+  }
+
+  /**
+   * Fetch all junction rows for a given contact_id.
+   *
+   * FIXME: align with codegen-patterns#358 pagination shape if it diverges.
+   */
+  async findByContactId(
+    contactId: string,
+    opts?: { cursor?: string; limit?: number },
+  ): Promise<OpportunityContact[]> {
+    return this.repository.findByContactId(contactId, opts);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Fan-out association methods (attach/detach/list/setPrimary) are NOT
+  // emitted here. They land via junction-association-codegen
+  // (pattern-stack/dealbrain-integrations#60) once
+  // pattern-stack/codegen-patterns#358 establishes the service-method
+  // emission machinery.
+  //
+  // Until #60 lands, consumers hand-write fan-out methods in their own
+  // service files against the canonical shape documented in
+  // .ai-docs/stacks/codegen-app-patterns/specs/cgp-62.md (see
+  // architectural_notes.cross_entity_access.canonical_shape in the stack
+  // plan). The hand-written methods are the executable spec for #60.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  // Inherited from BaseService:
+  //   findById, findByIds, list, count, exists, create, update, delete
+}
+"
+`;
+
+exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits opportunity.service.ts (left parent — junction accessor) 1`] = `
+"import { Injectable, Inject, Optional } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
+import { EVENT_BUS } from '@shared/constants/tokens';
+import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
+import { OpportunityRepository } from './opportunity.repository';
+import type { Opportunity } from './opportunity.entity';
+
+@Injectable()
+export class OpportunityService extends WithAnalytics(
+  SyncedEntityService<OpportunityRepository, Opportunity>,
+) {
+  protected override readonly entityName = 'opportunity';
+
+  /** Injected by NestJS when EventsModule is registered. */
+  @Optional() @Inject(EVENT_BUS)
+  protected override eventBus: any = undefined;
+
+  constructor(
+    protected override readonly repository: OpportunityRepository,
+  ) {
+    super(repository);
+  }
+
+  // Lifecycle events (created/updated/deleted + per-field changes) are emitted
+  // automatically by BaseService when the events subsystem is installed.
+  //
+  // Inherited from SyncedEntityService:
+  //   findById, findByIds, list, count, exists, create, update, delete
+  //   findByExternalId, findAllByUserId, findVisibleByUserId
+
+
+
+}
+"
+`;
+
+exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits contact.service.ts (right parent — junction accessor) 1`] = `
+"import { Injectable, Inject, Optional } from '@nestjs/common';
+import { WithAnalytics } from '@shared/base-classes/with-analytics';
+import { EVENT_BUS } from '@shared/constants/tokens';
+import { SyncedEntityService } from '@shared/base-classes/synced-entity-service';
+import { ContactRepository } from './contact.repository';
+import type { Contact } from './contact.entity';
+
+@Injectable()
+export class ContactService extends WithAnalytics(
+  SyncedEntityService<ContactRepository, Contact>,
+) {
+  protected override readonly entityName = 'contact';
+
+  /** Injected by NestJS when EventsModule is registered. */
+  @Optional() @Inject(EVENT_BUS)
+  protected override eventBus: any = undefined;
+
+  constructor(
+    protected override readonly repository: ContactRepository,
+  ) {
+    super(repository);
+  }
+
+  // Lifecycle events (created/updated/deleted + per-field changes) are emitted
+  // automatically by BaseService when the events subsystem is installed.
+  //
+  // Inherited from SyncedEntityService:
+  //   findById, findByIds, list, count, exists, create, update, delete
+  //   findByExternalId, findAllByUserId, findVisibleByUserId
+
+
+
+}
+"
+`;

--- a/test/junction/_helpers.ts
+++ b/test/junction/_helpers.ts
@@ -1,0 +1,174 @@
+/**
+ * Junction test bootstrap helper.
+ *
+ * Spins up a fresh tmp project, installs pinned peer deps, runs
+ * `codegen project init`, copies fixture entities + junctions, and runs
+ * `codegen entity new --all --force` followed by `codegen junction new --all --force`.
+ *
+ * Used by:
+ *   - test/junction/*.test.ts        (snapshot tests — read emitted files)
+ *   - test/smoke/run-smoke-junction.ts (compile + grep gate)
+ *
+ * Set KEEP_SMOKE_DIR=1 to preserve the tmp dir after cleanup() is called.
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
+const CLI_PATH = path.join(REPO_ROOT, 'src', 'cli', 'index.ts');
+
+export const VALID_SCENARIOS = ['junction', 'junction-cross-domain'] as const;
+export type Scenario = (typeof VALID_SCENARIOS)[number];
+
+export const VALID_ARCHITECTURES = ['clean-lite-ps', 'clean'] as const;
+export type Architecture = (typeof VALID_ARCHITECTURES)[number];
+
+export interface ScenarioMeta {
+  junctionName: string;
+  leftEnt: string;
+  rightEnt: string;
+  hasRole: boolean;
+}
+
+export const SCENARIO_META: Record<Scenario, ScenarioMeta> = {
+  'junction':              { junctionName: 'opportunity_contact',  leftEnt: 'opportunity', rightEnt: 'contact',  hasRole: true  },
+  'junction-cross-domain': { junctionName: 'opportunity_activity', leftEnt: 'opportunity', rightEnt: 'activity', hasRole: false },
+};
+
+export const FIXTURES_DIR_MAP: Record<Scenario, string> = {
+  'junction':              path.join(REPO_ROOT, 'test', 'smoke', 'fixtures-junction'),
+  'junction-cross-domain': path.join(REPO_ROOT, 'test', 'smoke', 'fixtures-junction-cross-domain'),
+};
+
+const RUNTIME_DEPS = [
+  '@nestjs/common@10',
+  '@nestjs/core@10',
+  '@nestjs/platform-express@10',
+  '@nestjs/swagger@7',
+  '@anatine/zod-openapi@2',
+  'drizzle-orm@0.45',
+  'reflect-metadata@0.2',
+  'pg@8',
+  'zod@3',
+  'yaml@2',
+];
+const DEV_DEPS = ['typescript@5', '@types/bun', '@types/pg@8'];
+
+export interface BootstrapOptions {
+  scenario: Scenario;
+  architecture: Architecture;
+  log?: (msg: string) => void;
+}
+
+export interface BootstrapResult {
+  projectDir: string;
+  scenario: Scenario;
+  architecture: Architecture;
+  /** Reads the contents of a file emitted into the tmp project (relative to projectDir). */
+  emittedFile(relPath: string): string;
+  /** Removes the tmp dir unless KEEP_SMOKE_DIR=1 is set. */
+  cleanup(): void;
+}
+
+function writeCodegenConfig(tmpDir: string, architecture: Architecture): void {
+  const configPath = path.join(tmpDir, 'codegen.config.yaml');
+  const content = [
+    'generate:',
+    `  architecture: ${architecture}`,
+    'paths:',
+    '  backend_src: src',
+    '  entities: entities',
+    '  generated: src/generated',
+  ].join('\n') + '\n';
+  fs.writeFileSync(configPath, content);
+}
+
+export async function bootstrapJunctionProject(opts: BootstrapOptions): Promise<BootstrapResult> {
+  const { scenario, architecture } = opts;
+  const log = opts.log ?? (() => {});
+
+  const fixturesDir = FIXTURES_DIR_MAP[scenario];
+  if (!fs.existsSync(fixturesDir)) {
+    throw new Error(`Fixtures directory not found: ${fixturesDir}`);
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegen-smoke-junction-'));
+  log(`tmp dir: ${tmpDir}`);
+
+  const run = (cmd: string): void => {
+    log(`$ ${cmd}`);
+    execSync(cmd, { cwd: tmpDir, stdio: 'inherit', env: { ...process.env } });
+  };
+
+  // 1. bun init
+  run('bun init -y');
+
+  // 2. install pinned deps
+  run(`bun add ${RUNTIME_DEPS.join(' ')}`);
+  run(`bun add -D ${DEV_DEPS.join(' ')}`);
+
+  // 3. codegen project init
+  run(`bun ${CLI_PATH} project init --yes --with-tsconfig`);
+
+  // override architecture
+  writeCodegenConfig(tmpDir, architecture);
+  log(`wrote codegen.config.yaml (architecture: ${architecture})`);
+
+  // 4. copy entity fixtures
+  const entityFixturesDir = path.join(fixturesDir, 'entities');
+  const entitiesDir = path.join(tmpDir, 'entities');
+  fs.mkdirSync(entitiesDir, { recursive: true });
+  const examplePath = path.join(entitiesDir, 'example.yaml');
+  if (fs.existsSync(examplePath)) fs.rmSync(examplePath);
+  for (const f of fs.readdirSync(entityFixturesDir)) {
+    if (!f.endsWith('.yaml') && !f.endsWith('.yml')) continue;
+    fs.copyFileSync(path.join(entityFixturesDir, f), path.join(entitiesDir, f));
+    log(`copied entity fixture: ${f}`);
+  }
+
+  // 5. codegen entity new --all
+  run(`bun ${CLI_PATH} entity new --all --force`);
+
+  // 6. copy junction fixtures
+  const junctionFixturesDir = path.join(fixturesDir, 'junctions');
+  const junctionsDir = path.join(tmpDir, 'junctions');
+  fs.mkdirSync(junctionsDir, { recursive: true });
+  for (const f of fs.readdirSync(junctionFixturesDir)) {
+    if (!f.endsWith('.yaml') && !f.endsWith('.yml')) continue;
+    fs.copyFileSync(path.join(junctionFixturesDir, f), path.join(junctionsDir, f));
+    log(`copied junction fixture: ${f}`);
+  }
+
+  // 7. codegen junction new --all
+  run(`bun ${CLI_PATH} junction new --all --force`);
+
+  const keep = process.env.KEEP_SMOKE_DIR === '1';
+
+  return {
+    projectDir: tmpDir,
+    scenario,
+    architecture,
+    emittedFile(relPath: string): string {
+      const fullPath = path.join(tmpDir, relPath);
+      if (!fs.existsSync(fullPath)) {
+        throw new Error(`Expected emitted file not found: ${fullPath}`);
+      }
+      return fs.readFileSync(fullPath, 'utf8');
+    },
+    cleanup(): void {
+      if (keep) {
+        log(`keeping tmp dir (KEEP_SMOKE_DIR=1): ${tmpDir}`);
+        return;
+      }
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        log(`cleaned up ${tmpDir}`);
+      } catch (err: unknown) {
+        log(`cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    },
+  };
+}

--- a/test/junction/opportunity-activity.test.ts
+++ b/test/junction/opportunity-activity.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Snapshot test: cross-domain junction (opportunity × activity, clean-lite-ps).
+ *
+ * Locks the emitted output of the junction codegen pipeline against drift.
+ * The smoke harness covers compile + grep; this covers full-file shape.
+ *
+ * Regen flow when emission intentionally changes:
+ *   bun test --update-snapshots test/junction/opportunity-activity.test.ts
+ *
+ * Then review the snapshot diff carefully — every line is load-bearing.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+import { bootstrapJunctionProject, type BootstrapResult } from './_helpers';
+
+describe('junction emission snapshot — opportunity_activity (clean-lite-ps)', () => {
+  let project: BootstrapResult;
+
+  beforeAll(async () => {
+    project = await bootstrapJunctionProject({
+      scenario: 'junction-cross-domain',
+      architecture: 'clean-lite-ps',
+    });
+  }, 120_000);
+
+  afterAll(() => {
+    project?.cleanup();
+  });
+
+  test('emits opportunity_activity.entity.ts', () => {
+    expect(project.emittedFile('src/modules/opportunity_activities/opportunity_activity.entity.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits opportunity_activity.repository.ts', () => {
+    expect(project.emittedFile('src/modules/opportunity_activities/opportunity_activity.repository.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits opportunity_activity.service.ts', () => {
+    expect(project.emittedFile('src/modules/opportunity_activities/opportunity_activity.service.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits opportunity.service.ts (left parent — junction accessor)', () => {
+    expect(project.emittedFile('src/modules/opportunities/opportunity.service.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits activity.service.ts (right parent — junction accessor)', () => {
+    expect(project.emittedFile('src/modules/activities/activity.service.ts'))
+      .toMatchSnapshot();
+  });
+});

--- a/test/junction/opportunity-contact.test.ts
+++ b/test/junction/opportunity-contact.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Snapshot test: intra-domain junction (opportunity × contact, clean-lite-ps).
+ *
+ * Locks the emitted output of the junction codegen pipeline against drift.
+ * The smoke harness covers compile + grep; this covers full-file shape.
+ *
+ * Regen flow when emission intentionally changes:
+ *   bun test --update-snapshots test/junction/opportunity-contact.test.ts
+ *
+ * Then review the snapshot diff carefully — every line is load-bearing.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+
+import { bootstrapJunctionProject, type BootstrapResult } from './_helpers';
+
+describe('junction emission snapshot — opportunity_contact (clean-lite-ps)', () => {
+  let project: BootstrapResult;
+
+  beforeAll(async () => {
+    project = await bootstrapJunctionProject({
+      scenario: 'junction',
+      architecture: 'clean-lite-ps',
+    });
+  }, 120_000);
+
+  afterAll(() => {
+    project?.cleanup();
+  });
+
+  test('emits opportunity_contact.entity.ts', () => {
+    expect(project.emittedFile('src/modules/opportunity_contacts/opportunity_contact.entity.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits opportunity_contact.repository.ts', () => {
+    expect(project.emittedFile('src/modules/opportunity_contacts/opportunity_contact.repository.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits opportunity_contact.service.ts', () => {
+    expect(project.emittedFile('src/modules/opportunity_contacts/opportunity_contact.service.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits opportunity.service.ts (left parent — junction accessor)', () => {
+    expect(project.emittedFile('src/modules/opportunities/opportunity.service.ts'))
+      .toMatchSnapshot();
+  });
+
+  test('emits contact.service.ts (right parent — junction accessor)', () => {
+    expect(project.emittedFile('src/modules/contacts/contact.service.ts'))
+      .toMatchSnapshot();
+  });
+});

--- a/test/smoke/run-smoke-junction.ts
+++ b/test/smoke/run-smoke-junction.ts
@@ -10,31 +10,23 @@
  * Each scenario × both architectures (clean-lite-ps by default; pass
  * --architecture clean for the second pass) = four total code paths.
  *
- * Flow per scenario + architecture:
- *   1. Create a fresh tmp project.
- *   2. bun init + install pinned peer deps.
- *   3. codegen project init --yes --with-tsconfig
- *   4. Copy scenario entities into entities/.
- *   5. codegen entity new --all --force (generates parent entity files).
- *   6. Copy scenario junctions into junctions/.
- *   7. codegen junction new --all --force (generates junction files).
- *   8. bunx tsc --noEmit --skipLibCheck.
- *   9. Grep assertions on generated output.
+ * Bootstrap (tmp project, deps, codegen run) is delegated to
+ * `test/junction/_helpers.ts` so snapshot tests can share the same path.
+ * This file owns the compile + grep gate.
  */
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
-const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
-const CLI_PATH = path.join(REPO_ROOT, 'src', 'cli', 'index.ts');
-
-const VALID_SCENARIOS = ['junction', 'junction-cross-domain'] as const;
-type Scenario = (typeof VALID_SCENARIOS)[number];
-
-const VALID_ARCHITECTURES = ['clean-lite-ps', 'clean'] as const;
-type Architecture = (typeof VALID_ARCHITECTURES)[number];
+import {
+  bootstrapJunctionProject,
+  SCENARIO_META,
+  VALID_ARCHITECTURES,
+  VALID_SCENARIOS,
+  type Architecture,
+  type Scenario,
+} from '../junction/_helpers';
 
 // ---------------------------------------------------------------------------
 // Arg parsing
@@ -83,35 +75,6 @@ if (!VALID_ARCHITECTURES.includes(architectureArg)) {
   process.exit(2);
 }
 
-const KEEP = process.env.KEEP_SMOKE_DIR === '1';
-
-// Fixture directories per scenario
-const FIXTURES_DIR_MAP: Record<Scenario, string> = {
-  'junction':              path.join(REPO_ROOT, 'test', 'smoke', 'fixtures-junction'),
-  'junction-cross-domain': path.join(REPO_ROOT, 'test', 'smoke', 'fixtures-junction-cross-domain'),
-};
-
-// Expected junction + left/right entity names per scenario
-const SCENARIO_META: Record<Scenario, { junctionName: string; leftEnt: string; rightEnt: string; hasRole: boolean }> = {
-  'junction':              { junctionName: 'opportunity_contact', leftEnt: 'opportunity', rightEnt: 'contact', hasRole: true },
-  'junction-cross-domain': { junctionName: 'opportunity_activity', leftEnt: 'opportunity', rightEnt: 'activity', hasRole: false },
-};
-
-// Pinned deps (same as run-smoke.ts)
-const RUNTIME_DEPS = [
-  '@nestjs/common@10',
-  '@nestjs/core@10',
-  '@nestjs/platform-express@10',
-  '@nestjs/swagger@7',
-  '@anatine/zod-openapi@2',
-  'drizzle-orm@0.45',
-  'reflect-metadata@0.2',
-  'pg@8',
-  'zod@3',
-  'yaml@2',
-];
-const DEV_DEPS = ['typescript@5', '@types/bun', '@types/pg@8'];
-
 // ---------------------------------------------------------------------------
 // Logging
 // ---------------------------------------------------------------------------
@@ -127,15 +90,6 @@ function logError(msg: string): void { console.error(`${elapsed()} [FAIL] ${msg}
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function run(cmd: string, cwd: string, env: NodeJS.ProcessEnv = {}): void {
-  log(`$ ${cmd}`);
-  execSync(cmd, {
-    cwd,
-    stdio: 'inherit',
-    env: { ...process.env, ...env },
-  });
-}
 
 function runSilent(cmd: string, cwd: string): { code: number; out: string; err: string } {
   const parts = cmd.split(' ');
@@ -164,19 +118,6 @@ function filterConsumerErrors(output: string): string[] {
     errors.push(line);
   }
   return errors;
-}
-
-function cleanup(dir: string): void {
-  if (KEEP) {
-    log(`keeping tmp dir (KEEP_SMOKE_DIR=1): ${dir}`);
-    return;
-  }
-  try {
-    fs.rmSync(dir, { recursive: true, force: true });
-    log(`cleaned up ${dir}`);
-  } catch (err: unknown) {
-    logError(`cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
 }
 
 function pascalCase(s: string): string {
@@ -233,8 +174,6 @@ function assertJunctionEmission(
     ? `src/modules/${pluralName}`
     : `app/backend/src/domain/${pluralName}`;
 
-  const leftCamel = camelCase(`${leftEnt}_id`);
-  const rightCamel = camelCase(`${rightEnt}_id`);
   const leftPascal = pascalCase(leftEnt);
   const rightPascal = pascalCase(rightEnt);
 
@@ -273,9 +212,6 @@ function assertJunctionEmission(
   }
 
   // ── Repository file ──────────────────────────────────────────────────────
-  const repoDir = architecture === 'clean-lite-ps'
-    ? junctionDir
-    : `app/backend/src/infrastructure/persistence/drizzle`;
   const repoFile = reads(
     architecture === 'clean-lite-ps'
       ? `${junctionDir}/${junctionName}.repository.ts`
@@ -298,9 +234,6 @@ function assertJunctionEmission(
   assertContains(repoFile, /limit\?:\s*number/, 'repo: limit pagination param');
 
   // ── Service file ─────────────────────────────────────────────────────────
-  const svcDir = architecture === 'clean-lite-ps'
-    ? junctionDir
-    : `app/backend/src/application/${pluralName}`;
   const svcFile = reads(
     architecture === 'clean-lite-ps'
       ? `${junctionDir}/${junctionName}.service.ts`
@@ -380,7 +313,7 @@ function pluralize(s: string): string {
   return s + 's';
 }
 
-function assertBarrelIncludes(generatedSrc: string, pluralName: string, architecture: Architecture): void {
+function assertBarrelIncludes(generatedSrc: string, pluralName: string, _architecture: Architecture): void {
   const modulesBarrel = path.join(generatedSrc, 'src/generated/modules.ts');
   const schemaBarrel = path.join(generatedSrc, 'src/generated/schema.ts');
 
@@ -402,91 +335,25 @@ function assertBarrelIncludes(generatedSrc: string, pluralName: string, architec
 }
 
 // ---------------------------------------------------------------------------
-// codegen.config.yaml injection for architecture override
-// ---------------------------------------------------------------------------
-
-function writeCodegenConfig(tmpDir: string, architecture: Architecture): void {
-  const configPath = path.join(tmpDir, 'codegen.config.yaml');
-  // Minimal config that sets the architecture and leaves other settings to
-  // defaults. project init creates this file; we overwrite the generate block.
-  const content = [
-    'generate:',
-    `  architecture: ${architecture}`,
-    'paths:',
-    '  backend_src: src',
-    '  entities: entities',
-    '  generated: src/generated',
-  ].join('\n') + '\n';
-
-  fs.writeFileSync(configPath, content);
-  log(`wrote codegen.config.yaml (architecture: ${architecture})`);
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<number> {
   log(`smoke-junction scenario=${scenarioArg} architecture=${architectureArg}`);
 
-  const fixturesDir = FIXTURES_DIR_MAP[scenarioArg];
-  if (!fs.existsSync(fixturesDir)) {
-    logError(`Fixtures directory not found: ${fixturesDir}`);
-    return 1;
-  }
-
-  const tmpBase = os.tmpdir();
-  const tmpDir = fs.mkdtempSync(path.join(tmpBase, `codegen-smoke-junction-`));
-  log(`tmp dir: ${tmpDir}`);
-
   let exitCode = 0;
+  let result: Awaited<ReturnType<typeof bootstrapJunctionProject>> | null = null;
 
   try {
-    // 1. bun init -y
-    run('bun init -y', tmpDir);
-
-    // 2. Install runtime deps
-    run(`bun add ${RUNTIME_DEPS.join(' ')}`, tmpDir);
-    run(`bun add -D ${DEV_DEPS.join(' ')}`, tmpDir);
-
-    // 3. codegen project init
-    run(`bun ${CLI_PATH} project init --yes --with-tsconfig`, tmpDir);
-
-    // Overwrite codegen.config.yaml to set the target architecture.
-    writeCodegenConfig(tmpDir, architectureArg);
-
-    // 4. Copy entity fixtures into entities/
-    const entityFixturesDir = path.join(fixturesDir, 'entities');
-    const entitiesDir = path.join(tmpDir, 'entities');
-    fs.mkdirSync(entitiesDir, { recursive: true });
-    // Remove example.yaml that init dropped
-    const examplePath = path.join(entitiesDir, 'example.yaml');
-    if (fs.existsSync(examplePath)) fs.rmSync(examplePath);
-    for (const f of fs.readdirSync(entityFixturesDir)) {
-      if (!f.endsWith('.yaml') && !f.endsWith('.yml')) continue;
-      fs.copyFileSync(path.join(entityFixturesDir, f), path.join(entitiesDir, f));
-      log(`copied entity fixture: ${f}`);
-    }
-
-    // 5. codegen entity new --all
-    run(`bun ${CLI_PATH} entity new --all --force`, tmpDir);
-
-    // 6. Copy junction fixtures into junctions/
-    const junctionFixturesDir = path.join(fixturesDir, 'junctions');
-    const junctionsDir = path.join(tmpDir, 'junctions');
-    fs.mkdirSync(junctionsDir, { recursive: true });
-    for (const f of fs.readdirSync(junctionFixturesDir)) {
-      if (!f.endsWith('.yaml') && !f.endsWith('.yml')) continue;
-      fs.copyFileSync(path.join(junctionFixturesDir, f), path.join(junctionsDir, f));
-      log(`copied junction fixture: ${f}`);
-    }
-
-    // 7. codegen junction new --all
-    run(`bun ${CLI_PATH} junction new --all --force`, tmpDir);
+    result = await bootstrapJunctionProject({
+      scenario: scenarioArg,
+      architecture: architectureArg,
+      log,
+    });
 
     // 8. bunx tsc --noEmit --skipLibCheck
     log('running bunx tsc --noEmit --skipLibCheck');
-    const tsc = runSilent('bunx tsc --noEmit --skipLibCheck', tmpDir);
+    const tsc = runSilent('bunx tsc --noEmit --skipLibCheck', result.projectDir);
     const consumerErrors = filterConsumerErrors(tsc.out + tsc.err);
     if (consumerErrors.length > 0) {
       for (const line of consumerErrors) console.error(line);
@@ -503,8 +370,8 @@ async function main(): Promise<number> {
         ? junctionName.slice(0, -1) + 'ies'
         : junctionName + 's';
 
-      assertJunctionEmission(tmpDir, scenarioArg, architectureArg);
-      assertBarrelIncludes(tmpDir, pluralName, architectureArg);
+      assertJunctionEmission(result.projectDir, scenarioArg, architectureArg);
+      assertBarrelIncludes(result.projectDir, pluralName, architectureArg);
     }
 
   } catch (err: unknown) {
@@ -514,7 +381,7 @@ async function main(): Promise<number> {
     }
     exitCode = 1;
   } finally {
-    cleanup(tmpDir);
+    if (result) result.cleanup();
   }
 
   if (exitCode === 0) {


### PR DESCRIPTION
## Summary

- Adds bun:test snapshot coverage for the junction codegen pipeline (2 scenarios × 5 artifacts = 10 snapshots), locking emitted output against drift.
- Extracts the tmp-project bootstrap from `test/smoke/run-smoke-junction.ts` into `test/junction/_helpers.ts` so the smoke harness and snapshot tests share one path.
- Wires `just test-junction` into `just test-all`.

Closes PR A of pattern-stack/dealbrain-integrations#61. PR B (coexistence fixture) stacks on codegen-patterns#358 and is not included here.

## Scope: clean-lite-ps only

Per user direction (see `.ai-docs/stacks/codegen-app-patterns/specs/61.md` §Discoveries), both PR A and PR B of CGP-61 are scoped to the `clean-lite-ps` architecture. Snapshots and the smoke gate cover the two clean-lite-ps variants (`test-smoke-junction`, `test-smoke-junction-cross-domain`).

## Snapshots

For each of `opportunity_contact` (intra-domain) and `opportunity_activity` (cross-domain):

- `<junction>.entity.ts` — composite PK, BaseJunctionFields (is_primary, started_at, ended_at, sourced_from, confidence, matched_at), `relations()` extension const
- `<junction>.repository.ts` — `findBy{Left,Right}Id` pairing-aware finders, `{ cursor?, limit? }` pagination
- `<junction>.service.ts` — `WithAnalytics(BaseService<...>)`, `@Optional() @Inject(EVENT_BUS)`, fan-out comment block, no `attach` / `detach` / `setPrimary`
- left parent service (e.g. `opportunity.service.ts`) — junction accessor from #60
- right parent service (e.g. `contact.service.ts` / `activity.service.ts`) — junction accessor from #60

Regen flow after intentional template changes: `bun test --update-snapshots test/junction/`.

## Known gap (not filed)

`just test-all` does not gate the `-clean` smoke variants, and they fail on `main` with 17 typecheck errors against the clean-arch emission path. Three root causes:

1. `@mguay/nestjs-trpc` is not in the smoke harness `RUNTIME_DEPS`
2. `@repo/db/server/schema` (monorepo alias) is unreachable in the smoke tmp project
3. The junction repo template's relative import (`./opportunity_contact.entity`) is wrong for the clean-arch directory layout

Documented in `.ai-docs/stacks/codegen-app-patterns/specs/61.md` §Discoveries. Per user direction, **not tracked separately** — the clean architecture may be rebuilt from clean-lite-ps, at which point this resolves. The three root causes stay documented in the spec as a record for anyone who later chooses to fix clean-arch in place.

## Test plan

- [x] `just test-smoke-junction` (clean-lite-ps intra-domain) — green
- [x] `just test-smoke-junction-cross-domain` (clean-lite-ps cross-domain) — green
- [x] `just test-junction` — 10 snapshots pass, deterministic across two runs
- [x] `just test-all` — green end-to-end (1747 unit + all smokes + 10 snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Closes pattern-stack/dealbrain-integrations#61
