### PR TITLE
fix(junction): dedupe shared imports across multi-junction parents (0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-05-23
+
+Hotfix for the junction emit pipeline (CGP-60, shipped in 0.7.0). When a parent entity participated in **multiple junctions** (e.g. `contact` appearing as the right side of both `account_contact` and `opportunity_contact`), each junction's `_inject-parent-{service,module}-import-clp-{left,right}.ejs.t` template emitted the same shared `import { forwardRef } from '@nestjs/common';` line independently — producing duplicate-import TS errors (TS2300 `Duplicate identifier 'forwardRef'`). The same loop also re-emitted the counterparty entity type import (`import type { Account } from '../accounts/account.entity'`), which collided with the parent's own `belongs_to` import emitted by `service.ejs.t`.
+
+### Fixed
+
+- **`fix(codegen)` — junction import dedupe across multi-junction parents.** Split each of the 4 existing junction inject templates (`_inject-parent-{service,module}-import-clp-{left,right}.ejs.t`) into 3 narrower inject templates with broader `skip_if` guards:
+  - `_inject-parent-{service,module}-forwardref-clp-{left,right}.ejs.t` — emits only `import { forwardRef }`, gated by `skip_if: "import { forwardRef"` (matches actual import line, not body usage)
+  - `_inject-parent-service-counterparty-clp-{left,right}.ejs.t` — emits the counterparty entity type import, gated by `skip_if: "from '<counterparty-path>'"` (matches any prior import from that path, including the parent's `belongs_to` import)
+  - Existing `_inject-parent-{service,module}-import-clp-{left,right}.ejs.t` — narrowed to just the junction-specific imports (already had a per-junction `skip_if`)
+- Updated junction snapshot tests (`test/junction/__snapshots__/opportunity-contact.test.ts.snap`, `opportunity-activity.test.ts.snap`) to reflect the new split-block layout.
+
+### Migration note
+
+No breaking change for the emitted code semantics — the output is functionally identical for single-junction projects, and now actually compiles for multi-junction projects. Greenfield re-emit is safe; existing emitted files re-emit cleanly via `--force`.
+
 ## [0.6.8] — 2026-04-28
 
 Hotfix for enum codegen in the `clean-lite-ps` template pipeline. Surfaced during integration-patterns Wave 0b: enum-typed YAML fields emitted a Drizzle `text()` column instead of a `pgEnum`, so `InferSelectModel` resolved to `string` instead of the literal-union type and forced hand-casts in consumer code (e.g. `as DecryptedIntegrationRow['status']`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/templates/junction/new/_inject-parent-module-forwardref-clp-left.ejs.t
+++ b/templates/junction/new/_inject-parent-module-forwardref-clp-left.ejs.t
@@ -1,0 +1,8 @@
+---
+to: "<%= architecture === 'clean-lite-ps' && exposeOnParent.left ? parentModulePathLeft : '' %>"
+inject: true
+after: "from '@nestjs/common';"
+skip_if: "import { forwardRef"
+---
+// CGP-60 — forwardRef resolves parent↔junction module cycle
+import { forwardRef } from '@nestjs/common';

--- a/templates/junction/new/_inject-parent-module-forwardref-clp-right.ejs.t
+++ b/templates/junction/new/_inject-parent-module-forwardref-clp-right.ejs.t
@@ -1,0 +1,8 @@
+---
+to: "<%= architecture === 'clean-lite-ps' && exposeOnParent.right ? parentModulePathRight : '' %>"
+inject: true
+after: "from '@nestjs/common';"
+skip_if: "import { forwardRef"
+---
+// CGP-60 — forwardRef resolves parent↔junction module cycle
+import { forwardRef } from '@nestjs/common';

--- a/templates/junction/new/_inject-parent-module-import-clp-left.ejs.t
+++ b/templates/junction/new/_inject-parent-module-import-clp-left.ejs.t
@@ -5,5 +5,4 @@ after: "from '@nestjs/common';"
 skip_if: "<%= classNames.module %> }"
 ---
 // CGP-60 — junction module wiring
-import { forwardRef } from '@nestjs/common';
 import { <%= classNames.module %> } from '<%= junctionModuleImportFromLeft %>';

--- a/templates/junction/new/_inject-parent-module-import-clp-right.ejs.t
+++ b/templates/junction/new/_inject-parent-module-import-clp-right.ejs.t
@@ -5,5 +5,4 @@ after: "from '@nestjs/common';"
 skip_if: "<%= classNames.module %> }"
 ---
 // CGP-60 — junction module wiring
-import { forwardRef } from '@nestjs/common';
 import { <%= classNames.module %> } from '<%= junctionModuleImportFromRight %>';

--- a/templates/junction/new/_inject-parent-service-counterparty-clp-left.ejs.t
+++ b/templates/junction/new/_inject-parent-service-counterparty-clp-left.ejs.t
@@ -1,0 +1,7 @@
+---
+to: "<%= architecture === 'clean-lite-ps' && exposeOnParent.left ? parentServicePathLeft : '' %>"
+inject: true
+after: "from '@nestjs/common';"
+skip_if: "from '<%= rightEntityImportFromJunction %>'"
+---
+import type { <%= rightEntityPascal %> } from '<%= rightEntityImportFromJunction %>';

--- a/templates/junction/new/_inject-parent-service-counterparty-clp-right.ejs.t
+++ b/templates/junction/new/_inject-parent-service-counterparty-clp-right.ejs.t
@@ -1,0 +1,7 @@
+---
+to: "<%= architecture === 'clean-lite-ps' && exposeOnParent.right ? parentServicePathRight : '' %>"
+inject: true
+after: "from '@nestjs/common';"
+skip_if: "from '<%= leftEntityImportFromJunction %>'"
+---
+import type { <%= leftEntityPascal %> } from '<%= leftEntityImportFromJunction %>';

--- a/templates/junction/new/_inject-parent-service-forwardref-clp-left.ejs.t
+++ b/templates/junction/new/_inject-parent-service-forwardref-clp-left.ejs.t
@@ -1,0 +1,8 @@
+---
+to: "<%= architecture === 'clean-lite-ps' && exposeOnParent.left ? parentServicePathLeft : '' %>"
+inject: true
+after: "from '@nestjs/common';"
+skip_if: "import { forwardRef"
+---
+// CGP-60 — forwardRef resolves circular module dep (junction → parent)
+import { forwardRef } from '@nestjs/common';

--- a/templates/junction/new/_inject-parent-service-forwardref-clp-right.ejs.t
+++ b/templates/junction/new/_inject-parent-service-forwardref-clp-right.ejs.t
@@ -1,0 +1,8 @@
+---
+to: "<%= architecture === 'clean-lite-ps' && exposeOnParent.right ? parentServicePathRight : '' %>"
+inject: true
+after: "from '@nestjs/common';"
+skip_if: "import { forwardRef"
+---
+// CGP-60 — forwardRef resolves circular module dep (junction → parent)
+import { forwardRef } from '@nestjs/common';

--- a/templates/junction/new/_inject-parent-service-import-clp-left.ejs.t
+++ b/templates/junction/new/_inject-parent-service-import-clp-left.ejs.t
@@ -4,8 +4,6 @@ inject: true
 after: "from '@nestjs/common';"
 skip_if: "<%= classNames.service %> }"
 ---
-// CGP-60 — junction service + types (forwardRef resolves circular module dep)
-import { forwardRef } from '@nestjs/common';
+// CGP-60 — junction service + types
 import { <%= classNames.service %>, <%= entityNamePascal %>LinkInput } from '<%= junctionServiceImportFromLeft %>';
 import type { <%= entityNamePascal %> } from '../<%= entityNamePlural %>/<%= name %>.entity';
-import type { <%= rightEntityPascal %> } from '<%= rightEntityImportFromJunction %>';

--- a/templates/junction/new/_inject-parent-service-import-clp-right.ejs.t
+++ b/templates/junction/new/_inject-parent-service-import-clp-right.ejs.t
@@ -4,8 +4,6 @@ inject: true
 after: "from '@nestjs/common';"
 skip_if: "<%= classNames.service %> }"
 ---
-// CGP-60 — junction service + types (forwardRef resolves circular module dep)
-import { forwardRef } from '@nestjs/common';
+// CGP-60 — junction service + types
 import { <%= classNames.service %>, <%= entityNamePascal %>LinkInput } from '<%= junctionServiceImportFromRight %>';
 import type { <%= entityNamePascal %> } from '../<%= entityNamePlural %>/<%= name %>.entity';
-import type { <%= leftEntityPascal %> } from '<%= leftEntityImportFromJunction %>';

--- a/test/junction/__snapshots__/opportunity-activity.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-activity.test.ts.snap
@@ -316,10 +316,13 @@ export class OpportunityActivityService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits opportunity.service.ts (left parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
-// CGP-60 — junction service + types (forwardRef resolves circular module dep)
-import { forwardRef } from '@nestjs/common';
+// CGP-60 — junction service + types
 import { OpportunityActivityService, OpportunityActivityLinkInput } from '../opportunity_activities/opportunity_activity.service';
 import type { OpportunityActivity } from '../opportunity_activities/opportunity_activity.entity';
+
+// CGP-60 — forwardRef resolves circular module dep (junction → parent)
+import { forwardRef } from '@nestjs/common';
+
 import type { Activity } from '../activities/activity.entity';
 
 import { WithAnalytics } from '@shared/base-classes/with-analytics';
@@ -404,10 +407,13 @@ export class OpportunityService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_activity (clean-lite-ps) emits activity.service.ts (right parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
-// CGP-60 — junction service + types (forwardRef resolves circular module dep)
-import { forwardRef } from '@nestjs/common';
+// CGP-60 — junction service + types
 import { OpportunityActivityService, OpportunityActivityLinkInput } from '../opportunity_activities/opportunity_activity.service';
 import type { OpportunityActivity } from '../opportunity_activities/opportunity_activity.entity';
+
+// CGP-60 — forwardRef resolves circular module dep (junction → parent)
+import { forwardRef } from '@nestjs/common';
+
 import type { Opportunity } from '../opportunities/opportunity.entity';
 
 import { WithAnalytics } from '@shared/base-classes/with-analytics';

--- a/test/junction/__snapshots__/opportunity-contact.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-contact.test.ts.snap
@@ -326,10 +326,13 @@ export class OpportunityContactService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits opportunity.service.ts (left parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
-// CGP-60 — junction service + types (forwardRef resolves circular module dep)
-import { forwardRef } from '@nestjs/common';
+// CGP-60 — junction service + types
 import { OpportunityContactService, OpportunityContactLinkInput } from '../opportunity_contacts/opportunity_contact.service';
 import type { OpportunityContact } from '../opportunity_contacts/opportunity_contact.entity';
+
+// CGP-60 — forwardRef resolves circular module dep (junction → parent)
+import { forwardRef } from '@nestjs/common';
+
 import type { Contact } from '../contacts/contact.entity';
 
 import { WithAnalytics } from '@shared/base-classes/with-analytics';
@@ -414,10 +417,13 @@ export class OpportunityService extends WithAnalytics(
 
 exports[`junction emission snapshot — opportunity_contact (clean-lite-ps) emits contact.service.ts (right parent — junction accessor) 1`] = `
 "import { Injectable, Inject, Optional } from '@nestjs/common';
-// CGP-60 — junction service + types (forwardRef resolves circular module dep)
-import { forwardRef } from '@nestjs/common';
+// CGP-60 — junction service + types
 import { OpportunityContactService, OpportunityContactLinkInput } from '../opportunity_contacts/opportunity_contact.service';
 import type { OpportunityContact } from '../opportunity_contacts/opportunity_contact.entity';
+
+// CGP-60 — forwardRef resolves circular module dep (junction → parent)
+import { forwardRef } from '@nestjs/common';
+
 import type { Opportunity } from '../opportunities/opportunity.entity';
 
 import { WithAnalytics } from '@shared/base-classes/with-analytics';


### PR DESCRIPTION
## Summary

Hotfix for a 0.7.0 (CGP-60) regression hit when a parent entity participates in **multiple junctions**.

### The bug

\`contact\` appears as the right side of both \`account_contact\` AND \`opportunity_contact\`. Each junction's \`_inject-parent-{service,module}-import-clp-{left,right}.ejs.t\` template independently emits this 4-line block:

\`\`\`ts
// CGP-60 — junction service + types (forwardRef resolves circular module dep)
import { forwardRef } from '@nestjs/common';
import { <JunctionService>, <Junction>LinkInput } from '...';
import type { <Junction> } from '...';
import type { <Counterparty> } from '...';
\`\`\`

\`skip_if\` matched only the junction's own class name (unique per junction → never skipped), so **all 4 lines re-emitted per junction**. Result in our \`contact.service.ts\`:

\`\`\`ts
import { forwardRef } from '@nestjs/common';   // from opportunity_contact
// ...
import { forwardRef } from '@nestjs/common';   // from account_contact   ← TS2300 duplicate
\`\`\`

Same problem for the counterparty entity import — the junction's \`import type { Account }\` collides with the parent's own \`belongs_to\` import emitted by \`service.ejs.t\`.

### The fix

Split each of the 4 inject templates into 3 narrower templates with finer-grained \`skip_if\`:

| Template | Emits | skip_if |
|---|---|---|
| \`_inject-parent-{svc,mod}-forwardref-clp-{l,r}.ejs.t\` (new) | \`import { forwardRef }\` only | \`"import { forwardRef"\` (matches import line, NOT body \`@Inject(forwardRef(...))\`) |
| \`_inject-parent-service-counterparty-clp-{l,r}.ejs.t\` (new) | counterparty entity type only | \`"from '<counterparty-path>'"\` (matches any prior import from that path) |
| \`_inject-parent-{svc,mod}-import-clp-{l,r}.ejs.t\` (existing, narrowed) | junction-specific imports | unchanged per-junction guard |

### Subtle detail

\`skip_if: "forwardRef"\` plain would fire AFTER the body-inject templates run (Hygen alphabetical order: \`_inject-parent-{svc}-clp-{l,r}.ejs.t\` writes \`@Inject(forwardRef(() => ...))\` BEFORE \`_inject-parent-{svc}-forwardref-clp-{l,r}.ejs.t\` runs). The body usage matches the broad skip → import never gets added → \`forwardRef\` referenced but unimported. \`"import { forwardRef"\` is the necessary specificity.

## Test plan

- [x] Updated junction snapshot tests for single-junction \`opportunity_contact\` + cross-domain \`opportunity_activity\` cases. \`bun test test/junction\` — 10/10 pass.
- [x] Real-world end-to-end against \`dealbrain-integrations\` (which has the multi-junction case): \`contact\` participates in both \`account_contact\` + \`opportunity_contact\`. Pre-fix: TS2300 errors at \`tsc --noEmit\`. Post-fix: shell + packages typecheck clean, 929/929 tests pass.
- [x] CHANGELOG entry added under [0.7.1].

## Migration

None. Output is functionally identical for single-junction projects; multi-junction projects now compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)