### PR TITLE
feat(junction): identity uniqueness includes role discriminator

### DIFF
--- a/src/__tests__/templates/junction-identity-pk.test.ts
+++ b/src/__tests__/templates/junction-identity-pk.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Focused template test for junction identity uniqueness (role discriminator).
+ *
+ * The junction's true identity is the FK pair PLUS its role discriminator when
+ * one is declared: the same (left, right) pair with two different roles is two
+ * domain-distinct rows (e.g. a contact who is both `champion` AND
+ * `decision_maker` on one opportunity). With a PK over only (leftId, rightId)
+ * those rows collide at the DB level even though they are domain-distinct.
+ *
+ * This test renders templates/junction/new/entity.ejs.t directly with
+ * controlled locals and asserts the emitted composite primary key:
+ *   - role-bearing junction → PK includes `table.role`, role column is .notNull()
+ *   - role-less junction    → PK is exactly (leftId, rightId), no role column
+ *
+ * The full-file snapshots in test/junction/ lock the surrounding shape; this
+ * test isolates the identity-uniqueness contract so a regression names itself.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+
+const JUNCTION_ENTITY_TEMPLATE = readFileSync(
+  resolve(import.meta.dir, '../../../templates/junction/new/entity.ejs.t'),
+  'utf8',
+);
+
+/** Strip the Hygen front-matter so we render only the EJS body. */
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return source;
+  return lines.slice(end + 1).join('\n');
+}
+
+/**
+ * Minimal locals mirroring what templates/junction/new/prompt.js computes.
+ * `hasRole` is derived from fields.role.choices in prompt.js; here we toggle it
+ * directly to exercise both branches.
+ */
+function localsFor({ hasRole }: { hasRole: boolean }): Record<string, unknown> {
+  const drizzleImports = [
+    'boolean',
+    'numeric',
+    'pgTable',
+    'primaryKey',
+    'relations',
+    'text',
+    'timestamp',
+    'uuid',
+  ];
+  if (hasRole) drizzleImports.push('pgEnum');
+  drizzleImports.sort();
+
+  return {
+    name: 'opportunity_contact',
+    tableName: 'opportunity_contacts',
+    tableVarName: 'opportunityContacts',
+    leftEntity: 'opportunity',
+    rightEntity: 'contact',
+    leftTable: 'opportunities',
+    rightTable: 'contacts',
+    leftColumn: 'opportunity_id',
+    rightColumn: 'contact_id',
+    leftColumnCamel: 'opportunityId',
+    rightColumnCamel: 'contactId',
+    onDeleteLeft: 'restrict',
+    onDeleteRight: 'restrict',
+    hasRole,
+    roleEnumName: hasRole ? 'opportunityContactRoleEnum' : null,
+    roleEnumValues: hasRole ? ['champion', 'decision_maker', 'influencer'] : [],
+    temporal: true,
+    sourced: true,
+    hasCustomFields: false,
+    processedCustomFields: [],
+    drizzleImports,
+    classNames: { entity: 'OpportunityContact' },
+  };
+}
+
+function render(locals: Record<string, unknown>): string {
+  return ejs.render(extractBody(JUNCTION_ENTITY_TEMPLATE), locals, { rmWhitespace: false });
+}
+
+describe('junction identity uniqueness — composite PK includes role discriminator', () => {
+  it('role-bearing junction: PK is (leftId, rightId, role)', () => {
+    const out = render(localsFor({ hasRole: true }));
+    expect(out).toContain(
+      'primaryKey({ columns: [table.opportunityId, table.contactId, table.role] })',
+    );
+    // The two-column PK must NOT be emitted for a role-bearing junction.
+    expect(out).not.toContain('primaryKey({ columns: [table.opportunityId, table.contactId] })');
+  });
+
+  it('role-bearing junction: role column is NOT NULL (it is part of the PK)', () => {
+    const out = render(localsFor({ hasRole: true }));
+    expect(out).toContain("role: opportunityContactRoleEnum('role').notNull()");
+  });
+
+  it('role-less junction: PK stays (leftId, rightId), no role column', () => {
+    const out = render(localsFor({ hasRole: false }));
+    expect(out).toContain('primaryKey({ columns: [table.opportunityId, table.contactId] })');
+    expect(out).not.toContain('table.role');
+    expect(out).not.toContain("role:");
+  });
+});

--- a/templates/junction/new/entity.ejs.t
+++ b/templates/junction/new/entity.ejs.t
@@ -45,8 +45,10 @@ export const <%= tableVarName %> = pgTable(
     <%= rightColumnCamel %>: uuid('<%= rightColumn %>').notNull().references(() => <%= rightTable %>.id, { onDelete: '<%= onDeleteRight %>' }),
 <%_ if (hasRole) { _%>
 
-    // Role enum (per-pairing; declared in junction YAML's fields.role.choices)
-    role: <%= roleEnumName %>('role'),
+    // Role enum (per-pairing; declared in junction YAML's fields.role.choices).
+    // NOT NULL because role is part of the junction's identity (composite PK
+    // below): the same pair with two different roles is two distinct rows.
+    role: <%= roleEnumName %>('role').notNull(),
 <%_ } _%>
 
     // BaseJunctionFields — is_primary is always emitted
@@ -83,8 +85,17 @@ export const <%= tableVarName %> = pgTable(
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },
   (table) => [
+<%_ if (hasRole) { _%>
+    // Composite primary key on the two FK columns PLUS role (Q4 resolution: no
+    // surrogate id). Role is part of the junction's identity — the same pair
+    // with two different roles is two distinct rows (e.g. a contact who is both
+    // `champion` and `decision_maker` on one opportunity). This is the
+    // ON CONFLICT target for syncUpsert on role-bearing junctions.
+    primaryKey({ columns: [table.<%= leftColumnCamel %>, table.<%= rightColumnCamel %>, table.role] }),
+<%_ } else { _%>
     // Composite primary key on the two FK columns (Q4 resolution: no surrogate id)
     primaryKey({ columns: [table.<%= leftColumnCamel %>, table.<%= rightColumnCamel %>] }),
+<%_ } _%>
   ],
 );
 

--- a/test/junction/__snapshots__/opportunity-contact.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-contact.test.ts.snap
@@ -36,8 +36,10 @@ export const opportunityContacts = pgTable(
     opportunityId: uuid('opportunity_id').notNull().references(() => opportunities.id, { onDelete: 'restrict' }),
     contactId: uuid('contact_id').notNull().references(() => contacts.id, { onDelete: 'restrict' }),
 
-    // Role enum (per-pairing; declared in junction YAML's fields.role.choices)
-    role: opportunityContactRoleEnum('role'),
+    // Role enum (per-pairing; declared in junction YAML's fields.role.choices).
+    // NOT NULL because role is part of the junction's identity (composite PK
+    // below): the same pair with two different roles is two distinct rows.
+    role: opportunityContactRoleEnum('role').notNull(),
 
     // BaseJunctionFields — is_primary is always emitted
     isPrimary: boolean('is_primary').notNull().default(false),
@@ -56,8 +58,12 @@ export const opportunityContacts = pgTable(
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
   },
   (table) => [
-    // Composite primary key on the two FK columns (Q4 resolution: no surrogate id)
-    primaryKey({ columns: [table.opportunityId, table.contactId] }),
+    // Composite primary key on the two FK columns PLUS role (Q4 resolution: no
+    // surrogate id). Role is part of the junction's identity — the same pair
+    // with two different roles is two distinct rows (e.g. a contact who is both
+    // \`champion\` and \`decision_maker\` on one opportunity). This is the
+    // ON CONFLICT target for syncUpsert on role-bearing junctions.
+    primaryKey({ columns: [table.opportunityId, table.contactId, table.role] }),
   ],
 );
 


### PR DESCRIPTION
## The bug

The Junction pattern emitted a junction table whose composite primary key spanned only the two FK columns `(leftId, rightId)`. But for junctions with a `role` discriminator, the true identity is `(leftId, rightId, role)`. With a PK over only the FK pair, two **domain-distinct** rows for the same pair with **different roles** collided at the DB level.

Concrete failure (dealbrain CRM): a contact who is both `champion` AND `decision_maker` on one opportunity (`opportunity_contact`), or both `employee` AND `advisor` on one account (`account_contact`), could not be stored.

## The fix

When the junction declares a role (`fields.role.choices` → `hasRole`), the emitted composite PK now spans `(leftId, rightId, role)` and the `role` column is emitted `.notNull()` (PK columns cannot be nullable). Role-less junctions are unchanged: PK stays `(leftId, rightId)`, no role column.

This restores the original spec-59 intent — *"composite primary key on the two FK columns plus the role column"* — which the implementation had dropped, and gives role-bearing junctions a stable `ON CONFLICT` target for `syncUpsert`.

### Emitted Drizzle (role-bearing junction)
```ts
role: opportunityContactRoleEnum('role').notNull(),
// ...
(table) => [
  primaryKey({ columns: [table.opportunityId, table.contactId, table.role] }),
],
```

## How role is detected

In `templates/junction/new/prompt.js` (unchanged): `hasRole = Array.isArray(fields.role?.choices) && fields.role.choices.length > 0`. Reliable for the real consumers — both dealbrain CRM junctions declare `role: { type: enum, choices: [...], required: true }`.

## Tests

- New focused contract test `src/__tests__/templates/junction-identity-pk.test.ts`: renders the EJS template directly and asserts role-bearing → PK incl. `table.role` + `.notNull()`; role-less → two-col PK, no role column. (3 tests, pass)
- Regenerated `test/junction/__snapshots__/opportunity-contact.test.ts.snap` — diff is **exactly** the role `.notNull()` + PK addition. The role-less `opportunity_activity` snapshot is untouched.
- Full unit suite: 1845 pass / 0 fail. Codegen integration (`bun test/run-test.ts full`): all green.

## Migration note for consumers

This changes the emitted primary key for role-bearing junctions. Consumers re-emit junctions, then `drizzle-kit generate` a migration (PK change on a fresh table is a clean `ALTER`; existing rows that violated the old two-col uniqueness would have been impossible to insert anyway). After re-emit, junction sync sinks can switch their SELECT-then-INSERT/UPDATE fallback to `onConflict(target: [leftId, rightId, role])`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)