### PR TITLE
feat(emit): unique index for external_id_tracking + fold Synced impliedBehaviors

### DIFF
--- a/src/__tests__/clean-lite-ps/entity-fk-template.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-fk-template.test.ts
@@ -237,6 +237,114 @@ describe('soft-delete FK warning (issue #41)', () => {
   });
 });
 
+// ============================================================================
+// external_id_tracking unique index emission
+//
+// The external_id_tracking behavior declares external_id with
+// drizzleImports: ['varchar', 'index'] — it INTENDS an index. The entity
+// template now emits a unique index over (provider, external_id), the
+// ON CONFLICT target the sync sink's syncUpsert relies on.
+// ============================================================================
+
+// Synced entity declaring the behavior explicitly.
+const syncedExplicitDefinition = {
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', pattern: 'Synced' },
+  fields: { email: { type: 'string', required: true } },
+  relationships: {},
+  behaviors: ['timestamps', 'external_id_tracking'],
+};
+
+// Synced entity that does NOT re-declare external_id_tracking — the pattern
+// implies it (impliedBehaviors fold).
+const syncedImpliedDefinition = {
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', pattern: 'Synced' },
+  fields: { email: { type: 'string', required: true } },
+  relationships: {},
+  behaviors: ['timestamps'],
+};
+
+// Plain Base entity carrying the behavior directly (no pattern).
+const baseWithBehaviorDefinition = {
+  entity: { name: 'widget', plural: 'widgets', table: 'widgets', pattern: 'Base' },
+  fields: { label: { type: 'string', required: true } },
+  relationships: {},
+  behaviors: ['external_id_tracking'],
+};
+
+// Plain Base entity WITHOUT the behavior — must emit no index.
+const baseNoBehaviorDefinition = {
+  entity: { name: 'widget', plural: 'widgets', table: 'widgets', pattern: 'Base' },
+  fields: { label: { type: 'string', required: true } },
+  relationships: {},
+  behaviors: [],
+};
+
+describe('external_id_tracking unique index emission', () => {
+  it('emits uniqueIndex over (provider, external_id) when behavior is declared explicitly', () => {
+    const locals = buildCleanLitePsLocals(syncedExplicitDefinition, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(output).toContain(
+      "uniqueIndex('uq_contacts_provider_external_id').on(t.provider, t.externalId)",
+    );
+  });
+
+  it('imports uniqueIndex from drizzle-orm/pg-core', () => {
+    const locals = buildCleanLitePsLocals(syncedExplicitDefinition, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(locals.clpDrizzleImports).toContain('uniqueIndex');
+    expect(output).toContain('uniqueIndex,');
+    expect(output).toContain("from 'drizzle-orm/pg-core';");
+  });
+
+  it('passes the index as the pgTable extra-config callback returning an array', () => {
+    const locals = buildCleanLitePsLocals(syncedExplicitDefinition, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    // (t) => [ ... ] form — the modern Drizzle extra-config signature.
+    expect(output).toMatch(/\},\s*\(t\) => \[\s*[\s\S]*uniqueIndex\(/);
+    // The index follows the column block (appears after providerMetadata).
+    const colPos = output.indexOf("providerMetadata: jsonb('provider_metadata')");
+    const idxPos = output.indexOf("uniqueIndex('uq_contacts_provider_external_id')");
+    expect(colPos).toBeGreaterThan(-1);
+    expect(idxPos).toBeGreaterThan(colPos);
+  });
+
+  it('emits the index for a pattern: Synced entity that does NOT re-declare the behavior', () => {
+    const locals = buildCleanLitePsLocals(syncedImpliedDefinition, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    // impliedBehaviors fold — pattern: Synced implies external_id_tracking.
+    expect(locals.hasExternalIdTracking).toBe(true);
+    expect(output).toContain("externalId: varchar('external_id')");
+    expect(output).toContain("provider: varchar('provider')");
+    expect(output).toContain("providerMetadata: jsonb('provider_metadata')");
+    expect(output).toContain(
+      "uniqueIndex('uq_contacts_provider_external_id').on(t.provider, t.externalId)",
+    );
+  });
+
+  it('emits the index for a non-Synced entity carrying the behavior directly', () => {
+    const locals = buildCleanLitePsLocals(baseWithBehaviorDefinition, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(output).toContain(
+      "uniqueIndex('uq_widgets_provider_external_id').on(t.provider, t.externalId)",
+    );
+  });
+
+  it('does NOT emit an index or uniqueIndex import without the behavior', () => {
+    const locals = buildCleanLitePsLocals(baseNoBehaviorDefinition, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(locals.clpDrizzleImports).not.toContain('uniqueIndex');
+    expect(output).not.toContain('uniqueIndex');
+    // pgTable closes with no extra-config callback.
+    expect(output).not.toMatch(/\},\s*\(t\) => \[/);
+  });
+});
+
 describe('prompt-extension processBelongsTo on_delete propagation', () => {
   it('includes onDelete in clpBelongsTo entries', () => {
     const locals = buildCleanLitePsLocals(messageDefinitionCascade, EMPTY_BASE_LOCALS);

--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -3,7 +3,10 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+import {
+  buildCleanLitePsLocals,
+  resolveImpliedBehaviors,
+} from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
 
 // Minimal base locals (the real version has many more fields, but we only need
 // the shape to test the extension itself)
@@ -505,6 +508,62 @@ describe('buildCleanLitePsLocals — PATTERN-5 registry integration', () => {
       expect(locals.serviceBaseImport).toBe(expected.serviceBaseImport);
       expect(locals.patternName).toBe(pascal);
     }
+  });
+});
+
+describe('impliedBehaviors fold — pattern-implied behaviors merge into emit', () => {
+  // A pattern: Synced entity with NO explicit external_id_tracking behavior.
+  const syncedNoExplicitBehavior = {
+    entity: { name: 'account', plural: 'accounts', table: 'accounts', pattern: 'Synced' },
+    fields: { name: { type: 'string', required: true } },
+    relationships: {},
+    behaviors: ['timestamps'],
+  };
+
+  it('resolveImpliedBehaviors returns external_id_tracking for pattern: Synced', () => {
+    expect(resolveImpliedBehaviors(syncedNoExplicitBehavior.entity)).toContain(
+      'external_id_tracking',
+    );
+  });
+
+  it('resolveImpliedBehaviors walks the patterns: [...] array form', () => {
+    const multi = { name: 'deal', plural: 'deals', table: 'deals', patterns: ['Synced'] };
+    expect(resolveImpliedBehaviors(multi)).toContain('external_id_tracking');
+  });
+
+  it('resolveImpliedBehaviors returns [] for a pattern with no impliedBehaviors', () => {
+    expect(resolveImpliedBehaviors({ name: 'task', plural: 'tasks', pattern: 'Base' })).toEqual([]);
+  });
+
+  it('a Synced entity gets hasExternalIdTracking even without re-declaring the behavior', () => {
+    const locals = buildCleanLitePsLocals(syncedNoExplicitBehavior, EMPTY_BASE_LOCALS);
+    expect(locals.hasExternalIdTracking).toBe(true);
+  });
+
+  it('explicit external_id_tracking declaration stays a no-op (silent dedup)', () => {
+    const explicit = {
+      ...syncedNoExplicitBehavior,
+      behaviors: ['timestamps', 'external_id_tracking'],
+    };
+    const implied = buildCleanLitePsLocals(syncedNoExplicitBehavior, EMPTY_BASE_LOCALS);
+    const declared = buildCleanLitePsLocals(explicit, EMPTY_BASE_LOCALS);
+
+    // Re-declaring the implied behavior must not change the resolved flag or
+    // the Drizzle imports — explicit and implied paths converge.
+    expect(declared.hasExternalIdTracking).toBe(true);
+    expect(implied.hasExternalIdTracking).toBe(true);
+    expect(declared.clpDrizzleImports).toEqual(implied.clpDrizzleImports);
+  });
+
+  it('a Base entity (no pattern) does NOT gain external_id_tracking', () => {
+    const base = {
+      entity: { name: 'task', plural: 'tasks', table: 'tasks', pattern: 'Base' },
+      fields: { title: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+    };
+    const locals = buildCleanLitePsLocals(base, EMPTY_BASE_LOCALS);
+    expect(locals.hasExternalIdTracking).toBe(false);
   });
 });
 

--- a/templates/entity/new/clean-lite-ps/entity.ejs.t
+++ b/templates/entity/new/clean-lite-ps/entity.ejs.t
@@ -64,6 +64,12 @@ export const <%= entityNamePlural %> = pgTable(
     deletedAt: timestamp('deleted_at'),
 <%_ } _%>
   },
+<%_ if (hasExternalIdTracking) { _%>
+  (t) => [
+    // external_id_tracking behavior — ON CONFLICT target for syncUpsert
+    uniqueIndex('uq_<%= entityNamePlural %>_provider_external_id').on(t.provider, t.externalId),
+  ],
+<%_ } _%>
 );
 <%_ if (clpHasRelationsBlock) { _%>
 <%_ const needsMany = typeof clpExistingHasMany !== 'undefined' && clpExistingHasMany.length > 0; _%>

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -105,6 +105,38 @@ export function resolvePatternBaseClasses(entity) {
   };
 }
 
+/**
+ * Resolve the behaviors implied by an entity's declared pattern(s).
+ *
+ * A pattern (e.g. `Synced`) may declare `impliedBehaviors` — behaviors the
+ * entity gets for free without re-declaring them in its `behaviors:` array.
+ * Walks every declared pattern (both the `pattern: X` and `patterns: [...]`
+ * shapes), unions their `impliedBehaviors`, and returns a deduped list.
+ * Unknown patterns are skipped silently — composition validation surfaces
+ * those separately (src/patterns/validate-composition.ts).
+ *
+ * @param {object} entity - the entity block from the parsed YAML
+ * @returns {string[]} deduped implied behavior names
+ */
+export function resolveImpliedBehaviors(entity) {
+  const names = [];
+  if (typeof entity.pattern === 'string' && entity.pattern) {
+    names.push(entity.pattern);
+  }
+  if (Array.isArray(entity.patterns)) {
+    names.push(...entity.patterns);
+  }
+
+  const implied = new Set();
+  for (const name of names) {
+    const def = getPattern(name);
+    for (const b of def?.impliedBehaviors ?? []) {
+      implied.add(b);
+    }
+  }
+  return Array.from(implied);
+}
+
 // ============================================================================
 // Helper utilities
 // ============================================================================
@@ -441,10 +473,13 @@ function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSof
     imports.add('timestamp');
   }
 
-  // external_id_tracking behavior injects varchar + jsonb columns
+  // external_id_tracking behavior injects varchar + jsonb columns plus a
+  // unique index over (provider, external_id) — the ON CONFLICT target the
+  // sync sink's syncUpsert relies on.
   if (hasExternalIdTracking) {
     imports.add('varchar');
     imports.add('jsonb');
+    imports.add('uniqueIndex');
   }
 
   if (belongsTo.length > 0 || hasMany.length > 0) {
@@ -787,8 +822,20 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // Process entity fields
   const processedFields = processFields(fields);
 
-  // Behavior flags (re-read from behaviors array for clean-lite-ps use)
-  const behaviorNames = behaviors.map((b) => (typeof b === 'string' ? b : b.name));
+  // Behavior flags (re-read from behaviors array for clean-lite-ps use).
+  //
+  // Fold in the resolved pattern's `impliedBehaviors` (ADR-031): an entity
+  // declaring e.g. `pattern: Synced` need not re-declare the
+  // `external_id_tracking` behavior — the pattern contributes it. Deduped
+  // with any explicit `behaviors:` entries, explicit-first so order is
+  // stable for pre-existing fixtures. Mirrors the dedup in
+  // src/patterns/validate-composition.ts.
+  const explicitBehaviorNames = behaviors.map((b) => (typeof b === 'string' ? b : b.name));
+  const impliedBehaviorNames = resolveImpliedBehaviors(entity);
+  const behaviorNames = [
+    ...explicitBehaviorNames,
+    ...impliedBehaviorNames.filter((b) => !explicitBehaviorNames.includes(b)),
+  ];
   const hasTimestamps = behaviorNames.includes('timestamps');
   const hasSoftDelete = behaviorNames.includes('soft_delete');
   const hasUserTracking = behaviorNames.includes('user_tracking');


### PR DESCRIPTION
## What

Two clean-lite-ps emit gaps that block the dealbrain-integrations CRM sync sinks.

### 1. Emit the unique index for `external_id_tracking` entities
The `external_id_tracking` behavior (`src/behaviors/external-id-tracking.ts`) declares `external_id` with `drizzleImports: ['varchar', 'index']` — it intends an index — but the clean-lite-ps entity template emitted no indexes.

Now emits, as the `pgTable(...)` extra-config callback:
```ts
(t) => [
  // external_id_tracking behavior — ON CONFLICT target for syncUpsert
  uniqueIndex('uq_<table>_provider_external_id').on(t.provider, t.externalId),
],
```
plus the `uniqueIndex` import from `drizzle-orm/pg-core`. This is the `ON CONFLICT` target the sync sink's `syncUpsert` relies on.

### 2. Fold `Synced`'s `impliedBehaviors` into the emit
`src/patterns/library/synced.pattern.ts` declares `impliedBehaviors: ['external_id_tracking']` and its docstring promises an entity need not re-declare it — but the clean-lite-ps emit path only read the explicit `behaviors:` array. New `resolveImpliedBehaviors(entity)` helper unions the declared pattern(s) `impliedBehaviors`; `buildCleanLitePsLocals` folds them into the resolved behavior set (deduped, explicit-first; mirrors `src/patterns/validate-composition.ts`).

After this, a `pattern: Synced` entity emits `external_id`/`provider`/`provider_metadata` columns + the unique index **without** re-declaring `external_id_tracking`.

## Tests
- +12 focused tests:
  - `entity-fk-template.test.ts`: index emission, `uniqueIndex` import, `pgTable` extra-config `(t) => [...]` shape, Synced-without-explicit-behavior emits cols+index, non-Synced-with-behavior, absence guard (no index / no import without the behavior).
  - `prompt-extension.test.ts`: `resolveImpliedBehaviors` unit (string + array forms, empty for Base), fold integration (`hasExternalIdTracking` true for `pattern: Synced`), explicit-declaration dedup no-op, Base entity stays false.
- Full unit suite: **1770 pass / 0 fail** (was 1758).
- Full snapshot test (`bun test/run-test.ts full`): green — the snapshot baseline is `architecture: clean`, unaffected by this clean-lite-ps-only change.
- Relationship smoke (`--scenario relationship`, CRM `pattern: Synced` fixtures): regenerates + `tsc --noEmit` clean.

## Consumer impact
- Existing explicit `external_id_tracking:` declarations in YAML are now **redundant but harmless** (silent dedup) — dealbrain CRM YAMLs can drop the line.
- Pick up via `bun install` + re-emit. New unique index will appear in a fresh migration diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)