### PR TITLE
feat(track-c): C1 — bootstrap @pattern-stack/codegen-crm + IFieldDefinitionReader

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
   ],
   "devDependencies": {
     "@anatine/zod-openapi": "^2.2.8",
+    "@pattern-stack/codegen-crm": "workspace:*",
     "@cubejs-client/core": "^1.0.0",
     "@nestjs/common": "10",
     "@nestjs/core": "10",

--- a/packages/codegen-crm/README.md
+++ b/packages/codegen-crm/README.md
@@ -1,0 +1,48 @@
+# @pattern-stack/codegen-crm
+
+The **L2 CRM surface package** for [`@pattern-stack/codegen`](https://www.npmjs.com/package/@pattern-stack/codegen).
+
+A *surface package* ships the type-shaped **ports** and **DI tokens** for one
+integration surface (here: CRM — `account`, `contact`, `opportunity`). The
+code generator emits an L3 composing port (`CrmPort`) that injects these ports;
+consumers implement them against a specific provider (Salesforce, HubSpot, …).
+The full rationale — why surface vocabulary lives in a per-surface package
+rather than in the codegen core — is in **[ADR-036 — Surface packages](../../docs/adrs/ADR-036-surface-packages.md)**.
+
+## Layers
+
+```
+L1  @pattern-stack/codegen        — codegen subsystems (IChangeSource, registries)
+L2  @pattern-stack/codegen-crm    — THIS PACKAGE: type-shaped CRM ports + tokens
+L3  generated CrmPort             — composes the L2 ports (Track C · C6)
+    consumer adapters             — implement the ports per provider
+```
+
+## Exports
+
+| Export | Kind | Since |
+|---|---|---|
+| `IFieldDefinitionReader` | port — lists a provider's CRM field definitions (standard + custom) | C1 (#330) |
+| `CrmFieldDescriptor`, `CrmFieldType`, `CrmEntity` | type vocab | C1 (#330) |
+| `CRM_FIELD_DEFINITION_READER` | DI token (`Symbol.for`) | C1 (#330) |
+
+```ts
+import {
+  IFieldDefinitionReader,
+  CRM_FIELD_DEFINITION_READER,
+  type CrmFieldDescriptor,
+} from '@pattern-stack/codegen-crm';
+```
+
+This package ships **ports only** — no implementing classes. Implementations
+are consumer-side (e.g. `pattern-stack/integration-patterns`).
+
+## Roadmap
+
+- **C2** — `IPicklistReader`
+- **C3** — `IAssociationReader`
+- **C4** — `CrmCapabilities` descriptor
+
+## License
+
+MIT

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@pattern-stack/codegen-crm",
+  "version": "0.1.0",
+  "description": "L2 CRM surface package for @pattern-stack/codegen — type-shaped CRM ports (field/picklist/association readers) and DI tokens. See ADR-036.",
+  "type": "module",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean --out-dir dist",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "peerDependencies": {
+    "@pattern-stack/codegen": "^0.11.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^6.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/codegen-crm/src/index.ts
+++ b/packages/codegen-crm/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @pattern-stack/codegen-crm — public surface barrel.
+ *
+ * The L2 CRM surface package: type-shaped ports + DI tokens that the generated
+ * L3 `CrmPort` composes. See ADR-036 (surface packages) and ../README.md.
+ */
+
+export * from './ports/field-definition-reader.port';
+export * from './tokens';

--- a/packages/codegen-crm/src/ports/field-definition-reader.port.ts
+++ b/packages/codegen-crm/src/ports/field-definition-reader.port.ts
@@ -1,0 +1,72 @@
+/**
+ * CRM L2 port — field-definition reader (Track C · C1, #330).
+ *
+ * `IFieldDefinitionReader` is the type-shaped port a consumer implements to
+ * expose a provider's CRM field metadata (standard + custom fields) to the
+ * generated L3 `CrmPort` (C6). The vocabulary that shapes it — `CrmFieldType`,
+ * `CrmFieldDescriptor`, the `account | contact | opportunity` entity set —
+ * lives HERE in the CRM surface package, not in `@pattern-stack/codegen`
+ * (ADR-036 §7: surface-specific type vocab is owned by the surface package).
+ *
+ * This package ships the port only. The implementing class is consumer-side
+ * (tracked in `pattern-stack/integration-patterns`); nothing here implements it.
+ */
+
+/** Canonical CRM entities this surface serves. */
+export type CrmEntity = 'account' | 'contact' | 'opportunity';
+
+/**
+ * Normalized CRM field type. Providers' native field types map onto this closed
+ * vocabulary by the consumer's reader implementation. `unknown` is the explicit
+ * escape hatch for a provider type with no canonical mapping (kept rather than
+ * throwing, so a single unmapped field doesn't fail the whole listing).
+ */
+export type CrmFieldType =
+  | 'string'
+  | 'text'
+  | 'number'
+  | 'currency'
+  | 'percent'
+  | 'date'
+  | 'datetime'
+  | 'boolean'
+  | 'picklist'
+  | 'multipicklist'
+  | 'reference'
+  | 'unknown';
+
+/** One field definition from a provider, normalized to the CRM vocab. */
+export interface CrmFieldDescriptor {
+  /** Provider field id / API name. */
+  id: string;
+  /** User-facing name. */
+  label: string;
+  /** Normalized field type. */
+  type: CrmFieldType;
+  /** Which CRM entity this field belongs to. */
+  entity: CrmEntity;
+  /** True for provider custom fields, false for standard fields. */
+  custom: boolean;
+  /**
+   * Optional provider-specific extras — picklist values, string length,
+   * reference target, etc. Deliberately untyped at this seam; downstream
+   * readers (C2 `IPicklistReader`, C3 `IAssociationReader`) own the shaped
+   * accessors.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Reads field definitions for a CRM entity from a provider connection.
+ */
+export interface IFieldDefinitionReader {
+  /**
+   * List field definitions for a given entity type from the provider.
+   * Returns BOTH standard and custom fields; the consumer filters with
+   * `descriptor.custom` when only custom fields are needed.
+   *
+   * @param integrationId The connection / integration identifier to read against.
+   * @param entity        The CRM entity whose fields to list.
+   */
+  list(integrationId: string, entity: CrmEntity): Promise<CrmFieldDescriptor[]>;
+}

--- a/packages/codegen-crm/src/tokens.ts
+++ b/packages/codegen-crm/src/tokens.ts
@@ -1,0 +1,19 @@
+/**
+ * CRM surface package — DI tokens (Track C · C1, #330).
+ *
+ * One token per CRM L2 port. Consumers bind their reader implementations to
+ * these in their NestJS module; the generated L3 `CrmPort` (C6) injects them.
+ *
+ * `Symbol.for(...)` (the global symbol registry) is used so a token matches by
+ * key across duplicated module instances / import boundaries — important for a
+ * published package that may be deduped or doubly-installed in a consumer tree.
+ * This package establishes its own token convention (it is the first surface
+ * package); the integration *subsystem* uses string tokens for its own
+ * documented reasons, but a standalone published surface package is the case
+ * `Symbol.for` is designed for.
+ */
+
+/** DI token for the CRM `IFieldDefinitionReader` (C1). */
+export const CRM_FIELD_DEFINITION_READER = Symbol.for(
+  '@pattern-stack/codegen-crm.field-definition-reader',
+);

--- a/packages/codegen-crm/tsconfig.json
+++ b/packages/codegen-crm/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "//": "Standalone library config. There is no shared library base to extend (the repo-root tsconfig.json extends test/scaffold and carries scaffold-only paths/includes unsuited to a published lib); mirrors the compilerOptions used by tsconfig.build.json. See ADR-036.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/src/__tests__/packages/codegen-crm-smoke.test.ts
+++ b/src/__tests__/packages/codegen-crm-smoke.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Cross-workspace smoke test for @pattern-stack/codegen-crm (Track C · C1, #330).
+ *
+ * Resolves the package BY ITS PUBLISHED NAME from a sibling workspace (the
+ * codegen root, where this test lives) — proving `bun install` linked the new
+ * workspace package and its public barrel exports the C1 port + token. This is
+ * the issue's "a consumer workspace imports IFieldDefinitionReader and
+ * CRM_FIELD_DEFINITION_READER … both resolve" DoD check.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  CRM_FIELD_DEFINITION_READER,
+  type IFieldDefinitionReader,
+  type CrmFieldDescriptor,
+  type CrmFieldType,
+  type CrmEntity,
+} from '@pattern-stack/codegen-crm';
+
+describe('@pattern-stack/codegen-crm public barrel', () => {
+  it('exports the CRM_FIELD_DEFINITION_READER token as a registered symbol', () => {
+    expect(typeof CRM_FIELD_DEFINITION_READER).toBe('symbol');
+    // Symbol.for → registered in the global registry under the package-scoped key.
+    expect(CRM_FIELD_DEFINITION_READER.description).toBe(
+      '@pattern-stack/codegen-crm.field-definition-reader',
+    );
+    expect(CRM_FIELD_DEFINITION_READER).toBe(
+      Symbol.for('@pattern-stack/codegen-crm.field-definition-reader'),
+    );
+  });
+
+  it('exposes IFieldDefinitionReader as an implementable type-shaped port', async () => {
+    // A trivial in-test implementation proves the port + vocab types compose.
+    const descriptor: CrmFieldDescriptor = {
+      id: 'Amount',
+      label: 'Amount',
+      type: 'currency' satisfies CrmFieldType,
+      entity: 'opportunity' satisfies CrmEntity,
+      custom: false,
+    };
+    const reader: IFieldDefinitionReader = {
+      async list(_integrationId, entity) {
+        return entity === 'opportunity' ? [descriptor] : [];
+      },
+    };
+    await expect(reader.list('conn-1', 'opportunity')).resolves.toEqual([descriptor]);
+    await expect(reader.list('conn-1', 'account')).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements **#330** (Track C, parent #328). Creates the first L2 surface package — validating the surface-package convention end-to-end (ADR-036, merged in #400).

## What landed
- **`packages/codegen-crm/`** workspace package: `package.json` (`@pattern-stack/codegen-crm`, ESM, publishable), `tsconfig.json`, `README.md` (links ADR-036), `src/{index.ts, tokens.ts, ports/field-definition-reader.port.ts}`.
- **`IFieldDefinitionReader`** port + `CrmFieldDescriptor` / `CrmFieldType` / `CrmEntity` vocab. The type-shaped CRM vocab lives **in codegen-crm, not in codegen** (ADR-036 §7).
- **`CRM_FIELD_DEFINITION_READER`** = `Symbol.for('@pattern-stack/codegen-crm.field-definition-reader')` token + public barrel re-exporting port + token.
- Cross-workspace **smoke test** (`src/__tests__/packages/codegen-crm-smoke.test.ts`) resolves the port + token **by package name** from the root workspace.

## Verified
- `bun install` links the workspace package (symlinked into `node_modules/@pattern-stack/codegen-crm`).
- Package `tsc --noEmit` clean; `tsup` build emits `dist/` (index.js + .d.ts).
- `npm publish --dry-run` packs cleanly — ships `README.md` + `dist/` + `package.json` only (no `src`, via `prepublishOnly` build).
- `just test-all` green (EXIT=0): 2272 unit (+2 cross-workspace smoke) + baseline + smoke + junction.

## ⚠️ Publish-pipeline finding (flagged — NOT changed here)
`just publish` runs a **single root `npm publish`** from an `origin/main` worktree; it does **not** iterate workspaces. So as-is it will **not** publish `@pattern-stack/codegen-crm`. Per your "stop and flag if multi-package release orchestration is non-trivial" guidance, I did **not** rewire the release pipeline — the package is independently publishable (dry-run verified), but turning `just publish` into a multi-package release is a separate decision. **Needs your call** (options: per-package `just publish-crm`, a workspace-loop in `publish`, or a changesets-style tool).

## Interpretation calls
1. **`@pattern-stack/codegen` dependency.** The root package is the workspace *root*, not a `packages/*` member, so a member can't `workspace:*`-reference it. Expressed codegen as a **`peerDependency: ^0.11.0`** on codegen-crm (the semantically correct L2-beside-L1 relationship — the consumer installs both). Nothing is imported from codegen yet (forward-looking). Root dev-depends on codegen-crm (`workspace:*`) so the root test suite can import it by name.
2. **Version `0.1.0`** for the new package (matches the existing `@pattern-stack/graph-components` precedent; independent semver, not lockstep with codegen 0.11.0). Flag if you want lockstep.
3. **`tsconfig.json` is standalone**, not `extends`-ing a base — there is no shared *library* base (root tsconfig extends `test/scaffold` with scaffold-only paths/includes); mirrors `tsconfig.build.json` compilerOptions. Matches the graph-components precedent.
4. **`CrmEntity` type alias** extracted from the inline `'account'|'contact'|'opportunity'` union for reuse across the descriptor + `list()` — the issue invited refinement ("lock it in code review").
5. **Token is `Symbol.for`** per the issue verbatim — correct here (fresh package, no prior convention; contrast C7 where the integration subsystem's established string-token convention won).

`crm` stays `crm` per the C0 naming note (own surface, no context clash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)