### PR TITLE
chore(release): 0.9.1 — JobHandlerMeta.triggers + publish-recipe mise fix

### DIFF
--- a/justfile
+++ b/justfile
@@ -191,11 +191,16 @@ publish:
     git worktree add "${workdir}" origin/main
     cd "${workdir}"
 
-    mise trust >/dev/null 2>&1 || true
-    mise install >/dev/null 2>&1 || true
+    # Resolve toolchain through mise explicitly — the user may also have asdf
+    # whose `bun` shim shadows mise in this non-interactive shell and can't
+    # resolve a version in the ephemeral worktree (no .tool-versions). Trust the
+    # exact workdir and run bun/npm via `mise exec` so .mise.toml wins. Errors
+    # are NOT swallowed — a setup failure must abort, not fall through.
+    mise trust "${workdir}"
+    mise install
 
-    bun install
-    npm publish
+    mise exec -- bun install
+    mise exec -- npm publish
 
     echo "✓ Published @pattern-stack/codegen@${version}"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Releases the `@JobHandler({ triggers })` authoring field from #388 and fixes the `just publish` recipe.

## Why 0.9.1
`#388` merged the fix but didn't bump the version. `0.9.0` is already on npm and consumers pin exact versions, so a new version is required for them to consume it. Patch bump — additive, backward-compatible (new optional `JobHandlerMeta.triggers`).

## publish recipe fix
`just publish` failed with asdf's `No version is set for command bun … .tool-versions` error. Root cause: asdf and mise coexist; asdf's `bun` shim shadows mise in the recipe's non-interactive shell and can't resolve a version in the ephemeral `/tmp` worktree (repo declares tools in `.mise.toml`, not `.tool-versions`). Fix: `mise trust "${workdir}"` + run `bun`/`npm` via `mise exec --` so `.mise.toml` wins, and stop swallowing mise errors so setup failures abort loudly.

## After merge
`just publish` → publishes `0.9.1`. Then in `dealbrain-integrations`: bump the pin + `codegen subsystem install jobs --force` + regen (writeback slice 0b).

Note: the 3 pre-existing `junction.ts`/`barrel-generator.ts` **typecheck** errors are unrelated and don't gate the publish (it runs `bun run build` via tsup, not `tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)