### PR TITLE
fix(sync): junction toProjection projects full structural shape — release 0.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/base-classes/junction-sync-repository.ts
+++ b/runtime/base-classes/junction-sync-repository.ts
@@ -165,21 +165,32 @@ export abstract class JunctionSyncRepository<
   }
 
   /**
-   * Project a raw junction row to the differ shape. `id` is the COMPOSITE
-   * externalId (the junction has no surrogate id). Override to widen the
-   * projection beyond the identity tuple (the template emits a concrete
-   * `toProjection` carrying the role + local FKs + timestamps).
+   * Project a raw junction row to the differ shape: the COMPOSITE externalId
+   * `id` (junctions have no surrogate id) plus the local FK columns, role (when
+   * role-bearing) and timestamps — matching the emitted
+   * `<Junction>SyncProjection` interface (id + leftId + rightId + role? +
+   * createdAt + updatedAt). Junction projections are purely structural, so this
+   * is fully generic over `syncConfig` — no per-junction override is emitted.
    */
   protected toProjection(
-    _row: TEntity,
+    row: TEntity,
     write: Record<string, unknown>,
     _provider: string,
   ): TSyncProjection {
     const cfg = this.syncConfig;
+    const r = row as Record<string, unknown>;
     const leftExt = write[`${cfg.left.column.replace(/Id$/, '')}ExternalId`] as string;
     const rightExt = write[`${cfg.right.column.replace(/Id$/, '')}ExternalId`] as string;
-    const role = cfg.roleColumn ? (write['role'] as string) : undefined;
-    return { id: buildCompositeExternalId(leftExt, rightExt, role) } as TSyncProjection;
+    const role = cfg.roleColumn ? (r[cfg.roleColumn] as string | undefined) : undefined;
+    const out: Record<string, unknown> = {
+      id: buildCompositeExternalId(leftExt, rightExt, role),
+      [cfg.left.column]: r[cfg.left.column],
+      [cfg.right.column]: r[cfg.right.column],
+    };
+    if (cfg.roleColumn) out[cfg.roleColumn] = r[cfg.roleColumn];
+    out['createdAt'] = r['createdAt'];
+    out['updatedAt'] = r['updatedAt'];
+    return out as TSyncProjection;
   }
 
   /** Build the identity WHERE clause `(left, right[, role])`. */

--- a/src/__tests__/runtime/base-classes/junction-sync-repository.spec.ts
+++ b/src/__tests__/runtime/base-classes/junction-sync-repository.spec.ts
@@ -149,6 +149,13 @@ describe('JunctionSyncRepository.syncUpsertOne', () => {
     const conflict = m.capture.conflict[0] as { target: unknown[] };
     expect(conflict.target).toHaveLength(3); // role-inclusive
     expect(proj.id).toBe('o-ext::c-ext::champion');
+    // projection carries the full structural shape from the row, not just `id`
+    // (regression: toProjection previously returned `{ id }` only)
+    expect(proj.opportunityId).toBe('opp-1');
+    expect(proj.contactId).toBe('con-1');
+    expect(proj.role).toBe('champion');
+    expect(proj.createdAt).toEqual(new Date('2026-01-01'));
+    expect(proj.updatedAt).toEqual(new Date('2026-01-02'));
   });
 
   it('throws when the left parent is unresolved (strict)', async () => {


### PR DESCRIPTION
Follow-up to #374. The 0.7.6 junction sync-override emitted the `<Junction>SyncProjection` interface but `JunctionSyncRepository.toProjection` returned only `{ id }`, so junction projections had `undefined` FK/role/timestamps — which consumer junction sinks read. Surfaced consuming into dealbrain-integrations **#124** (junction projection tests failed once the test-double `.onConflictDoUpdate` gap was fixed and the real toProjection ran).

**Fix:** make the base `toProjection` complete — junction projections are purely structural, so derive `id` (composite) + FK columns + role + timestamps generically from `syncConfig` + the row. No per-junction template override (the doc claimed one was emitted; it never was). Adds a regression test asserting the full projection shape, not just `id`.

`just test-all` green locally (unit + baseline + smoke + relationship + junction + junction-cross-domain). Bundles the **0.7.7** release bump.

Unblocks dealbrain-integrations #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)