### PR TITLE
fix(sync): ignore external_id_tracking columns in differ

### DIFF
--- a/runtime/subsystems/sync/deep-equal.differ.ts
+++ b/runtime/subsystems/sync/deep-equal.differ.ts
@@ -44,6 +44,14 @@ import type {
 /**
  * Default ignore list. Keep in sync with consumer canonical-record shapes —
  * adding a row-metadata field here means no sync will ever mark it changed.
+ *
+ * Includes the columns contributed by the `external_id_tracking` behavior
+ * (`external_id`/`externalId`, `provider`, `provider_metadata`/`providerMetadata`).
+ * These are sync-tracking metadata, not domain attributes: they ride on the
+ * canonical record but must never register as a field change (the external id
+ * is the record's identity, not a mutable value). Listed in both snake_case
+ * and camelCase so the differ ignores them regardless of the consumer's
+ * canonical projection casing.
  */
 const DEFAULT_IGNORE_FIELDS: ReadonlySet<string> = new Set([
   'id',
@@ -53,6 +61,10 @@ const DEFAULT_IGNORE_FIELDS: ReadonlySet<string> = new Set([
   'type',
   'lastModifiedAt',
   'fields',
+  'external_id',
+  'externalId',
+  'provider',
+  'provider_metadata',
   'providerMetadata',
 ]);
 

--- a/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
+++ b/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
@@ -228,8 +228,9 @@ describe('ExecuteSyncUseCase', () => {
       expect(recorder.items[0].operation).toBe('created');
       expect(recorder.items[0].status).toBe('success');
       expect(recorder.items[0].localId).toBe('local-ext-1');
+      // external_id is sync-tracking metadata (record identity), not a domain
+      // attribute — the differ ignores it, so it never appears in changedFields.
       expect(recorder.items[0].changedFields).toEqual({
-        external_id: { from: null, to: 'ext-1' },
         amount: { from: null, to: 100 },
         stageName: { from: null, to: 'Prospecting' },
       });
@@ -374,14 +375,17 @@ describe('ExecuteSyncUseCase', () => {
         {
           externalId: 'a',
           operation: 'created',
-          record: { external_id: 'a' },
+          // amount is a real domain field so the diff isn't noop — without it
+          // the record carries only the (ignored) external_id and short-circuits
+          // before reaching the sink, so it could never fail.
+          record: { external_id: 'a', amount: 1 },
           cursor: { v: 1 },
           source: 'poll',
         },
         {
           externalId: 'b',
           operation: 'created',
-          record: { external_id: 'b' },
+          record: { external_id: 'b', amount: 2 },
           cursor: { v: 2 },
           source: 'poll',
         },


### PR DESCRIPTION
## What

`DEFAULT_IGNORE_FIELDS` in the sync subsystem's deep-equal differ ignored `providerMetadata` but **not** its sibling `external_id_tracking` columns — `external_id`/`externalId` and `provider`. Those columns are contributed to every `Synced`-pattern entity by the `external_id_tracking` behavior, ride on the canonical record, and were leaking into `changed_fields` audit rows (and into the diff of every created record).

## Why

External id is the record's **identity**, and `provider` is **provenance** — neither is a mutable domain attribute. They should never register as a field change, exactly like the already-ignored `providerMetadata`. Ignoring `providerMetadata` but not its siblings was an inconsistency, not a deliberate choice.

Surfaced by a spike wiring the sync orchestrator against real CRM entities in `dealbrain-integrations`.

## Change

- Add `external_id`, `externalId`, `provider`, `provider_metadata` to `DEFAULT_IGNORE_FIELDS` (both casings, so it's projection-casing-agnostic) + doc comment.
- Update two `execute-sync` specs whose fixtures encoded the old behavior:
  - *created happy path* — `external_id` no longer expected in `changedFields`.
  - *all-failed run* — fixtures carried only `external_id`; now ignored, they'd diff to noop and never reach the throwing sink. Added a real `amount` field to preserve the test's intent.

## Tests

`723 pass, 0 fail` across 52 subsystem specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)