### PR TITLE
feat(sync): emit Synced/Junction sync-override (generic base + emitted syncConfig) — Rule-5 lift (#374)

### DIFF
--- a/ai-docs/specs/2026-05-24-emit-synced-junction-sync-override.md
+++ b/ai-docs/specs/2026-05-24-emit-synced-junction-sync-override.md
@@ -1,0 +1,205 @@
+# Emit the Synced/Junction sync-override (codegen-patterns implementation spec)
+
+**Issue:** #374 · **Rides on:** PR #373 (`@generated` banner), #372 (junction role-inclusive PK)
+**Contract spec (the WHAT):** `dealbrain-integrations/.ai-docs/specs/a2-codegen-sync-override.md`
+**This doc (the HOW):** resolves the 5 implementation decisions the contract spec left open.
+**Author:** Dug + Claude · **Date:** 2026-05-24
+
+---
+
+## Goal
+
+Lift the ~230-line hand-written inbound-sync write surface (currently duplicated across 5 `force:true` generated repos in dealbrain-integrations and silently wiped on every `codegen entity new --all`) into codegen. Generic logic lands in the runtime base classes; per-entity `syncConfig` literals + `TSyncWrite`/`TSyncProjection` types are emitted by the templates — same idiom as `behaviors` / `patternConfig`.
+
+## Context
+
+### Current state
+- `runtime/base-classes/synced-entity-repository.ts:46` — `syncUpsert` is a throwing stub. `SyncedEntityRepository<TEntity>` is single-param, extends `BaseRepository<TEntity>` (`runtime/base-classes/base-repository.ts`).
+- `BaseRepository` provides `runner(tx)` (`:75`), `baseQuery()` (`:230`), `withTimestamps()` (`:245`), `protected readonly db`, `protected abstract readonly table`.
+- Junction repos extend `BaseRepository` directly (`templates/junction/new/repository.ejs.t`) — no sync surface today.
+- As of #372, role-bearing junction PKs span `(leftId, rightId, role)` — a real ON CONFLICT target (`templates/junction/new/entity.ejs.t:89-94`). Role-less junctions keep `(leftId, rightId)`.
+
+### Template scope already available (no new derivation needed)
+**Entity (clean-lite-ps), `prompt-extension.js`:**
+- `clpBelongsTo[]` — `{ field, camelField, relatedEntity, relatedEntityPascal, relatedTable (plural var), nullable, importPath: '../<plural>/<target>.entity', relationKey, isSelfFk, onDelete }`. **FK columns are split OUT of `clpProcessedFields` into here.**
+- `clpProcessedFields` (= non-FK fields) — each `{ name, camelName, type, tsType, nullable, required, hasChoices, choices, ... }`.
+- `hasExternalIdTracking`, `hasSoftDelete`, `hasTimestamps`, `hasUserTracking`, `eavEnabled`, `patternName`, `classNames`, `renderPatternConfigLiteral`.
+
+**Junction, `prompt.js`:**
+- `leftEntity/rightEntity` (+ `…Pascal`, `…Plural`, `…Camel`), `leftColumn/rightColumn` (+ `…Camel`), `leftTable/rightTable` (parent table var names), `hasRole`, `roleEnumName`, `leftEntityImportFromJunction`/`rightEntityImportFromJunction` (`../<plural>/<entity>.entity`), `classNames`.
+
+### Reference (the wiped hand-impl — read as spec-by-example, but see Decision 3)
+- Entity: `dealbrain-integrations/src/modules/accounts/account.repository.ts`
+- Junction: `dealbrain-integrations/src/modules/account_contacts/account_contact.repository.ts`
+- Sinks (the consumer contract the signatures must satisfy): `dealbrain-integrations/src/modules/crm_sync/sinks/*.sink.ts`
+
+### Invariants to preserve (do NOT lose on the lift)
+Opportunistic-FK-null **+ no-clobber-with-null** in the conflict `set` (entity); strict-throw on unresolved FK (junction); provider scoping on **every** external-id lookup; self-FK as `refTable: 'self'`; tombstone-by-clearing when `soft_delete: false`; projection omits `provider`/`provider_metadata` (keeps `externalId`); batch `syncUpsert` reads `provider` per-input and skips incomplete rows.
+
+---
+
+## The 5 design decisions
+
+### Decision 1 — `SyncUpsertConfig` shape (full, incl. write columns)
+
+The contract spec's `SyncConfig` lacked a write-column list. The generic upsert separates three column roles: **identity** (conflict target, only in `values`), **copy-through** (`values` + `set`), **resolved FK** (conditional in `set`). New type (named `SyncUpsertConfig` to avoid collision with the sync subsystem's `DetectionConfig`):
+
+```ts
+// runtime/base-classes/sync-upsert-config.ts
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+
+export interface SyncFkResolver {
+  column: string;        // local FK column (camel key into this.table), e.g. 'parentAccountId'
+  writeKey: string;      // key on TSyncWrite carrying the parent external id (see Decision 4)
+  refTable: PgTableWithColumns<any> | 'self';  // 'self' → this.table
+  strict?: boolean;      // true = throw on unresolved (junction); falsy = opportunistic null (entity)
+}
+
+export interface SyncUpsertConfig {
+  conflictTarget: string[];   // camel keys into this.table, e.g. ['provider', 'externalId']
+  writeColumns: string[];     // canonical cols copied verbatim write→values/set (camel). EXCLUDES
+                              // externalId, provider, FK columns, and behavior-managed timestamps.
+  fkResolvers: SyncFkResolver[];
+  projectionColumns: string[];// cols picked into the projection (camel), incl. id/externalId/timestamps
+  eav: boolean;
+  softDelete: boolean;
+}
+```
+
+Generic upsert assembly in the base:
+- `values = { externalId: write.externalId, provider, ...pick(write, writeColumns), ...resolvedFks, ...(timestamps ? { updatedAt: now } : {}) }`
+- `set    = { ...pick(write, writeColumns), ...conditionalResolvedFks, ...(timestamps ? { updatedAt: now } : {}) }` — `externalId`/`provider` never in `set` (they're the identity); each resolved FK included **only when non-null this run** (no-clobber).
+
+### Decision 2 — FK resolvers carry live Drizzle table handles (not strings)
+
+`renderPatternConfigLiteral` quotes strings, so it **cannot** emit a live table identifier. Therefore the `syncConfig` literal is **hand-emitted by the template** (not routed through `renderPatternConfigLiteral`), with `refTable` as either the string `'self'` or the imported parent-table const:
+
+```ts
+fkResolvers: [
+  { column: 'parentAccountId', writeKey: 'parentExternalId', refTable: 'self' },
+  // non-self synced FK:
+  { column: 'accountId', writeKey: 'accountExternalId', refTable: accounts },
+],
+```
+
+The base resolves `refTable === 'self' ? this.table : refTable`, then `SELECT id WHERE (provider, externalId) = (provider, write[writeKey])`. Non-self FK parent tables are imported into the repo file from `clpBelongsTo[].importPath` (`../<plural>/<target>.entity`). **#368 watch:** dedupe parent-table imports against the entity's own import and each other (template-level `Set` of already-imported modules) — the multi-junction import-dedup bug lived exactly here.
+
+> Note: `account` only has a self-FK, so the DBI oracle does **not** exercise the non-self synced-FK import path. Cover it with a codegen unit test (a synced entity with a `belongs_to` a *different* synced entity).
+
+### Decision 3 — Junction base uses `onConflictDoUpdate` on the `(left,right,role)` PK (supersedes the stale reference)
+
+The DBI junction reference (`account_contact.repository.ts:117-128`) used SELECT-then-INSERT/UPDATE **because the role-inclusive constraint didn't exist when it was written**. Post-#372 it does. The lift emits the **better** version:
+
+```ts
+await db.insert(this.table)
+  .values({ [leftCol]: leftId, [rightCol]: rightId, ...(roleColumn ? { [roleColumn]: write.role } : {}), updatedAt: now })
+  .onConflictDoUpdate({
+    target: roleColumn ? [this.table[leftCol], this.table[rightCol], this.table[roleColumn]]
+                       : [this.table[leftCol], this.table[rightCol]],
+    set: { updatedAt: now },
+  })
+  .returning();
+```
+
+New base `JunctionSyncRepository<TEntity, TSyncWrite, TSyncProjection>` (`runtime/base-classes/junction-sync-repository.ts`) extends `BaseRepository<TEntity>`. Config:
+
+```ts
+export interface JunctionSyncConfig {
+  left:  { column: string; refTable: PgTableWithColumns<any> };  // strict
+  right: { column: string; refTable: PgTableWithColumns<any> };  // strict
+  roleColumn: string | null;   // null → role-less junction (2-part composite, 2-col conflict)
+}
+```
+
+Both FK resolutions are **strict** (throw on unresolved → orchestrator records a failed item and continues). Composite externalId build/parse are **static helpers in the base file** (`buildCompositeExternalId` / `parseCompositeExternalId`, `::` delimiter, 3 parts when role else 2), replacing the per-repo free functions in the reference. `findByExternalIdProjected` / `softDeleteByExternalId` parse the composite, resolve both parents **non-throwing** (→ `null`), then select/delete by tuple. Junction projection `id` is the synthesized composite string (no surrogate id column).
+
+### Decision 4 — `TSyncWrite` / `TSyncProjection` emission + FK-key naming
+
+Emitted per entity, gated on `pattern === 'Synced'`. Field TS types come from `clpProcessedFields[].tsType` (already maps YAML type → TS, narrows enums to literal unions) with `| null` appended when `nullable`.
+
+- **`TSyncWrite`** = `externalId: string` + `pick(clpProcessedFields, writeColumns)` (typed, nullable-aware) + one `<writeKey>?: string | null` per `clpBelongsTo` FK + `fields?: Record<string, unknown>`. Excludes `id`, timestamps, `provider`, `providerMetadata`, and the resolved local FK columns.
+- **`TSyncProjection`** = `id` + `externalId` + `pick(clpProcessedFields)` + each FK local column + `createdAt`/`updatedAt`. Omits `provider`/`providerMetadata`.
+
+**FK-key naming (RESOLVED — Open Question 1, option a):** `writeKey = ${relationKey}ExternalId` (e.g. `parentAccount` → `parentAccountExternalId`). Deterministic, no new YAML surface. The DBI account sink renames its one write-key `parentExternalId → parentAccountExternalId` (sink is consumer-owned glue, not one of the 5 generated repos; method signatures unchanged, only the field name moves). Junction FK keys use `${camelCase(entity)}ExternalId` (e.g. `accountExternalId`) — already matches the reference.
+
+### Decision 5 — EAV seam: overridable no-op hook, config-gated (live path lands in #124)
+
+**No sink passes a `fields` bag today**, so the DBI oracle does not exercise the live EAV write — it activates downstream in #124. Emit the seam as an overridable hook on the base, default no-op:
+
+```ts
+protected async writeCustomFields(_db: DrizzleTx, _entityId: string, _userId: string, _fields: Record<string, unknown>): Promise<void> {}
+```
+
+`syncUpsertOne` calls it inside the tx only when `syncConfig.eav && write.fields` non-empty. When `eav: true`, the template emits a concrete override that injects `FieldValueService` and delegates to `upsertFieldsTransactional(entityType, entityId, userId, fields, db)` — aligning with the use-case path (`templates/entity/new/clean-lite-ps/use-cases/create.ejs.t:52`) and the downstream #126 batch projector contract (shared `FieldValueService` write; no duplicate key→def resolution). Repo→`FieldValueService` injection is an eav-gated exception to the layer rules, isolated to eav repos only — base stays portable (core/extension principle).
+
+---
+
+## Plan
+
+### Step 1 — `SyncUpsertConfig` type
+- File: `runtime/base-classes/sync-upsert-config.ts` (new)
+- Add `SyncUpsertConfig` + `SyncFkResolver` (Decision 1). Export from `runtime/base-classes/index.ts` if a barrel exists.
+
+### Step 2 — Implement generic logic in `SyncedEntityRepository`
+- File: `runtime/base-classes/synced-entity-repository.ts`
+- Widen to `SyncedEntityRepository<TEntity, TSyncWrite = Partial<TEntity>, TSyncProjection = TEntity>` (defaults keep existing single-param subclasses compiling).
+- Add `protected abstract readonly syncConfig: SyncUpsertConfig`.
+- Implement `syncUpsertOne(write, provider, tx)`, `findByExternalIdProjected(externalId, provider)`, `softDeleteByExternalId(externalId, provider, tx)`, `toProjection(row)` (generic pick over `projectionColumns`), `writeCustomFields` (no-op hook), and **concretize** `syncUpsert(inputs)` (batch wrapper, per-input provider, skip incomplete). Replace the stub at `:46`.
+- Preserve every invariant from Context (opportunistic null, no-clobber, provider scoping, tombstone-by-clearing vs `deletedAt`, projection omit).
+
+### Step 3 — New `JunctionSyncRepository` base
+- File: `runtime/base-classes/junction-sync-repository.ts` (new)
+- Decision 3: `JunctionSyncConfig`, generic methods using `onConflictDoUpdate`, strict dual-FK resolution, static composite build/parse helpers, role/role-less branch.
+
+### Step 4 — Entity template emission
+- File: `templates/entity/new/clean-lite-ps/repository.ejs.t`
+- Gate on `patternName === 'Synced'`: emit `TSyncWrite`/`TSyncProjection` interfaces, the hand-emitted `syncConfig` literal (Decision 2 — live `refTable` handles, deduped parent-table imports), widen the `extends` to `SyncedEntityRepository<Entity, EntitySyncWrite, EntitySyncProjection>`, and (when `eavEnabled`) emit the `writeCustomFields` override + `FieldValueService` injection.
+- Derive `writeColumns`/`projectionColumns`/`fkResolvers` in the template (or, cleaner, pre-compute in `prompt-extension.js` `buildCleanLitePsLocals` as `clpSyncConfig` + `clpSyncWriteFields`/`clpSyncProjectionFields` and emit from there — **preferred**, keeps EJS thin and unit-testable).
+
+### Step 5 — Junction template emission
+- File: `templates/junction/new/repository.ejs.t`
+- Emit junction `TSyncWrite`/`TSyncProjection`, the `JunctionSyncConfig` literal (live `leftTable`/`rightTable` handles + parent imports), `extends JunctionSyncRepository<…>`. Keep the existing two pairing-finders. Role/role-less branch on `hasRole`.
+
+### Step 6 — Pattern library
+- File: `src/patterns/library/synced.pattern.ts`
+- Update `repositoryInheritedMethods` to list the now-real `syncUpsertOne`, `findByExternalIdProjected`, `softDeleteByExternalId` (+ keep `syncUpsert`). Update the inherited-method comment lines the template prints.
+
+### Step 7 — Tests
+- Base unit tests (Memory/pg-lite or table mock): FK resolution (opportunistic-null + no-clobber), provider scoping, `findByExternalIdProjected`, `softDeleteByExternalId` (both `softDelete` branches), batch `syncUpsert`. Junction: strict dual-FK resolution + composite build/parse + role-less variant.
+- Template-emission tests: `pattern: Synced` emits config + types + `@generated` banner; non-self synced-FK import path; junction variant; eav override path; no hand-method expectation remains.
+- Update baseline snapshots (`test/baseline/`) for synced fixtures — diff should be exactly the new sync surface.
+
+---
+
+## Acceptance Criteria
+
+**codegen-patterns:**
+- [x] `SyncedEntityRepository.syncUpsert` stub replaced; all 5 methods + config implemented and unit-tested (both `softDelete` branches, opportunistic-null, no-clobber, provider scoping, batch).
+- [x] `JunctionSyncRepository` implemented with `onConflictDoUpdate` on the role-inclusive PK; role + role-less covered.
+- [x] Templates emit `syncConfig` + `TSyncWrite`/`TSyncProjection` (entity + junction); parent-table imports deduped (#368). *(`@generated` banner deferred to PR #373 — not on this branch; see Implementation notes.)*
+- [x] `synced.pattern.ts` inherited-method list updated.
+- [x] `bun run build` + suite green; junction snapshots regenerated (clean baseline unaffected — see Implementation notes). *(Pristine `main` carries 3 pre-existing `junction.ts`/`barrel-generator.ts` typecheck errors + 1 smoke-junction regex failure — unrelated; not masked, not fixed here.)*
+
+**DBI validation oracle (the unambiguous "done", owned by dealbrain-integrations):**
+- [ ] Point DBI at `file:/Users/dug/Projects/codegen-patterns` → `bun install` → `bun run codegen`.
+- [ ] `git diff` on the 5 repos (`accounts`, `contacts`, `opportunities`, `account_contacts`, `opportunity_contacts`) shows **only generated content** — no hand glue to lose.
+- [ ] `bun run typecheck` → **0 errors** (sinks resolve against generated/inherited methods). *(Gated on Open Question 1 — sinks may need the `parentExternalId → parentAccountExternalId` rename.)*
+- [ ] Full DBI unit suite green (**699** at last green).
+- [ ] Publish a `@pattern-stack/codegen` bump; DBI consumes; #124 re-emit lands clean.
+
+---
+
+## Open Questions
+
+1. **✅ RESOLVED — FK-external-id write-key naming.** Option (a): emit `writeKey = ${relationKey}ExternalId` (→ `parentAccountExternalId`); DBI sink renames its one write-key `parentExternalId → parentAccountExternalId`. The contract-spec §6 "signatures unchanged" clause governs *method* signatures (unchanged); only the write *field* name moves. **Action carried into the DBI side of the oracle:** the typecheck-0 step includes the sink rename.
+2. **✅ RESOLVED — syncConfig in `prompt-extension.js` vs inline EJS.** Pre-computed in JS: `buildSyncSurface(...)` in `prompt-extension.js` returns `clpSyncConfig` + `clpSyncFkResolvers` + `clpSyncWriteFields`/`clpSyncWriteFkFields` + `clpSyncProjectionFields` + `clpSyncParentTableImports` (+ `hasSyncSurface`). The junction side computes the equivalents in `templates/junction/new/prompt.js` (`junctionSyncConfig`, `syncWriteFields`, `syncProjectionFields`, `syncParentImports`, `leftSyncWriteKey`/`rightSyncWriteKey`, `roleColumnCamel`/`roleTsType`). EJS stays thin: it only hand-emits the literal (so `refTable` is a live identifier) and the interfaces. `buildSyncSurface` is exported for unit tests.
+3. **✅ RESOLVED — Type-param defaults vs abstract `syncConfig`.** `syncConfig` is abstract. One non-generated synced repo exists: the hand-written `TestCrmRepository` in `test/scaffold/tests/synced-entity-repository.test.ts` — given a minimal hand-written `syncConfig` in this PR. Its `syncUpsert throws not implemented` assertion was replaced (the method is now concrete; empty input → `[]`).
+4. **✅ RESOLVED — Junction `userId`.** Stays write-only context (no column), matching the reference. The base ignores it except as the `userId` arg for a hypothetical future junction-EAV write.
+
+## Implementation notes (post-build truths)
+
+- **`@generated` banner (PR #373) not on this branch.** The clean-lite-ps `repository.ejs.t` carries no `@generated`/`DO NOT EDIT` banner today, so the lift emits none. When #373 lands, add the banner to the template head; the acceptance-criteria banner check applies then, not now.
+- **EAV import path.** The eav override imports `FieldValueService` from `../field_values/field_value.service` (underscores), matching the existing `use-cases/create.ejs.t` convention (`../../field_values/field_value.service` from one level deeper). The Decision-5 prose's hyphenated example was illustrative.
+- **Baseline is `clean` architecture; sync surface is clean-lite-ps + junction.** `test/baseline/` is generated with `generate.architecture: clean`, which routes through `templates/entity/new/backend/`. The sync-override emission lives in `templates/entity/new/clean-lite-ps/repository.ejs.t` and `templates/junction/new/repository.ejs.t`, so the **clean baseline is unchanged**. The observable codegen diff is the two junction repository snapshots in `test/junction/__snapshots__/` (regenerated; diff = exactly the new sync surface: `TSyncWrite`/`TSyncProjection` + `JunctionSyncConfig` literal + widened `extends` + parent imports + updated inherited-methods comment).
+- **EJS escaping gotcha.** `refTable` and `roleColumn` literal values MUST be emitted with `<%-` (raw), not `<%=` (escapes `'` → `&#39;`).
+- **Static composite helpers signature.** `parseCompositeExternalId(externalId, withRole: boolean)` and `buildCompositeExternalId(left, right, role?)` — `withRole`/`role?` select the 2- vs 3-part shape (vs the reference's role-only 3-part form).

--- a/runtime/base-classes/index.ts
+++ b/runtime/base-classes/index.ts
@@ -19,8 +19,17 @@ export type { EventCategory } from './lifecycle-events';
 export { BaseFindByIdUseCase, BaseListUseCase } from './base-read-use-cases';
 export type { IFindByIdService, IListService } from './base-read-use-cases';
 
+// Sync upsert config (consumed by SyncedEntityRepository + JunctionSyncRepository)
+export type { SyncUpsertConfig, SyncFkResolver } from './sync-upsert-config';
+
 // Family-specific repository base classes
 export { SyncedEntityRepository } from './synced-entity-repository';
+export {
+  JunctionSyncRepository,
+  buildCompositeExternalId,
+  parseCompositeExternalId,
+} from './junction-sync-repository';
+export type { JunctionSyncConfig } from './junction-sync-repository';
 export { ActivityEntityRepository } from './activity-entity-repository';
 export { MetadataEntityRepository } from './metadata-entity-repository';
 export { KnowledgeEntityRepository } from './knowledge-entity-repository';

--- a/runtime/base-classes/junction-sync-repository.ts
+++ b/runtime/base-classes/junction-sync-repository.ts
@@ -1,0 +1,284 @@
+/**
+ * JunctionSyncRepository<TEntity, TSyncWrite, TSyncProjection>
+ *
+ * Base for junction repos that participate in inbound sync (#374). A junction's
+ * sync identity is the tuple `(leftId, rightId[, role])` — there is no native
+ * `external_id`/`provider` column, so the sync seam's externalId is a COMPOSITE
+ * string `<leftExternalId>::<rightExternalId>[::<role>]` (see the static
+ * build/parse helpers below).
+ *
+ * Both parent FKs are resolved STRICTLY in the write path (a missing parent
+ * throws → the orchestrator records a failed item and continues). As of #372
+ * role-bearing junctions carry a unique constraint over `(left, right, role)`,
+ * so the upsert uses `onConflictDoUpdate` (not the legacy select-then-write).
+ * Role-less junctions conflict on `(left, right)`.
+ */
+import { and, eq } from 'drizzle-orm';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+import type { DrizzleTx } from '../types/drizzle';
+import { BaseRepository } from './base-repository';
+
+export interface JunctionSyncConfig {
+  /** Left endpoint: local FK column (camel) + strict parent table. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  left: { column: string; refTable: PgTableWithColumns<any> };
+  /** Right endpoint: local FK column (camel) + strict parent table. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  right: { column: string; refTable: PgTableWithColumns<any> };
+  /** Role column (camel), or null for a role-less (2-part composite) junction. */
+  roleColumn: string | null;
+}
+
+export abstract class JunctionSyncRepository<
+  TEntity,
+  TSyncWrite,
+  TSyncProjection,
+> extends BaseRepository<TEntity> {
+  /**
+   * Declarative junction sync surface. Concrete repos declare this — the
+   * template emits it with live parent-table handles.
+   */
+  protected abstract readonly syncConfig: JunctionSyncConfig;
+
+  /**
+   * Upsert ONE junction row by its composite identity, in a single transaction:
+   *   1. resolve the REQUIRED left FK (provider-scoped) — STRICT: missing → throws;
+   *   2. resolve the REQUIRED right FK (provider-scoped) — STRICT: missing → throws;
+   *   3. insert-or-update on the `(left, right[, role])` conflict target.
+   *
+   * Idempotent. Returns the composite externalId as the projection `id`.
+   *
+   * @param write     parent external ids (`<left>ExternalId`/`<right>ExternalId`)
+   *                  + optional `role` + `userId`
+   * @param provider  adapter/provider label used to scope the parent lookups
+   * @param tx        optional outer transaction; when omitted we open our own
+   */
+  async syncUpsertOne(
+    write: TSyncWrite,
+    provider: string,
+    tx?: DrizzleTx,
+  ): Promise<TSyncProjection> {
+    const cfg = this.syncConfig;
+    const w = write as Record<string, unknown>;
+    const leftWriteKey = `${cfg.left.column.replace(/Id$/, '')}ExternalId`;
+    const rightWriteKey = `${cfg.right.column.replace(/Id$/, '')}ExternalId`;
+
+    const run = async (db: DrizzleTx): Promise<TSyncProjection> => {
+      const leftId = await this.resolveStrict(
+        db, cfg.left.refTable, w[leftWriteKey] as string, provider, cfg.left.column,
+      );
+      const rightId = await this.resolveStrict(
+        db, cfg.right.refTable, w[rightWriteKey] as string, provider, cfg.right.column,
+      );
+
+      const now = new Date();
+      const role = cfg.roleColumn ? (w['role'] as unknown) : undefined;
+      const values: Record<string, unknown> = {
+        [cfg.left.column]: leftId,
+        [cfg.right.column]: rightId,
+        ...(cfg.roleColumn ? { [cfg.roleColumn]: role } : {}),
+        ...(this.behaviors.timestamps ? { updatedAt: now } : {}),
+      };
+      const target = cfg.roleColumn
+        ? [this.table[cfg.left.column], this.table[cfg.right.column], this.table[cfg.roleColumn]]
+        : [this.table[cfg.left.column], this.table[cfg.right.column]];
+
+      const rows = await db
+        .insert(this.table)
+        .values(values as never)
+        .onConflictDoUpdate({
+          target,
+          set: { ...(this.behaviors.timestamps ? { updatedAt: now } : {}) } as never,
+        })
+        .returning();
+
+      const saved = rows[0] as Record<string, unknown>;
+      return this.toProjection(saved as TEntity, w, provider);
+    };
+
+    return tx ? run(tx) : this.db.transaction((t) => run(t));
+  }
+
+  /**
+   * Canonical-projected lookup by the COMPOSITE externalId, differ-ready. Parses
+   * the composite, resolves BOTH parents NON-throwing (→ null), then selects by
+   * the identity tuple. Returns `null` on malformed composite / unresolved
+   * parent / no row (a missing "before" side is a create from the differ's view).
+   */
+  async findByExternalIdProjected(
+    externalId: string,
+    provider: string,
+  ): Promise<TSyncProjection | null> {
+    const cfg = this.syncConfig;
+    const parsed = parseCompositeExternalId(externalId, cfg.roleColumn !== null);
+    if (!parsed) return null;
+
+    const leftId = await this.resolveLoose(this.db, cfg.left.refTable, parsed.left, provider);
+    if (leftId === null) return null;
+    const rightId = await this.resolveLoose(this.db, cfg.right.refTable, parsed.right, provider);
+    if (rightId === null) return null;
+
+    const rows = await this.db
+      .select()
+      .from(this.table)
+      .where(this.identityWhere(leftId, rightId, parsed.role))
+      .limit(1);
+    const row = rows[0] as TEntity | undefined;
+    if (!row) return null;
+
+    const w: Record<string, unknown> = {
+      [`${cfg.left.column.replace(/Id$/, '')}ExternalId`]: parsed.left,
+      [`${cfg.right.column.replace(/Id$/, '')}ExternalId`]: parsed.right,
+      ...(cfg.roleColumn ? { role: parsed.role } : {}),
+      userId: '',
+    };
+    return this.toProjection(row, w, provider);
+  }
+
+  /**
+   * Hard-delete the junction by composite externalId. Junctions have no
+   * `deleted_at` and no external-linkage columns to clear, so a sync "delete"
+   * removes the row. Resolves both parents NON-throwing, then deletes by the
+   * identity tuple. Returns the composite id, or `null` when nothing matched.
+   */
+  async softDeleteByExternalId(
+    externalId: string,
+    provider: string,
+    tx?: DrizzleTx,
+  ): Promise<{ id: string } | null> {
+    const cfg = this.syncConfig;
+    const parsed = parseCompositeExternalId(externalId, cfg.roleColumn !== null);
+    if (!parsed) return null;
+    const db = this.runner(tx);
+
+    const leftId = await this.resolveLoose(db, cfg.left.refTable, parsed.left, provider);
+    if (leftId === null) return null;
+    const rightId = await this.resolveLoose(db, cfg.right.refTable, parsed.right, provider);
+    if (rightId === null) return null;
+
+    const rows = await db
+      .delete(this.table)
+      .where(this.identityWhere(leftId, rightId, parsed.role))
+      .returning({ id: this.table[cfg.left.column] });
+    return rows[0] ? { id: externalId } : null;
+  }
+
+  /**
+   * Project a raw junction row to the differ shape. `id` is the COMPOSITE
+   * externalId (the junction has no surrogate id). Override to widen the
+   * projection beyond the identity tuple (the template emits a concrete
+   * `toProjection` carrying the role + local FKs + timestamps).
+   */
+  protected toProjection(
+    _row: TEntity,
+    write: Record<string, unknown>,
+    _provider: string,
+  ): TSyncProjection {
+    const cfg = this.syncConfig;
+    const leftExt = write[`${cfg.left.column.replace(/Id$/, '')}ExternalId`] as string;
+    const rightExt = write[`${cfg.right.column.replace(/Id$/, '')}ExternalId`] as string;
+    const role = cfg.roleColumn ? (write['role'] as string) : undefined;
+    return { id: buildCompositeExternalId(leftExt, rightExt, role) } as TSyncProjection;
+  }
+
+  /** Build the identity WHERE clause `(left, right[, role])`. */
+  private identityWhere(leftId: string, rightId: string, role: string | undefined) {
+    const cfg = this.syncConfig;
+    const conds = [
+      eq(this.table[cfg.left.column], leftId),
+      eq(this.table[cfg.right.column], rightId),
+    ];
+    if (cfg.roleColumn && role !== undefined) {
+      conds.push(eq(this.table[cfg.roleColumn], role));
+    }
+    return and(...conds);
+  }
+
+  /** Resolve a parent id (provider-scoped), throwing when unresolved. */
+  private async resolveStrict(
+    db: DrizzleTx,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    refTable: PgTableWithColumns<any>,
+    parentExternalId: string,
+    provider: string,
+    column: string,
+  ): Promise<string> {
+    const id = await this.resolveLoose(db, refTable, parentExternalId, provider);
+    if (!id) {
+      throw new Error(
+        `${this.constructor.name}.syncUpsertOne: unresolved parent ` +
+          `'${parentExternalId}' (provider '${provider}') for '${column}' — ` +
+          `parent not synced yet`,
+      );
+    }
+    return id;
+  }
+
+  /** Resolve a parent id (provider-scoped), returning null when unresolved. */
+  private async resolveLoose(
+    db: DrizzleTx,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    refTable: PgTableWithColumns<any>,
+    parentExternalId: string | null | undefined,
+    provider: string,
+  ): Promise<string | null> {
+    if (!parentExternalId) return null;
+    const rows = await db
+      .select({ id: refTable['id'] })
+      .from(refTable)
+      .where(
+        and(
+          eq(refTable['provider'], provider),
+          eq(refTable['externalId'], parentExternalId),
+        ),
+      )
+      .limit(1);
+    return (rows[0]?.id as string | undefined) ?? null;
+  }
+}
+
+// ============================================================================
+// Composite externalId — the junction sync seam's deterministic identity.
+//
+// Format: `<leftExternalId>::<rightExternalId>[::<role>]`
+//   e.g. `hubspot:42::hubspot:99::employee`  (role-bearing)
+//        `hubspot:42::hubspot:99`            (role-less)
+//
+// Vendor-prefixed ids use a SINGLE colon, so `::` is an unambiguous delimiter.
+// Kept static in the base (replacing the per-repo free functions) so every
+// junction's lookups + its ChangeSource share one definition.
+// ============================================================================
+
+/**
+ * Build the composite externalId from the two parent external ids (+ role when
+ * the junction is role-bearing).
+ */
+export function buildCompositeExternalId(
+  leftExternalId: string,
+  rightExternalId: string,
+  role?: string,
+): string {
+  return role !== undefined
+    ? `${leftExternalId}::${rightExternalId}::${role}`
+    : `${leftExternalId}::${rightExternalId}`;
+}
+
+/**
+ * Parse a composite externalId. `withRole` selects the expected part count
+ * (3 when role-bearing, else 2). Returns `null` when the shape doesn't match
+ * or any part is empty.
+ */
+export function parseCompositeExternalId(
+  externalId: string,
+  withRole: boolean,
+): { left: string; right: string; role: string | undefined } | null {
+  const parts = externalId.split('::');
+  const expected = withRole ? 3 : 2;
+  if (parts.length !== expected || parts.some((p) => p.length === 0)) return null;
+  return {
+    left: parts[0] as string,
+    right: parts[1] as string,
+    role: withRole ? (parts[2] as string) : undefined,
+  };
+}

--- a/runtime/base-classes/sync-upsert-config.ts
+++ b/runtime/base-classes/sync-upsert-config.ts
@@ -1,0 +1,58 @@
+/**
+ * SyncUpsertConfig + SyncFkResolver
+ *
+ * Declarative description of an entity's inbound-sync write surface, consumed
+ * by `SyncedEntityRepository.syncUpsertOne` / `findByExternalIdProjected` /
+ * `softDeleteByExternalId` / `toProjection`. Each `pattern: Synced` repository
+ * declares a concrete `syncConfig: SyncUpsertConfig` (emitted by the template),
+ * the same idiom as `behaviors: BehaviorConfig`.
+ *
+ * Named `SyncUpsertConfig` (not `SyncConfig`) to avoid colliding with the sync
+ * subsystem's `DetectionConfig`/`SyncConfig` surface.
+ *
+ * The generic upsert separates three column roles:
+ *   - identity      (`conflictTarget`) — only in `values`, never in `set`
+ *   - copy-through  (`writeColumns`)   — in both `values` and `set`
+ *   - resolved FK   (`fkResolvers`)    — conditional in `set` (no-clobber)
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+
+/**
+ * Resolves a local FK column from a parent's external id, provider-scoped.
+ *
+ * The base does `SELECT id FROM <refTable> WHERE (provider, externalId) =
+ * (provider, write[writeKey])`. `refTable === 'self'` resolves to `this.table`
+ * (self-FK). `strict: true` throws when the parent is unresolved (junction
+ * posture); falsy leaves the column null this run (opportunistic, entity
+ * posture).
+ */
+export interface SyncFkResolver {
+  /** Local FK column — camel key into `this.table`, e.g. `'parentAccountId'`. */
+  column: string;
+  /** Key on `TSyncWrite` carrying the parent external id (see Decision 4). */
+  writeKey: string;
+  /** Parent table to resolve against; `'self'` → `this.table`. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  refTable: PgTableWithColumns<any> | 'self';
+  /** true = throw on unresolved (junction); falsy = opportunistic null (entity). */
+  strict?: boolean;
+}
+
+export interface SyncUpsertConfig {
+  /** Camel keys into `this.table` forming the conflict target, e.g. `['provider', 'externalId']`. */
+  conflictTarget: string[];
+  /**
+   * Canonical columns copied verbatim write→values/set (camel). EXCLUDES
+   * `externalId`, `provider`, FK columns, and behavior-managed timestamps.
+   */
+  writeColumns: string[];
+  /** Conditional, provider-scoped FK resolvers. */
+  fkResolvers: SyncFkResolver[];
+  /** Columns picked into the projection (camel), incl. id/externalId/timestamps. */
+  projectionColumns: string[];
+  /** When true, `syncUpsertOne` calls `writeCustomFields` for a non-empty `fields` bag. */
+  eav: boolean;
+  /** When true, deletes set `deletedAt`; when false, tombstone-by-clearing external_id/provider. */
+  softDelete: boolean;
+}

--- a/runtime/base-classes/synced-entity-repository.ts
+++ b/runtime/base-classes/synced-entity-repository.ts
@@ -123,7 +123,7 @@ export abstract class SyncedEntityRepository<
         .insert(this.table)
         .values(values as never)
         .onConflictDoUpdate({
-          target: cfg.conflictTarget.map((c) => this.table[c]),
+          target: cfg.conflictTarget.map((c: string) => this.table[c]),
           set: set as never,
         })
         .returning();

--- a/runtime/base-classes/synced-entity-repository.ts
+++ b/runtime/base-classes/synced-entity-repository.ts
@@ -1,15 +1,32 @@
 /**
- * SyncedEntityRepository<TEntity>
+ * SyncedEntityRepository<TEntity, TSyncWrite, TSyncProjection>
  *
  * Family-specific base for Synced entities (contacts, accounts, opportunities).
- * Adds external ID lookups, user-scoped queries, and sync stubs.
+ * Adds external ID lookups, user-scoped queries, and the generic inbound-sync
+ * write surface (canonical→Drizzle upsert + provider-scoped FK resolution +
+ * EAV dual-write seam), driven by the concrete repo's `syncConfig`.
  *
- * Concrete repos extend this and declare their table + behaviors.
+ * The type params default so pre-existing single-param subclasses keep
+ * compiling; `pattern: Synced` repos declare all three plus `syncConfig`.
  */
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+import type { DrizzleTx } from '../types/drizzle';
 import { BaseRepository } from './base-repository';
+import type { SyncUpsertConfig, SyncFkResolver } from './sync-upsert-config';
 
-export abstract class SyncedEntityRepository<TEntity> extends BaseRepository<TEntity> {
+export abstract class SyncedEntityRepository<
+  TEntity,
+  TSyncWrite = Partial<TEntity>,
+  TSyncProjection = TEntity,
+> extends BaseRepository<TEntity> {
+  /**
+   * Declarative sync write surface. Concrete (`pattern: Synced`) repositories
+   * declare this — the template emits it from the entity's fields + FKs.
+   */
+  protected abstract readonly syncConfig: SyncUpsertConfig;
+
   /**
    * Find a single entity by its external CRM identifier.
    */
@@ -39,12 +56,249 @@ export abstract class SyncedEntityRepository<TEntity> extends BaseRepository<TEn
     return rows as TEntity[];
   }
 
+  // ==========================================================================
+  // Inbound sync (#374) — canonical→Drizzle write + provider-scoped FK
+  // resolution + EAV dual-write seam, all inside a SINGLE transaction.
+  // Driven entirely by `this.syncConfig`; the per-entity shape lives there.
+  // ==========================================================================
+
   /**
-   * Sync upsert — bulk insert-or-update from external CRM data.
-   * Concrete repositories must implement with the appropriate conflict target.
+   * Upsert ONE entity by its `(provider, externalId)` identity, in a single
+   * transaction:
+   *   1. resolve each `syncConfig.fkResolvers` FK (provider-scoped). Strict
+   *      resolvers throw on unresolved; non-strict leave the column null.
+   *   2. insert-or-update the canonical columns via `onConflictDoUpdate` on the
+   *      `conflictTarget`. Resolved FKs are only written into `set` when
+   *      non-null this run (no-clobber).
+   *   3. EAV dual-write of `write.fields` via `writeCustomFields` when
+   *      `syncConfig.eav` and the bag is non-empty (same tx).
+   *
+   * Idempotent: a second call with the same identity updates in place. Returns
+   * the canonical projection (so the orchestrator records `local_id`).
+   *
+   * @param write     canonical fields + parent external ids + custom-field bag
+   * @param provider  adapter/provider label persisted + used to scope lookups
+   * @param tx        optional outer transaction; when omitted we open our own
    */
-  async syncUpsert(_inputs: Array<Partial<TEntity>>): Promise<TEntity[]> {
-    throw new Error('syncUpsert not implemented — override in concrete repository');
+  async syncUpsertOne(
+    write: TSyncWrite,
+    provider: string,
+    tx?: DrizzleTx,
+  ): Promise<TSyncProjection> {
+    const cfg = this.syncConfig;
+    const w = write as Record<string, unknown>;
+
+    const run = async (db: DrizzleTx): Promise<TSyncProjection> => {
+      // 1. FK resolution (provider-scoped). Strict → throw; else opportunistic null.
+      const resolvedFks: Record<string, string | null> = {};
+      for (const fk of cfg.fkResolvers) {
+        resolvedFks[fk.column] = await this.resolveFk(db, fk, w[fk.writeKey], provider);
+      }
+
+      // 2. Canonical → Drizzle insert-or-update by the conflict target.
+      const now = new Date();
+      const copyThrough: Record<string, unknown> = {};
+      for (const col of cfg.writeColumns) copyThrough[col] = w[col];
+
+      const values: Record<string, unknown> = {
+        externalId: w['externalId'],
+        provider,
+        ...copyThrough,
+        ...resolvedFks,
+        ...(this.behaviors.timestamps ? { updatedAt: now } : {}),
+      };
+
+      // `set` excludes the identity (externalId/provider). Resolved FKs are
+      // only written when non-null this run — never clobber a previously
+      // resolved parent with null on a later run that dropped the ref.
+      const set: Record<string, unknown> = {
+        ...copyThrough,
+        ...(this.behaviors.timestamps ? { updatedAt: now } : {}),
+      };
+      for (const fk of cfg.fkResolvers) {
+        if (resolvedFks[fk.column] !== null) set[fk.column] = resolvedFks[fk.column];
+      }
+
+      const rows = await db
+        .insert(this.table)
+        .values(values as never)
+        .onConflictDoUpdate({
+          target: cfg.conflictTarget.map((c) => this.table[c]),
+          set: set as never,
+        })
+        .returning();
+
+      const saved = rows[0] as Record<string, unknown>;
+
+      // 3. EAV dual-write seam — same tx. No-op unless the entity opts in.
+      const fields = w['fields'] as Record<string, unknown> | undefined;
+      if (cfg.eav && fields && Object.keys(fields).length > 0) {
+        await this.writeCustomFields(
+          db,
+          saved['id'] as string,
+          w['userId'] as string,
+          fields,
+        );
+      }
+
+      return this.toProjection(saved as TEntity);
+    };
+
+    return tx ? run(tx) : this.db.transaction((t) => run(t));
+  }
+
+  /**
+   * Canonical-projected lookup by external id (differ-ready). Returns `null`
+   * when no local row exists. Provider-scoped so a HubSpot id can't match a
+   * Salesforce row.
+   */
+  async findByExternalIdProjected(
+    externalId: string,
+    provider: string,
+  ): Promise<TSyncProjection | null> {
+    const rows = await this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table['provider'], provider),
+          eq(this.table['externalId'], externalId),
+        ),
+      )
+      .limit(1);
+    const row = rows[0] as TEntity | undefined;
+    return row ? this.toProjection(row) : null;
+  }
+
+  /**
+   * Sync "delete" by external id, provider-scoped. When `softDelete: true`,
+   * sets `deletedAt`. When `softDelete: false`, tombstone-by-clearing: null out
+   * `external_id`/`provider` so the row no longer matches future inbound
+   * changes while preserving local-id references. Returns `{ id }` or `null`.
+   */
+  async softDeleteByExternalId(
+    externalId: string,
+    provider: string,
+    tx?: DrizzleTx,
+  ): Promise<{ id: string } | null> {
+    const db = this.runner(tx);
+    const set = this.syncConfig.softDelete
+      ? { deletedAt: new Date(), updatedAt: new Date() }
+      : { externalId: null, provider: null, updatedAt: new Date() };
+    const rows = await db
+      .update(this.table)
+      .set(set as never)
+      .where(
+        and(
+          eq(this.table['provider'], provider),
+          eq(this.table['externalId'], externalId),
+        ),
+      )
+      .returning({ id: this.table['id'] });
+    return rows[0] ? { id: rows[0].id as string } : null;
+  }
+
+  /**
+   * Batch sync upsert — concretizes the former abstract stub. Delegates to
+   * `syncUpsertOne` per input inside one transaction. Inputs are raw partial
+   * rows: provider is read from each input's own `provider` column; rows
+   * missing `externalId`/`provider` are skipped.
+   */
+  async syncUpsert(inputs: Array<Partial<TEntity>>): Promise<TEntity[]> {
+    if (inputs.length === 0) return [];
+    return this.db.transaction(async (tx) => {
+      const out: TEntity[] = [];
+      for (const input of inputs) {
+        const rec = input as Record<string, unknown>;
+        if (!rec['externalId'] || !rec['provider']) continue;
+        const proj = await this.syncUpsertOne(
+          input as unknown as TSyncWrite,
+          rec['provider'] as string,
+          tx,
+        );
+        const id = (proj as Record<string, unknown>)['id'] as string;
+        const row = await tx
+          .select()
+          .from(this.table)
+          .where(eq(this.table['id'], id))
+          .limit(1);
+        out.push(row[0] as TEntity);
+      }
+      return out;
+    });
+  }
+
+  /**
+   * Project a raw row to the canonical differ shape — a generic pick over
+   * `syncConfig.projectionColumns`. Override only for synthesized projections
+   * (e.g. junctions); entities use this verbatim.
+   */
+  protected toProjection(row: TEntity): TSyncProjection {
+    const r = row as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const col of this.syncConfig.projectionColumns) out[col] = r[col];
+    return out as TSyncProjection;
+  }
+
+  /**
+   * EAV dual-write seam (#374, live path lands in #124). No-op by default;
+   * `eav: true` entities emit a concrete override that injects
+   * `FieldValueService` and delegates to `upsertFieldsTransactional` so the
+   * dual-write joins the same tx (`db`). Kept as an explicit hook so the base
+   * stays portable (the FieldValueService dependency is eav-only).
+   */
+  protected async writeCustomFields(
+    _db: DrizzleTx,
+    _entityId: string,
+    _userId: string,
+    _fields: Record<string, unknown>,
+  ): Promise<void> {
+    // Intentionally empty until the entity opts into EAV.
+  }
+
+  /**
+   * Resolve one FK from a parent external id (provider-scoped). `self` resolves
+   * against `this.table`. Strict resolvers throw when unresolved; non-strict
+   * return null. A null/absent write value short-circuits to null.
+   */
+  private async resolveFk(
+    db: DrizzleTx,
+    fk: SyncFkResolver,
+    rawExternalId: unknown,
+    provider: string,
+  ): Promise<string | null> {
+    const parentExternalId = rawExternalId as string | null | undefined;
+    if (!parentExternalId) {
+      if (fk.strict) {
+        throw new Error(
+          `${this.constructor.name}.syncUpsertOne: missing required parent ` +
+            `external id for '${fk.column}' (writeKey '${fk.writeKey}')`,
+        );
+      }
+      return null;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refTable: PgTableWithColumns<any> =
+      fk.refTable === 'self' ? this.table : fk.refTable;
+    const rows = await db
+      .select({ id: refTable['id'] })
+      .from(refTable)
+      .where(
+        and(
+          eq(refTable['provider'], provider),
+          eq(refTable['externalId'], parentExternalId),
+        ),
+      )
+      .limit(1);
+    const id = (rows[0]?.id as string | undefined) ?? null;
+    if (id === null && fk.strict) {
+      throw new Error(
+        `${this.constructor.name}.syncUpsertOne: unresolved parent ` +
+          `'${parentExternalId}' (provider '${provider}') for '${fk.column}' — ` +
+          `parent not synced yet`,
+      );
+    }
+    return id;
   }
 
   /**

--- a/src/__tests__/clean-lite-ps/sync-repository-template.test.ts
+++ b/src/__tests__/clean-lite-ps/sync-repository-template.test.ts
@@ -129,6 +129,34 @@ describe('buildSyncSurface derivation', () => {
     ]);
     expect(cfg.projectionColumns).not.toContain('provider');
   });
+
+  it('marks a required FK resolver strict and leaves a nullable FK opportunistic', () => {
+    // strictness is sourced from the FK FIELD's `required` — NOT the
+    // relationship-level `nullable` (which defaults true when undeclared).
+    const belongsTo = [
+      {
+        field: 'account_id', camelField: 'accountId', relationKey: 'account',
+        relatedTable: 'accounts', relatedEntity: 'account', isSelfFk: false,
+        nullable: true, importPath: '../accounts/account.entity',
+      },
+      {
+        field: 'parent_id', camelField: 'parentId', relationKey: 'parent',
+        relatedTable: 'leads', relatedEntity: 'lead', isSelfFk: true,
+        nullable: true, importPath: '../leads/lead.entity',
+      },
+    ];
+    const fields = {
+      account_id: { type: 'uuid', required: true, foreign_key: 'accounts.id' },
+      parent_id: { type: 'uuid', nullable: true, foreign_key: 'leads.id' },
+    };
+    const surface = buildSyncSurface('Synced', [], belongsTo, true, false, false, fields) as any;
+    const byCol = Object.fromEntries(surface.fkResolvers.map((r: any) => [r.column, r]));
+    // required, non-null FK column → strict (unresolved parent = failed item)
+    expect(byCol.accountId.strict).toBe(true);
+    // nullable FK (self-FK hierarchy) → opportunistic, even though the
+    // relationship-level nullable would have defaulted the same way
+    expect(byCol.parentId.strict).toBe(false);
+  });
 });
 
 // ============================================================================

--- a/src/__tests__/clean-lite-ps/sync-repository-template.test.ts
+++ b/src/__tests__/clean-lite-ps/sync-repository-template.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Template-emission tests for the synced-entity sync surface (#374).
+ *
+ * Verifies that `pattern: Synced` repositories emit:
+ *   - TSyncWrite / TSyncProjection interfaces (nullable-aware, FK write-keys,
+ *     projection omits provider/providerMetadata)
+ *   - the hand-emitted syncConfig literal with LIVE refTable handles
+ *     ('self' for self-FK; imported parent table for non-self synced FK)
+ *   - deduped parent-table imports (#368)
+ *   - the widened `extends SyncedEntityRepository<E, EWrite, EProjection>`
+ *   - the eav writeCustomFields override + FieldValueService injection
+ * and that non-Synced entities emit none of it.
+ */
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import {
+  buildCleanLitePsLocals,
+  buildSyncSurface,
+} from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const REPO_TEMPLATE = readFileSync(
+  resolve(import.meta.dir, '../../../templates/entity/new/clean-lite-ps/repository.ejs.t'),
+  'utf8',
+);
+
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) if (lines[i] === '---') { end = i; break; }
+  return end === -1 ? source : lines.slice(end + 1).join('\n');
+}
+const render = (locals: Record<string, unknown>) =>
+  ejs.render(extractBody(REPO_TEMPLATE), locals, { rmWhitespace: false });
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+// Self-FK synced entity (the account oracle shape).
+const account = {
+  entity: { name: 'account', plural: 'accounts', table: 'accounts', pattern: 'Synced' },
+  fields: {
+    user_id: { type: 'uuid', required: true },
+    name: { type: 'string', required: true },
+    domain: { type: 'string', nullable: true },
+    employee_count: { type: 'integer', nullable: true },
+  },
+  behaviors: ['timestamps'],
+  relationships: {
+    parent_account: {
+      type: 'belongs_to', target: 'account', foreign_key: 'parent_account_id',
+      nullable: true, on_delete: 'set_null',
+    },
+  },
+};
+
+// Non-self synced FK (contact belongs_to account) + soft_delete + eav.
+const contact = {
+  entity: { name: 'contact', plural: 'contacts', table: 'contacts', pattern: 'Synced' },
+  eav: true,
+  fields: {
+    user_id: { type: 'uuid', required: true },
+    email: { type: 'string', required: true },
+  },
+  behaviors: ['timestamps', 'soft_delete'],
+  relationships: {
+    account: { type: 'belongs_to', target: 'account', foreign_key: 'account_id', nullable: true },
+  },
+};
+
+// Plain Base entity — emits no sync surface.
+const widget = {
+  entity: { name: 'widget', plural: 'widgets', table: 'widgets', pattern: 'Base' },
+  fields: { label: { type: 'string', required: true } },
+  behaviors: [],
+};
+
+// ============================================================================
+// buildSyncSurface (pure derivation)
+// ============================================================================
+
+describe('buildSyncSurface derivation', () => {
+  it('returns null for non-Synced patterns', () => {
+    expect(buildSyncSurface('Base', [], [], true, false, false)).toBeNull();
+  });
+
+  it('derives writeColumns from non-FK fields and conflictTarget (provider, externalId)', () => {
+    const locals = buildCleanLitePsLocals(account, {});
+    expect(locals.clpSyncConfig).not.toBeNull();
+    const cfg = locals.clpSyncConfig as any;
+    expect(cfg.conflictTarget).toEqual(['provider', 'externalId']);
+    expect(cfg.writeColumns).toEqual(['userId', 'name', 'domain', 'employeeCount']);
+  });
+
+  it('names the FK write-key ${relationKey}ExternalId and self-FK refTable self', () => {
+    const locals = buildCleanLitePsLocals(account, {});
+    const fk = (locals.clpSyncFkResolvers as any[])[0];
+    expect(fk.column).toBe('parentAccountId');
+    expect(fk.writeKey).toBe('parentAccountExternalId');
+    expect(fk.isSelfFk).toBe(true);
+  });
+
+  it('non-self synced FK uses target table name + adds a parent import', () => {
+    const locals = buildCleanLitePsLocals(contact, {});
+    const fk = (locals.clpSyncFkResolvers as any[])[0];
+    expect(fk.column).toBe('accountId');
+    expect(fk.writeKey).toBe('accountExternalId');
+    expect(fk.isSelfFk).toBe(false);
+    expect(fk.refTable).toBe('accounts');
+    expect(locals.clpSyncParentTableImports).toEqual([
+      { table: 'accounts', importPath: '../accounts/account.entity' },
+    ]);
+  });
+
+  it('self-FK contributes NO parent import', () => {
+    const locals = buildCleanLitePsLocals(account, {});
+    expect(locals.clpSyncParentTableImports).toEqual([]);
+  });
+
+  it('projectionColumns include id/externalId/FK/timestamps, never provider', () => {
+    const locals = buildCleanLitePsLocals(account, {});
+    const cfg = locals.clpSyncConfig as any;
+    expect(cfg.projectionColumns).toEqual([
+      'id', 'externalId', 'userId', 'name', 'domain', 'employeeCount',
+      'parentAccountId', 'createdAt', 'updatedAt',
+    ]);
+    expect(cfg.projectionColumns).not.toContain('provider');
+  });
+});
+
+// ============================================================================
+// Emitted output
+// ============================================================================
+
+describe('synced repository emission — self-FK (account)', () => {
+  const out = render(buildCleanLitePsLocals(account, {}) as Record<string, unknown>);
+
+  it('emits TSyncWrite with nullable-aware fields + FK write-key', () => {
+    expect(out).toContain('export interface AccountSyncWrite {');
+    expect(out).toContain('readonly externalId: string;');
+    expect(out).toContain('readonly domain: string | null;');
+    expect(out).toContain('readonly employeeCount: number | null;');
+    expect(out).toContain('readonly parentAccountExternalId?: string | null;');
+    expect(out).toContain('readonly fields?: Record<string, unknown>;');
+  });
+
+  it('emits TSyncProjection omitting provider/providerMetadata', () => {
+    expect(out).toContain('export interface AccountSyncProjection {');
+    expect(out).toContain('readonly parentAccountId: string | null;');
+    expect(out).toContain('readonly createdAt: Date;');
+    expect(out).not.toContain('readonly provider:');
+    expect(out).not.toContain('readonly providerMetadata');
+  });
+
+  it('widens the extends clause to the three-param base', () => {
+    expect(out).toContain('extends SyncedEntityRepository<');
+    expect(out).toContain('AccountSyncWrite,');
+    expect(out).toContain('AccountSyncProjection');
+  });
+
+  it('emits the syncConfig literal with refTable: \'self\' (not HTML-escaped)', () => {
+    expect(out).toContain("refTable: 'self'");
+    expect(out).not.toContain('&#39;');
+    expect(out).toContain("conflictTarget: ['provider', 'externalId']");
+    expect(out).toContain('protected readonly syncConfig: SyncUpsertConfig = {');
+  });
+
+  it('imports SyncUpsertConfig + DrizzleTx', () => {
+    expect(out).toContain("import type { SyncUpsertConfig } from '@shared/base-classes/sync-upsert-config';");
+    expect(out).toContain('DrizzleTx');
+  });
+
+  it('updates the inherited-methods comment to the now-real methods', () => {
+    expect(out).toContain('syncUpsertOne, findByExternalIdProjected, softDeleteByExternalId, syncUpsert');
+  });
+
+  it('does NOT emit an eav override for a non-eav entity', () => {
+    expect(out).not.toContain('FieldValueService');
+    expect(out).not.toContain('writeCustomFields');
+  });
+});
+
+describe('synced repository emission — non-self FK + eav (contact)', () => {
+  const out = render(buildCleanLitePsLocals(contact, {}) as Record<string, unknown>);
+
+  it('imports the parent table as a live handle and uses it in fkResolvers', () => {
+    expect(out).toContain("import { accounts } from '../accounts/account.entity';");
+    expect(out).toContain("{ column: 'accountId', writeKey: 'accountExternalId', refTable: accounts }");
+  });
+
+  it('emits eav: true + FieldValueService injection + writeCustomFields override', () => {
+    expect(out).toContain('eav: true');
+    expect(out).toContain("import { FieldValueService } from '../field_values/field_value.service';");
+    expect(out).toContain('private readonly fieldValues: FieldValueService,');
+    expect(out).toContain('protected override async writeCustomFields(');
+    expect(out).toContain("this.fieldValues.upsertFieldsTransactional('contact', entityId, userId, fields, db)");
+  });
+
+  it('threads softDelete: true into the syncConfig', () => {
+    expect(out).toContain('softDelete: true');
+  });
+});
+
+describe('non-Synced repository emission', () => {
+  const out = render(buildCleanLitePsLocals(widget, {}) as Record<string, unknown>);
+
+  it('emits no sync surface', () => {
+    expect(out).not.toContain('SyncWrite');
+    expect(out).not.toContain('SyncProjection');
+    expect(out).not.toContain('syncConfig');
+    expect(out).not.toContain('SyncUpsertConfig');
+  });
+
+  it('keeps the single-param extends', () => {
+    expect(out).toContain('extends BaseRepository<Widget> {');
+  });
+});

--- a/src/__tests__/runtime/base-classes/junction-sync-repository.spec.ts
+++ b/src/__tests__/runtime/base-classes/junction-sync-repository.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * JunctionSyncRepository sync-surface unit tests (#374).
+ *
+ * Exercises strict dual-FK resolution (throw on unresolved), onConflictDoUpdate
+ * on the (left,right,role) / (left,right) target, the composite build/parse
+ * helpers (role + role-less variants), and the non-throwing lookups
+ * (findByExternalIdProjected / softDeleteByExternalId).
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import {
+  JunctionSyncRepository,
+  buildCompositeExternalId,
+  parseCompositeExternalId,
+  type JunctionSyncConfig,
+} from '../../../../runtime/base-classes/junction-sync-repository';
+import type { DrizzleClient, DrizzleTx } from '../../../../runtime/types/drizzle';
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+
+// ============================================================================
+// Tables / config
+// ============================================================================
+
+const makeTbl = (cols: string[]) =>
+  Object.fromEntries(cols.map((c) => [c, { name: c }])) as unknown as PgTableWithColumns<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+const opportunities = makeTbl(['id', 'provider', 'externalId']);
+const contacts = makeTbl(['id', 'provider', 'externalId']);
+const junctionTable = makeTbl(['opportunityId', 'contactId', 'role', 'createdAt', 'updatedAt']);
+
+interface OppContact {
+  opportunityId: string;
+  contactId: string;
+  role: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+interface OppContactWrite {
+  opportunityExternalId: string;
+  contactExternalId: string;
+  role: string;
+  userId: string;
+}
+interface OppContactProjection {
+  id: string;
+  opportunityId: string;
+  contactId: string;
+  role?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const roleConfig: JunctionSyncConfig = {
+  left: { column: 'opportunityId', refTable: opportunities },
+  right: { column: 'contactId', refTable: contacts },
+  roleColumn: 'role',
+};
+
+// ============================================================================
+// Sequencing mock (mirrors the synced-entity spec)
+// ============================================================================
+
+function makeMock() {
+  const queue: unknown[][] = [];
+  const capture = { values: [] as unknown[], conflict: [] as unknown[] };
+  const query: Record<string, unknown> & PromiseLike<unknown> = {
+    then: (resolve: (v: unknown) => unknown) =>
+      Promise.resolve(queue.length ? queue.shift() : []).then(resolve),
+    catch: () => Promise.resolve([]),
+    finally: (cb: () => void) => Promise.resolve([]).finally(cb),
+  };
+  for (const m of ['select', 'from', 'where', 'limit', 'insert', 'returning', 'delete', 'update', 'set']) {
+    query[m] = mock(() => query);
+  }
+  query['values'] = mock((v: unknown) => { capture.values.push(v); return query; });
+  query['onConflictDoUpdate'] = mock((v: unknown) => { capture.conflict.push(v); return query; });
+  query['transaction'] = mock((cb: (tx: unknown) => unknown) => cb(query));
+  return {
+    db: query as unknown as DrizzleClient & DrizzleTx,
+    enqueue: (rows: unknown[]) => queue.push(rows),
+    capture,
+  };
+}
+
+class OppContactRepository extends JunctionSyncRepository<OppContact, OppContactWrite, OppContactProjection> {
+  readonly table = junctionTable;
+  protected readonly syncConfig: JunctionSyncConfig;
+  protected readonly behaviors = { timestamps: true, softDelete: false, userTracking: false };
+  constructor(db: DrizzleClient, config: JunctionSyncConfig = roleConfig) {
+    super(db);
+    this.syncConfig = config;
+  }
+}
+
+const jrow = (): OppContact => ({
+  opportunityId: 'opp-1', contactId: 'con-1', role: 'champion',
+  createdAt: new Date('2026-01-01'), updatedAt: new Date('2026-01-02'),
+});
+
+// ============================================================================
+// Composite helpers
+// ============================================================================
+
+describe('composite externalId helpers', () => {
+  it('builds and parses a 3-part role-bearing composite', () => {
+    const id = buildCompositeExternalId('hubspot:42', 'hubspot:99', 'champion');
+    expect(id).toBe('hubspot:42::hubspot:99::champion');
+    expect(parseCompositeExternalId(id, true)).toEqual({
+      left: 'hubspot:42', right: 'hubspot:99', role: 'champion',
+    });
+  });
+
+  it('builds and parses a 2-part role-less composite', () => {
+    const id = buildCompositeExternalId('a', 'b');
+    expect(id).toBe('a::b');
+    expect(parseCompositeExternalId(id, false)).toEqual({ left: 'a', right: 'b', role: undefined });
+  });
+
+  it('returns null on wrong part count', () => {
+    expect(parseCompositeExternalId('a::b', true)).toBeNull();   // role expected
+    expect(parseCompositeExternalId('a::b::c', false)).toBeNull(); // role not expected
+  });
+
+  it('returns null on empty part', () => {
+    expect(parseCompositeExternalId('a::::c', true)).toBeNull();
+  });
+});
+
+// ============================================================================
+// syncUpsertOne — strict dual-FK resolution
+// ============================================================================
+
+describe('JunctionSyncRepository.syncUpsertOne', () => {
+  it('resolves both parents and upserts on (left,right,role)', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'opp-1' }]); // left resolution
+    m.enqueue([{ id: 'con-1' }]); // right resolution
+    m.enqueue([jrow()]);          // upsert RETURNING
+    const repo = new OppContactRepository(m.db);
+
+    const proj = await repo.syncUpsertOne(
+      { opportunityExternalId: 'o-ext', contactExternalId: 'c-ext', role: 'champion', userId: 'u' },
+      'hubspot',
+    );
+
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect(values.opportunityId).toBe('opp-1');
+    expect(values.contactId).toBe('con-1');
+    expect(values.role).toBe('champion');
+    const conflict = m.capture.conflict[0] as { target: unknown[] };
+    expect(conflict.target).toHaveLength(3); // role-inclusive
+    expect(proj.id).toBe('o-ext::c-ext::champion');
+  });
+
+  it('throws when the left parent is unresolved (strict)', async () => {
+    const m = makeMock();
+    m.enqueue([]); // left resolution finds nothing
+    const repo = new OppContactRepository(m.db);
+
+    await expect(
+      repo.syncUpsertOne(
+        { opportunityExternalId: 'missing', contactExternalId: 'c-ext', role: 'champion', userId: 'u' },
+        'hubspot',
+      ),
+    ).rejects.toThrow(/unresolved parent 'missing'/);
+  });
+
+  it('throws when the right parent is unresolved (strict)', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'opp-1' }]); // left resolves
+    m.enqueue([]);                 // right unresolved
+    const repo = new OppContactRepository(m.db);
+
+    await expect(
+      repo.syncUpsertOne(
+        { opportunityExternalId: 'o-ext', contactExternalId: 'missing', role: 'champion', userId: 'u' },
+        'hubspot',
+      ),
+    ).rejects.toThrow(/unresolved parent 'missing'/);
+  });
+
+  it('role-less junction conflicts on (left,right) and omits role from values', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'opp-1' }]);
+    m.enqueue([{ id: 'con-1' }]);
+    m.enqueue([jrow()]);
+    const repo = new OppContactRepository(m.db, { ...roleConfig, roleColumn: null });
+
+    const proj = await repo.syncUpsertOne(
+      { opportunityExternalId: 'o-ext', contactExternalId: 'c-ext', role: 'ignored', userId: 'u' },
+      'hubspot',
+    );
+
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect('role' in values).toBe(false);
+    const conflict = m.capture.conflict[0] as { target: unknown[] };
+    expect(conflict.target).toHaveLength(2);
+    expect(proj.id).toBe('o-ext::c-ext'); // 2-part composite
+  });
+});
+
+// ============================================================================
+// findByExternalIdProjected / softDeleteByExternalId — non-throwing resolve
+// ============================================================================
+
+describe('JunctionSyncRepository.findByExternalIdProjected', () => {
+  it('returns null on malformed composite', async () => {
+    const m = makeMock();
+    const repo = new OppContactRepository(m.db);
+    expect(await repo.findByExternalIdProjected('only-two::parts', 'hubspot')).toBeNull();
+  });
+
+  it('returns null when a parent is unresolved (non-throwing)', async () => {
+    const m = makeMock();
+    m.enqueue([]); // left unresolved
+    const repo = new OppContactRepository(m.db);
+    expect(await repo.findByExternalIdProjected('o::c::champion', 'hubspot')).toBeNull();
+  });
+
+  it('returns the projection when row found', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'opp-1' }]); // left
+    m.enqueue([{ id: 'con-1' }]); // right
+    m.enqueue([jrow()]);          // row
+    const repo = new OppContactRepository(m.db);
+    const proj = await repo.findByExternalIdProjected('o::c::champion', 'hubspot');
+    expect(proj?.id).toBe('o::c::champion');
+  });
+});
+
+describe('JunctionSyncRepository.softDeleteByExternalId', () => {
+  it('deletes by tuple and returns the composite id', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'opp-1' }]); // left
+    m.enqueue([{ id: 'con-1' }]); // right
+    m.enqueue([{ id: 'opp-1' }]); // delete RETURNING
+    const repo = new OppContactRepository(m.db);
+    const res = await repo.softDeleteByExternalId('o::c::champion', 'hubspot');
+    expect(res).toEqual({ id: 'o::c::champion' });
+  });
+
+  it('returns null when nothing deleted', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'opp-1' }]);
+    m.enqueue([{ id: 'con-1' }]);
+    m.enqueue([]); // delete RETURNING empty
+    const repo = new OppContactRepository(m.db);
+    expect(await repo.softDeleteByExternalId('o::c::champion', 'hubspot')).toBeNull();
+  });
+});

--- a/src/__tests__/runtime/base-classes/synced-entity-repository.spec.ts
+++ b/src/__tests__/runtime/base-classes/synced-entity-repository.spec.ts
@@ -1,0 +1,377 @@
+/**
+ * SyncedEntityRepository sync-surface unit tests (#374).
+ *
+ * Exercises the generic inbound-sync write surface — syncUpsertOne (FK
+ * resolution: opportunistic-null + no-clobber + provider scoping), toProjection
+ * (omit provider), findByExternalIdProjected, softDeleteByExternalId (both
+ * softDelete branches), and the batch syncUpsert (per-input provider, skip
+ * incomplete) — against an in-memory query mock that sequences results and
+ * captures the values/set/where args.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import { SyncedEntityRepository } from '../../../../runtime/base-classes/synced-entity-repository';
+import type { SyncUpsertConfig } from '../../../../runtime/base-classes/sync-upsert-config';
+import type { DrizzleClient, DrizzleTx } from '../../../../runtime/types/drizzle';
+import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+
+// ============================================================================
+// Test entity / table / config
+// ============================================================================
+
+interface Account {
+  id: string;
+  externalId: string | null;
+  provider: string | null;
+  userId: string;
+  name: string;
+  domain: string | null;
+  parentAccountId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date | null;
+}
+
+interface AccountSyncWrite {
+  externalId: string;
+  userId: string;
+  name: string;
+  domain: string | null;
+  parentAccountExternalId?: string | null;
+  fields?: Record<string, unknown>;
+}
+
+const accountsTable = {
+  id: { name: 'id' },
+  externalId: { name: 'external_id' },
+  provider: { name: 'provider' },
+  userId: { name: 'user_id' },
+  name: { name: 'name' },
+  domain: { name: 'domain' },
+  parentAccountId: { name: 'parent_account_id' },
+  createdAt: { name: 'created_at' },
+  updatedAt: { name: 'updated_at' },
+  deletedAt: { name: 'deleted_at' },
+} as unknown as PgTableWithColumns<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+const baseConfig: SyncUpsertConfig = {
+  conflictTarget: ['provider', 'externalId'],
+  writeColumns: ['userId', 'name', 'domain'],
+  fkResolvers: [
+    { column: 'parentAccountId', writeKey: 'parentAccountExternalId', refTable: 'self' },
+  ],
+  projectionColumns: [
+    'id', 'externalId', 'userId', 'name', 'domain', 'parentAccountId', 'createdAt', 'updatedAt',
+  ],
+  eav: false,
+  softDelete: false,
+};
+
+// ============================================================================
+// Sequencing query mock — each terminal await yields the next queued result.
+// Captures the last values()/set()/where() args for assertions.
+// ============================================================================
+
+interface MockHandle {
+  db: DrizzleClient & DrizzleTx;
+  /** queue a result for the next awaited query */
+  enqueue: (rows: unknown[]) => void;
+  capture: { values: unknown[]; set: unknown[]; conflict: unknown[] };
+}
+
+function makeMock(): MockHandle {
+  const queue: unknown[][] = [];
+  const capture = { values: [] as unknown[], set: [] as unknown[], conflict: [] as unknown[] };
+
+  const query: Record<string, unknown> & PromiseLike<unknown> = {
+    then: (resolve: (v: unknown) => unknown) =>
+      Promise.resolve(queue.length ? queue.shift() : []).then(resolve),
+    catch: () => Promise.resolve([]),
+    finally: (cb: () => void) => Promise.resolve([]).finally(cb),
+  };
+
+  const passthrough = [
+    'select', 'from', '$dynamic', 'where', 'limit', 'offset', 'orderBy',
+    'insert', 'returning', 'update', 'delete',
+  ];
+  for (const m of passthrough) query[m] = mock(() => query);
+  query['values'] = mock((v: unknown) => { capture.values.push(v); return query; });
+  query['set'] = mock((v: unknown) => { capture.set.push(v); return query; });
+  query['onConflictDoUpdate'] = mock((v: unknown) => { capture.conflict.push(v); return query; });
+  query['transaction'] = mock((cb: (tx: unknown) => unknown) => cb(query));
+
+  return {
+    db: query as unknown as DrizzleClient & DrizzleTx,
+    enqueue: (rows) => queue.push(rows),
+    capture,
+  };
+}
+
+class AccountRepository extends SyncedEntityRepository<Account, AccountSyncWrite, Account> {
+  readonly table = accountsTable;
+  protected readonly syncConfig: SyncUpsertConfig;
+  protected readonly behaviors = { timestamps: true, softDelete: false, userTracking: false };
+
+  constructor(db: DrizzleClient, config: SyncUpsertConfig = baseConfig) {
+    super(db);
+    this.syncConfig = config;
+  }
+}
+
+function row(over: Partial<Account> = {}): Account {
+  return {
+    id: 'acc-1',
+    externalId: 'ext-1',
+    provider: 'hubspot',
+    userId: 'user-1',
+    name: 'Acme',
+    domain: 'acme.com',
+    parentAccountId: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+    ...over,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SyncedEntityRepository.syncUpsertOne — FK resolution', () => {
+  it('resolves a self-FK opportunistically and writes it into values + set', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'parent-1' }]); // FK resolution SELECT
+    m.enqueue([row({ parentAccountId: 'parent-1' })]); // upsert RETURNING
+    const repo = new AccountRepository(m.db);
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: 'acme.com', parentAccountExternalId: 'parent-ext' },
+      'hubspot',
+    );
+
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect(values.externalId).toBe('ext-1');
+    expect(values.provider).toBe('hubspot');
+    expect(values.parentAccountId).toBe('parent-1');
+    const conflict = m.capture.conflict[0] as { set: Record<string, unknown> };
+    // No-clobber: resolved FK IS in set (non-null this run).
+    expect(conflict.set.parentAccountId).toBe('parent-1');
+    // Identity columns never in set.
+    expect(conflict.set.externalId).toBeUndefined();
+    expect(conflict.set.provider).toBeUndefined();
+  });
+
+  it('leaves FK null and OMITS it from set when parent is unresolved (no-clobber)', async () => {
+    const m = makeMock();
+    m.enqueue([]); // FK resolution finds nothing
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db);
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: null, parentAccountExternalId: 'missing' },
+      'hubspot',
+    );
+
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect(values.parentAccountId).toBeNull();
+    const conflict = m.capture.conflict[0] as { set: Record<string, unknown> };
+    // Never clobber a previously-resolved parent with null.
+    expect('parentAccountId' in conflict.set).toBe(false);
+  });
+
+  it('leaves FK null when no parentExternalId is supplied (does not query)', async () => {
+    const m = makeMock();
+    m.enqueue([row()]); // only the upsert RETURNING — no FK SELECT
+    const repo = new AccountRepository(m.db);
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: null },
+      'hubspot',
+    );
+
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect(values.parentAccountId).toBeNull();
+  });
+
+  it('scopes the FK lookup by provider', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'parent-1' }]);
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db);
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: null, parentAccountExternalId: 'p-ext' },
+      'salesforce',
+    );
+
+    // where() was called for the FK SELECT (provider-scoped and().eq()).
+    expect((m.db as any).where).toHaveBeenCalled();
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect(values.provider).toBe('salesforce');
+  });
+});
+
+describe('SyncedEntityRepository.syncUpsertOne — projection', () => {
+  it('projects only projectionColumns (omits provider/providerMetadata)', async () => {
+    const m = makeMock();
+    m.enqueue([row({ parentAccountId: null })]); // no FK ext id → no SELECT
+    const repo = new AccountRepository(m.db);
+
+    const proj = await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: 'acme.com' },
+      'hubspot',
+    ) as unknown as Record<string, unknown>;
+
+    expect(proj.id).toBe('acc-1');
+    expect(proj.externalId).toBe('ext-1');
+    expect(proj.name).toBe('Acme');
+    expect('provider' in proj).toBe(false);
+    expect('providerMetadata' in proj).toBe(false);
+    expect('deletedAt' in proj).toBe(false);
+  });
+});
+
+describe('SyncedEntityRepository.syncUpsertOne — EAV seam', () => {
+  it('calls writeCustomFields when eav and fields non-empty', async () => {
+    const m = makeMock();
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db, { ...baseConfig, eav: true });
+    const spy = mock(async () => {});
+    // @ts-expect-error override protected for test
+    repo.writeCustomFields = spy;
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: null, fields: { tier: 'gold' } },
+      'hubspot',
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][2]).toBe('user-1'); // userId
+    expect(spy.mock.calls[0][3]).toEqual({ tier: 'gold' });
+  });
+
+  it('does NOT call writeCustomFields when eav is false', async () => {
+    const m = makeMock();
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db, { ...baseConfig, eav: false });
+    const spy = mock(async () => {});
+    // @ts-expect-error override protected for test
+    repo.writeCustomFields = spy;
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: null, fields: { tier: 'gold' } },
+      'hubspot',
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call writeCustomFields when fields bag is empty', async () => {
+    const m = makeMock();
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db, { ...baseConfig, eav: true });
+    const spy = mock(async () => {});
+    // @ts-expect-error override protected for test
+    repo.writeCustomFields = spy;
+
+    await repo.syncUpsertOne(
+      { externalId: 'ext-1', userId: 'user-1', name: 'Acme', domain: null, fields: {} },
+      'hubspot',
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('SyncedEntityRepository.findByExternalIdProjected', () => {
+  it('returns the projection when a row matches (provider-scoped)', async () => {
+    const m = makeMock();
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db);
+
+    const proj = await repo.findByExternalIdProjected('ext-1', 'hubspot') as unknown as Record<string, unknown>;
+    expect(proj.id).toBe('acc-1');
+    expect('provider' in proj).toBe(false);
+  });
+
+  it('returns null when no row matches', async () => {
+    const m = makeMock();
+    m.enqueue([]);
+    const repo = new AccountRepository(m.db);
+
+    const proj = await repo.findByExternalIdProjected('missing', 'hubspot');
+    expect(proj).toBeNull();
+  });
+});
+
+describe('SyncedEntityRepository.softDeleteByExternalId', () => {
+  it('tombstone-by-clearing when softDelete: false', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'acc-1' }]);
+    const repo = new AccountRepository(m.db, { ...baseConfig, softDelete: false });
+
+    const res = await repo.softDeleteByExternalId('ext-1', 'hubspot');
+    expect(res).toEqual({ id: 'acc-1' });
+    const set = m.capture.set[0] as Record<string, unknown>;
+    expect(set.externalId).toBeNull();
+    expect(set.provider).toBeNull();
+    expect('deletedAt' in set).toBe(false);
+  });
+
+  it('sets deletedAt when softDelete: true', async () => {
+    const m = makeMock();
+    m.enqueue([{ id: 'acc-1' }]);
+    const repo = new AccountRepository(m.db, { ...baseConfig, softDelete: true });
+
+    await repo.softDeleteByExternalId('ext-1', 'hubspot');
+    const set = m.capture.set[0] as Record<string, unknown>;
+    expect(set.deletedAt).toBeInstanceOf(Date);
+    expect('externalId' in set).toBe(false);
+  });
+
+  it('returns null when no row matched', async () => {
+    const m = makeMock();
+    m.enqueue([]);
+    const repo = new AccountRepository(m.db);
+
+    expect(await repo.softDeleteByExternalId('ghost', 'hubspot')).toBeNull();
+  });
+});
+
+describe('SyncedEntityRepository.syncUpsert (batch)', () => {
+  it('returns [] for empty input without touching the db', async () => {
+    const m = makeMock();
+    const repo = new AccountRepository(m.db);
+    expect(await repo.syncUpsert([])).toEqual([]);
+    expect((m.db as any).transaction).not.toHaveBeenCalled();
+  });
+
+  it('skips rows missing externalId or provider', async () => {
+    const m = makeMock();
+    // one valid input: FK skip (no parent ext) → upsert RETURNING → re-select row
+    m.enqueue([row()]);   // upsert RETURNING
+    m.enqueue([row()]);   // re-select by id
+    const repo = new AccountRepository(m.db);
+
+    const out = await repo.syncUpsert([
+      { name: 'no-ext' } as Partial<Account>,                         // skipped (no externalId)
+      { externalId: 'ext-2' } as Partial<Account>,                    // skipped (no provider)
+      { externalId: 'ext-1', provider: 'hubspot', userId: 'u', name: 'Acme' } as Partial<Account>,
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('acc-1');
+  });
+
+  it('reads provider per-input', async () => {
+    const m = makeMock();
+    m.enqueue([row()]);
+    m.enqueue([row()]);
+    const repo = new AccountRepository(m.db);
+
+    await repo.syncUpsert([
+      { externalId: 'ext-1', provider: 'salesforce', userId: 'u', name: 'A' } as Partial<Account>,
+    ]);
+    const values = m.capture.values[0] as Record<string, unknown>;
+    expect(values.provider).toBe('salesforce');
+  });
+});

--- a/src/__tests__/templates/junction-sync-repository.test.ts
+++ b/src/__tests__/templates/junction-sync-repository.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Template-emission tests for the junction sync surface (#374).
+ *
+ * Invokes templates/junction/new/prompt.js against fixtures (so the derivation
+ * is under test, not hand-built locals), then renders repository.ejs.t and
+ * asserts:
+ *   - TSyncWrite / TSyncProjection (role + role-less)
+ *   - JunctionSyncConfig literal with LIVE refTable handles, deduped imports
+ *   - extends JunctionSyncRepository<E, EWrite, EProjection>
+ *   - roleColumn emitted as 'role' / null (not HTML-escaped)
+ *   - the two pairing finders are preserved
+ */
+import { describe, it, expect } from 'bun:test';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import ejs from 'ejs';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import promptModule from '../../../templates/junction/new/prompt.js';
+
+const REPO_TEMPLATE = readFileSync(
+  resolve(import.meta.dir, '../../../templates/junction/new/repository.ejs.t'),
+  'utf8',
+);
+
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) if (lines[i] === '---') { end = i; break; }
+  return end === -1 ? source : lines.slice(end + 1).join('\n');
+}
+
+/** Write a junction YAML to a temp file and run the real prompt.js against it. */
+async function localsFromYaml(yaml: string): Promise<Record<string, unknown>> {
+  const dir = mkdtempSync(resolve(tmpdir(), 'junction-sync-'));
+  const file = resolve(dir, 'junction.yaml');
+  writeFileSync(file, yaml, 'utf8');
+  return promptModule.prompt({ args: { yaml: file } }) as Promise<Record<string, unknown>>;
+}
+
+const render = (locals: Record<string, unknown>) =>
+  ejs.render(extractBody(REPO_TEMPLATE), locals, { rmWhitespace: false });
+
+// prompt.js reads `fields.role.choices` directly (the CLI normalizes YAML
+// `values:` → `choices:` upstream; invoking prompt.js in isolation we supply
+// `choices:` as the normalized shape).
+const ROLE_YAML = `pattern: Junction
+between: [opportunity, contact]
+fields:
+  role:
+    type: enum
+    choices: [champion, decision_maker, influencer]
+    nullable: false
+`;
+
+const ROLELESS_YAML = `pattern: Junction
+between: [opportunity, activity]
+`;
+
+describe('junction sync emission — role-bearing (opportunity_contact)', () => {
+  it('derives the sync write/projection locals + parent imports', async () => {
+    const locals = await localsFromYaml(ROLE_YAML);
+    expect(locals.leftSyncWriteKey).toBe('opportunityExternalId');
+    expect(locals.rightSyncWriteKey).toBe('contactExternalId');
+    expect(locals.roleColumnCamel).toBe('role');
+    expect((locals.junctionSyncConfig as any).leftRefTable).toBe('opportunities');
+    expect((locals.junctionSyncConfig as any).rightRefTable).toBe('contacts');
+    expect(locals.syncParentImports).toHaveLength(2);
+  });
+
+  it('emits TSyncWrite with both external ids + role union + userId', async () => {
+    const out = render(await localsFromYaml(ROLE_YAML));
+    expect(out).toContain('export interface OpportunityContactSyncWrite {');
+    expect(out).toContain('readonly opportunityExternalId: string;');
+    expect(out).toContain('readonly contactExternalId: string;');
+    expect(out).toContain("readonly role: 'champion' | 'decision_maker' | 'influencer';");
+    expect(out).toContain('readonly userId: string;');
+  });
+
+  it('emits TSyncProjection with composite id + local FKs + role + timestamps', async () => {
+    const out = render(await localsFromYaml(ROLE_YAML));
+    expect(out).toContain('export interface OpportunityContactSyncProjection {');
+    expect(out).toContain('readonly id: string;');
+    expect(out).toContain('readonly opportunityId: string;');
+    expect(out).toContain('readonly contactId: string;');
+    expect(out).toContain('readonly createdAt: Date;');
+  });
+
+  it('extends JunctionSyncRepository with the three params + live refTables', async () => {
+    const out = render(await localsFromYaml(ROLE_YAML));
+    expect(out).toContain('extends JunctionSyncRepository<');
+    expect(out).toContain('OpportunityContactSyncWrite,');
+    expect(out).toContain('OpportunityContactSyncProjection');
+    expect(out).toContain("left: { column: 'opportunityId', refTable: opportunities }");
+    expect(out).toContain("right: { column: 'contactId', refTable: contacts }");
+    expect(out).toContain("roleColumn: 'role'");
+    expect(out).not.toContain('&#39;');
+  });
+
+  it('imports the parent tables (deduped) and keeps both pairing finders', async () => {
+    const out = render(await localsFromYaml(ROLE_YAML));
+    expect(out).toContain("import { opportunities } from '../opportunities/opportunity.entity';");
+    expect(out).toContain("import { contacts } from '../contacts/contact.entity';");
+    expect(out).toContain('async findByOpportunityId(');
+    expect(out).toContain('async findByContactId(');
+    expect(out).toContain('syncUpsertOne, findByExternalIdProjected, softDeleteByExternalId');
+  });
+});
+
+describe('junction sync emission — role-less (opportunity_activity)', () => {
+  it('emits roleColumn: null and omits role from the interfaces', async () => {
+    const locals = await localsFromYaml(ROLELESS_YAML);
+    expect(locals.roleColumnCamel).toBeNull();
+    const out = render(locals);
+    expect(out).toContain('roleColumn: null');
+    expect(out).not.toContain('readonly role:');
+  });
+});

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -123,6 +123,9 @@ const VENDORED_RUNTIME_FILES: Array<{ runtime: string; target: string }> = [
 	{ runtime: 'base-classes/base-service.ts', target: 'src/shared/base-classes/base-service.ts' },
 	{ runtime: 'base-classes/synced-entity-repository.ts', target: 'src/shared/base-classes/synced-entity-repository.ts' },
 	{ runtime: 'base-classes/synced-entity-service.ts', target: 'src/shared/base-classes/synced-entity-service.ts' },
+	// Inbound-sync write surface (#374) — deps of synced/junction repos
+	{ runtime: 'base-classes/sync-upsert-config.ts', target: 'src/shared/base-classes/sync-upsert-config.ts' },
+	{ runtime: 'base-classes/junction-sync-repository.ts', target: 'src/shared/base-classes/junction-sync-repository.ts' },
 	{ runtime: 'base-classes/activity-entity-repository.ts', target: 'src/shared/base-classes/activity-entity-repository.ts' },
 	{ runtime: 'base-classes/activity-entity-service.ts', target: 'src/shared/base-classes/activity-entity-service.ts' },
 	{ runtime: 'base-classes/metadata-entity-repository.ts', target: 'src/shared/base-classes/metadata-entity-repository.ts' },

--- a/src/patterns/library/synced.pattern.ts
+++ b/src/patterns/library/synced.pattern.ts
@@ -23,7 +23,8 @@ export const SyncedPattern = definePattern({
 	serviceImport: '@shared/base-classes/synced-entity-service',
 	repositoryInheritedMethods: [
 		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-		'findByExternalId, findAllByUserId, findVisibleByUserId, syncUpsert',
+		'findByExternalId, findManyByExternalIds, findAllByUserId, findVisibleByUserId',
+		'syncUpsertOne, findByExternalIdProjected, softDeleteByExternalId, syncUpsert',
 	],
 	serviceInheritedMethods: [
 		'findById, findByIds, list, count, exists, create, update, delete',

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -723,6 +723,125 @@ function processSearchQueries(queriesBlock, processedFields, belongsTo, entityNa
 }
 
 // ============================================================================
+// Sync write-surface derivation (#374)
+// ============================================================================
+
+/**
+ * Pre-compute the inbound-sync write surface for a `pattern: Synced` entity.
+ * Keeps the EJS thin + unit-testable: the template hand-emits the syncConfig
+ * literal (so `refTable` can carry a LIVE Drizzle table handle, which
+ * renderPatternConfigLiteral cannot express) using these locals.
+ *
+ * Returns null when the entity is not Synced.
+ *
+ * @param {string} patternName     resolved pattern name
+ * @param {object[]} processedFields  nonFkFields (camel + tsType + nullable)
+ * @param {object[]} belongsTo      clpBelongsTo entries
+ * @param {boolean} hasTimestamps
+ * @param {boolean} eavEnabled
+ * @param {boolean} hasSoftDelete
+ */
+export function buildSyncSurface(patternName, processedFields, belongsTo, hasTimestamps, eavEnabled, hasSoftDelete) {
+  if (patternName !== 'Synced') return null;
+
+  // Copy-through columns: every non-FK declared field. external_id_tracking
+  // columns (external_id/provider/provider_metadata) are injected by the
+  // behavior, NOT present in processedFields, so they're already excluded.
+  const writeColumns = processedFields.map((f) => f.camelName);
+
+  // FK resolvers — one per belongs_to. writeKey = `${relationKey}ExternalId`
+  // (Decision 4). refTable is the string 'self' for self-FKs, else the parent
+  // table var name (emitted as a live identifier by the template).
+  const fkResolvers = belongsTo.map((rel) => ({
+    column: rel.camelField,
+    writeKey: `${rel.relationKey}ExternalId`,
+    refTable: rel.isSelfFk ? 'self' : rel.relatedTable,
+    isSelfFk: rel.isSelfFk,
+    nullable: rel.nullable,
+    relatedTable: rel.relatedTable,
+    relatedEntity: rel.relatedEntity,
+    importPath: rel.importPath,
+  }));
+
+  // Projection columns: id + externalId + copy-through + local FK columns +
+  // timestamps. Omits provider/provider_metadata.
+  const projectionColumns = [
+    'id',
+    'externalId',
+    ...writeColumns,
+    ...belongsTo.map((rel) => rel.camelField),
+    ...(hasTimestamps ? ['createdAt', 'updatedAt'] : []),
+  ];
+
+  // The syncConfig object literal the template hand-emits. fkResolvers carry a
+  // sentinel so the template can swap `refTable` to either 'self' or the live
+  // table identifier.
+  const syncConfig = {
+    conflictTarget: ['provider', 'externalId'],
+    writeColumns,
+    projectionColumns,
+    eav: !!eavEnabled,
+    softDelete: !!hasSoftDelete,
+  };
+
+  // TSyncWrite fields: externalId:string, copy-through (typed, nullable-aware),
+  // one `<writeKey>?: string | null` per FK, fields?: Record<string, unknown>.
+  const writeFields = processedFields.map((f) => ({
+    camelName: f.camelName,
+    tsType: f.nullable ? `${f.tsType} | null` : f.tsType,
+  }));
+  const writeFkFields = fkResolvers.map((fk) => ({
+    name: fk.writeKey,
+    tsType: 'string | null',
+  }));
+
+  // TSyncProjection fields: id + externalId + copy-through (typed) + each local
+  // FK column (typed string, nullable per rel) + createdAt/updatedAt.
+  const projectionFields = [
+    { camelName: 'id', tsType: 'string' },
+    { camelName: 'externalId', tsType: 'string' },
+    ...processedFields.map((f) => ({
+      camelName: f.camelName,
+      tsType: f.nullable ? `${f.tsType} | null` : f.tsType,
+    })),
+    ...belongsTo.map((rel) => ({
+      camelName: rel.camelField,
+      tsType: rel.nullable ? 'string | null' : 'string',
+    })),
+    ...(hasTimestamps
+      ? [
+          { camelName: 'createdAt', tsType: 'Date' },
+          { camelName: 'updatedAt', tsType: 'Date' },
+        ]
+      : []),
+  ];
+
+  // Parent-table imports for non-self FKs, deduped (#368). Each entry imports
+  // the parent table var from its entity file. The entity's OWN table import is
+  // emitted separately by the template; we exclude self-FKs here.
+  const parentImportMap = new Map();
+  for (const fk of fkResolvers) {
+    if (fk.isSelfFk) continue;
+    if (!parentImportMap.has(fk.relatedTable)) {
+      parentImportMap.set(fk.relatedTable, {
+        table: fk.relatedTable,
+        importPath: fk.importPath,
+      });
+    }
+  }
+  const parentTableImports = Array.from(parentImportMap.values());
+
+  return {
+    syncConfig,
+    fkResolvers,
+    writeFields,
+    writeFkFields,
+    projectionFields,
+    parentTableImports,
+  };
+}
+
+// ============================================================================
 // Main export
 // ============================================================================
 
@@ -1028,6 +1147,16 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     zodChainOutput: zodChainForOutput(f),
   }));
 
+  // Sync write-surface derivation (#374) — null unless pattern: Synced.
+  const syncSurface = buildSyncSurface(
+    patternName,
+    nonFkFields,
+    belongsTo,
+    hasTimestamps,
+    eavEnabled,
+    hasSoftDelete,
+  );
+
   // EVT-7: emits locals flow through from baseLocals (prompt.js computed them
   // against the full events registry). When this helper is called in isolation
   // (e.g. from unit tests) baseLocals.hasEmits may be undefined — provide
@@ -1071,6 +1200,17 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     patternConfig: patternConfigBlock,
     renderPatternConfigLiteral,
     ...patternConfigClasses,
+
+    // Sync write-surface (#374) — emitted only for pattern: Synced. The
+    // template hand-emits the syncConfig literal (live refTable handles) +
+    // TSyncWrite/TSyncProjection from these.
+    hasSyncSurface: syncSurface !== null,
+    clpSyncConfig: syncSurface?.syncConfig ?? null,
+    clpSyncFkResolvers: syncSurface?.fkResolvers ?? [],
+    clpSyncWriteFields: syncSurface?.writeFields ?? [],
+    clpSyncWriteFkFields: syncSurface?.writeFkFields ?? [],
+    clpSyncProjectionFields: syncSurface?.projectionFields ?? [],
+    clpSyncParentTableImports: syncSurface?.parentTableImports ?? [],
 
     // Behavior flags (also exposed at top level for template use)
     hasTimestamps,

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -741,7 +741,7 @@ function processSearchQueries(queriesBlock, processedFields, belongsTo, entityNa
  * @param {boolean} eavEnabled
  * @param {boolean} hasSoftDelete
  */
-export function buildSyncSurface(patternName, processedFields, belongsTo, hasTimestamps, eavEnabled, hasSoftDelete) {
+export function buildSyncSurface(patternName, processedFields, belongsTo, hasTimestamps, eavEnabled, hasSoftDelete, fields) {
   if (patternName !== 'Synced') return null;
 
   // Copy-through columns: every non-FK declared field. external_id_tracking
@@ -758,6 +758,13 @@ export function buildSyncSurface(patternName, processedFields, belongsTo, hasTim
     refTable: rel.isSelfFk ? 'self' : rel.relatedTable,
     isSelfFk: rel.isSelfFk,
     nullable: rel.nullable,
+    // Strict resolution (throw on unresolved parent → failed item) when the FK
+    // COLUMN is required/non-null; opportunistic null otherwise. Sourced from
+    // the FK field's `required` — the relationship-level `nullable` is
+    // unreliable (defaults true when undeclared, e.g. a `belongs_to` with no
+    // explicit `nullable:`). Nullable FKs (e.g. self-FK hierarchies) stay
+    // opportunistic. (#374)
+    strict: fields?.[rel.field]?.required === true,
     relatedTable: rel.relatedTable,
     relatedEntity: rel.relatedEntity,
     importPath: rel.importPath,
@@ -1155,6 +1162,7 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     hasTimestamps,
     eavEnabled,
     hasSoftDelete,
+    fields,
   );
 
   // EVT-7: emits locals flow through from baseLocals (prompt.js computed them

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -22,15 +22,65 @@ import { eq<%= hasMultiFieldQuery ? ', and' : '' %><%= hasOrderedQuery ? ', desc
 import { sql } from 'drizzle-orm';
 <% } -%>
 import { DRIZZLE } from '@shared/constants/tokens';
-import type { DrizzleClient<% if (eavValueTable) { %>, DrizzleTx<% } %> } from '@shared/types/drizzle';
+import type { DrizzleClient<% if (eavValueTable || (typeof hasSyncSurface !== 'undefined' && hasSyncSurface)) { %>, DrizzleTx<% } %> } from '@shared/types/drizzle';
 import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
+<% if (typeof hasSyncSurface !== 'undefined' && hasSyncSurface) { -%>
+import type { SyncUpsertConfig } from '@shared/base-classes/sync-upsert-config';
+<% } -%>
 <% if (hasTimestamps || hasSoftDelete || hasUserTracking) { -%>
 import type { BehaviorConfig } from '@shared/base-classes/base-repository';
 <% } -%>
+<% if (eavEnabled) { -%>
+import { FieldValueService } from '../field_values/field_value.service';
+<% } -%>
 import { <%= entityNamePlural %>, type <%= classNames.entity %> } from './<%= entityName %>.entity';
+<%_ if (typeof hasSyncSurface !== 'undefined' && hasSyncSurface) { _%>
+<%_ clpSyncParentTableImports.forEach((imp) => { _%>
+import { <%= imp.table %> } from '<%= imp.importPath %>';
+<%_ }); _%>
+<%_ } _%>
+<%_ if (typeof hasSyncSurface !== 'undefined' && hasSyncSurface) { _%>
+
+/**
+ * Canonical fields a synced <%= entityName %> write carries (#374). Copy-through
+ * columns are typed from the entity; each FK is named by its parent's external
+ * id and resolved <%= clpSyncFkResolvers.length > 0 ? 'in syncUpsertOne' : 'as configured' %>. Provider/providerMetadata are persistence
+ * seam, not carried here.
+ */
+export interface <%= classNames.entity %>SyncWrite {
+  readonly externalId: string;
+<%_ clpSyncWriteFields.forEach((f) => { _%>
+  readonly <%= f.camelName %>: <%- f.tsType %>;
+<%_ }); _%>
+<%_ clpSyncWriteFkFields.forEach((f) => { _%>
+  readonly <%= f.name %>?: <%- f.tsType %>;
+<%_ }); _%>
+  /** Flat custom-field bag (EAV). */
+  readonly fields?: Record<string, unknown>;
+}
+
+/**
+ * Canonical-projected view of a <%= entityName %> row, keyed for the sync differ
+ * (#374). external_id_tracking columns (provider/providerMetadata) are OMITTED;
+ * externalId is kept.
+ */
+export interface <%= classNames.entity %>SyncProjection {
+<%_ clpSyncProjectionFields.forEach((f) => { _%>
+  readonly <%= f.camelName %>: <%- f.tsType %>;
+<%_ }); _%>
+}
+<%_ } _%>
 
 @Injectable()
+<%_ if (typeof hasSyncSurface !== 'undefined' && hasSyncSurface) { _%>
+export class <%= classNames.repository %> extends <%= repositoryBaseClass %><
+  <%= classNames.entity %>,
+  <%= classNames.entity %>SyncWrite,
+  <%= classNames.entity %>SyncProjection
+> {
+<%_ } else { _%>
 export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%= classNames.entity %>> {
+<%_ } _%>
   readonly table = <%= entityNamePlural %>;
 <% if (hasTimestamps || hasSoftDelete || hasUserTracking) { -%>
 
@@ -49,10 +99,50 @@ export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%=
   // runtime (identical shape to `behaviors: BehaviorConfig`).
   protected override readonly patternConfig = <%- renderPatternConfigLiteral(patternConfig, '  ', '  ') %> as const;
 <% } -%>
+<%_ if (typeof hasSyncSurface !== 'undefined' && hasSyncSurface) { _%>
 
+  // Inbound-sync write surface (#374). Drives the generic syncUpsertOne /
+  // findByExternalIdProjected / softDeleteByExternalId on the base. FK
+  // resolvers carry LIVE Drizzle table handles ('self' → this.table).
+  protected readonly syncConfig: SyncUpsertConfig = {
+    conflictTarget: [<%- clpSyncConfig.conflictTarget.map((c) => `'${c}'`).join(', ') %>],
+    writeColumns: [<%- clpSyncConfig.writeColumns.map((c) => `'${c}'`).join(', ') %>],
+    fkResolvers: [
+<%_ clpSyncFkResolvers.forEach((fk) => { _%>
+      { column: '<%= fk.column %>', writeKey: '<%= fk.writeKey %>', refTable: <%- fk.isSelfFk ? "'self'" : fk.refTable %> },
+<%_ }); _%>
+    ],
+    projectionColumns: [<%- clpSyncConfig.projectionColumns.map((c) => `'${c}'`).join(', ') %>],
+    eav: <%= clpSyncConfig.eav %>,
+    softDelete: <%= clpSyncConfig.softDelete %>,
+  };
+<%_ } _%>
+
+<%_ if (eavEnabled) { -%>
+  constructor(
+    @Inject(DRIZZLE) db: DrizzleClient,
+    private readonly fieldValues: FieldValueService,
+  ) {
+    super(db);
+  }
+
+  /**
+   * EAV dual-write override (#374 seam → #124 live path). Delegates to the
+   * shared FieldValueService so the inbound-sync write joins the same tx.
+   */
+  protected override async writeCustomFields(
+    db: DrizzleTx,
+    entityId: string,
+    userId: string,
+    fields: Record<string, unknown>,
+  ): Promise<void> {
+    await this.fieldValues.upsertFieldsTransactional('<%= entityName %>', entityId, userId, fields, db);
+  }
+<%_ } else { -%>
   constructor(@Inject(DRIZZLE) db: DrizzleClient) {
     super(db);
   }
+<%_ } -%>
 <% if (hasDeclarativeQueries) { -%>
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -109,7 +109,7 @@ export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%=
     writeColumns: [<%- clpSyncConfig.writeColumns.map((c) => `'${c}'`).join(', ') %>],
     fkResolvers: [
 <%_ clpSyncFkResolvers.forEach((fk) => { _%>
-      { column: '<%= fk.column %>', writeKey: '<%= fk.writeKey %>', refTable: <%- fk.isSelfFk ? "'self'" : fk.refTable %> },
+      { column: '<%= fk.column %>', writeKey: '<%= fk.writeKey %>', refTable: <%- fk.isSelfFk ? "'self'" : fk.refTable %><%= fk.strict ? ', strict: true' : '' %> },
 <%_ }); _%>
     ],
     projectionColumns: [<%- clpSyncConfig.projectionColumns.map((c) => `'${c}'`).join(', ') %>],

--- a/templates/junction/new/prompt.js
+++ b/templates/junction/new/prompt.js
@@ -378,6 +378,63 @@ export default {
     const rightEntityCamel = camelCase(rightEntity);
 
     // ======================================================================
+    // Inbound-sync write surface (#374)
+    // ======================================================================
+    // The junction sync identity is the tuple (leftId, rightId[, role]); its
+    // externalId is a COMPOSITE string. Both parent FKs resolve strictly. FK
+    // write-keys use `${camelCase(entity)}ExternalId` (matches the reference).
+
+    const leftSyncWriteKey = `${leftEntityCamel}ExternalId`;
+    const rightSyncWriteKey = `${rightEntityCamel}ExternalId`;
+    const roleColumnCamel = hasRole ? 'role' : null;
+    // Role TS type — literal union from the enum choices, else absent.
+    const roleTsType = hasRole
+      ? roleChoices.map((c) => `'${c}'`).join(' | ')
+      : null;
+
+    // JunctionSyncConfig literal fields. refTable is emitted as a live table
+    // identifier (leftTable/rightTable) by the template.
+    const syncConfig = {
+      leftColumn: leftColumnCamel,
+      leftRefTable: leftTable,
+      rightColumn: rightColumnCamel,
+      rightRefTable: rightTable,
+      roleColumn: roleColumnCamel,
+    };
+
+    // TSyncWrite fields: both parent external ids + optional role + userId.
+    const syncWriteFields = [
+      { name: leftSyncWriteKey, tsType: 'string' },
+      { name: rightSyncWriteKey, tsType: 'string' },
+      ...(hasRole ? [{ name: 'role', tsType: roleTsType }] : []),
+      { name: 'userId', tsType: 'string' },
+    ];
+
+    // TSyncProjection fields: composite id + local FK columns + optional role +
+    // timestamps. No surrogate id column on a junction.
+    const syncProjectionFields = [
+      { name: 'id', tsType: 'string' },
+      { name: leftColumnCamel, tsType: 'string' },
+      { name: rightColumnCamel, tsType: 'string' },
+      ...(hasRole ? [{ name: 'role', tsType: roleTsType }] : []),
+      { name: 'createdAt', tsType: 'Date' },
+      { name: 'updatedAt', tsType: 'Date' },
+    ];
+
+    // Parent-table imports for the FK resolvers, deduped (#368). Junction
+    // endpoints are distinct by schema, so two imports unless they collide.
+    const syncParentImports = [];
+    const seenSyncImports = new Set();
+    for (const imp of [
+      { table: leftTable, importPath: leftEntityImportFromJunction },
+      { table: rightTable, importPath: rightEntityImportFromJunction },
+    ]) {
+      if (seenSyncImports.has(imp.table)) continue;
+      seenSyncImports.add(imp.table);
+      syncParentImports.push(imp);
+    }
+
+    // ======================================================================
     // Class names
     // ======================================================================
 
@@ -464,6 +521,18 @@ export default {
       // Parent table Drizzle var names (for FK .references())
       leftTable,
       rightTable,
+
+      // ──────────────────────────────────────────────────────────────────
+      // Inbound-sync write surface (#374)
+      // ──────────────────────────────────────────────────────────────────
+      leftSyncWriteKey,
+      rightSyncWriteKey,
+      roleColumnCamel,
+      roleTsType,
+      junctionSyncConfig: syncConfig,
+      syncWriteFields,
+      syncProjectionFields,
+      syncParentImports,
 
       // ──────────────────────────────────────────────────────────────────
       // CGP-60 — fan-out locals

--- a/templates/junction/new/repository.ejs.t
+++ b/templates/junction/new/repository.ejs.t
@@ -7,11 +7,42 @@ import { Injectable, Inject } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { DRIZZLE } from '@shared/constants/tokens';
 import type { DrizzleClient } from '@shared/types/drizzle';
-import { BaseRepository } from '@shared/base-classes/base-repository';
+import { JunctionSyncRepository } from '@shared/base-classes/junction-sync-repository';
+import type { JunctionSyncConfig } from '@shared/base-classes/junction-sync-repository';
+<%_ syncParentImports.forEach((imp) => { _%>
+import { <%= imp.table %> } from '<%= imp.importPath %>';
+<%_ }); _%>
 import { <%= tableVarName %>, type <%= classNames.entity %> } from './<%= name %>.entity';
 
+/**
+ * Canonical fields a synced <%= name %> junction write carries (#374). BOTH
+ * parent FKs are named by their vendor external ids and resolved STRICTLY in
+ * the tx (a missing parent throws → the orchestrator records a failed item and
+ * continues). `userId` is run context (no column on the junction).
+ */
+export interface <%= classNames.entity %>SyncWrite {
+<%_ syncWriteFields.forEach((f) => { _%>
+  readonly <%= f.name %>: <%- f.tsType %>;
+<%_ }); _%>
+}
+
+/**
+ * Canonical-projected view of a <%= name %> junction row, keyed for the sync
+ * differ (#374). `id` is the COMPOSITE externalId (the junction has no
+ * surrogate id); the FKs are the LOCAL resolved uuids.
+ */
+export interface <%= classNames.entity %>SyncProjection {
+<%_ syncProjectionFields.forEach((f) => { _%>
+  readonly <%= f.name %>: <%- f.tsType %>;
+<%_ }); _%>
+}
+
 @Injectable()
-export class <%= classNames.repository %> extends BaseRepository<<%= classNames.entity %>> {
+export class <%= classNames.repository %> extends JunctionSyncRepository<
+  <%= classNames.entity %>,
+  <%= classNames.entity %>SyncWrite,
+  <%= classNames.entity %>SyncProjection
+> {
   readonly table = <%= tableVarName %>;
 
   // Junctions track temporal validity via started_at / ended_at, NOT via
@@ -20,6 +51,14 @@ export class <%= classNames.repository %> extends BaseRepository<<%= classNames.
     timestamps: true,
     softDelete: false,
     userTracking: false,
+  };
+
+  // Inbound-sync write surface (#374). Both endpoints resolve strictly against
+  // the live parent tables; role-bearing junctions conflict on (left,right,role).
+  protected readonly syncConfig: JunctionSyncConfig = {
+    left: { column: '<%= junctionSyncConfig.leftColumn %>', refTable: <%= junctionSyncConfig.leftRefTable %> },
+    right: { column: '<%= junctionSyncConfig.rightColumn %>', refTable: <%= junctionSyncConfig.rightRefTable %> },
+    roleColumn: <%- junctionSyncConfig.roleColumn ? `'${junctionSyncConfig.roleColumn}'` : 'null' %>,
   };
 
   constructor(@Inject(DRIZZLE) db: DrizzleClient) {
@@ -63,6 +102,7 @@ export class <%= classNames.repository %> extends BaseRepository<<%= classNames.
     return rows as <%= classNames.entity %>[];
   }
 
-  // Inherited from BaseRepository:
+  // Inherited from JunctionSyncRepository (+ BaseRepository):
   //   findById, findByIds, list, count, exists, create, update, delete, upsertMany
+  //   syncUpsertOne, findByExternalIdProjected, softDeleteByExternalId
 }

--- a/test/junction/__snapshots__/opportunity-activity.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-activity.test.ts.snap
@@ -80,11 +80,43 @@ import { Injectable, Inject } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { DRIZZLE } from '@shared/constants/tokens';
 import type { DrizzleClient } from '@shared/types/drizzle';
-import { BaseRepository } from '@shared/base-classes/base-repository';
+import { JunctionSyncRepository } from '@shared/base-classes/junction-sync-repository';
+import type { JunctionSyncConfig } from '@shared/base-classes/junction-sync-repository';
+import { opportunities } from '../opportunities/opportunity.entity';
+import { activities } from '../activities/activity.entity';
 import { opportunityActivities, type OpportunityActivity } from './opportunity_activity.entity';
 
+/**
+ * Canonical fields a synced opportunity_activity junction write carries (#374). BOTH
+ * parent FKs are named by their vendor external ids and resolved STRICTLY in
+ * the tx (a missing parent throws → the orchestrator records a failed item and
+ * continues). \`userId\` is run context (no column on the junction).
+ */
+export interface OpportunityActivitySyncWrite {
+  readonly opportunityExternalId: string;
+  readonly activityExternalId: string;
+  readonly userId: string;
+}
+
+/**
+ * Canonical-projected view of a opportunity_activity junction row, keyed for the sync
+ * differ (#374). \`id\` is the COMPOSITE externalId (the junction has no
+ * surrogate id); the FKs are the LOCAL resolved uuids.
+ */
+export interface OpportunityActivitySyncProjection {
+  readonly id: string;
+  readonly opportunityId: string;
+  readonly activityId: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
 @Injectable()
-export class OpportunityActivityRepository extends BaseRepository<OpportunityActivity> {
+export class OpportunityActivityRepository extends JunctionSyncRepository<
+  OpportunityActivity,
+  OpportunityActivitySyncWrite,
+  OpportunityActivitySyncProjection
+> {
   readonly table = opportunityActivities;
 
   // Junctions track temporal validity via started_at / ended_at, NOT via
@@ -93,6 +125,14 @@ export class OpportunityActivityRepository extends BaseRepository<OpportunityAct
     timestamps: true,
     softDelete: false,
     userTracking: false,
+  };
+
+  // Inbound-sync write surface (#374). Both endpoints resolve strictly against
+  // the live parent tables; role-bearing junctions conflict on (left,right,role).
+  protected readonly syncConfig: JunctionSyncConfig = {
+    left: { column: 'opportunityId', refTable: opportunities },
+    right: { column: 'activityId', refTable: activities },
+    roleColumn: null,
   };
 
   constructor(@Inject(DRIZZLE) db: DrizzleClient) {
@@ -136,8 +176,9 @@ export class OpportunityActivityRepository extends BaseRepository<OpportunityAct
     return rows as OpportunityActivity[];
   }
 
-  // Inherited from BaseRepository:
+  // Inherited from JunctionSyncRepository (+ BaseRepository):
   //   findById, findByIds, list, count, exists, create, update, delete, upsertMany
+  //   syncUpsertOne, findByExternalIdProjected, softDeleteByExternalId
 }
 "
 `;

--- a/test/junction/__snapshots__/opportunity-contact.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-contact.test.ts.snap
@@ -96,11 +96,45 @@ import { Injectable, Inject } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { DRIZZLE } from '@shared/constants/tokens';
 import type { DrizzleClient } from '@shared/types/drizzle';
-import { BaseRepository } from '@shared/base-classes/base-repository';
+import { JunctionSyncRepository } from '@shared/base-classes/junction-sync-repository';
+import type { JunctionSyncConfig } from '@shared/base-classes/junction-sync-repository';
+import { opportunities } from '../opportunities/opportunity.entity';
+import { contacts } from '../contacts/contact.entity';
 import { opportunityContacts, type OpportunityContact } from './opportunity_contact.entity';
 
+/**
+ * Canonical fields a synced opportunity_contact junction write carries (#374). BOTH
+ * parent FKs are named by their vendor external ids and resolved STRICTLY in
+ * the tx (a missing parent throws → the orchestrator records a failed item and
+ * continues). \`userId\` is run context (no column on the junction).
+ */
+export interface OpportunityContactSyncWrite {
+  readonly opportunityExternalId: string;
+  readonly contactExternalId: string;
+  readonly role: 'champion' | 'decision_maker' | 'influencer';
+  readonly userId: string;
+}
+
+/**
+ * Canonical-projected view of a opportunity_contact junction row, keyed for the sync
+ * differ (#374). \`id\` is the COMPOSITE externalId (the junction has no
+ * surrogate id); the FKs are the LOCAL resolved uuids.
+ */
+export interface OpportunityContactSyncProjection {
+  readonly id: string;
+  readonly opportunityId: string;
+  readonly contactId: string;
+  readonly role: 'champion' | 'decision_maker' | 'influencer';
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
 @Injectable()
-export class OpportunityContactRepository extends BaseRepository<OpportunityContact> {
+export class OpportunityContactRepository extends JunctionSyncRepository<
+  OpportunityContact,
+  OpportunityContactSyncWrite,
+  OpportunityContactSyncProjection
+> {
   readonly table = opportunityContacts;
 
   // Junctions track temporal validity via started_at / ended_at, NOT via
@@ -109,6 +143,14 @@ export class OpportunityContactRepository extends BaseRepository<OpportunityCont
     timestamps: true,
     softDelete: false,
     userTracking: false,
+  };
+
+  // Inbound-sync write surface (#374). Both endpoints resolve strictly against
+  // the live parent tables; role-bearing junctions conflict on (left,right,role).
+  protected readonly syncConfig: JunctionSyncConfig = {
+    left: { column: 'opportunityId', refTable: opportunities },
+    right: { column: 'contactId', refTable: contacts },
+    roleColumn: 'role',
   };
 
   constructor(@Inject(DRIZZLE) db: DrizzleClient) {
@@ -152,8 +194,9 @@ export class OpportunityContactRepository extends BaseRepository<OpportunityCont
     return rows as OpportunityContact[];
   }
 
-  // Inherited from BaseRepository:
+  // Inherited from JunctionSyncRepository (+ BaseRepository):
   //   findById, findByIds, list, count, exists, create, update, delete, upsertMany
+  //   syncUpsertOne, findByExternalIdProjected, softDeleteByExternalId
 }
 "
 `;

--- a/test/scaffold/tests/synced-entity-repository.test.ts
+++ b/test/scaffold/tests/synced-entity-repository.test.ts
@@ -30,6 +30,17 @@ beforeAll(async () => {
   class TestCrmRepository extends SyncedEntityRepository<CrmEntity> {
     readonly table = crmEntities;
     protected readonly behaviors = { timestamps: true, softDelete: true, userTracking: false };
+    // #374: syncConfig is now abstract on the base. A minimal config keeps this
+    // hand-written test repo compiling; the generic sync surface is unit-tested
+    // separately in src/__tests__/runtime/base-classes/.
+    protected readonly syncConfig = {
+      conflictTarget: ['provider', 'externalId'],
+      writeColumns: ['name'],
+      fkResolvers: [],
+      projectionColumns: ['id', 'externalId', 'name'],
+      eav: false,
+      softDelete: true,
+    };
   }
 
   repo = new TestCrmRepository(getTestDb() as any);
@@ -111,8 +122,8 @@ d('findAllByUserId', () => {
 });
 
 d('abstract stubs', () => {
-  test('syncUpsert throws not implemented', async () => {
-    await expect(repo.syncUpsert([])).rejects.toThrow('syncUpsert not implemented');
+  test('syncUpsert returns [] for empty input (#374: now concrete)', async () => {
+    await expect(repo.syncUpsert([])).resolves.toEqual([]);
   });
 
   test('findVisibleByUserId throws not implemented', async () => {

--- a/test/smoke/run-smoke-junction.ts
+++ b/test/smoke/run-smoke-junction.ts
@@ -221,7 +221,9 @@ function assertJunctionEmission(
       : `app/backend/src/infrastructure/persistence/drizzle/${junctionName.replace(/_/g, '-')}.repository.ts`,
   );
 
-  assertContains(repoFile, /extends BaseRepository<\w+>/, 'repo: extends BaseRepository');
+  // #374: junctions now extend JunctionSyncRepository (which extends BaseRepository)
+  // to inherit the inbound-sync write surface (syncUpsertOne/etc.).
+  assertContains(repoFile, /extends JunctionSyncRepository</, 'repo: extends JunctionSyncRepository');
   assertContains(
     repoFile,
     new RegExp(`findBy${leftPascal}Id\\s*\\(`),


### PR DESCRIPTION
Closes #374. Lifts the ~230-line hand-written inbound-sync write surface (duplicated across 5 `force:true` repos in dealbrain-integrations and silently wiped on every `codegen entity new --all`) into codegen. Generic logic lives in the runtime base classes; per-entity `syncConfig` literals + `TSyncWrite`/`TSyncProjection` types are emitted by the templates — same idiom as `behaviors`/`patternConfig`.

Implementation spec: `ai-docs/specs/2026-05-24-emit-synced-junction-sync-override.md` (resolves the 5 design decisions the contract spec left open). Rides on #373 (`@generated` banner) — rebased onto it; the new sync-surface output carries the banner.

## What's generated

For every `pattern: Synced` entity (inherited/generated, previously hand-written):
- `syncUpsertOne(write, provider, tx?)` — single-tx upsert: opportunistic FK resolution (+ **no-clobber-with-null** in the conflict `set`), provider-scoped `onConflictDoUpdate`, config-gated EAV dual-write hook.
- `findByExternalIdProjected(externalId, provider)` — provider-scoped canonical projection (differ-ready).
- `softDeleteByExternalId(externalId, provider, tx?)` — `deletedAt` when `soft_delete`, else tombstone-by-clearing `external_id`/`provider`.
- batch `syncUpsert(inputs)` — concretizes the former throwing stub; per-input provider, skips incomplete rows.
- `toProjection`, `TSyncWrite`/`TSyncProjection` types; projection omits `provider`/`provider_metadata`.

For junctions: new `JunctionSyncRepository` base — strict dual-FK resolution + `onConflictDoUpdate` on the `(left,right,role)` PK (per #372), role/role-less variants, static composite `externalId` build/parse.

## Design decisions (see spec)
1. `SyncUpsertConfig` separates identity / copy-through (`writeColumns`) / resolved-FK column roles.
2. FK resolvers carry **live** Drizzle table handles (`'self'` or imported parent) — literal hand-emitted, not via `renderPatternConfigLiteral`; parent imports deduped (#368).
3. Junction uses `onConflictDoUpdate` (supersedes the stale select-then-write reference, which predated #372).
4. Types derived from field metadata; FK write-key = `${relationKey}ExternalId`.
5. EAV seam = config-gated overridable no-op hook (live `FieldValueService` path activates downstream in #124).

## Validation
- `bun run build` OK · `bun run typecheck` → only the 3 pre-existing `junction.ts`/`barrel-generator.ts` errors (unchanged on `main`, out of scope) · `just test-unit` 2073 pass · `just test-baseline` green · `bun test test/junction/` 10 pass (banner present).
- +53 new tests: base specs (FK resolution incl. no-clobber, provider scoping, both soft-delete branches, batch), junction (strict dual-FK, composite parse, role-less), template-emission (config + types + banner, non-self synced-FK import path the DBI oracle can't reach, eav override).
- Independently validated by the `validator` agent: **PASS**, all 8 spec invariants non-vacuously covered.

## Remaining acceptance gate (downstream, dealbrain-integrations)
The unambiguous "done" is the DBI oracle: point DBI at this branch → regenerate → the 5 repos show only generated content → `typecheck` 0 → 699 tests. Requires one consumer-side rename (`parentExternalId → parentAccountExternalId` in the account sink — the FK-key misnomer fix). Unblocks #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
