### PR TITLE
feat(auth): RequesterContext boundary — auth → ambient scope over HTTP (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-05-25
+
+Closes the loop on ambient tenant scoping (0.8.0): adds the **RequesterContext
+boundary** that turns an authenticated request into ambient scope, so scoping
+actually engages over HTTP — including Swagger's "Authorize" bearer flow. See
+ADR-0002 (`ai-docs/adrs/0002-requester-context-boundary.md`).
+
+### Added
+
+- **`feat(auth)` — `RequesterContextMiddleware` + `installRequesterContext`.** New
+  `runtime/subsystems/auth/middleware/requester-context.ts`. The Express-style
+  middleware resolves the requester via the consumer's `IUserContext` and runs the
+  rest of the request inside `withRequester(...)`, so every downstream repository
+  read/write is auto-scoped (ADR-0001) with no threaded `userId`. ALS-correct
+  (middleware, not interceptor). `installRequesterContext(app)` is the one-liner
+  for `main.ts`: resolves `AUTH_USER_CONTEXT` from the root container
+  (`app.get(token, { strict: false })`), no-ops with a warning when unbound.
+  Exported from the auth barrel. Verified over real HTTP — two concurrent requests
+  with different bearer tokens each observe their own scope; an unauthenticated
+  request observes none (`requester-context.http.spec.ts`).
+- **`feat(auth)` — optional `IUserContext.resolveRequester(req)`.** Supplies the
+  full `org`/`superuser` `RequesterContext` (org member list resolved at the
+  boundary). Backward compatible: when absent, the boundary derives plain `'user'`
+  scope from `getCurrentUserId`.
+
+### Changed
+
+- **`feat(scaffold)` — generated `main.ts` persists Swagger auth.**
+  `SwaggerModule.setup(...)` now passes `{ swaggerOptions: { persistAuthorization:
+  true } }`, so the "Authorize" bearer token survives reloads and keeps flowing as
+  the `Authorization` header the boundary reads. The generated `main.ts` also
+  carries a commented `installRequesterContext(app)` hint (not a static import — so
+  scaffolds without the auth subsystem still compile).
+
+### Notes
+
+- Wiring is opt-in: add `installRequesterContext(app)` to your bootstrap after
+  `NestFactory.create`. Auto-patching it in at `subsystem install auth` time (like
+  the Swagger block) is a deferred follow-up (ADR-0002). A tRPC-side boundary and
+  junction-repo scoping remain deferred.
+
 ## [0.8.0] — 2026-05-25
 
 Adds **ambient tenant scoping** to `BaseRepository`: user-owned repos filter every

--- a/ai-docs/adrs/0002-requester-context-boundary.md
+++ b/ai-docs/adrs/0002-requester-context-boundary.md
@@ -1,0 +1,73 @@
+# ADR-0002 — RequesterContext boundary (auth → ambient scope)
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Builds on:** [ADR-0001](./0001-ambient-tenant-scoping.md)
+- **Affects:** `runtime/subsystems/auth/protocols/user-context.ts`, new `runtime/subsystems/auth/middleware/requester-context.ts`, `src/cli/shared/init-scaffold.ts`
+
+## Context
+
+ADR-0001 made `BaseRepository` scope reads/writes by the **ambient**
+`RequesterContext`, but left the boundary install as a deferral: nothing actually
+*sets* that context on an HTTP request. So a Swagger-driven call (the generated
+controllers already carry `@ApiBearerAuth()`, so the "Authorize" button injects a
+bearer header) reached the repo with no context — unscoped in lenient mode, or a
+`No requester context active` throw in strict mode. This ADR closes the loop.
+
+The auth subsystem already ships the seam: `IUserContext.getCurrentUserId(req)`
+(consumer-bound under `AUTH_USER_CONTEXT`), documented to decode exactly that
+bearer header. What was missing was the piece that runs `withRequester(...)`
+around the request using it.
+
+## Decision
+
+1. **`IUserContext.resolveRequester?(req): Promise<RequesterContext>`** — optional.
+   When implemented, it supplies the full `org`/`superuser` context; when absent,
+   the boundary derives plain `'user'` scope from `getCurrentUserId`. Backward
+   compatible — existing `IUserContext` impls keep working untouched.
+
+2. **`makeRequesterContextMiddleware(userContext, opts)`** (Express-style) — resolves
+   the requester, then runs the rest of the pipeline inside `withRequester(ctx, …)`.
+   ALS correctness: `als.run` invokes its callback synchronously and Express
+   dispatches downstream inside `next()`, so all handlers (and their awaits)
+   inherit the context. Implemented as **middleware, not an interceptor** —
+   interceptors returning an Observable do not preserve ALS cleanly.
+
+3. **`installRequesterContext(app)`** — the one-liner consumers add to `main.ts`.
+   Resolves `AUTH_USER_CONTEXT` from the **root container** (`app.get(token,
+   { strict: false })`) so it sees the consumer's AppModule binding — sidestepping
+   the module-scoping problem (the token is provided in AppModule, not AuthModule).
+   No-ops with a warning when the token is unbound, so the call is safe even before
+   auth is wired.
+
+4. **`persistAuthorization: true`** on the generated `main.ts` `SwaggerModule.setup`
+   — the "Authorize" bearer token survives reloads, so it keeps flowing as the
+   `Authorization` header that the boundary turns into scope.
+
+## Trust + failure model
+
+- The boundary **trusts** what `IUserContext` returns — authn (validating the
+  token) and authz (which scope a requester may claim) live in the impl, exactly
+  as for a hand-threaded `userId`.
+- Unresolved requester (no/invalid credentials — public routes, the OAuth callback
+  itself) → proceed **unscoped** (`onUnresolved: 'unscoped'`, default). Lenient
+  repos run unscoped; strict repos throw downstream (correct — unauthenticated
+  callers must not reach scoped data). `onUnresolved: 'reject'` fails at the
+  boundary instead.
+
+## Why a one-liner, not auto-wired into the default scaffold
+
+The generated default `main.ts` must compile for scaffolds that never install the
+auth subsystem, so it cannot statically `import` an auth-subsystem path. The
+install is therefore a documented one-liner (shipped + tested helper) plus a
+commented hint in the generated `main.ts`. Auto-patching `main.ts` at
+`subsystem install auth` time (as Swagger is patched via `ast-patch`) is the
+natural follow-up.
+
+## Deferred
+
+- `subsystem install auth` auto-patching the `installRequesterContext(app)` call
+  into an existing `main.ts` (ast-patch), mirroring the Swagger block.
+- A tRPC equivalent middleware (dealbrain's original boundary), for consumers
+  exposing tRPC instead of / alongside REST.
+- Junction-repo scoping (carried over from ADR-0001).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/auth/index.ts
+++ b/runtime/subsystems/auth/index.ts
@@ -112,5 +112,13 @@ export {
 // Controller
 export { AuthController } from './controllers/auth.controller';
 
+// Middleware — RequesterContext boundary (bridges auth → ambient tenant scope)
+export {
+  installRequesterContext,
+  makeRequesterContextMiddleware,
+  resolveRequesterContext,
+  type RequesterContextOptions,
+} from './middleware/requester-context';
+
 // Module
 export { AuthModule, type AuthModuleOptions } from './auth.module';

--- a/runtime/subsystems/auth/middleware/requester-context.ts
+++ b/runtime/subsystems/auth/middleware/requester-context.ts
@@ -1,0 +1,141 @@
+/**
+ * RequesterContext boundary install — bridges authentication to ambient
+ * tenant scoping.
+ *
+ * This is the missing link that makes `BaseRepository`'s ambient scoping
+ * (see `base-classes/tenant-context.ts`) actually engage on HTTP requests:
+ * it reads the requester off each request (via the consumer-bound
+ * `IUserContext`) and runs the rest of the request inside `withRequester(...)`,
+ * so every downstream repository read/write is automatically scoped — no
+ * threaded `userId`.
+ *
+ * ## Wiring (one line in your bootstrap)
+ *
+ * In `main.ts`, after `NestFactory.create`:
+ *
+ * ```ts
+ * import { installRequesterContext } from './shared/subsystems/auth/middleware/requester-context';
+ * const app = await NestFactory.create(AppModule);
+ * installRequesterContext(app); // no-op + warn if AUTH_USER_CONTEXT is unbound
+ * ```
+ *
+ * `installRequesterContext` resolves `AUTH_USER_CONTEXT` from the root DI
+ * container (so it sees the binding the consumer provides in AppModule) and
+ * registers a global Express middleware. Pairs with Swagger's `@ApiBearerAuth`
+ * "Authorize" button: paste a token there and every request it sends now flows
+ * through this boundary into a scoped repository call.
+ *
+ * ## Trust + failure model
+ *
+ * - The middleware TRUSTS whatever `IUserContext` returns — authentication and
+ *   authorization (validating the token, deciding which scope a requester may
+ *   claim) are the `IUserContext` implementation's job, exactly as for a
+ *   hand-threaded `userId`.
+ * - When the requester cannot be resolved (no/invalid credentials — e.g. a
+ *   public route, or the OAuth callback itself), the request proceeds WITHOUT
+ *   an ambient context (`onUnresolved: 'unscoped'`, the default). A
+ *   `userTracking` repo in lenient mode then runs unscoped; in strict mode it
+ *   throws downstream — which is correct: unauthenticated callers must not
+ *   reach scoped data. Set `onUnresolved: 'reject'` to fail the request at the
+ *   boundary instead.
+ */
+import type { INestApplication } from '@nestjs/common';
+import {
+  withRequester,
+  type RequesterContext,
+} from '../../../base-classes/tenant-context';
+import { AUTH_USER_CONTEXT } from '../auth.tokens';
+import type { IUserContext } from '../protocols/user-context';
+
+/** Minimal Express-style middleware signature (avoids an `express` dep). */
+type NextFn = (err?: unknown) => void;
+type RequestHandler = (req: unknown, res: unknown, next: NextFn) => void;
+
+export interface RequesterContextOptions {
+  /**
+   * What to do when `IUserContext` cannot resolve a requester (throws, or
+   * returns no `userId`).
+   * - `'unscoped'` (default): proceed without a context — public routes work;
+   *   scoped repos run unscoped (lenient) or throw downstream (strict).
+   * - `'reject'`: fail the request at the boundary (`next(error)`).
+   */
+  onUnresolved?: 'unscoped' | 'reject';
+}
+
+/**
+ * Resolve the ambient context for a request: prefer the richer
+ * `resolveRequester` (org/superuser), else derive plain `'user'` scope from
+ * `getCurrentUserId`. Returns `undefined` when no requester can be determined.
+ */
+export async function resolveRequesterContext(
+  userContext: IUserContext,
+  req: unknown,
+): Promise<RequesterContext | undefined> {
+  if (typeof userContext.resolveRequester === 'function') {
+    const ctx = await userContext.resolveRequester(req);
+    return ctx?.userId ? ctx : undefined;
+  }
+  const userId = await userContext.getCurrentUserId(req);
+  return userId ? { userId, organizationId: null } : undefined;
+}
+
+/**
+ * Build the global middleware. Runs the remainder of the request inside
+ * `withRequester(...)` so the ambient context propagates through every `await`
+ * to downstream repositories.
+ */
+export function makeRequesterContextMiddleware(
+  userContext: IUserContext,
+  options: RequesterContextOptions = {},
+): RequestHandler {
+  const onUnresolved = options.onUnresolved ?? 'unscoped';
+  return (req, _res, next) => {
+    resolveRequesterContext(userContext, req).then(
+      (ctx) => {
+        if (!ctx) {
+          next();
+          return;
+        }
+        // als.run executes its callback synchronously; Express dispatches the
+        // rest of the pipeline inside next(), so all downstream handlers (and
+        // their awaits) inherit this context.
+        withRequester(ctx, async () => {
+          next();
+        });
+      },
+      (err) => {
+        if (onUnresolved === 'reject') {
+          next(err);
+          return;
+        }
+        next();
+      },
+    );
+  };
+}
+
+/**
+ * Register the requester-context boundary on a Nest app. Resolves
+ * `AUTH_USER_CONTEXT` from the root container (so it sees the consumer's
+ * AppModule binding) and installs the global middleware. No-ops with a warning
+ * when `AUTH_USER_CONTEXT` is not bound, so calling it unconditionally in
+ * bootstrap is safe.
+ */
+export function installRequesterContext(
+  app: INestApplication,
+  options: RequesterContextOptions = {},
+): void {
+  const userContext = app.get<IUserContext>(AUTH_USER_CONTEXT, {
+    strict: false,
+  });
+  if (!userContext) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[auth] installRequesterContext: AUTH_USER_CONTEXT is not bound — ' +
+        'request scoping NOT installed. Provide an IUserContext under ' +
+        'AUTH_USER_CONTEXT in your AppModule to enable ambient tenant scoping.',
+    );
+    return;
+  }
+  app.use(makeRequesterContextMiddleware(userContext, options));
+}

--- a/runtime/subsystems/auth/protocols/user-context.ts
+++ b/runtime/subsystems/auth/protocols/user-context.ts
@@ -17,6 +17,23 @@
  * dependency on `express` / `fastify` / NestJS request types. The concrete
  * adapter narrows it (e.g. via a `Request` import).
  */
+import type { RequesterContext } from '../../../base-classes/tenant-context';
+
 export interface IUserContext {
   getCurrentUserId(req: unknown): Promise<string>;
+  /**
+   * Optional richer resolution of the full ambient requester context — the
+   * org/superuser dimensions on top of `userId`. When implemented, the
+   * `RequesterContextMiddleware` (see `../middleware/requester-context`) uses
+   * it verbatim to scope reads/writes; when omitted, the middleware falls back
+   * to `{ userId: await getCurrentUserId(req), organizationId: null }` (plain
+   * `'user'` scope).
+   *
+   * Implement this when the app supports org-shared (`'org'`) or admin
+   * (`'superuser'`) data visibility — resolve `organizationId` + the
+   * `orgUserIds` member list here, at the trust boundary, so repositories stay
+   * single-table. AUTHORIZATION (which scope a requester may claim) is the
+   * implementation's responsibility; the repo trusts what this returns.
+   */
+  resolveRequester?(req: unknown): Promise<RequesterContext>;
 }

--- a/src/__tests__/cli/project.test.ts
+++ b/src/__tests__/cli/project.test.ts
@@ -175,6 +175,26 @@ describe('buildInitPlan', () => {
 		expect(plan.summary.architecture).toBe('clean-lite-ps');
 	});
 
+	test('vendors the ambient-scope primitive (tenant-context) into base-classes', async () => {
+		const cwd = mkTempDir('tenantctx');
+		const ctx = await loadContext({ cwd, skipDetection: true });
+		const plan = await buildInitPlan(ctx, { cwd, skipScan: true });
+		const paths = plan.entries.map((e) => e.relPath);
+		expect(paths).toContain('src/shared/base-classes/tenant-context.ts');
+	});
+
+	test('generated main.ts persists Swagger auth + carries the requester-context install hint', async () => {
+		const cwd = mkTempDir('maints');
+		const ctx = await loadContext({ cwd, skipDetection: true });
+		const plan = await buildInitPlan(ctx, { cwd, skipScan: true });
+		const mainTs = plan.entries.find((e) => e.relPath === 'src/main.ts');
+		expect(mainTs?.content).toBeDefined();
+		// Swagger "Authorize" token survives reloads → keeps flowing as a header.
+		expect(mainTs!.content).toContain('persistAuthorization: true');
+		// One-liner that turns that header into ambient tenant scope.
+		expect(mainTs!.content).toContain('installRequesterContext(app)');
+	});
+
 	test('plans the ZodValidationPipe scaffold under src/shared/pipes (task #23)', async () => {
 		const cwd = mkTempDir('zodpipe');
 		const ctx = await loadContext({ cwd, skipDetection: true });

--- a/src/__tests__/runtime/subsystems/auth/requester-context.http.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/requester-context.http.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * RequesterContext boundary — real HTTP integration.
+ *
+ * Boots an actual `node:http` server whose only middleware is
+ * `makeRequesterContextMiddleware`, then drives it with real `fetch` requests
+ * carrying `Authorization: Bearer <token>` headers. Proves the boundary works
+ * over the wire — including AsyncLocalStorage isolation across CONCURRENT,
+ * overlapping requests (each observes only its own requester, even across an
+ * `await` inside the handler).
+ *
+ * This is the "via HTTP" end-to-end proof for ADR-0002. (Plain HTTP on
+ * localhost — TLS adds no signal to what's under test: header → ambient scope.)
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { makeRequesterContextMiddleware } from '../../../../../runtime/subsystems/auth/middleware/requester-context';
+import { tryGetRequester } from '../../../../../runtime/base-classes/tenant-context';
+import type { IUserContext } from '../../../../../runtime/subsystems/auth/protocols/user-context';
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Fake auth: decode the bearer token to a userId, mapping `bad`→empty,
+ * missing→throw. Mirrors `decode(req.headers.authorization).sub` shape.
+ */
+const userContext: IUserContext = {
+  async getCurrentUserId(req: unknown): Promise<string> {
+    const auth = (req as http.IncomingMessage).headers.authorization;
+    if (!auth) throw new Error('missing Authorization header');
+    const token = auth.replace(/^Bearer\s+/i, '');
+    if (token === 'bad') return '';
+    return `user-${token}`;
+  },
+};
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const middleware = makeRequesterContextMiddleware(userContext);
+  server = http.createServer((req, res) => {
+    middleware(req, res, async () => {
+      // Cross an await to prove the context survives async continuations.
+      await delay(15);
+      const ctx = tryGetRequester();
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ scope: ctx ?? null }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function getScope(token?: string): Promise<unknown> {
+  const headers = token ? { authorization: `Bearer ${token}` } : undefined;
+  const res = await fetch(baseUrl, { headers });
+  return (await res.json()).scope;
+}
+
+describe('RequesterContext over HTTP', () => {
+  it('scopes a request to its bearer-derived user', async () => {
+    expect(await getScope('alice')).toEqual({ userId: 'user-alice', organizationId: null });
+  });
+
+  it('proceeds unscoped (null) when no Authorization header is present', async () => {
+    expect(await getScope()).toBeNull();
+  });
+
+  it('proceeds unscoped when the requester resolves to an empty userId', async () => {
+    expect(await getScope('bad')).toBeNull();
+  });
+
+  it('isolates concurrent overlapping requests (no ALS cross-talk)', async () => {
+    const [a, b, c, none] = await Promise.all([
+      getScope('alice'),
+      getScope('bob'),
+      getScope('carol'),
+      getScope(),
+    ]);
+    expect(a).toEqual({ userId: 'user-alice', organizationId: null });
+    expect(b).toEqual({ userId: 'user-bob', organizationId: null });
+    expect(c).toEqual({ userId: 'user-carol', organizationId: null });
+    expect(none).toBeNull();
+  });
+});

--- a/src/__tests__/runtime/subsystems/auth/requester-context.spec.ts
+++ b/src/__tests__/runtime/subsystems/auth/requester-context.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * RequesterContext boundary tests.
+ *
+ * Validates that the middleware bridges IUserContext → ambient scope: it runs
+ * the downstream handler inside `withRequester(...)` (so `tryGetRequester()`
+ * observes the context), falls back gracefully on unresolved requesters, and
+ * that `installRequesterContext` no-ops safely when AUTH_USER_CONTEXT is unbound.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import {
+  makeRequesterContextMiddleware,
+  resolveRequesterContext,
+  installRequesterContext,
+} from '../../../../../runtime/subsystems/auth/middleware/requester-context';
+import { tryGetRequester } from '../../../../../runtime/base-classes/tenant-context';
+import type { IUserContext } from '../../../../../runtime/subsystems/auth/protocols/user-context';
+
+const FAKE_REQ = { headers: { authorization: 'Bearer x' } };
+
+/** Run the middleware once; capture the ambient context observed inside next(). */
+function runMiddleware(
+  userContext: IUserContext,
+  opts?: Parameters<typeof makeRequesterContextMiddleware>[1],
+): Promise<{ captured: ReturnType<typeof tryGetRequester>; err: unknown; called: boolean }> {
+  const mw = makeRequesterContextMiddleware(userContext, opts);
+  return new Promise((resolve) => {
+    mw(FAKE_REQ, {}, (err?: unknown) => {
+      resolve({ captured: tryGetRequester(), err, called: true });
+    });
+  });
+}
+
+describe('resolveRequesterContext', () => {
+  it('derives user scope from getCurrentUserId when resolveRequester is absent', async () => {
+    const uc: IUserContext = { getCurrentUserId: async () => 'u1' };
+    expect(await resolveRequesterContext(uc, FAKE_REQ)).toEqual({
+      userId: 'u1',
+      organizationId: null,
+    });
+  });
+
+  it('prefers resolveRequester when implemented', async () => {
+    const ctx = { userId: 'u2', organizationId: 'o1', scope: 'org' as const, orgUserIds: ['u2', 'u3'] };
+    const uc: IUserContext = {
+      getCurrentUserId: async () => 'u2',
+      resolveRequester: async () => ctx,
+    };
+    expect(await resolveRequesterContext(uc, FAKE_REQ)).toEqual(ctx);
+  });
+
+  it('returns undefined when no userId can be determined', async () => {
+    const uc: IUserContext = { getCurrentUserId: async () => '' };
+    expect(await resolveRequesterContext(uc, FAKE_REQ)).toBeUndefined();
+  });
+
+  it('returns undefined when resolveRequester yields an empty userId', async () => {
+    const uc: IUserContext = {
+      getCurrentUserId: async () => 'ignored',
+      resolveRequester: async () => ({ userId: '', organizationId: null }),
+    };
+    expect(await resolveRequesterContext(uc, FAKE_REQ)).toBeUndefined();
+  });
+});
+
+describe('makeRequesterContextMiddleware', () => {
+  it('runs downstream inside the ambient context (user scope)', async () => {
+    const uc: IUserContext = { getCurrentUserId: async () => 'u1' };
+    const { captured, err } = await runMiddleware(uc);
+    expect(err).toBeUndefined();
+    expect(captured).toEqual({ userId: 'u1', organizationId: null });
+  });
+
+  it('propagates the full org context from resolveRequester', async () => {
+    const ctx = { userId: 'u2', organizationId: 'o1', scope: 'org' as const, orgUserIds: ['u2'] };
+    const uc: IUserContext = {
+      getCurrentUserId: async () => 'u2',
+      resolveRequester: async () => ctx,
+    };
+    const { captured } = await runMiddleware(uc);
+    expect(captured).toEqual(ctx);
+  });
+
+  it('proceeds unscoped (no context) when the requester cannot be resolved', async () => {
+    const uc: IUserContext = {
+      getCurrentUserId: async () => {
+        throw new Error('no token');
+      },
+    };
+    const { captured, err, called } = await runMiddleware(uc);
+    expect(called).toBe(true);
+    expect(err).toBeUndefined();
+    expect(captured).toBeUndefined();
+  });
+
+  it('rejects the request when onUnresolved="reject"', async () => {
+    const uc: IUserContext = {
+      getCurrentUserId: async () => {
+        throw new Error('no token');
+      },
+    };
+    const { err } = await runMiddleware(uc, { onUnresolved: 'reject' });
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('no token');
+  });
+
+  it('does not leak context outside the request (next-less callers stay clean)', () => {
+    // Sanity: outside any middleware run, no ambient context is active.
+    expect(tryGetRequester()).toBeUndefined();
+  });
+});
+
+describe('installRequesterContext', () => {
+  it('registers the middleware when AUTH_USER_CONTEXT is bound', () => {
+    const uc: IUserContext = { getCurrentUserId: async () => 'u1' };
+    const use = mock(() => {});
+    const app = { get: () => uc, use } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    installRequesterContext(app);
+    expect(use).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops (does not call app.use) when AUTH_USER_CONTEXT is unbound', () => {
+    const use = mock(() => {});
+    // app.get(token, { strict: false }) returns undefined when unbound.
+    const app = { get: () => undefined, use } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    installRequesterContext(app);
+    expect(use).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/shared/init-scaffold.ts
+++ b/src/cli/shared/init-scaffold.ts
@@ -357,8 +357,20 @@ async function bootstrap(): Promise<void> {
       } as NonNullable<typeof nestDocument.components>['schemas'],
     };
 
-    SwaggerModule.setup(config.openapi.path ?? '/docs', app, nestDocument);
+    // \`persistAuthorization\` keeps the "Authorize" bearer token across page
+    // reloads, so the token pasted in Swagger UI keeps flowing as the
+    // \`Authorization\` header — which the RequesterContext boundary (below)
+    // turns into ambient tenant scope on every request.
+    SwaggerModule.setup(config.openapi.path ?? '/docs', app, nestDocument, {
+      swaggerOptions: { persistAuthorization: true },
+    });
   }
+
+  // Ambient tenant scoping (auth subsystem). Uncomment once the auth subsystem
+  // is installed and an IUserContext is bound under AUTH_USER_CONTEXT — then
+  // every request is scoped to its requester with no threaded userId:
+  //   import { installRequesterContext } from './shared/subsystems/auth/middleware/requester-context';
+  //   installRequesterContext(app); // no-op + warn if AUTH_USER_CONTEXT is unbound
 
   const port = Number(process.env.PORT ?? 3000);
   await app.listen(port);


### PR DESCRIPTION
Closes the loop on ambient tenant scoping (#380 / ADR-0001). 0.8.0 made `BaseRepository` scope by the **ambient** `RequesterContext`, but nothing *set* that context on an HTTP request — so a Swagger-driven call (controllers already carry `@ApiBearerAuth()`) reached the repo unscoped (lenient) or threw (strict). This wires the boundary. See `ai-docs/adrs/0002-requester-context-boundary.md`.

## What changed

- **`runtime/subsystems/auth/middleware/requester-context.ts` (new)**
  - `makeRequesterContextMiddleware(userContext, opts)` — resolves the requester via the consumer's `IUserContext`, then runs the rest of the request inside `withRequester(...)`, so every downstream repo read/write auto-scopes with **no threaded `userId`**. ALS-correct (**middleware, not interceptor** — interceptors returning an Observable don't preserve `AsyncLocalStorage` cleanly).
  - `installRequesterContext(app)` — the one-liner for `main.ts`. Resolves `AUTH_USER_CONTEXT` from the **root container** (`app.get(token, { strict: false })`, so it sees the AppModule binding). **No-ops + warns** when unbound, so it's safe to call unconditionally.
- **`IUserContext.resolveRequester?(req)` (optional)** — supplies the full `org`/`superuser` context (org member list resolved at the boundary). Backward compatible: absent ⇒ derive plain `'user'` scope from `getCurrentUserId`.
- **Generated `main.ts`** — `SwaggerModule.setup(...)` now passes `{ swaggerOptions: { persistAuthorization: true } }` so the "Authorize" bearer token survives reloads and keeps flowing as the `Authorization` header. Plus a commented `installRequesterContext(app)` hint (not a static import — no-auth scaffolds still compile).

## The flow this enables

Swagger **Authorize** (paste bearer) → token persists → sent as `Authorization` header on every request → `IUserContext` decodes it → `withRequester(...)` → `findById`/`list`/… auto-scoped to that user. No `userId` parameters anywhere.

## Verified over real HTTP

`requester-context.http.spec.ts` boots a real `node:http` server with the middleware and drives it with `fetch`:
- bearer `alice` → scope `user-alice`; no header → unscoped (null); empty userId → unscoped.
- **Concurrency:** 3 overlapping requests with different tokens (+ an `await` inside the handler) each observe only their own scope — no `AsyncLocalStorage` cross-talk.

Plus: **2103 unit tests** + full scaffold-emit suite green; new runtime files typecheck clean; `src` typecheck clean. Consumer (dealbrain-integrations) unaffected — it doesn't install the auth subsystem.

## Trust + failure model

The boundary **trusts** what `IUserContext` returns (authn/authz live in the impl, as for a threaded `userId`). Unresolved requester (public route, OAuth callback) → proceed **unscoped** by default; `onUnresolved: 'reject'` fails at the boundary instead.

## Deferred (ADR-0002)

- `subsystem install auth` auto-patching `installRequesterContext(app)` into an existing `main.ts` (via `ast-patch`, like the Swagger block).
- A tRPC-side boundary middleware.
- Junction-repo scoping (carried from ADR-0001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)