### PR TITLE
fix(jobs): add `triggers` authoring field to JobHandlerMeta (BRIDGE-6 follow-up)

### DIFF
--- a/runtime/subsystems/jobs/job-handler.base.ts
+++ b/runtime/subsystems/jobs/job-handler.base.ts
@@ -16,6 +16,7 @@
  */
 // TODO(logging-subsystem): swap to ILogger once ADR-028 lands
 import type { Logger } from '@nestjs/common';
+import type { EventOfType, EventTypeName } from '../events/generated/types';
 import type { JobRun } from './job-orchestrator.protocol';
 
 // ─── ParentClosePolicy ──────────────────────────────────────────────────────
@@ -60,6 +61,35 @@ export interface ScopeRef<TInput, TScope extends string = string> {
   from: (input: TInput) => string;
 }
 
+/**
+ * Bridge trigger authoring shape (BRIDGE-6 follow-up — BRIDGE-6 shipped the
+ * generator + runtime for `@JobHandler({ triggers })` but never added the
+ * authoring field to this type; the generator's tests scan source as strings,
+ * so a real decorator was never compiled and the gap went uncaught).
+ *
+ * Declared on `@JobHandler({ triggers })`; the codegen bridge-registry
+ * generator (`src/cli/shared/bridge-registry-generator.ts`) scans these from
+ * source and emits `bridge/generated/registry.ts`, validating each `event`
+ * against the generated `eventRegistry` at `gen-all`. The distributed union
+ * narrows `map`/`when` per `event`, so callbacks are typed against the event
+ * payload (ADR-023, "typed against PayloadOfType<T>").
+ *
+ * Typed against events' generated types — the same `import type` coupling the
+ * bridge already has (erased at runtime). `jobs` must NOT import `bridge`, so
+ * the post-gen `BridgeTriggerEntry` is deliberately not referenced here;
+ * `triggerId`/`jobType` are computed by the generator, not authored.
+ */
+export type JobTrigger<TInput> = {
+  [T in EventTypeName]: {
+    /** Event type that fires this trigger. Validated against `eventRegistry`. */
+    event: T;
+    /** Maps the event to the job input. Inlined verbatim into the registry. */
+    map: (event: EventOfType<T>) => TInput;
+    /** Optional guard; `false` → wrapper records `status='skipped'`. */
+    when?: (event: EventOfType<T>) => boolean;
+  };
+}[EventTypeName];
+
 export interface JobHandlerMeta<TInput> {
   pool?: string;
   scope?: ScopeRef<TInput>;
@@ -68,6 +98,12 @@ export interface JobHandlerMeta<TInput> {
   dedupe?: DedupePolicy<TInput>;
   timeoutMs?: number;
   replayFrom?: 'scratch' | 'last_step' | 'last_checkpoint';
+  /**
+   * Bridge triggers (ADR-023 Tier 3). Codegen scans these into `bridgeRegistry`;
+   * the framework `BridgeDeliveryHandler` starts this job per matched event.
+   * Absent for jobs started directly or via `IEventFlow.publishAndStart`.
+   */
+  triggers?: readonly JobTrigger<TInput>[];
 }
 
 // ─── Runtime option shapes ──────────────────────────────────────────────────

--- a/src/__tests__/runtime/subsystems/job-handler.base.types.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-handler.base.types.spec.ts
@@ -13,6 +13,7 @@ import {
   JobHandler,
   JobHandlerBase,
   type JobContext,
+  type JobTrigger,
 } from '../../../../runtime/subsystems/jobs/job-handler.base';
 
 interface OnboardingInput {
@@ -55,5 +56,49 @@ describe('JobHandlerBase — type compilation', () => {
     // type-checks. If `ctx.input` widened to `unknown`, the cast-free
     // reads above would fail compilation.
     expect(OnboardingHandler).toBeDefined();
+  });
+});
+
+// ── BRIDGE-6 follow-up: `@JobHandler({ triggers })` authoring type ──────────
+// The contract: a real decorator carrying `triggers` must COMPILE, and `map` /
+// `when` must see the event NARROWED to its payload (not the full union). The
+// bridge-registry-generator's own tests scan source as strings and never
+// compile a decorator — so this is the coverage that the missing
+// `JobHandlerMeta.triggers` field would otherwise have failed silently.
+
+interface SyncContactInput {
+  contactId: string;
+}
+
+@JobHandler<SyncContactInput>('contact.writeback.types-test', {
+  pool: 'external_crm',
+  triggers: [
+    {
+      event: 'contact_created',
+      // `e` must narrow to ContactCreatedEvent — payload access is cast-free.
+      map: (e) => {
+        const _type: 'contact_created' = e.type;
+        const _contactId: string = e.payload.contactId;
+        const _accountId: string | null = e.payload.accountId;
+        void _type;
+        void _accountId;
+        return { contactId: _contactId };
+      },
+      when: (e) => e.payload.accountId !== null,
+    },
+  ],
+})
+class ContactWritebackHandler extends JobHandlerBase<SyncContactInput, void> {
+  async run(_ctx: JobContext<SyncContactInput>): Promise<void> {}
+}
+
+// Negative: only known `EventTypeName` literals are valid trigger events.
+// @ts-expect-error 'not_a_real_event' is not a known event type
+const _badEvent: JobTrigger<SyncContactInput>['event'] = 'not_a_real_event';
+void _badEvent;
+
+describe('JobHandlerMeta.triggers — authoring type (BRIDGE-6 follow-up)', () => {
+  it('@JobHandler({ triggers }) compiles and narrows map/when per event', () => {
+    expect(ContactWritebackHandler).toBeDefined();
   });
 });


### PR DESCRIPTION
## Problem

BRIDGE-6 shipped the bridge-registry **generator** (AST-scans `@JobHandler({ triggers })` → emits `bridge/generated/registry.ts`) and the **runtime** (`bridge_delivery`, `BridgeDeliveryHandler`, `bridgeRegistry`), but never added the `triggers` field to `JobHandlerMeta`. The decorator is typed `JobHandler<TInput>(type, meta: JobHandlerMeta<TInput>)`, so authoring `@JobHandler('x', { triggers: [...] })` is a **TypeScript excess-property error** — the documented Tier-3 API (ADR-023, bridge SKILL.md) doesn't actually typecheck.

It went uncaught because the generator's tests (`bridge-registry-generator.test.ts`) scan source **as strings** and never compile a real decorator.

Found while planning HubSpot writeback in `dealbrain-integrations` (which consumes the `0.9.0` runtime).

## Fix

- Add **`JobTrigger<TInput>`** to `runtime/subsystems/jobs/job-handler.base.ts` — a distributed union over `EventTypeName` so `map`/`when` **narrow per `event`** (typed against the event payload, per ADR-023 "typed against `PayloadOfType<T>`").
- Add **`JobHandlerMeta.triggers?: readonly JobTrigger<TInput>[]`**.
- Add the **missing compile-level test** in `job-handler.base.types.spec.ts`: a real `@JobHandler({ triggers })` must compile and narrow `map`'s param to the event payload, and an unknown event must be rejected (`@ts-expect-error`).

### Layering note
`JobTrigger` is typed via `import type { EventOfType, EventTypeName } from '../events/generated/types'` — the **same erased, type-only coupling the bridge already has**, and `jobs` already references the `events_*` reserved pools. **`jobs` still does not import `bridge`**: the post-gen `BridgeTriggerEntry` is deliberately not referenced; `triggerId`/`jobType` are generator-computed, not authored.

## Validation

- ✅ Typecheck clean on both changed files (`tsc -p tsconfig.json`).
- ✅ The negative `@ts-expect-error` genuinely fires (unknown events rejected).
- ✅ 41 tests pass across the bridge-registry generator + job-handler suites — generator behaviour unchanged.

## ⚠️ Pre-existing CI note (not from this PR)
`tsc -p tsconfig.build.json` reports **3 errors in `src/cli/commands/junction.ts` + `src/cli/shared/barrel-generator.ts`** (Junction type missing `name`/`table`). Confirmed present on `main` at the base commit (count `3 == 3` with/without this change) — unrelated to this PR, but it will keep the build-typecheck red until fixed. Flagging so this PR's CI failure isn't misattributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)