### PR TITLE
feat(#375): reprojectsOnNoop capability on ISyncSink + orchestrator gate

### DIFF
--- a/runtime/subsystems/sync/execute-sync.use-case.ts
+++ b/runtime/subsystems/sync/execute-sync.use-case.ts
@@ -278,11 +278,35 @@ export class ExecuteSyncUseCase<T extends Record<string, unknown>> {
     );
 
     if (diff === 'noop') {
+      // Sinks that declare `reprojectsOnNoop` reproject side data the differ
+      // can't see (e.g. EAV field_values) — so fall through to the idempotent
+      // upsert instead of short-circuiting. The canonical state is unchanged,
+      // so the audit `operation` stays `'noop'`, but we capture the local id
+      // returned by the upsert. Sinks without the flag keep today's behavior.
+      if (!this.sink.reprojectsOnNoop) {
+        await this.recorder.recordItem({
+          syncRunId: runId,
+          entityType: input.subscription.domain,
+          externalId: change.externalId,
+          localId: null,
+          operation: 'noop',
+          status: 'success',
+          changedFields: {},
+          tenantId: input.tenantId,
+        });
+        return;
+      }
+
+      const { id: noopLocalId } = await this.sink.upsertByExternalId(
+        input.userId,
+        change.record,
+        input.provider,
+      );
       await this.recorder.recordItem({
         syncRunId: runId,
         entityType: input.subscription.domain,
         externalId: change.externalId,
-        localId: null,
+        localId: noopLocalId,
         operation: 'noop',
         status: 'success',
         changedFields: {},

--- a/runtime/subsystems/sync/sync-sink.protocol.ts
+++ b/runtime/subsystems/sync/sync-sink.protocol.ts
@@ -52,4 +52,11 @@ export interface ISyncSink<TCanonical> {
     userId: string,
     externalId: string,
   ): Promise<{ id: string } | null>;
+
+  /**
+   * When true, the orchestrator does NOT short-circuit on a `noop` diff — it
+   * still calls upsertByExternalId so the sink can reproject side data (e.g.
+   * EAV field_values) the differ doesn't see. Default false.
+   */
+  readonly reprojectsOnNoop?: boolean;
 }

--- a/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
+++ b/src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts
@@ -78,6 +78,10 @@ class FakeSink implements ISyncSink<CanonicalOpp> {
   readonly rows = new Map<string, CanonicalOpp>();
   /** External ids for which `upsertByExternalId` should throw. */
   failOn = new Set<string>();
+  /** Count of `upsertByExternalId` calls — lets tests assert reprojection. */
+  upsertCalls = 0;
+  /** Capability flag — `true` opts the sink into always-reproject on noop. */
+  reprojectsOnNoop?: boolean;
 
   async findByExternalId(
     _userId: string,
@@ -91,6 +95,7 @@ class FakeSink implements ISyncSink<CanonicalOpp> {
     record: CanonicalOpp,
     _provider: string,
   ): Promise<{ id: string; saved: CanonicalOpp }> {
+    this.upsertCalls++;
     if (this.failOn.has(record.external_id)) {
       throw new Error(`sink boom for ${record.external_id}`);
     }
@@ -323,12 +328,70 @@ describe('ExecuteSyncUseCase', () => {
       await orch.execute(makeInput());
 
       expect(recorder.items[0].operation).toBe('noop');
+      expect(recorder.items[0].localId).toBeNull();
       expect(recorder.items[0].changedFields).toEqual({});
       // Sink.upsertByExternalId was not called — row in the map is the
       // pre-existing reference (the change-record copy would also equal,
       // but we assert `upsertByExternalId` did not run by checking the
       // map still points to `existing`).
+      expect(sink.upsertCalls).toBe(0);
       expect(sink.rows.get('ext-1')).toBe(existing);
+    });
+  });
+
+  describe('reprojectsOnNoop capability (#375)', () => {
+    it('calls upsertByExternalId on a noop diff when the sink declares it', async () => {
+      sink.reprojectsOnNoop = true;
+      const existing: CanonicalOpp = {
+        external_id: 'ext-1',
+        amount: 100,
+        stageName: 'Prospecting',
+      };
+      sink.rows.set('ext-1', existing);
+      const change: Change<CanonicalOpp> = {
+        externalId: 'ext-1',
+        operation: 'updated',
+        // Canonically identical → differ returns 'noop'. A custom-field-only
+        // edit (EAV bag) looks exactly like this to the canonical differ.
+        record: { ...existing },
+        cursor: { v: 1 },
+        source: 'poll',
+      };
+      const source = new ArrayChangeSource([change]);
+      const orch = makeOrchestrator(source, sink, recorder, cursors);
+      await orch.execute(makeInput());
+
+      // The sink WAS called so it can reproject side data the differ can't see.
+      expect(sink.upsertCalls).toBe(1);
+      // Canonical state is unchanged → audit operation is still 'noop'...
+      expect(recorder.items[0].operation).toBe('noop');
+      expect(recorder.items[0].changedFields).toEqual({});
+      // ...but the local id returned by the upsert is captured.
+      expect(recorder.items[0].localId).toBe('local-ext-1');
+    });
+
+    it('still short-circuits on a noop diff when the sink does not declare it', async () => {
+      // reprojectsOnNoop is undefined (absent) — byte-identical to today.
+      const existing: CanonicalOpp = {
+        external_id: 'ext-1',
+        amount: 100,
+        stageName: 'Prospecting',
+      };
+      sink.rows.set('ext-1', existing);
+      const change: Change<CanonicalOpp> = {
+        externalId: 'ext-1',
+        operation: 'updated',
+        record: { ...existing },
+        cursor: { v: 1 },
+        source: 'poll',
+      };
+      const source = new ArrayChangeSource([change]);
+      const orch = makeOrchestrator(source, sink, recorder, cursors);
+      await orch.execute(makeInput());
+
+      expect(sink.upsertCalls).toBe(0);
+      expect(recorder.items[0].operation).toBe('noop');
+      expect(recorder.items[0].localId).toBeNull();
     });
   });
 


### PR DESCRIPTION
Closes #375

## What

Adds an optional `reprojectsOnNoop` capability to the sync subsystem's `ISyncSink` protocol and has `ExecuteSyncUseCase` honor it: when the sink declares the flag, the orchestrator does **not** short-circuit on a `noop` diff — it still calls the idempotent `upsertByExternalId` so the sink can reproject side data the canonical differ can't see (e.g. EAV `field_values` from a custom-property-only edit). Backwards-compatible: optional field, absent/`false` = today's short-circuit, byte-identical.

## Changes (sync-subsystem only)

**`runtime/subsystems/sync/sync-sink.protocol.ts`** — new optional member on `ISyncSink<TCanonical>`:

```ts
/**
 * When true, the orchestrator does NOT short-circuit on a `noop` diff — it
 * still calls upsertByExternalId so the sink can reproject side data (e.g.
 * EAV field_values) the differ doesn't see. Default false.
 */
readonly reprojectsOnNoop?: boolean;
```

No coupling to any consumer/dealbrain concept — a plain optional boolean.

**`runtime/subsystems/sync/execute-sync.use-case.ts`** — `processChange`, at the `if (diff === 'noop')` branch: when `this.sink.reprojectsOnNoop` is falsy/absent it short-circuits exactly as before. When `true` it falls through to `upsertByExternalId(...)`, records the audit item with `operation: 'noop'` (canonical state unchanged) but captures the returned `localId`. The only new branch is on the capability flag — never on entity type, preserving the orchestrator's "one class, reused across every tuple" property.

**`src/__tests__/runtime/subsystems/execute-sync.use-case.spec.ts`** — `FakeSink` gains an `upsertCalls` counter and a `reprojectsOnNoop` flag; a new `reprojectsOnNoop capability (#375)` describe block asserts: a sink with the flag gets `upsertByExternalId` called on a `noop` diff (operation `'noop'`, `localId` captured); a sink without it short-circuits (no upsert, `localId` null). The pre-existing noop test was tightened to assert `upsertCalls === 0`.

## Composition

The EAV sink that declares this capability (`reprojectsOnNoop = true` on the generated sink/repo for a `pattern: Synced` entity with `eav: true`) rides on the sync-override work in #374. This PR is solely the orchestrator's noop-gating + the protocol capability.

## Validation

- `bun run build` — exit 0, clean.
- Sync-subsystem test suite (`execute-sync.use-case.spec.ts`) — 16 pass / 0 fail.
- Did **not** validate a `file:` consume into dealbrain-integrations: the orchestrator is runtime-copied into the consumer, so consuming this requires a runtime re-sync there — skipped as out of scope for this PR.

Touched only the three sync-subsystem files above; no repository/template/base edits (#374's territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)