### PR TITLE
feat(runtime): ambient tenant scoping for user-owned repos (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-25
+
+Adds **ambient tenant scoping** to `BaseRepository`: user-owned repos filter every
+read/write by the requester automatically, instead of relying on hand-threaded
+`userId` parameters. Ports the proven `dealbrain` `RequesterContext` pattern into
+the codegen substrate. See ADR-0001 (`ai-docs/adrs/0001-ambient-tenant-scoping.md`).
+
+### Added
+
+- **`feat(runtime)` — `tenant-context.ts` ambient scope primitive.** New
+  `runtime/base-classes/tenant-context.ts`: an `AsyncLocalStorage`-backed
+  `RequesterContext { userId, organizationId, scope?, orgUserIds? }` with
+  `withRequester(ctx, fn)` (set at a boundary), `requireRequester()` /
+  `tryGetRequester()` (read inside repos), and `withUserScope` / `withOrgScope` /
+  `withSuperuserScope` helpers. Scope model (`'user' | 'org' | 'superuser'`)
+  copied verbatim from `dealbrain` `packages/integrations/src/framework`.
+  Vendored into consumers via `init-scaffold` and exported from the base-classes
+  barrel.
+- **`feat(runtime)` — `BaseRepository.scopePredicate()` + `scopeAnd()`.** When a
+  repo declares `behaviors.userTracking` (i.e. the entity has the `user_tracking`
+  behavior) and an ambient `RequesterContext` is active, `findById`, `findByIds`,
+  `list`, `count`, `update`, and `delete` automatically filter by `user_id`:
+  `= ctx.userId` (`user`), `IN ctx.orgUserIds` (`org`; empty ⇒ matches nothing),
+  or unfiltered (`superuser`). **No new per-entity config knob** — it rides the
+  existing (previously dormant) `userTracking` flag. No template changes.
+- **Unit coverage** — `base-repository.spec.ts` gains a scoping suite that renders
+  real Drizzle SQL (via `QueryBuilder`) to assert the emitted `WHERE` per scope,
+  gating (off when `userTracking` false / no context), strict-mode throw, and the
+  combined soft-delete + scope + leaf predicate.
+
+### Changed
+
+- **`scopeEnforcement` (lenient default).** With no ambient context active, a
+  `userTracking` repo is **not** scoped — adopting ambient scoping is additive,
+  and isolation engages only once a boundary installs `withRequester(...)`. Set
+  `protected readonly scopeEnforcement = 'strict'` on a repo or family base to
+  make a missing boundary throw (fail-loud). Validated against
+  `dealbrain-integrations` (no `userTracking` repos today): typecheck + 737 tests
+  green, behavior unchanged.
+
+### Fixed
+
+- **`fix(runtime)` — soft-delete guard no longer dropped on `findById` /
+  `list({where})` / bespoke query methods.** Drizzle's `.where()` *overrides* a
+  prior `.where()` on a `$dynamic()` query, so the soft-delete `isNull` filter
+  that `baseQuery()` added was being silently discarded whenever a leaf method
+  chained its own `.where()` — only no-arg `list()` and `count()` actually
+  excluded soft-deleted rows. `baseQuery(extra?)` now folds soft-delete + scope +
+  the leaf predicate into a single AND-joined `WHERE`.
+  - **Migration:** on `soft_delete` entities, `findById(id)` and `list({ where })`
+    now correctly **exclude** soft-deleted rows (previously returned them). Code
+    that relied on the old behavior to read a soft-deleted row must query
+    `deletedAt` explicitly.
+
 ## [0.7.8] — 2026-05-25
 
 Fixes a NestJS DI-resolution bug in cross-entity module wiring. A generated service that injects a sibling entity's **repository** — junction `.list()` composition (CGP-60), EAV value→definition resolution (`eav_value_table`) — failed at runtime because the sibling module exported only its **service**, never its repository (ADR-002). The code typechecked (`tsc` can't see DI wiring), so it shipped and only surfaced on a consumer's first `NestFactory` boot (dealbrain-integrations).

--- a/ai-docs/adrs/0001-ambient-tenant-scoping.md
+++ b/ai-docs/adrs/0001-ambient-tenant-scoping.md
@@ -1,0 +1,87 @@
+# ADR-0001 — Ambient tenant scoping for user-owned repositories
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Affects:** `runtime/base-classes/base-repository.ts`, new `runtime/base-classes/tenant-context.ts`, `src/cli/shared/init-scaffold.ts`
+- **Ported from:** `dealbrain` `packages/integrations/src/framework/tenant-context.ts` (the proven production pattern, added 2026-05-22)
+
+## Context
+
+Generated repositories scoped data to a user by **threading `userId` explicitly**
+through bespoke query methods (`findByUserId`, `findByUserIdAndStage`, …). The
+generic accessors every repo inherits — `findById`, `findByIds`, `list`,
+`count` — applied **no** ownership filter at all: `findById(id)` would return any
+row regardless of who owns it. Cross-tenant isolation depended on every call site
+remembering to use a `*ByUserId` method, which is exactly the "forgot to scope"
+class of bug.
+
+`dealbrain` solved this in its hand-written integration package with an
+AsyncLocalStorage-backed `RequesterContext`: scope is set once at each boundary
+and read implicitly inside the repository base, so isolation is automatic and a
+missing boundary fails loud. This ADR ports that pattern into the codegen
+substrate so every generated consumer gets it.
+
+## Decision
+
+1. **Ambient context primitive** (`tenant-context.ts`). An `AsyncLocalStorage`
+   holding `RequesterContext { userId, organizationId, scope?, orgUserIds? }`,
+   with `withRequester(ctx, fn)` to set it at boundaries and
+   `requireRequester()` / `tryGetRequester()` to read it. Scope model copied
+   verbatim from `dealbrain`: `'user'` | `'org'` | `'superuser'`.
+
+2. **`BaseRepository.scopePredicate()`** reads the ambient context and returns a
+   `user_id` filter, **gated on the existing `behaviors.userTracking` flag** —
+   no new per-entity config knob. `user_tracking` already adds the `user_id`
+   column and emits `userTracking: true`; that flag was previously dormant
+   (declared, never read), so giving it the "auto-scope" meaning is conflict-free.
+   - `'user'` → `user_id = ctx.userId`
+   - `'org'` → `user_id IN ctx.orgUserIds` (empty list ⇒ `sql\`false\`` — fail-closed)
+   - `'superuser'` → no filter
+
+3. **Single-`WHERE` combination.** Drizzle's `.where()` *overrides* a prior
+   `.where()` on a `$dynamic()` query (verified empirically) — so the scope (and
+   the pre-existing soft-delete guard) cannot be added as a second chained
+   `.where()`; it would be silently dropped. `baseQuery(extra?)` now folds
+   soft-delete + scope + the leaf predicate into one AND-joined `WHERE`. Reads
+   (`findById`, `findByIds`, `list`, `count`) and by-id writes (`update`,
+   `delete`) all carry the guard.
+
+4. **Lenient by default, strict opt-in** (`scopeEnforcement`). With no ambient
+   context active, a `userTracking` repo is **not** scoped (`'lenient'`) — so the
+   change is additive: existing consumers behave exactly as before until they
+   install `withRequester(...)` at their boundaries. A repo (or family base) can
+   override `scopeEnforcement = 'strict'` to make a missing boundary throw
+   (`dealbrain`'s fail-loud semantics) — recommended for new multi-tenant apps.
+
+## Consequences
+
+- **Soft-delete bug fixed as a side effect.** Because leaf predicates were
+  chained via a second `.where()`, the soft-delete guard was being dropped on
+  `findById` / `list({where})` / every bespoke query method — only no-arg
+  `list()` and `count()` actually excluded soft-deleted rows. The single-`WHERE`
+  refactor fixes this: `findById` on a `softDelete` entity now correctly excludes
+  deleted rows. **Behavior change** — see CHANGELOG migration note.
+- **No template changes.** The predicate lives entirely in the hand-maintained
+  base class; concrete repos opt in purely via the `user_tracking` behavior.
+- **`create()` is not auto-scoped.** Inserting still sets `user_id` from the
+  write payload (e.g. the sync write surface). Auto-injecting the owner on insert
+  is deferred.
+
+## Deferred / not in scope
+
+- Junction repositories (`JunctionSyncRepository`) — parent-entity subquery
+  scoping, as `dealbrain` does. Follow-up.
+- Boundary auto-install — codegen does not yet emit `withRequester(...)` into the
+  worker `process()` / use-case / controller it generates; consumers wire it
+  (recipe in `tenant-context.ts`). Follow-up.
+- Sync-upsert (`onConflict (provider, externalId)`) write-path scoping.
+
+## Alternatives rejected
+
+- **Per-entity `organization_id` column** — nullable-legacy pitfalls; `user_id IN
+  (orgUserIds)` works for every user-owned table and keeps repos single-table.
+- **Drizzle middleware / global filter** — drizzle 0.45 has no stable per-query
+  middleware hook that sees the ambient context cleanly; the base-class chokepoint
+  is simpler and explicit.
+- **Keep threading `userId`** — the status quo; parameter pollution and the
+  forgotten-scope footgun this ADR removes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.7.8",
+  "version": "0.8.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/base-classes/base-repository.ts
+++ b/runtime/base-classes/base-repository.ts
@@ -9,10 +9,15 @@
  *
  * NOT @Injectable — concrete repositories are @Injectable and inject DRIZZLE.
  */
-import { eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { PgTableWithColumns, PgColumn } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
 import type { DrizzleClient, DrizzleTx } from '../types/drizzle';
+import {
+  requireRequester,
+  tryGetRequester,
+  type RequesterScope,
+} from './tenant-context';
 
 // ============================================================================
 // Interfaces
@@ -59,6 +64,21 @@ export abstract class BaseRepository<TEntity> {
     userTracking: false,
   };
 
+  /**
+   * Ambient tenant-scope enforcement for `userTracking` repos (see
+   * `scopePredicate`). Only has effect when `behaviors.userTracking === true`.
+   *
+   * - `'lenient'` (default): when no ambient requester context is active,
+   *   reads/writes are NOT scoped — preserves pre-scoping behavior, so adopting
+   *   ambient scoping is additive. Scoping kicks in automatically once a
+   *   boundary installs `withRequester(...)`.
+   * - `'strict'`: a missing ambient context throws (`requireRequester`),
+   *   making a forgotten boundary fail loud instead of silently returning
+   *   cross-tenant rows. Recommended for new multi-tenant consumers — override
+   *   in a concrete repo or a family base class.
+   */
+  protected readonly scopeEnforcement: 'lenient' | 'strict' = 'lenient';
+
   protected readonly db: DrizzleClient;
 
   constructor(db: DrizzleClient) {
@@ -85,9 +105,7 @@ export abstract class BaseRepository<TEntity> {
    * Returns null if not found (or soft-deleted when softDelete=true).
    */
   async findById(id: string): Promise<TEntity | null> {
-    const rows = await this.baseQuery()
-      .where(eq(this.table['id'], id))
-      .limit(1);
+    const rows = await this.baseQuery(eq(this.table['id'], id)).limit(1);
     return (rows[0] as TEntity) ?? null;
   }
 
@@ -97,7 +115,7 @@ export abstract class BaseRepository<TEntity> {
    */
   async findByIds(ids: string[]): Promise<TEntity[]> {
     if (ids.length === 0) return [];
-    const rows = await this.baseQuery().where(inArray(this.table['id'], ids));
+    const rows = await this.baseQuery(inArray(this.table['id'], ids));
     return rows as TEntity[];
   }
 
@@ -105,11 +123,8 @@ export abstract class BaseRepository<TEntity> {
    * List entities with optional filtering, pagination, and ordering.
    */
   async list(options?: ListOptions): Promise<TEntity[]> {
-    let query = this.baseQuery();
+    let query = this.baseQuery(options?.where);
 
-    if (options?.where) {
-      query = query.where(options.where) as typeof query;
-    }
     if (options?.orderBy) {
       query = query.orderBy(options.orderBy as SQL) as typeof query;
     }
@@ -137,6 +152,10 @@ export abstract class BaseRepository<TEntity> {
     if (this.behaviors.softDelete) {
       conditions.push(isNull(this.table['deletedAt']));
     }
+    const scope = this.scopePredicate();
+    if (scope) {
+      conditions.push(scope);
+    }
     if (where) {
       conditions.push(where);
     }
@@ -144,8 +163,6 @@ export abstract class BaseRepository<TEntity> {
     if (conditions.length === 1) {
       query = query.where(conditions[0]) as typeof query;
     } else if (conditions.length > 1) {
-      // Combine with AND by building the condition inline
-      const { and } = await import('drizzle-orm');
       query = query.where(and(...conditions)) as typeof query;
     }
 
@@ -186,7 +203,7 @@ export abstract class BaseRepository<TEntity> {
     const rows = await this.runner(tx)
       .update(this.table)
       .set(data as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-      .where(eq(this.table['id'], id))
+      .where(this.scopeAnd(eq(this.table['id'], id)))
       .returning();
     return rows[0] as TEntity;
   }
@@ -202,11 +219,11 @@ export abstract class BaseRepository<TEntity> {
       await runner
         .update(this.table)
         .set({ deletedAt: new Date() } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-        .where(eq(this.table['id'], id));
+        .where(this.scopeAnd(eq(this.table['id'], id)));
     } else {
       await runner
         .delete(this.table)
-        .where(eq(this.table['id'], id));
+        .where(this.scopeAnd(eq(this.table['id'], id)));
     }
   }
 
@@ -224,15 +241,74 @@ export abstract class BaseRepository<TEntity> {
   // ============================================================================
 
   /**
-   * Base SELECT query that automatically excludes soft-deleted rows
-   * when softDelete behavior is enabled.
+   * Base SELECT query that automatically applies the ambient guards —
+   * soft-delete exclusion (when `softDelete`) and tenant scope (when
+   * `userTracking` + an active requester context) — combined with an optional
+   * caller `extra` predicate into a SINGLE `WHERE`.
+   *
+   * Pass the leaf predicate as `extra` rather than chaining a second
+   * `.where(...)`: Drizzle's `.where()` OVERRIDES (does not AND) a prior
+   * `.where()` on a `$dynamic()` query, so a chained call would silently drop
+   * the soft-delete and scope guards. `baseQuery(extra)` is the safe form.
    */
-  protected baseQuery() {
+  protected baseQuery(extra?: SQL) {
     const query = this.db.select().from(this.table).$dynamic();
-    if (this.behaviors.softDelete) {
-      return query.where(isNull(this.table['deletedAt']));
+    const where = this.scopeAnd(extra, { softDelete: this.behaviors.softDelete });
+    return where ? query.where(where) : query;
+  }
+
+  /**
+   * Build the ambient tenant-scope predicate for this repo's table.
+   *
+   * Returns `undefined` (no scoping) when:
+   *   - `behaviors.userTracking` is false (repo is not user-owned), or
+   *   - no ambient requester context is active AND `scopeEnforcement` is
+   *     `'lenient'` (the default — preserves pre-scoping behavior).
+   *
+   * When a requester context is active, scopes by `user_id` per the ambient
+   * scope: `'user'` → `user_id = ctx.userId`; `'org'` → `user_id IN
+   * ctx.orgUserIds` (empty list matches nothing — fail-closed); `'superuser'`
+   * → no filter. See `tenant-context.ts` for the boundary-install contract.
+   */
+  protected scopePredicate(): SQL | undefined {
+    if (!this.behaviors.userTracking) return undefined;
+    const ctx =
+      this.scopeEnforcement === 'strict'
+        ? requireRequester()
+        : tryGetRequester();
+    if (!ctx) return undefined;
+    const scope: RequesterScope = ctx.scope ?? 'user';
+    switch (scope) {
+      case 'superuser':
+        return undefined;
+      case 'org':
+        return ctx.orgUserIds && ctx.orgUserIds.length > 0
+          ? inArray(this.table['userId'], ctx.orgUserIds as string[])
+          : sql`false`;
+      case 'user':
+      default:
+        return eq(this.table['userId'], ctx.userId);
     }
-    return query;
+  }
+
+  /**
+   * Combine the ambient scope predicate (and, optionally, the soft-delete
+   * guard) with a caller `extra` predicate into one `SQL`. Returns `undefined`
+   * when nothing applies. Used by read + by-id write paths so a single
+   * `.where(...)` carries every guard.
+   */
+  protected scopeAnd(
+    extra?: SQL,
+    opts?: { softDelete?: boolean },
+  ): SQL | undefined {
+    const conditions: SQL[] = [];
+    if (opts?.softDelete) conditions.push(isNull(this.table['deletedAt']));
+    const scope = this.scopePredicate();
+    if (scope) conditions.push(scope);
+    if (extra) conditions.push(extra);
+    if (conditions.length === 0) return undefined;
+    if (conditions.length === 1) return conditions[0];
+    return and(...conditions);
   }
 
   /**

--- a/runtime/base-classes/index.ts
+++ b/runtime/base-classes/index.ts
@@ -4,6 +4,19 @@
 export { BaseRepository } from './base-repository';
 export type { BehaviorConfig, ListOptions } from './base-repository';
 
+// Ambient tenant scope (AsyncLocalStorage) — read by BaseRepository.scopePredicate,
+// set at request/worker boundaries via withRequester/withUserScope/etc.
+export {
+  withRequester,
+  requireRequester,
+  tryGetRequester,
+  requireRequesterScope,
+  withUserScope,
+  withOrgScope,
+  withSuperuserScope,
+} from './tenant-context';
+export type { RequesterContext, RequesterScope } from './tenant-context';
+
 export { BaseService } from './base-service';
 export type { IBaseRepository } from './base-service';
 

--- a/runtime/base-classes/tenant-context.ts
+++ b/runtime/base-classes/tenant-context.ts
@@ -1,0 +1,175 @@
+/**
+ * Ambient requester context — AsyncLocalStorage-backed tenant scope.
+ *
+ * The alternative to threading `userId`/`organizationId` through every
+ * repository/service signature. Set ONCE at each boundary the generated app
+ * owns, read implicitly inside `BaseRepository` (see `scopePredicate`).
+ *
+ * ## Where to set it (boundaries)
+ *
+ *   - HTTP / tRPC handlers — from the authenticated `ctx.user`
+ *   - OAuth callback controllers — from the authenticated session
+ *   - Queue/worker `process()` — from the job's owning user after the
+ *     job's record is loaded
+ *
+ * Each boundary wraps the rest of the request in `withRequester({ userId,
+ * organizationId }, () => ...)`. The context propagates through every `await`
+ * to all downstream repo/service calls without being passed explicitly.
+ *
+ * ## Where to read it
+ *
+ *   - `BaseRepository.scopePredicate()` reads it (via `tryGetRequester` in
+ *     lenient mode, `requireRequester` in strict mode) and filters every read
+ *     by the ambient scope when the repo declares `userTracking: true`.
+ *
+ * ## Why AsyncLocalStorage over an explicit parameter
+ *
+ * Threading `userId` (and later `organizationId`) through dozens of method
+ * signatures is pure parameter pollution. Ambient context also lets a repo
+ * make the "I forgot to scope" mistake impossible at runtime: in strict mode
+ * `requireRequester()` throws when no context is active, surfacing a missing
+ * boundary call loudly rather than silently leaking cross-tenant data.
+ *
+ * ## Not-found semantics
+ *
+ * When a row exists but belongs to a different requester, scoped reads return
+ * `null`/`[]` — identical to "truly doesn't exist". No existence oracle;
+ * callers throw NotFound uniformly. Standard security practice.
+ *
+ * ## Testing
+ *
+ * Tests that exercise scoped repos must wrap the call in `withRequester(...)`.
+ * In strict mode an unwrapped call hitting `requireRequester()` throws — by
+ * design. In lenient mode (the default) an unwrapped call is simply unscoped.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Data-visibility scope. The auth layer decides which scope a request is
+ * allowed to claim; the repo trusts whatever the ambient context says.
+ *
+ * - `'user'`: filter every read by `user_id = ctx.userId`. Default.
+ * - `'org'`: filter every read by membership in the requester's org, resolved
+ *   via `user_id IN (ctx.orgUserIds)` rather than via a per-entity
+ *   `organization_id` column. Works for every user-owned table and keeps repos
+ *   single-table — the org member list is pre-resolved at the boundary.
+ * - `'superuser'`: no scope filter. Engineering / internal-tools only.
+ *
+ * AUTHORIZATION (who is allowed to claim each scope) lives in boundary
+ * middleware, not in the repo. The repo trusts the ambient context — same
+ * trust model as a threaded `userId`.
+ */
+export type RequesterScope = 'user' | 'org' | 'superuser';
+
+export interface RequesterContext {
+  /**
+   * The user making the request. Always present — even in `'org'` and
+   * `'superuser'` scopes it is the audit-trail "who actually did this".
+   */
+  readonly userId: string;
+  /**
+   * The organization the requester belongs to. Required when
+   * `scope === 'org'`; may be null for `'user'` (users with no org) and for
+   * `'superuser'` (cross-org reads).
+   */
+  readonly organizationId: string | null;
+  /**
+   * Data-visibility scope. Defaults to `'user'` when omitted.
+   */
+  readonly scope?: RequesterScope;
+  /**
+   * For `scope === 'org'`: the list of user IDs in the requester's org,
+   * pre-resolved by the boundary middleware that established the `'org'`
+   * scope (one `SELECT users.id WHERE organization_id = X` at the trust
+   * boundary). Repos use this as a literal `IN (...)` filter — they never
+   * JOIN to `users` themselves. Required when `scope === 'org'`.
+   */
+  readonly orgUserIds?: readonly string[];
+}
+
+const als = new AsyncLocalStorage<RequesterContext>();
+
+/**
+ * Set the ambient requester context for the duration of `fn`. The context
+ * propagates through `await` boundaries to all downstream calls. Nesting is
+ * fine — an inner `withRequester` overrides the outer for its callback.
+ */
+export function withRequester<T>(
+  ctx: RequesterContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return als.run(ctx, fn);
+}
+
+/**
+ * Read the ambient requester context. Throws if no context is active — by
+ * design. Used by repos in strict scope-enforcement mode; an unwrapped call
+ * site is a missing boundary.
+ */
+export function requireRequester(): RequesterContext {
+  const ctx = als.getStore();
+  if (!ctx) {
+    throw new Error(
+      'No requester context active. Wrap the entry point in ' +
+        'withRequester({ userId, organizationId }, fn). See tenant-context.ts.',
+    );
+  }
+  return ctx;
+}
+
+/**
+ * Read the ambient requester context without throwing. Returns `undefined`
+ * when no context is active. Used by repos in lenient scope-enforcement mode
+ * (the default) and by code paths that legitimately run outside a request.
+ */
+export function tryGetRequester(): RequesterContext | undefined {
+  return als.getStore();
+}
+
+/**
+ * Resolve the effective scope for the ambient context, defaulting to `'user'`.
+ */
+export function requireRequesterScope(): RequesterScope {
+  return requireRequester().scope ?? 'user';
+}
+
+/**
+ * Convenience helpers for setting scope explicitly. All three preserve
+ * `userId` in the context (audit trail) regardless of scope.
+ *
+ * - `withUserScope`: regular end-user requests. Most call sites.
+ * - `withOrgScope`: admin / org-shared resource access. The caller MUST verify
+ *   the requester's role permits `'org'` before calling — the helper does not
+ *   enforce authorization. `orgUserIds` is pre-resolved at the boundary.
+ * - `withSuperuserScope`: engineering scripts / internal tools. `organizationId`
+ *   is null (cross-org is the point). Same authorization caveat applies.
+ */
+export function withUserScope<T>(
+  userId: string,
+  organizationId: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withRequester({ userId, organizationId, scope: 'user' }, fn);
+}
+
+export function withOrgScope<T>(
+  userId: string,
+  organizationId: string,
+  orgUserIds: readonly string[],
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withRequester(
+    { userId, organizationId, scope: 'org', orgUserIds },
+    fn,
+  );
+}
+
+export function withSuperuserScope<T>(
+  userId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withRequester(
+    { userId, organizationId: null, scope: 'superuser' },
+    fn,
+  );
+}

--- a/src/__tests__/runtime/base-classes/base-repository.spec.ts
+++ b/src/__tests__/runtime/base-classes/base-repository.spec.ts
@@ -7,8 +7,20 @@
  */
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { BaseRepository, type BehaviorConfig, type ListOptions } from '../../../../runtime/base-classes/base-repository';
+import {
+  withRequester,
+  withOrgScope,
+  withSuperuserScope,
+} from '../../../../runtime/base-classes/tenant-context';
 import type { DrizzleClient } from '../../../../runtime/types/drizzle';
-import type { PgTableWithColumns } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  text,
+  timestamp,
+  QueryBuilder,
+  type PgTableWithColumns,
+} from 'drizzle-orm/pg-core';
+import { eq, type SQL } from 'drizzle-orm';
 
 // ============================================================================
 // Test entity and table setup
@@ -386,4 +398,125 @@ describe('BaseRepository', () => {
     });
   });
 
+});
+
+// ============================================================================
+// Ambient tenant scoping (RequesterContext via AsyncLocalStorage)
+// ============================================================================
+
+/**
+ * These tests render real Drizzle SQL via a QueryBuilder-backed `db` so we can
+ * assert the actual WHERE clause `baseQuery` produces — the mock `db` above
+ * only records call shapes and cannot show predicate content.
+ */
+const widgets = pgTable('widget', {
+  id: text('id').primaryKey(),
+  userId: text('user_id'),
+  deletedAt: timestamp('deleted_at'),
+});
+
+class ScopingTestRepo extends BaseRepository<{ id: string; userId: string }> {
+  readonly table = widgets as unknown as PgTableWithColumns<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  protected readonly behaviors: BehaviorConfig;
+  constructor(behaviors: Partial<BehaviorConfig> = {}) {
+    // A QueryBuilder is enough to render .toSQL() for SELECTs (no driver needed).
+    super(new QueryBuilder() as unknown as DrizzleClient);
+    this.behaviors = { timestamps: false, softDelete: false, userTracking: true, ...behaviors };
+  }
+  // Expose protected members for assertions.
+  pred(): SQL | undefined {
+    return this.scopePredicate();
+  }
+  renderFindById(id: string): string {
+    return this.baseQuery(eq(this.table['id'], id)).toSQL().sql;
+  }
+}
+
+class StrictScopingTestRepo extends ScopingTestRepo {
+  protected readonly scopeEnforcement = 'strict' as const;
+}
+
+describe('BaseRepository — ambient tenant scoping', () => {
+  describe('scopePredicate gating', () => {
+    it('returns undefined when userTracking is off (even inside a context)', async () => {
+      const repo = new ScopingTestRepo({ userTracking: false });
+      await withRequester({ userId: 'u1', organizationId: null }, async () => {
+        expect(repo.pred()).toBeUndefined();
+      });
+    });
+
+    it('returns undefined when userTracking is on but no context is active (lenient default)', () => {
+      const repo = new ScopingTestRepo();
+      expect(repo.pred()).toBeUndefined();
+    });
+
+    it('throws when userTracking is on, strict, and no context is active', () => {
+      const repo = new StrictScopingTestRepo();
+      expect(() => repo.pred()).toThrow(/No requester context active/);
+    });
+
+    it('does not scope superuser reads', async () => {
+      const repo = new ScopingTestRepo();
+      await withSuperuserScope('admin-1', async () => {
+        expect(repo.pred()).toBeUndefined();
+      });
+    });
+  });
+
+  describe('rendered WHERE clauses', () => {
+    it('user scope filters by user_id', async () => {
+      const repo = new ScopingTestRepo();
+      await withRequester({ userId: 'u1', organizationId: null }, async () => {
+        const sql = repo.renderFindById('w1');
+        expect(sql).toContain('"user_id"');
+        expect(sql).toMatch(/"widget"\."user_id"\s*=/);
+        expect(sql).toContain('"id"');
+      });
+    });
+
+    it('org scope filters by user_id IN (member list)', async () => {
+      const repo = new ScopingTestRepo();
+      await withOrgScope('u1', 'org-1', ['u1', 'u2', 'u3'], async () => {
+        const sql = repo.renderFindById('w1');
+        expect(sql).toMatch(/"user_id"\s+in\s*\(/i);
+      });
+    });
+
+    it('org scope with no members fails closed (matches nothing)', async () => {
+      const repo = new ScopingTestRepo();
+      await withOrgScope('u1', 'org-1', [], async () => {
+        const sql = repo.renderFindById('w1').toLowerCase();
+        expect(sql).toContain('false');
+        expect(sql).not.toMatch(/"user_id"\s+in/);
+      });
+    });
+
+    it('superuser scope renders no user_id filter', async () => {
+      const repo = new ScopingTestRepo();
+      await withSuperuserScope('admin-1', async () => {
+        // user_id appears in the SELECT projection; assert it is not a predicate.
+        const sql = repo.renderFindById('w1');
+        expect(sql).not.toMatch(/"user_id"\s*(=|in)/i);
+      });
+    });
+
+    it('unscoped repo renders no user_id filter even inside a context', async () => {
+      const repo = new ScopingTestRepo({ userTracking: false });
+      await withRequester({ userId: 'u1', organizationId: null }, async () => {
+        const sql = repo.renderFindById('w1');
+        expect(sql).not.toMatch(/"user_id"\s*(=|in)/i);
+      });
+    });
+
+    it('combines soft-delete + scope + leaf predicate in one WHERE', async () => {
+      const repo = new ScopingTestRepo({ softDelete: true });
+      await withRequester({ userId: 'u1', organizationId: null }, async () => {
+        const sql = repo.renderFindById('w1').toLowerCase();
+        expect(sql).toContain('deleted_at');
+        expect(sql).toContain('user_id');
+        // single combined WHERE, AND-joined (not a dropped guard)
+        expect(sql).toContain(' and ');
+      });
+    });
+  });
 });

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -120,6 +120,8 @@ function loadRuntimeFile(relPath: string): string {
 const VENDORED_RUNTIME_FILES: Array<{ runtime: string; target: string }> = [
 	// base-classes — consumer-facing inheritance targets
 	{ runtime: 'base-classes/base-repository.ts', target: 'src/shared/base-classes/base-repository.ts' },
+	// Ambient tenant scope — imported by base-repository.ts (scopePredicate)
+	{ runtime: 'base-classes/tenant-context.ts', target: 'src/shared/base-classes/tenant-context.ts' },
 	{ runtime: 'base-classes/base-service.ts', target: 'src/shared/base-classes/base-service.ts' },
 	{ runtime: 'base-classes/synced-entity-repository.ts', target: 'src/shared/base-classes/synced-entity-repository.ts' },
 	{ runtime: 'base-classes/synced-entity-service.ts', target: 'src/shared/base-classes/synced-entity-service.ts' },


### PR DESCRIPTION
Ports `dealbrain`'s `AsyncLocalStorage` **RequesterContext** pattern into the codegen substrate so user-owned repos filter every read/write by the requester automatically — instead of relying on hand-threaded `userId` parameters. See `ai-docs/adrs/0001-ambient-tenant-scoping.md`.

## What changed

- **`runtime/base-classes/tenant-context.ts` (new)** — `RequesterContext { userId, organizationId, scope?, orgUserIds? }` over `AsyncLocalStorage`, with `withRequester`/`requireRequester`/`tryGetRequester` and `withUserScope`/`withOrgScope`/`withSuperuserScope`. Scope model (`user`/`org`/`superuser`) copied verbatim from dealbrain. Vendored via `init-scaffold`; exported from the base-classes barrel.
- **`BaseRepository.scopePredicate()` + `scopeAnd()`** — gated on the existing (previously **dormant**) `userTracking` behavior flag. When a context is active, `findById`/`findByIds`/`list`/`count`/`update`/`delete` auto-filter by `user_id`: `= ctx.userId` (user), `IN ctx.orgUserIds` (org; empty ⇒ matches nothing), unfiltered (superuser). **No new per-entity knob, no template changes.**
- **`scopeEnforcement: 'lenient' | 'strict'`** — lenient default: no active context ⇒ not scoped, so adoption is **additive**. Override to `'strict'` for fail-loud (a missing boundary throws), recommended for new multi-tenant apps.

## Bug fixed along the way

Drizzle's `.where()` **overrides** (not ANDs) a prior `.where()` on a `$dynamic()` query — so the soft-delete guard `baseQuery()` added was silently dropped on `findById` / `list({where})` / every bespoke query method (only no-arg `list()` and `count()` actually excluded soft-deleted rows). `baseQuery(extra?)` now folds soft-delete + scope + leaf predicate into one AND-joined `WHERE`.

⚠️ **Migration:** on `soft_delete` entities, `findById(id)` and `list({ where })` now correctly **exclude** soft-deleted rows (previously returned them). Code relying on the old behavior must query `deletedAt` explicitly.

## Verification

- codegen-patterns: **2086 unit tests pass / 0 fail** + `bun test/run-test.ts full` green (scaffold regenerated end-to-end, proving the vendored-file wiring resolves).
- dealbrain-integrations (consumer regression): vendored both files in → **typecheck + 737 tests green**, behavior unchanged (no `userTracking` repos there today).

## Deferred (in ADR)

- Junction-repo scoping (parent-entity subquery, as dealbrain does)
- Codegen auto-emitting `withRequester(...)` into the worker/use-case/controller boundaries
- Sync-upsert (`onConflict (provider, externalId)`) write-path scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)