### PR TITLE
docs(junction): make attach() non-idempotency explicit (CGP-60 post-merge)

### DIFF
--- a/templates/junction/new/service.ejs.t
+++ b/templates/junction/new/service.ejs.t
@@ -75,8 +75,16 @@ export class <%= classNames.service %> extends WithAnalytics(
   // ═══════════════════════════════════════════════════════════════════════
 
   /**
-   * Create (or upsert via the repo's create method) a junction row linking
-   * a <%= leftEntity %> and a <%= rightEntity %>. Returns the persisted row.
+   * Create a junction row linking a <%= leftEntity %> and a <%= rightEntity %>.
+   * Returns the persisted row.
+   *
+   * **Idempotency:** NOT idempotent at the service layer in v1. A duplicate
+   * pair raises the DB-level composite-PK unique-constraint error from the
+   * underlying repository's `create`. Callers requiring idempotency should
+   * either check existence via `findBy<%= leftEntityPascal %>Id` + filter,
+   * or wrap the call in try/catch on the unique-violation error. A future
+   * leaf may add a transactional check-then-create here if a consumer
+   * surfaces the need (track as a follow-up if so).
    */
   async attach(
     <%= leftEntityCamel %>Id: string,


### PR DESCRIPTION
## Summary

Post-merge follow-up to #364 (CGP-60 junction fan-out). Single-file docstring fix.

The generated junction service's `attach()` method had a misleading docstring (`"Create (or upsert via the repo's create method)"`) — the implementation is not actually idempotent; a duplicate `(<L>Id, <R>Id)` pair raises the composite-PK unique-constraint error from the repo's `create`. The new docstring names this behavior explicitly and points callers at the workarounds.

## What changed

\`templates/junction/new/service.ejs.t\` — docstring on the emitted \`attach()\` method only. No behavior change.

## What did not change

The forwardRef justification comment in `module.ejs.t` (review ask #1 from the #364 implementation review) was already present in the merged template at lines 21-24. My pre-merge review flagged it as missing — that was a false positive. No action needed there.

## Why not bundled into #364

#364 was already merged when the review identified this. Cutting a clean follow-up rather than a force-push to the merged branch.

## Test plan

- [x] `just test-smoke-junction` (clean-lite-ps intra-domain) green
- [x] No code path changes — docstring only

## Refs

- Implementation review: posted in this session as the BE-38-75-style 8-section review of #364
- Original issue: pattern-stack/dealbrain-integrations#60 (closed by #364)

🤖 Generated with [Claude Code](https://claude.com/claude-code)