### PR TITLE
fix(clean-lite-ps): create-DTO nullable fields must also be optional (CREATE-DTO-1)

### DIFF
--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -187,11 +187,16 @@ describe('buildCleanLitePsLocals', () => {
     expect(titleField).toBeDefined();
     expect(titleField!.nullable).toBe(true);
     expect(titleField!.zodChainCreate).toContain('.nullable()');
+    // nullable AND not required → must also be optional, so the create payload
+    // can omit the key entirely (not forced to send an explicit null).
+    expect(titleField!.zodChainCreate).toContain('.optional()');
 
     const firstNameField = locals.clpCreateDtoFields.find((f: any) => f.name === 'first_name');
     expect(firstNameField).toBeDefined();
     expect(firstNameField!.nullable).toBe(false);
     expect(firstNameField!.zodChainCreate).not.toContain('.nullable()');
+    // required → neither nullable nor optional.
+    expect(firstNameField!.zodChainCreate).not.toContain('.optional()');
   });
 
   it('sets hasTimestamps and hasSoftDelete flags from behaviors', () => {

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -495,28 +495,30 @@ function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSof
 function zodChainForCreate(field) {
   const { type, nullable, required, hasDefault, hasChoices, choices } = field;
 
+  // Apply nullability and optionality INDEPENDENTLY. A nullable column accepts
+  // null (`.nullable()`); a field without `required: true` may be omitted from
+  // the create payload (`.optional()`). A field that is both gets
+  // `.nullable().optional()`. Previously the `nullable` branch returned early,
+  // so a nullable-and-optional field never got `.optional()` — forcing callers
+  // to send an explicit `null` for every optional column (e.g. POST /accounts
+  // rejecting a body that omits `domain`/`industry`).
   if (hasChoices) {
-    const base = `z.enum([${choices.map((c) => `'${c}'`).join(', ')}])`;
-    if (!required && !nullable) return base + '.optional()';
-    if (nullable) return base + '.nullable()';
+    let base = `z.enum([${choices.map((c) => `'${c}'`).join(', ')}])`;
+    if (nullable) base += '.nullable()';
+    if (!required) base += '.optional()';
     return base;
   }
 
   let base = ZOD_TYPE_MAP[type] || 'z.unknown()';
 
   if (type === 'boolean' && hasDefault) {
+    // `.default()` already makes the input optional in Zod.
     base += `.default(${field.default ?? false})`;
     return base;
   }
 
-  if (nullable) {
-    return base + '.nullable()';
-  }
-
-  if (!required) {
-    return base + '.optional()';
-  }
-
+  if (nullable) base += '.nullable()';
+  if (!required) base += '.optional()';
   return base;
 }
 
@@ -1132,7 +1134,7 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // FK fields from belongs_to for create/output DTOs
   const belongsToFkFields = belongsTo.map((rel) => ({
     camelName: rel.camelField,
-    zodChainCreate: rel.nullable ? 'z.string().uuid().nullable()' : 'z.string().uuid()',
+    zodChainCreate: rel.nullable ? 'z.string().uuid().nullable().optional()' : 'z.string().uuid()',
     zodChainOutput: rel.nullable ? 'z.string().uuid().nullable()' : 'z.string().uuid()',
     nullable: rel.nullable,
   }));

--- a/templates/relationship/new/prompt.js
+++ b/templates/relationship/new/prompt.js
@@ -203,10 +203,13 @@ function processFields(fields) {
 function zodChainForCreate(field) {
   const { type, nullable, required, hasDefault, hasChoices, choices } = field;
 
+  // Nullability and optionality are independent — see the clean-lite-ps copy of
+  // this function for the rationale (nullable-and-optional fields must get both
+  // `.nullable()` and `.optional()`, not just `.nullable()`).
   if (hasChoices) {
-    const base = `z.enum([${choices.map((c) => `'${c}'`).join(", ")}])`;
-    if (!required && !nullable) return base + ".optional()";
-    if (nullable) return base + ".nullable()";
+    let base = `z.enum([${choices.map((c) => `'${c}'`).join(", ")}])`;
+    if (nullable) base += ".nullable()";
+    if (!required) base += ".optional()";
     return base;
   }
 
@@ -215,8 +218,8 @@ function zodChainForCreate(field) {
     base += `.default(${field.default ?? false})`;
     return base;
   }
-  if (nullable) return base + ".nullable()";
-  if (!required) return base + ".optional()";
+  if (nullable) base += ".nullable()";
+  if (!required) base += ".optional()";
   return base;
 }
 


### PR DESCRIPTION
Implements **CREATE-DTO-1** (`docs/specs/CREATE-DTO-1.md`).

## Problem

`zodChainForCreate` applied `.nullable()` and `.optional()` in **mutually-exclusive** branches. A field that is both `nullable` and not `required` (the common optional-column case — e.g. account `domain`/`industry`) took the `nullable` branch and got `.nullable()` only. `.nullable()` permits the *value* `null` but the **key stays required**, so a create payload omitting the field was rejected with "Required" (surfaced by `POST /accounts` in dbi).

## Fix

Apply nullability and optionality **independently** in:
- `templates/entity/new/clean-lite-ps/prompt-extension.js` — `zodChainForCreate` (enum + scalar branches) and the nullable FK create chain (~1135).
- `templates/relationship/new/prompt.js` — the duplicate `zodChainForCreate` for junction create DTOs.

The boolean-`hasDefault` early return is preserved (`.default()` already makes the input optional in Zod). Output/update DTOs are unchanged.

## Test

`src/__tests__/clean-lite-ps/prompt-extension.test.ts` extended: a nullable+non-required field's `zodChainCreate` now asserts **both** `.nullable()` and `.optional()`; a required field asserts neither.

**177 pass, 0 fail** (clean-lite-ps + relationship suites).

## Consumer note

Unblocks `POST` on Synced entities with optional columns; dbi regenerates (non-destructive on 0.8.1) to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)