### PR TITLE
fix(clean-lite-ps): emit default/foreign_key/index + unique_indexes to Drizzle

### DIFF
--- a/src/__tests__/clean-lite-ps/entity-column-features.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-column-features.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Template rendering tests for clean-lite-ps Drizzle column/table feature
+ * emission — the cohesive cluster of "YAML metadata read but not emitted" bugs:
+ *
+ *   #345 — field `default:` → `.default(...)` / `.defaultNow()` on the column
+ *   #354 — field `foreign_key: <table>.<col>` → `.references(() => ...)` + import
+ *   #355 — field `index: true` → `index('<table>_<col>_idx').on(t.<col>)` in the
+ *          pgTable extra-config callback + `index` import
+ *   #356 — top-level `unique_indexes:` → `uniqueIndex(...).on(...)` + import
+ *
+ * These mirror the rendering harness in entity-fk-template.test.ts (render the
+ * EJS body with locals from buildCleanLitePsLocals).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ejs from 'ejs';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const ENTITY_TEMPLATE = readFileSync(
+  resolve(import.meta.dir, '../../../templates/entity/new/clean-lite-ps/entity.ejs.t'),
+  'utf8',
+);
+
+function extractBody(source: string): string {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return source;
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return source;
+  return lines.slice(end + 1).join('\n');
+}
+
+function render(definition: Record<string, unknown>): {
+  output: string;
+  locals: Record<string, unknown>;
+} {
+  const locals = buildCleanLitePsLocals(definition, {}) as Record<string, unknown>;
+  const output = ejs.render(extractBody(ENTITY_TEMPLATE), locals, { rmWhitespace: false });
+  return { output, locals };
+}
+
+// ============================================================================
+// #345 — column defaults
+// ============================================================================
+
+describe('column defaults (#345)', () => {
+  const definition = {
+    entity: { name: 'conversation', plural: 'conversations', table: 'conversations', pattern: 'Base' },
+    fields: {
+      state: { type: 'enum', choices: ['created', 'active', 'completed'], required: true, default: 'created' },
+      exchange_count: { type: 'integer', required: true, default: 0 },
+      role_name: { type: 'string', required: true, default: 'user' },
+      is_archived: { type: 'boolean', default: false },
+      score: { type: 'decimal', default: 0 },
+      started_at: { type: 'datetime', default: 'now' },
+    },
+    relationships: {},
+    behaviors: [],
+  };
+
+  it('emits .default(literal) on an enum column', () => {
+    const { output } = render(definition);
+    expect(output).toContain(".default('created')");
+    expect(output).toContain("stateEnum('state').notNull().default('created')");
+  });
+
+  it('emits a bare numeric default on an integer column', () => {
+    const { output } = render(definition);
+    expect(output).toContain("integer('exchange_count').notNull().default(0)");
+  });
+
+  it('emits a quoted string default on a text column', () => {
+    const { output } = render(definition);
+    expect(output).toContain("text('role_name').notNull().default('user')");
+  });
+
+  it('emits a bare boolean default', () => {
+    const { output } = render(definition);
+    expect(output).toContain("boolean('is_archived').default(false)");
+  });
+
+  it('quotes a numeric (decimal) default — Drizzle numeric is string-typed', () => {
+    const { output } = render(definition);
+    expect(output).toContain("numeric('score').default('0')");
+  });
+
+  it("maps the `now` sentinel on a datetime column to .defaultNow()", () => {
+    const { output } = render(definition);
+    expect(output).toContain("timestamp('started_at').defaultNow()");
+  });
+
+  it('emits no default suffix when no default is declared', () => {
+    const { output } = render({
+      entity: { name: 'widget', plural: 'widgets', table: 'widgets', pattern: 'Base' },
+      fields: { label: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+    });
+    expect(output).toContain("label: text('label').notNull(),");
+    expect(output).not.toContain('.default(');
+  });
+});
+
+// ============================================================================
+// #354 — field-level foreign_key
+// ============================================================================
+
+describe('field-level foreign_key (#354)', () => {
+  const definition = {
+    entity: { name: 'tool_call', plural: 'tool_calls', table: 'tool_calls', pattern: 'Base' },
+    fields: {
+      conversation_id: { type: 'uuid', required: true, foreign_key: 'conversations.id' },
+      name: { type: 'string', required: true },
+    },
+    relationships: {},
+    behaviors: [],
+  };
+
+  it('appends .references(() => <table>.<col>) to the FK column chain', () => {
+    const { output } = render(definition);
+    expect(output).toContain(
+      "conversationId: uuid('conversation_id').notNull().references(() => conversations.id),",
+    );
+  });
+
+  it('imports the referenced table from the singularized entity path', () => {
+    const { output } = render(definition);
+    expect(output).toContain("import { conversations } from '../conversations/conversation.entity';");
+  });
+
+  it('omits .notNull() but still references on a nullable FK column', () => {
+    const { output } = render({
+      entity: { name: 'tool_call', plural: 'tool_calls', table: 'tool_calls', pattern: 'Base' },
+      fields: {
+        conversation_id: { type: 'uuid', foreign_key: 'conversations.id' },
+      },
+      relationships: {},
+      behaviors: [],
+    });
+    expect(output).toContain("conversationId: uuid('conversation_id').references(() => conversations.id),");
+    expect(output).not.toContain("uuid('conversation_id').notNull()");
+  });
+
+  it('uses the AnyPgColumn annotation + no self-import for a self-referential FK', () => {
+    const { output, locals } = render({
+      entity: { name: 'conversation', plural: 'conversations', table: 'conversations', pattern: 'Base' },
+      fields: {
+        branched_from_id: { type: 'uuid', foreign_key: 'conversations.id' },
+      },
+      relationships: {},
+      behaviors: [],
+    });
+    expect(output).toContain(
+      "branchedFromId: uuid('branched_from_id').references((): AnyPgColumn => conversations.id),",
+    );
+    expect(output).toContain('type AnyPgColumn');
+    expect(locals.clpHasSelfFk).toBe(true);
+    // No self-import.
+    expect(output).not.toContain("import { conversations } from");
+  });
+});
+
+// ============================================================================
+// #355 — field-level index: true
+// ============================================================================
+
+describe('single-column index (#355)', () => {
+  const definition = {
+    entity: { name: 'conversation', plural: 'conversations', table: 'conversations', pattern: 'Base' },
+    fields: {
+      role_name: { type: 'string', required: true, index: true },
+      state: { type: 'enum', choices: ['created', 'active'], required: true },
+    },
+    relationships: {},
+    behaviors: [],
+  };
+
+  it('emits a named index in the pgTable extra-config callback', () => {
+    const { output } = render(definition);
+    expect(output).toMatch(/\},\s*\(t\) => \[/);
+    expect(output).toContain("index('conversations_role_name_idx').on(t.roleName)");
+  });
+
+  it('imports index from drizzle-orm/pg-core', () => {
+    const { output, locals } = render(definition);
+    expect(locals.clpDrizzleImports).toContain('index');
+    expect(output).toContain('index,');
+  });
+
+  it('indexes a field-level FK column that is also marked index: true', () => {
+    const { output } = render({
+      entity: { name: 'tool_call', plural: 'tool_calls', table: 'tool_calls', pattern: 'Base' },
+      fields: {
+        conversation_id: { type: 'uuid', required: true, foreign_key: 'conversations.id', index: true },
+      },
+      relationships: {},
+      behaviors: [],
+    });
+    // Both the reference AND the index land.
+    expect(output).toContain(".references(() => conversations.id)");
+    expect(output).toContain("index('tool_calls_conversation_id_idx').on(t.conversationId)");
+  });
+
+  it('emits no callback or index import when no field declares index', () => {
+    const { output, locals } = render({
+      entity: { name: 'widget', plural: 'widgets', table: 'widgets', pattern: 'Base' },
+      fields: { label: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+    });
+    expect(locals.clpDrizzleImports).not.toContain('index');
+    expect(output).not.toMatch(/\},\s*\(t\) => \[/);
+  });
+});
+
+// ============================================================================
+// #356 — composite unique_indexes
+// ============================================================================
+
+describe('composite unique_indexes (#356)', () => {
+  const definition = {
+    entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
+    fields: {
+      conversation_id: { type: 'uuid', required: true },
+      sequence: { type: 'integer', required: true },
+      body: { type: 'string', required: true },
+    },
+    relationships: {},
+    behaviors: [],
+    unique_indexes: [{ fields: ['conversation_id', 'sequence'] }],
+  };
+
+  it('emits uniqueIndex over the camelCased columns with the default name', () => {
+    const { output } = render(definition);
+    expect(output).toContain(
+      "uniqueIndex('messages_conversation_id_sequence_uniq').on(t.conversationId, t.sequence)",
+    );
+  });
+
+  it('honors an explicit index name', () => {
+    const { output } = render({
+      ...definition,
+      unique_indexes: [
+        { fields: ['conversation_id', 'sequence'], name: 'messages_conversation_sequence_uniq' },
+      ],
+    });
+    expect(output).toContain(
+      "uniqueIndex('messages_conversation_sequence_uniq').on(t.conversationId, t.sequence)",
+    );
+  });
+
+  it('imports uniqueIndex from drizzle-orm/pg-core', () => {
+    const { output, locals } = render(definition);
+    expect(locals.clpDrizzleImports).toContain('uniqueIndex');
+    expect(output).toContain('uniqueIndex,');
+  });
+
+  it('coexists with single-column indexes in one extra-config callback', () => {
+    const { output } = render({
+      ...definition,
+      fields: {
+        conversation_id: { type: 'uuid', required: true, index: true },
+        sequence: { type: 'integer', required: true },
+        body: { type: 'string', required: true },
+      },
+    });
+    // exactly one (t) => [ callback
+    const matches = output.match(/\(t\) => \[/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(output).toContain("index('messages_conversation_id_idx').on(t.conversationId)");
+    expect(output).toContain(
+      "uniqueIndex('messages_conversation_id_sequence_uniq').on(t.conversationId, t.sequence)",
+    );
+  });
+});

--- a/src/__tests__/schema/unique-indexes.test.ts
+++ b/src/__tests__/schema/unique-indexes.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for the entity-YAML top-level `unique_indexes:` block (#356).
+ *
+ * Composite (multi-column) unique constraints — e.g. UNIQUE (conversation_id,
+ * sequence) — were silently rejected by the `.strict()` EntityDefinitionSchema
+ * before this key existed. Single-column uniqueness stays the field-level
+ * `unique: true` flag; this block is for constraints spanning 2+ columns.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { EntityDefinitionSchema } from '../../schema/entity-definition.schema';
+
+const base = {
+  entity: { name: 'message', plural: 'messages', table: 'messages' },
+  fields: {
+    conversation_id: { type: 'uuid', required: true },
+    sequence: { type: 'integer', required: true },
+  },
+};
+
+describe('unique_indexes block (#356)', () => {
+  it('is optional', () => {
+    const result = EntityDefinitionSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    expect(result.data!.unique_indexes).toBeUndefined();
+  });
+
+  it('accepts a composite unique index without an explicit name', () => {
+    const result = EntityDefinitionSchema.safeParse({
+      ...base,
+      unique_indexes: [{ fields: ['conversation_id', 'sequence'] }],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data!.unique_indexes).toEqual([
+      { fields: ['conversation_id', 'sequence'] },
+    ]);
+  });
+
+  it('accepts an explicit index name', () => {
+    const result = EntityDefinitionSchema.safeParse({
+      ...base,
+      unique_indexes: [
+        { fields: ['conversation_id', 'sequence'], name: 'messages_conversation_sequence_uniq' },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(result.data!.unique_indexes![0]!.name).toBe('messages_conversation_sequence_uniq');
+  });
+
+  it('rejects a single-column unique index (use field `unique: true` instead)', () => {
+    const result = EntityDefinitionSchema.safeParse({
+      ...base,
+      unique_indexes: [{ fields: ['conversation_id'] }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown keys inside an entry (.strict())', () => {
+    const result = EntityDefinitionSchema.safeParse({
+      ...base,
+      unique_indexes: [{ fields: ['conversation_id', 'sequence'], bogus: true }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -832,6 +832,24 @@ export const EntityDefinitionSchema = z
     // v2: Analytics / semantic layer configuration
     // Cube.js measure packs, custom cube name, and metric definitions
     analytics: AnalyticsBlockSchema.optional(),
+
+    // Composite (multi-column) unique indexes (#356). Single-column uniqueness
+    // is `unique: true` on the field itself; this declares constraints that
+    // span 2+ columns, e.g. UNIQUE (conversation_id, sequence). Emitted as a
+    // `uniqueIndex(...).on(...)` entry in the generated entity's pgTable
+    // extra-config callback. `name` defaults to <table>_<col1>_<col2>_uniq.
+    unique_indexes: z
+      .array(
+        z
+          .object({
+            fields: z
+              .array(z.string())
+              .min(2, "unique_indexes entries span 2+ columns — use `unique: true` on the field for single-column uniqueness"),
+            name: z.string().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
   })
   .strict()
   .refine(

--- a/src/schema/generate-json-schema.ts
+++ b/src/schema/generate-json-schema.ts
@@ -89,6 +89,15 @@ const EntityDefinitionSchema = z.object({
   fields: z.record(z.string(), FieldDefinitionSchema).describe("Field definitions"),
   relationships: z.record(z.string(), RelationshipSchema).optional().describe("Entity relationships"),
   behaviors: z.array(BehaviorSchema).optional().describe("Cross-cutting behaviors"),
+  unique_indexes: z
+    .array(
+      z.object({
+        fields: z.array(z.string()).describe("Columns the composite unique constraint spans (2+)"),
+        name: z.string().optional().describe("Index name (default <table>_<col1>_<col2>_uniq)"),
+      }),
+    )
+    .optional()
+    .describe("Composite (multi-column) unique indexes"),
 });
 
 // Generate using Zod v4's native JSON schema support

--- a/templates/entity/new/clean-lite-ps/entity.ejs.t
+++ b/templates/entity/new/clean-lite-ps/entity.ejs.t
@@ -22,6 +22,10 @@ import { type InferSelectModel } from 'drizzle-orm';
 import { <%= rel.relatedTable %> } from '<%= rel.importPath %>';
 <%_ } _%>
 <%_ }) _%>
+<%_ /* #354: field-level foreign_key target table imports */ _%>
+<%_ if (typeof clpFieldFkImports !== 'undefined') { clpFieldFkImports.forEach(imp => { _%>
+import { <%= imp.relatedTable %> } from '<%= imp.importPath %>';
+<%_ }) } _%>
 <%_ /* CGP-358b: import has_many target tables for many() relation const */ _%>
 <%_ if (typeof clpExistingHasMany !== 'undefined') { _%>
 <%_ clpExistingHasMany.filter(rel => !rel.isSelfRef).forEach(rel => { _%>
@@ -65,10 +69,15 @@ export const <%= entityNamePlural %> = pgTable(
     deletedAt: timestamp('deleted_at'),
 <%_ } _%>
   },
-<%_ if (hasExternalIdTracking) { _%>
+<%_ /* #355/#356: pgTable extra-config — indexes + composite unique indexes + external_id unique index */ _%>
+<%_ if (typeof clpTableConstraints !== 'undefined' && clpTableConstraints.length > 0) { _%>
   (t) => [
-    // external_id_tracking behavior — ON CONFLICT target for integrationUpsert
-    uniqueIndex('uq_<%= entityNamePlural %>_provider_external_id').on(t.provider, t.externalId),
+<%_ clpTableConstraints.forEach(c => { _%>
+<%_ if (c.comment) { _%>
+    // <%= c.comment %>
+<%_ } _%>
+    <%- c.expr %>,
+<%_ }) _%>
   ],
 <%_ } _%>
 );

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -145,6 +145,7 @@ const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
 const camelCase = (s) => s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
 const pascalCase = (s) => capitalize(camelCase(s));
 const pluralize = (s) => pluralizePkg.plural(s);
+const singularize = (s) => pluralizePkg.singular(s);
 
 // ============================================================================
 // Drizzle type mapping
@@ -260,13 +261,43 @@ function buildDrizzleChain(fieldName, field, drizzleType, enumName) {
     chain += '.notNull()';
   }
 
-  // Boolean defaults
-  if (drizzleType === 'boolean' && hasDefault) {
-    chain += `.default(${field.default})`;
+  // Column defaults (#345). The value is validated upstream (schema `default:`).
+  // Covers every scalar type, enum literals, and the `now` sentinel on
+  // timestamp/date columns — not just booleans.
+  if (hasDefault) {
+    chain += renderColumnDefault(field.default, drizzleType);
   }
 
-  // Timestamp defaults for datetime fields in behavior context handled separately
   return chain;
+}
+
+/**
+ * Render a Drizzle `.default(...)` (or `.defaultNow()`) suffix for a column.
+ *
+ * - timestamp/date + a `now`/`now()`/`current_timestamp` sentinel → `.defaultNow()`
+ * - numeric (Drizzle returns it as a string) → quoted, even for numeric YAML values
+ * - string / enum literal → single-quoted, escaped
+ * - number / boolean → bare literal
+ * - anything else (jsonb object/array default) → JSON literal
+ */
+function renderColumnDefault(value, drizzleType) {
+  if (
+    (drizzleType === 'timestamp' || drizzleType === 'date') &&
+    typeof value === 'string' &&
+    /^(now|now\(\)|current_timestamp)$/i.test(value)
+  ) {
+    return '.defaultNow()';
+  }
+  if (drizzleType === 'numeric') {
+    return `.default('${String(value)}')`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return `.default(${value})`;
+  }
+  if (typeof value === 'string') {
+    return `.default('${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}')`;
+  }
+  return `.default(${JSON.stringify(value)})`;
 }
 
 /**
@@ -447,9 +478,94 @@ function processBelongsTo(relationships, parentEntityNamePlural) {
 }
 
 /**
+ * Field-level `foreign_key:` + `index:` emission (#354, #355).
+ *
+ * Distinct from `relationships:`-driven belongs_to FKs (processBelongsTo),
+ * which own their own column + import. This handles features declared
+ * directly on a column field:
+ *
+ *   - `foreign_key: <table>.<column>` → append `.references(() => <table>.<column>)`
+ *     to the column's Drizzle chain (self-FKs get the `: AnyPgColumn` annotation)
+ *     and record the cross-module import. The table segment is the Drizzle table
+ *     export name (plural, e.g. `conversations`); the import path singularizes it
+ *     to the entity file (`../conversations/conversation.entity`).
+ *   - `index: true` → emit a named single-column index in the pgTable
+ *     extra-config callback (`<table>_<column>_idx`).
+ *
+ * Mutates each processed field's `drizzleChain` in place (the same objects are
+ * later rendered via clpProcessedFields). Returns the imports + index
+ * expressions the template needs.
+ *
+ * @param {object[]} renderedFields  the fields actually emitted as columns
+ *                                   (nonFkFields — belongs_to FK columns excluded)
+ * @param {object}   fields          raw field map keyed by snake_case name
+ * @param {string}   entityNamePlural Drizzle table export name for self-FK detection
+ */
+function processFieldFeatures(renderedFields, fields, entityNamePlural) {
+  const fkImports = [];
+  const indexExpressions = [];
+  const seenImports = new Set();
+  let hasSelfFieldFk = false;
+
+  for (const pf of renderedFields) {
+    const field = fields[pf.name];
+    if (!field) continue;
+
+    // --- foreign_key (#354) ---
+    if (typeof field.foreign_key === 'string' && field.foreign_key.includes('.')) {
+      const [relatedTable, fkColumn] = field.foreign_key.split('.');
+      const isSelfFk = relatedTable === entityNamePlural;
+      pf.drizzleChain += isSelfFk
+        ? `.references((): AnyPgColumn => ${relatedTable}.${fkColumn})`
+        : `.references(() => ${relatedTable}.${fkColumn})`;
+
+      if (isSelfFk) {
+        hasSelfFieldFk = true;
+      } else if (!seenImports.has(relatedTable)) {
+        seenImports.add(relatedTable);
+        fkImports.push({
+          relatedTable,
+          importPath: `../${relatedTable}/${singularize(relatedTable)}.entity`,
+        });
+      }
+    }
+
+    // --- index: true (#355) ---
+    if (field.index === true) {
+      indexExpressions.push({
+        comment: null,
+        expr: `index('${entityNamePlural}_${pf.name}_idx').on(t.${pf.camelName})`,
+      });
+    }
+  }
+
+  return { fkImports, indexExpressions, hasSelfFieldFk };
+}
+
+/**
+ * Composite unique index emission (#356).
+ *
+ * Top-level `unique_indexes: [{ fields: [...], name? }]` → a `uniqueIndex(...)`
+ * entry in the pgTable extra-config callback. Column names are camelCased to
+ * match the emitted Drizzle column identifiers; they may reference FK columns
+ * (belongs_to) or ordinary fields. Index name defaults to
+ * `<table>_<col1>_<col2>_..._uniq`.
+ */
+function processUniqueIndexes(uniqueIndexes, entityNamePlural) {
+  if (!Array.isArray(uniqueIndexes)) return [];
+
+  return uniqueIndexes.map((ui) => {
+    const cols = ui.fields;
+    const name = ui.name || `${entityNamePlural}_${cols.join('_')}_uniq`;
+    const onCols = cols.map((c) => `t.${camelCase(c)}`).join(', ');
+    return { comment: null, expr: `uniqueIndex('${name}').on(${onCols})` };
+  });
+}
+
+/**
  * Collect drizzle imports needed for entity fields
  */
-function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete, hasExternalIdTracking, hasMany = []) {
+function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete, hasExternalIdTracking, hasMany = [], extraImports = []) {
   const imports = new Set(['pgTable', 'uuid']);
 
   for (const field of processedFields) {
@@ -484,6 +600,13 @@ function collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSof
 
   if (belongsTo.length > 0 || hasMany.length > 0) {
     imports.add('relations');
+  }
+
+  // Caller-supplied extras: `index` (field-level index: true) and
+  // `uniqueIndex` (composite unique_indexes) — see processFieldFeatures /
+  // processUniqueIndexes.
+  for (const extra of extraImports) {
+    imports.add(extra);
   }
 
   return Array.from(imports).sort();
@@ -1033,6 +1156,33 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const fkFieldNames = new Set(belongsTo.map((r) => r.field));
   const nonFkFields = processedFields.filter((f) => !fkFieldNames.has(f.name));
 
+  // Field-level foreign_key + index emission (#354, #355). Mutates the
+  // drizzleChain of the rendered (non-belongs_to) columns in place. Skip FK
+  // imports for tables belongs_to already imports to avoid duplicate import
+  // lines.
+  const fieldFeatures = processFieldFeatures(nonFkFields, fields, entityNamePlural);
+  const belongsToTables = new Set(belongsTo.map((r) => r.relatedTable));
+  const clpFieldFkImports = fieldFeatures.fkImports.filter(
+    (imp) => !belongsToTables.has(imp.relatedTable),
+  );
+
+  // Composite unique indexes (#356).
+  const uniqueIndexExpressions = processUniqueIndexes(definition.unique_indexes, entityNamePlural);
+
+  // pgTable extra-config callback entries, in emission order: single-column
+  // indexes, composite unique indexes, then the external_id_tracking unique
+  // index (the ON CONFLICT target integrationUpsert relies on).
+  const clpTableConstraints = [
+    ...fieldFeatures.indexExpressions,
+    ...uniqueIndexExpressions,
+  ];
+  if (hasExternalIdTracking) {
+    clpTableConstraints.push({
+      comment: 'external_id_tracking behavior — ON CONFLICT target for integrationUpsert',
+      expr: `uniqueIndex('uq_${entityNamePlural}_provider_external_id').on(t.provider, t.externalId)`,
+    });
+  }
+
   // Enum field declarations — surface a separate collection so the entity
   // template can emit `export const xEnum = pgEnum('x', [...])` ahead of
   // the `pgTable(...)` block. Both FK-filtered and unfiltered processing
@@ -1045,8 +1195,13 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
       choices: f.choices,
     }));
 
-  // Drizzle imports needed
-  const drizzleEntityImports = collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete, hasExternalIdTracking, hasMany);
+  // Drizzle imports needed. `index` / `uniqueIndex` are pulled in only when a
+  // field declares `index: true` or the entity declares `unique_indexes:`
+  // (external_id_tracking adds `uniqueIndex` on its own flag below).
+  const extraDrizzleImports = [];
+  if (fieldFeatures.indexExpressions.length > 0) extraDrizzleImports.push('index');
+  if (uniqueIndexExpressions.length > 0) extraDrizzleImports.push('uniqueIndex');
+  const drizzleEntityImports = collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete, hasExternalIdTracking, hasMany, extraDrizzleImports);
   // Whether relations() import is needed (CGP-358b: also trigger on has_many)
   const hasRelationsBlock = belongsTo.length > 0 || hasMany.length > 0;
 
@@ -1269,8 +1424,14 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     // strict mode flags the table const with TS7022/TS7024 (circular initializer).
     // Surfaced by the cgp-62 relationship-scenario smoke when generating a CRM
     // account with a `parent_account_id` self-FK.
-    clpHasSelfFk: belongsTo.some((rel) => rel.isSelfFk),
+    clpHasSelfFk: belongsTo.some((rel) => rel.isSelfFk) || fieldFeatures.hasSelfFieldFk,
     clpEnumFields,
+
+    // Field-level foreign_key imports (#354) and pgTable extra-config
+    // entries: single-column indexes (#355) + composite unique indexes (#356)
+    // + the external_id_tracking unique index.
+    clpFieldFkImports,
+    clpTableConstraints,
 
     // Declarative queries
     processedQueries,


### PR DESCRIPTION
Closes #345, #354, #355, #356.

Cohesive cluster of "YAML column/table feature read but not emitted" gaps in the clean-lite-ps entity template. Each feature was validated upstream yet silently dropped at the Drizzle emission layer.

## What lands
- **#345 `default:`** — emit `.default(...)` / `.defaultNow()` for every scalar type, enum literals, and the `now`/`current_timestamp` sentinel on `timestamp`/`date` columns (was boolean-only). `numeric` (string-typed in Drizzle) defaults are quoted.
- **#354 field-level `foreign_key:`** — `foreign_key: <table>.<col>` on a column now emits `.references(() => <table>.<col>)` plus the singularized cross-module import (`../conversations/conversation.entity`). Self-FKs carry the `: AnyPgColumn` annotation and skip the self-import. (Distinct from `relationships:`-driven belongs_to FKs, which already worked.)
- **#355 `index: true`** — emits `index('<table>_<col>_idx').on(t.<col>)` in the pgTable extra-config callback + the `index` import. Composes with #354 (a FK column marked `index: true` gets both).
- **#356 `unique_indexes:`** — new top-level schema key for composite (2+ column) unique constraints; single-column uniqueness stays the field-level `unique: true` flag. Emits `uniqueIndex(...).on(...)`; index name defaults to `<table>_<col1>_<col2>_uniq`.

## Notable
- The pgTable extra-config callback is now **unified**: single-column indexes, composite unique indexes, and the existing `external_id_tracking` unique index all render through one `(t) => [ ... ]` instead of the behavior-only special case.
- Schema change is **only** the new optional `unique_indexes` key on `EntityDefinitionSchema` (#345/#354/#355 were pure template-emission gaps — `default`/`index`/`foreign_key` were already recognized at field level).
- `src/schema/generate-json-schema.ts` (editor-hint generator) updated to match, but it is **pre-existing broken** on the installed Zod (`z.toJSONSchema` is undefined) so the committed `.schema.json` is not regenerated. The real validation path is the Zod schema, which is updated.

## Tests
- `src/__tests__/clean-lite-ps/entity-column-features.test.ts` — emission assertions for all four (24 cases).
- `src/__tests__/schema/unique-indexes.test.ts` — validator accepts composite / rejects single-column + unknown keys.
- Full unit suite (2222 pass), clean-arch baseline (no drift), and relationship smoke (full clean-lite-ps generation + tsc) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)