### PR TITLE
feat(track-c): C7 — IEntityChangeSourceRegistry (L1)

### DIFF
--- a/.claude/skills/integration/protocols-and-ports.md
+++ b/.claude/skills/integration/protocols-and-ports.md
@@ -56,6 +56,17 @@ port is deliberate; the compromise analysis behind it is in epic #60.
 If a new detection mode emerges, add a value to the `ChangeSource`
 union and a metadata field if needed — not a new port.
 
+## `IEntityChangeSourceRegistry` — entity-keyed source resolution
+
+Resolves an `IChangeSource<T>` by entity name (`get<T>(name)`, `has`,
+`entities()`), throwing `UnknownEntityError` on a miss. It generalizes the
+per-entity `<ENTITY>_POLL_FETCH_REGISTRY` tokens into one registry so the L3
+surface port stays entity-agnostic. Use `MemoryEntityChangeSourceRegistry`
+(backed by a `Map`) for tests/simple wiring; bind under the
+`ENTITY_CHANGE_SOURCE_REGISTRY` token. Codegen emission of the populated
+registry is Track D (RFC-0001 §3); full authoring coverage lives in the C5
+surface-authoring guide.
+
 ## `IIntegrationSink<T>` — the write surface
 
 One sink per canonical entity. Speaks canonical externally; internal

--- a/runtime/subsystems/integration/entity-change-source-registry.memory.ts
+++ b/runtime/subsystems/integration/entity-change-source-registry.memory.ts
@@ -1,0 +1,40 @@
+/**
+ * Integration subsystem — in-memory entity-change-source registry
+ *
+ * Default `IEntityChangeSourceRegistry` backed by a `Map<entityName, source>`.
+ * Track D's codegen-emitted aggregator folds per-provider adapter
+ * contributions into one of these and binds it under
+ * `ENTITY_CHANGE_SOURCE_REGISTRY` (RFC-0001 §3); tests and simple consumers
+ * construct it directly.
+ *
+ * See {@link ./entity-change-source-registry.protocol} for the contract and
+ * #336 for scope.
+ */
+
+import type { IChangeSource } from './integration-change-source.protocol';
+import {
+  type IEntityChangeSourceRegistry,
+  UnknownEntityError,
+} from './entity-change-source-registry.protocol';
+
+export class MemoryEntityChangeSourceRegistry
+  implements IEntityChangeSourceRegistry
+{
+  constructor(private readonly sources: Map<string, IChangeSource<unknown>>) {}
+
+  get<T = unknown>(name: string): IChangeSource<T> {
+    const source = this.sources.get(name);
+    if (!source) {
+      throw new UnknownEntityError(name, [...this.sources.keys()]);
+    }
+    return source as IChangeSource<T>;
+  }
+
+  has(name: string): boolean {
+    return this.sources.has(name);
+  }
+
+  entities(): readonly string[] {
+    return [...this.sources.keys()];
+  }
+}

--- a/runtime/subsystems/integration/entity-change-source-registry.protocol.ts
+++ b/runtime/subsystems/integration/entity-change-source-registry.protocol.ts
@@ -1,0 +1,59 @@
+/**
+ * Integration subsystem — entity-keyed change-source registry (port)
+ *
+ * `IEntityChangeSourceRegistry` resolves an `IChangeSource<T>` by entity name.
+ * It generalizes today's per-entity DI tokens (`ACCOUNT_POLL_FETCH_REGISTRY`,
+ * `CONTACT_POLL_FETCH_REGISTRY`, …) into one entity-keyed registry, so the L3
+ * composing port (`<Surface>Port`, Track C C6) can be entity-agnostic at the
+ * type level instead of enumerating entities (epic #328 locked decision #5).
+ *
+ * This lives in L1 (the integration subsystem) rather than in a per-surface
+ * package because the same shape applies across surfaces — CRM (`account`,
+ * `contact`, `deal`), Mail (`email`, `thread`, `label`), Transcript
+ * (`transcript`, `speaker`, `utterance`), Meeting (`meeting`, `attendee`).
+ * Cross-surface plumbing belongs at L1 (epic #328 locked decision #6).
+ *
+ * Scope (Track C · C7): this is purely the L1 type + memory impl. Codegen does
+ * NOT yet emit this registry, and the existing per-entity tokens keep emitting
+ * unchanged — the retarget (and the per-entity-token deprecation) is Track D
+ * D3/D4 (RFC-0001 §3/§8).
+ *
+ * See #336 (this issue), #328 (parent epic), RFC-0001 §3 (the registry
+ * contract Track D emits the wiring for).
+ */
+
+import type { IChangeSource } from './integration-change-source.protocol';
+
+/**
+ * Entity-keyed resolver for change sources. The orchestrator (and the L3
+ * surface port) consume this, agnostic to whether a source came from a
+ * hand-written adapter or a configured `PollChangeSource<T>`.
+ */
+export interface IEntityChangeSourceRegistry {
+  /**
+   * Resolve a change source for a given entity name.
+   * Throws {@link UnknownEntityError} if the entity isn't registered.
+   */
+  get<T = unknown>(entityName: string): IChangeSource<T>;
+
+  /** True if the entity is registered. */
+  has(entityName: string): boolean;
+
+  /** List all entity names this registry serves. */
+  entities(): readonly string[];
+}
+
+/**
+ * Thrown by {@link IEntityChangeSourceRegistry.get} when no source is
+ * registered for the requested entity. The message enumerates the available
+ * entities so a misconfiguration (typo'd entity name, missing adapter
+ * contribution) is diagnosable from the error alone.
+ */
+export class UnknownEntityError extends Error {
+  constructor(entity: string, available: readonly string[]) {
+    super(
+      `No change source registered for entity '${entity}'. Available: ${available.join(', ')}`,
+    );
+    this.name = 'UnknownEntityError';
+  }
+}

--- a/runtime/subsystems/integration/index.ts
+++ b/runtime/subsystems/integration/index.ts
@@ -44,6 +44,14 @@ export type {
 } from './integration-run-recorder.protocol';
 export type { ILoopbackFingerprintStore } from './integration-loopback.protocol';
 
+// Entity-keyed change-source registry (C7, #336) — L1 protocol + memory impl.
+// Generalizes per-entity `<ENTITY>_POLL_FETCH_REGISTRY` tokens into one
+// entity-keyed registry so the L3 surface port (C6) is entity-agnostic. Codegen
+// retarget to emit it is Track D D3/D4 (RFC-0001 §3).
+export type { IEntityChangeSourceRegistry } from './entity-change-source-registry.protocol';
+export { UnknownEntityError } from './entity-change-source-registry.protocol';
+export { MemoryEntityChangeSourceRegistry } from './entity-change-source-registry.memory';
+
 // DetectionConfig (#226-1) — Zod schema + inferred types; canonical source
 // of filter/mapping shape consumed by primitives + codegen YAML validator
 export {
@@ -100,6 +108,7 @@ export { buildChangeSource } from './build-change-source';
 
 // Tokens
 export {
+  ENTITY_CHANGE_SOURCE_REGISTRY,
   INTEGRATION_CHANGE_SOURCE,
   INTEGRATION_CURSOR_STORE,
   INTEGRATION_FIELD_DIFFER,

--- a/runtime/subsystems/integration/integration.tokens.ts
+++ b/runtime/subsystems/integration/integration.tokens.ts
@@ -47,3 +47,17 @@ export const INTEGRATION_MODULE_OPTIONS = 'INTEGRATION_MODULE_OPTIONS' as const;
  * Consumed by `ExecuteIntegrationUseCase` to enforce the tenantId-is-required rule.
  */
 export const INTEGRATION_MULTI_TENANT = 'INTEGRATION_MULTI_TENANT' as const;
+
+/**
+ * Injection token for the entity-keyed `IEntityChangeSourceRegistry` (C7,
+ * #336). Bound to the codegen-emitted aggregator that folds per-provider
+ * adapter contributions into one registry (RFC-0001 §3, emitted by Track D
+ * D3/D4).
+ *
+ * A string constant, not `Symbol.for(...)`, to match this subsystem's token
+ * convention (see file header). The originating issue's code block proposed a
+ * `Symbol.for('@pattern-stack/codegen.entity-change-source-registry')` key,
+ * predating the sync→integration consolidation onto string tokens; kept as a
+ * string here for internal consistency with the other INTEGRATION_* tokens.
+ */
+export const ENTITY_CHANGE_SOURCE_REGISTRY = 'ENTITY_CHANGE_SOURCE_REGISTRY' as const;

--- a/src/__tests__/runtime/subsystems/entity-change-source-registry.spec.ts
+++ b/src/__tests__/runtime/subsystems/entity-change-source-registry.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the entity-keyed change-source registry (Track C · C7, #336).
+ *
+ * Covers the L1 memory impl: `get` resolves a registered source, `get` throws
+ * `UnknownEntityError` (with the available-entities list) on a miss, and `has`
+ * / `entities()` report membership. Imports through the integration subsystem
+ * barrel to lock the public export surface.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  MemoryEntityChangeSourceRegistry,
+  UnknownEntityError,
+  ENTITY_CHANGE_SOURCE_REGISTRY,
+  type IChangeSource,
+  type IEntityChangeSourceRegistry,
+} from '../../../../runtime/subsystems/integration';
+
+/** Minimal IChangeSource fake — the registry never calls listChanges. */
+function fakeSource<T = unknown>(label: string): IChangeSource<T> {
+  return {
+    label,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async *listChanges() {
+      /* no changes */
+    },
+  };
+}
+
+function makeRegistry(
+  names: string[],
+): { registry: IEntityChangeSourceRegistry; sources: Map<string, IChangeSource<unknown>> } {
+  const sources = new Map<string, IChangeSource<unknown>>(
+    names.map((n) => [n, fakeSource(`poll-${n}`)]),
+  );
+  return { registry: new MemoryEntityChangeSourceRegistry(sources), sources };
+}
+
+describe('MemoryEntityChangeSourceRegistry', () => {
+  it('get() resolves a registered source', () => {
+    const { registry, sources } = makeRegistry(['account', 'contact']);
+    expect(registry.get('account')).toBe(sources.get('account')!);
+    expect(registry.get('account').label).toBe('poll-account');
+  });
+
+  it('get() is generic — returns the source typed to the requested T', () => {
+    interface Account {
+      id: string;
+    }
+    const sources = new Map<string, IChangeSource<unknown>>([
+      ['account', fakeSource<Account>('poll-account')],
+    ]);
+    const registry = new MemoryEntityChangeSourceRegistry(sources);
+    const source = registry.get<Account>('account');
+    expect(source.label).toBe('poll-account');
+  });
+
+  it('get() throws UnknownEntityError listing available entities on a miss', () => {
+    const { registry } = makeRegistry(['account', 'contact']);
+    expect(() => registry.get('deal')).toThrow(UnknownEntityError);
+    try {
+      registry.get('deal');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnknownEntityError);
+      expect((err as Error).name).toBe('UnknownEntityError');
+      expect((err as Error).message).toBe(
+        "No change source registered for entity 'deal'. Available: account, contact",
+      );
+    }
+  });
+
+  it('has() reports membership', () => {
+    const { registry } = makeRegistry(['account']);
+    expect(registry.has('account')).toBe(true);
+    expect(registry.has('contact')).toBe(false);
+  });
+
+  it('entities() lists all registered entity names in insertion order', () => {
+    const { registry } = makeRegistry(['account', 'contact', 'lead']);
+    expect(registry.entities()).toEqual(['account', 'contact', 'lead']);
+  });
+
+  it('entities() on an empty registry is empty; get() lists nothing available', () => {
+    const { registry } = makeRegistry([]);
+    expect(registry.entities()).toEqual([]);
+    expect(() => registry.get('account')).toThrow(
+      "No change source registered for entity 'account'. Available: ",
+    );
+  });
+
+  it('exposes the DI token as a string constant', () => {
+    expect(ENTITY_CHANGE_SOURCE_REGISTRY).toBe('ENTITY_CHANGE_SOURCE_REGISTRY');
+  });
+});


### PR DESCRIPTION
Implements **#336** (Track C, parent #328). Adds the L1 entity-keyed change-source registry — the foundation that lets C6's `<Surface>Port` be entity-agnostic and the critical-path unblock for Track D D3/D4 (RFC-0001 §3 emits the wiring that populates it).

Pure protocol + memory impl. **No codegen emission changes**: the existing per-entity `<ENTITY>_POLL_FETCH_REGISTRY` tokens keep emitting unchanged; the swap-over is a coordinated Track D change (RFC §8).

## What landed (in the integration subsystem)
- **`entity-change-source-registry.protocol.ts`** — `IEntityChangeSourceRegistry` (`get<T>(name)` throwing `UnknownEntityError`, `has`, `entities()`) + `UnknownEntityError` (message enumerates available entities).
- **`entity-change-source-registry.memory.ts`** — `MemoryEntityChangeSourceRegistry` backed by `Map<entity, IChangeSource>`.
- **`integration.tokens.ts`** — `ENTITY_CHANGE_SOURCE_REGISTRY` token.
- **`index.ts`** — all three exported from the subsystem barrel.
- **Tests** — `get` hit/miss (UnknownEntityError + available list), generic `get`, `has`, `entities()` ordering, empty registry, token value.
- **`.claude/skills/integration/protocols-and-ports.md`** — one-line protocol note (full coverage deferred to the C5 surface-authoring guide, per DoD).

## Path corrections vs the (stale) issue
- The issue says `packages/codegen/src/subsystems/sync/` — this repo has no `packages/codegen/` layout and `sync` was renamed to `integration` (ADR-0005). Files live in `runtime/subsystems/integration/`, importing `IChangeSource<T>` from there. (Per team-lead's correction.)
- C1 dependency is L3-use-only; the L1 protocol + memory impl are standalone and built now.

## Interpretation call — DI token type
The issue's code block proposes `ENTITY_CHANGE_SOURCE_REGISTRY = Symbol.for('@pattern-stack/codegen.entity-change-source-registry')`. The integration subsystem **deliberately uses string-constant tokens** (documented rationale in `integration.tokens.ts`: "String constants (not Symbols) so they match by value across import boundaries — same convention as the events subsystem"). I made the token a **string constant** for internal consistency with the other `INTEGRATION_*` tokens, and documented the deviation inline. `Symbol.for` would also match across boundaries, so if you'd rather honor the issue's namespaced-symbol key verbatim, it's a one-line change — say the word.

## Tests
`just test-all` green (EXIT=0): 2270 unit (+7 new) + baseline + smoke + junction snapshots. `tsc` clean on all touched files (the 3 pre-existing junction/barrel errors are on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)