### PR TITLE
fix(templates): cross-entity modules export repository — DI boot fix + 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.8] — 2026-05-25
+
+Fixes a NestJS DI-resolution bug in cross-entity module wiring. A generated service that injects a sibling entity's **repository** — junction `.list()` composition (CGP-60), EAV value→definition resolution (`eav_value_table`) — failed at runtime because the sibling module exported only its **service**, never its repository (ADR-002). The code typechecked (`tsc` can't see DI wiring), so it shipped and only surfaced on a consumer's first `NestFactory` boot (dealbrain-integrations).
+
+### Fixed
+
+- **`fix(templates)` — entity modules export their repository.** `templates/entity/new/clean-lite-ps/module.ejs.t` now emits `exports: [<Service>, <Repository>]`. Cross-module consumers already imported the sibling *module*; the repository was just never exported, so DI couldn't resolve it. Exporting it means the consumer injects the **home-module instance** — the only place the repo's own dependencies are wired (e.g. an EAV entity's repository injects `FieldValueService` for the sync dual-write transaction, so it can only be constructed in its home module; local-providing it elsewhere can't satisfy that dep). ADR-002 revised: the repository is part of a module's public surface; use-case internals stay unexported.
+
+### Added
+
+- **DI-resolution smoke gate (`test/smoke/verify-boot.ts`).** Boots the generated `AppModule` via `NestFactory.create` + `app.init()` — instantiating every provider across every module — wired into the junction smoke (`run-smoke-junction.ts` step 10). Closes the gap that let the bug ship: the junction + EAV pipelines were gated only by `tsc` + grep, neither of which exercises runtime DI. Verified: reverting the repository export passes `tsc` but fails the boot gate with the exact `UnknownDependencies` error.
+
 ## [0.7.3] — 2026-05-23
 
 Auto-emits `<generated>/subsystems.ts` — a `SUBSYSTEM_MODULES` barrel of `forRoot()` calls for every installed subsystem. Removes the "did I forget to wire `SyncModule`?" class of silent-failure bug when a subsystem is declared in `subsystems.install` but never imported into AppModule.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/templates/entity/new/clean-lite-ps/module.ejs.t
+++ b/templates/entity/new/clean-lite-ps/module.ejs.t
@@ -112,7 +112,13 @@ import { <%= classNames.searchController %> } from './<%= entityName %>-search.c
     <%= searchQuery.useCaseClassName %>,
 <% } -%>
   ],
-  exports: [<%= classNames.service %>],  // Only service is exported (ADR-002)
+  // ADR-002 (revised): the service is the public API; the repository is ALSO
+  // exported so sibling modules that compose this entity cross-module (junction
+  // `.list()`, EAV value→definition resolution) inject the home-module instance
+  // — the only place the repo's own deps are wired (e.g. an EAV entity's repo
+  // injects FieldValueService for the #374 sync dual-write tx). Local-providing
+  // such a repo elsewhere can't satisfy those deps. Use-case internals stay unexported.
+  exports: [<%= classNames.service %>, <%= classNames.repository %>],
 })
 export class <%= classNames.module %> implements OnModuleInit {
   // OPENAPI-2: register this entity's Zod schemas with the shared

--- a/test/smoke/run-smoke-junction.ts
+++ b/test/smoke/run-smoke-junction.ts
@@ -379,6 +379,27 @@ async function main(): Promise<number> {
       assertBarrelIncludes(result.projectDir, pluralName, architectureArg);
     }
 
+    // 10. DI-resolution gate — boot the generated AppModule. `tsc` + grep
+    // cannot catch a junction module that typechecks but fails to resolve its
+    // injected parent repos at runtime (the wiring regression fixed in 0.7.8).
+    // NestFactory.create + init instantiates the whole graph, so an unresolved
+    // cross-module dependency throws here, not on a consumer's first boot.
+    if (exitCode === 0) {
+      log('booting AppModule (NestFactory DI resolution gate)');
+      const boot = runSilent(
+        `bun ${path.join(import.meta.dir, 'verify-boot.ts')} ${result.projectDir}`,
+        result.projectDir,
+      );
+      if (boot.code !== 0) {
+        console.error(boot.out);
+        console.error(boot.err);
+        logError('AppModule boot failed — DI graph did not resolve');
+        exitCode = 1;
+      } else {
+        log('boot OK (AppModule DI graph resolves)');
+      }
+    }
+
   } catch (err: unknown) {
     logError(err instanceof Error ? err.message : String(err));
     if (err instanceof Error && err.stack) {

--- a/test/smoke/verify-boot.ts
+++ b/test/smoke/verify-boot.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * DI-resolution gate: boot the generated `AppModule` and assert the whole
+ * NestJS dependency graph resolves.
+ *
+ * Runs inside a smoke harness tmp project (passed as argv[2]). It does the
+ * one thing `tsc --noEmit` cannot: `NestFactory.create(AppModule)` +
+ * `app.init()` instantiates every provider across every module, so a
+ * cross-module wiring bug — a service injecting a sibling repo whose home
+ * module doesn't export it, a junction module that can't resolve its parent
+ * repos, an EAV value-table module missing the definition repo — throws here
+ * instead of shipping to a consumer's first boot.
+ *
+ * This guard exists because that class of bug (a junction/EAV module that
+ * typechecks but fails DI at runtime) shipped once: the junction + EAV
+ * pipelines were only gated by `tsc` + grep, never by an actual boot. See
+ * CHANGELOG 0.7.8.
+ *
+ * No OpenAPI assertions here (that's verify-openapi.ts) — this is purely
+ * "does the container come up". DATABASE_URL is stubbed; pg.Pool is lazy and
+ * no query fires during module init, so no real DB is needed.
+ */
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function fail(msg: string): never {
+	console.error(`[boot-verify] FAIL: ${msg}`);
+	process.exit(1);
+}
+
+async function main(): Promise<void> {
+	const tmpDir = process.argv[2];
+	if (!tmpDir) fail('usage: verify-boot.ts <tmpDir>');
+
+	// AppModule's path aliases (@shared/*, @modules/*, @generated/*) resolve
+	// relative to the tmp project's tsconfig — make it the cwd.
+	process.chdir(tmpDir);
+
+	const nestCoreUrl = pathToFileURL(
+		path.join(tmpDir, 'node_modules', '@nestjs', 'core', 'index.js'),
+	).href;
+	const nestCommonUrl = pathToFileURL(
+		path.join(tmpDir, 'node_modules', '@nestjs', 'common', 'index.js'),
+	).href;
+	const { NestFactory } = (await import(nestCoreUrl)) as typeof import('@nestjs/core');
+	// Prime @nestjs/common from the tmp project to avoid package duplication.
+	await import(nestCommonUrl);
+
+	// pg.Pool never connects until a query runs; module init fires no queries.
+	process.env.DATABASE_URL =
+		process.env.DATABASE_URL ?? 'postgresql://stub:stub@127.0.0.1:1/stub';
+
+	const appModuleUrl = pathToFileURL(
+		path.join(tmpDir, 'src', 'app.module.ts'),
+	).href;
+	const { AppModule } = (await import(appModuleUrl)) as { AppModule: unknown };
+
+	// NestFactory.create + init resolves the ENTIRE provider graph. A missing
+	// cross-module export surfaces as an UnknownDependenciesException here.
+	const app = await NestFactory.create(AppModule as never, {
+		logger: false,
+		abortOnError: false,
+	});
+	await app.init();
+	await app.close();
+
+	console.log('[boot-verify] OK — AppModule DI graph resolves');
+}
+
+main().catch((err) => {
+	// NestFactory throws here on an unresolved dependency — that's the failure
+	// this guard is designed to catch, so surface it loudly and fail.
+	console.error('[boot-verify] FAIL: AppModule did not boot:');
+	console.error(err instanceof Error ? err.message : String(err));
+	process.exit(1);
+});


### PR DESCRIPTION
## Problem

A generated service that injects a sibling entity's **repository** — junction `.list()` composition (CGP-60), EAV value→definition resolution (`eav_value_table`) — fails NestJS DI at runtime. The sibling module exported only its **service**, never its repository (ADR-002), so the injected repo can't resolve. `tsc` doesn't see DI wiring, so it typechecks and ships — surfacing only on a consumer's first `NestFactory` boot (hit live in dealbrain-integrations: `field_value`→`field_definition`, `account_contact`→account/contact).

## Fix (one line)

`templates/entity/new/clean-lite-ps/module.ejs.t` now emits `exports: [<Service>, <Repository>]`. Consumers already imported the sibling *module*; the repo was just never exported. Exporting it means the consumer injects the **home-module instance** — the only place the repo's own deps are wired (an EAV entity's repo injects `FieldValueService` for the #374 sync dual-write tx, so it can only be constructed in its home module; local-providing it elsewhere can't satisfy that dep). **ADR-002 revised**: repository is part of a module's public surface; use-case internals stay unexported.

## Regression guard

New `test/smoke/verify-boot.ts` boots the generated `AppModule` (`NestFactory.create` + `app.init()` — instantiates every provider), wired into `run-smoke-junction.ts` step 10. Closes the gap that let this ship: junction + EAV pipelines were gated only by `tsc` + grep, neither of which exercises runtime DI.

**Verified the guard catches the bug**: reverting the export passes `tsc` but fails the boot gate with the exact `UnknownDependencies` error. `just test-all` green (2076 unit + baseline + smoke + both junction scenarios boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)