### PR TITLE
feat(track-c): C2–C4 — CRM picklist/association readers + capabilities

### DIFF
--- a/packages/codegen-crm/README.md
+++ b/packages/codegen-crm/README.md
@@ -25,6 +25,16 @@ L3  generated CrmPort             — composes the L2 ports (Track C · C6)
 | `IFieldDefinitionReader` | port — lists a provider's CRM field definitions (standard + custom) | C1 (#330) |
 | `CrmFieldDescriptor`, `CrmFieldType`, `CrmEntity` | type vocab | C1 (#330) |
 | `CRM_FIELD_DEFINITION_READER` | DI token (`Symbol.for`) | C1 (#330) |
+| `IPicklistReader`, `CrmPicklistValue` | port — resolves picklist/multipicklist field values | C2 (#331) |
+| `CRM_PICKLIST_READER` | DI token (`Symbol.for`) | C2 (#331) |
+| `IAssociationReader`, `CrmAssociation`, `CrmEntityType` | port — reads cross-entity associations | C3 (#332) |
+| `CRM_ASSOCIATION_READER` | DI token (`Symbol.for`) | C3 (#332) |
+| `CrmCapabilities`, `NO_CRM_CAPABILITIES` | per-adapter capability descriptor | C4 (#333) |
+| `CRM_CAPABILITIES` | DI token (`Symbol.for`) | C4 (#333) |
+
+> `CrmEntityType` (C3) is an alias of the canonical `CrmEntity` (C1) — the
+> union `'account' | 'contact' | 'opportunity'` has one source of truth; both
+> names are exported.
 
 ```ts
 import {
@@ -37,11 +47,46 @@ import {
 This package ships **ports only** — no implementing classes. Implementations
 are consumer-side (e.g. `pattern-stack/integration-patterns`).
 
+## Declaring capabilities
+
+An adapter declares which ports it implements and which entities it serves by
+spreading on top of `NO_CRM_CAPABILITIES`, and registers the descriptor under
+the `CRM_CAPABILITIES` token:
+
+```ts
+import {
+  type CrmCapabilities,
+  NO_CRM_CAPABILITIES,
+  CRM_CAPABILITIES,
+} from '@pattern-stack/codegen-crm';
+
+export const HUBSPOT_CRM_CAPABILITIES: CrmCapabilities = {
+  ...NO_CRM_CAPABILITIES,
+  fieldDefinitions: true,
+  picklists: true,
+  associations: true,
+  entities: ['account', 'contact', 'opportunity'],
+};
+
+// in the adapter's NestJS module:
+// { provide: CRM_CAPABILITIES, useValue: HUBSPOT_CRM_CAPABILITIES }
+```
+
+A consumer queries capabilities at runtime to gate behaviour:
+
+```ts
+if (caps.fieldDefinitions && caps.entities.includes('lead')) {
+  // safe to read custom fields for `lead` on this provider
+}
+```
+
+`entities` is runtime coverage data, not a type bound on the L3 `CrmPort` — the
+port stays entity-agnostic (ADR-036 §6). C6's `assertCrmAdapter()` checks each
+declared entity resolves via the change-source registry.
+
 ## Roadmap
 
-- **C2** — `IPicklistReader`
-- **C3** — `IAssociationReader`
-- **C4** — `CrmCapabilities` descriptor
+- **C6** — generated `CrmPort` composing port + `assertCrmAdapter`
 
 ## License
 

--- a/packages/codegen-crm/src/capabilities.ts
+++ b/packages/codegen-crm/src/capabilities.ts
@@ -1,0 +1,51 @@
+/**
+ * CRM surface capability descriptor (Track C · C4, #333).
+ *
+ * Each consumer adapter declares which CRM ports it implements and which
+ * entities it serves. The consumer framework uses this for runtime gating
+ * (e.g. "disable the Custom Fields UI for a provider that doesn't implement
+ * `IFieldDefinitionReader`").
+ *
+ * `entities` is **runtime data**, not a type bound on the L3 `CrmPort` (epic
+ * #328 locked decision #7 / ADR-036 §6): the port stays entity-agnostic, and
+ * capabilities declare which consumer-defined entities a given adapter can
+ * resolve. Consumers query at runtime — `caps.entities.includes('lead')`. C6's
+ * `assertCrmAdapter()` checks each `entities` entry resolves via the change
+ * source registry.
+ */
+
+export interface CrmCapabilities {
+  /** Implements `IFieldDefinitionReader`. */
+  fieldDefinitions: boolean;
+  /** Implements `IPicklistReader`. */
+  picklists: boolean;
+  /** Implements `IAssociationReader`. */
+  associations: boolean;
+  /**
+   * Consumer-defined entity names this adapter can resolve (runtime coverage,
+   * not a type bound). e.g. `['account', 'contact', 'opportunity', 'lead']`.
+   */
+  entities: readonly string[];
+  // Future ports get a boolean here as they ship.
+}
+
+/**
+ * The empty capability set — no ports, no entities. Spread on top to declare
+ * what an adapter supports:
+ *
+ * ```ts
+ * const HUBSPOT_CRM_CAPABILITIES: CrmCapabilities = {
+ *   ...NO_CRM_CAPABILITIES,
+ *   fieldDefinitions: true,
+ *   picklists: true,
+ *   associations: true,
+ *   entities: ['account', 'contact', 'opportunity'],
+ * };
+ * ```
+ */
+export const NO_CRM_CAPABILITIES: CrmCapabilities = {
+  fieldDefinitions: false,
+  picklists: false,
+  associations: false,
+  entities: [],
+};

--- a/packages/codegen-crm/src/index.ts
+++ b/packages/codegen-crm/src/index.ts
@@ -6,4 +6,7 @@
  */
 
 export * from './ports/field-definition-reader.port';
+export * from './ports/picklist-reader.port';
+export * from './ports/association-reader.port';
+export * from './capabilities';
 export * from './tokens';

--- a/packages/codegen-crm/src/ports/association-reader.port.ts
+++ b/packages/codegen-crm/src/ports/association-reader.port.ts
@@ -1,0 +1,52 @@
+/**
+ * CRM L2 port — association reader (Track C · C3, #332).
+ *
+ * Reads cross-entity associations (contact ↔ account ↔ opportunity). Both
+ * HubSpot (associations API) and Salesforce (lookup / master-detail
+ * relationships) expose this. Read-side only — outbound association writes are
+ * L1 sink territory + per-provider semantics (out of scope here).
+ *
+ * Ports only — the implementing class is consumer-side (ADR-036).
+ */
+
+import type { CrmEntity } from './field-definition-reader.port';
+
+/**
+ * The CRM entity set, under the C3 issue's `CrmEntityType` name. Aliased to the
+ * canonical `CrmEntity` (C1) so the package has a single source of truth for
+ * the union while both names resolve for consumers.
+ */
+export type CrmEntityType = CrmEntity;
+
+/** One association edge between two CRM records. */
+export interface CrmAssociation {
+  fromEntity: CrmEntityType;
+  fromId: string;
+  toEntity: CrmEntityType;
+  toId: string;
+  /** Provider-specific association type (HubSpot association type id, SFDC relationship name). */
+  associationType?: string;
+  /** Optional cardinality hint — the primary related record, when the provider distinguishes one. */
+  primary?: boolean;
+}
+
+/**
+ * Reads associations from one record to related records of a target entity.
+ */
+export interface IAssociationReader {
+  /**
+   * List associations from a single record to all related records of a given
+   * target entity.
+   *
+   * @param integrationId The connection / integration identifier.
+   * @param fromEntity    The source record's entity.
+   * @param fromId        The source record's provider id.
+   * @param toEntity      The target entity to list related records of.
+   */
+  list(
+    integrationId: string,
+    fromEntity: CrmEntityType,
+    fromId: string,
+    toEntity: CrmEntityType,
+  ): Promise<CrmAssociation[]>;
+}

--- a/packages/codegen-crm/src/ports/picklist-reader.port.ts
+++ b/packages/codegen-crm/src/ports/picklist-reader.port.ts
@@ -1,0 +1,44 @@
+/**
+ * CRM L2 port — picklist-value reader (Track C · C2, #331).
+ *
+ * Resolves the allowed values for a CRM picklist / multipicklist field. Both
+ * HubSpot (enumerated property options) and Salesforce (Picklist field types
+ * via `describeSObject`) expose this surface. Consumers typically call this
+ * AFTER `IFieldDefinitionReader` returns a `picklist`/`multipicklist`
+ * descriptor.
+ *
+ * Ports only — the implementing class is consumer-side (ADR-036).
+ */
+
+import type { CrmEntity } from './field-definition-reader.port';
+
+/** One allowed value of a CRM picklist field. */
+export interface CrmPicklistValue {
+  /** Wire value (the value stored/transmitted). */
+  value: string;
+  /** User-facing label. */
+  label: string;
+  /** Whether the value is currently active/selectable. */
+  active: boolean;
+  /** True if this is the field's default value. */
+  defaultValue?: boolean;
+}
+
+/**
+ * Reads picklist values for a `(entity, field)` pair from a provider.
+ */
+export interface IPicklistReader {
+  /**
+   * Resolve picklist values for a given (entity, field) pair. Call after
+   * `IFieldDefinitionReader` surfaces a `picklist`/`multipicklist` field.
+   *
+   * @param integrationId The connection / integration identifier.
+   * @param entity        The CRM entity owning the field.
+   * @param fieldId       The provider field id / API name (the descriptor `id`).
+   */
+  values(
+    integrationId: string,
+    entity: CrmEntity,
+    fieldId: string,
+  ): Promise<CrmPicklistValue[]>;
+}

--- a/packages/codegen-crm/src/tokens.ts
+++ b/packages/codegen-crm/src/tokens.ts
@@ -17,3 +17,18 @@
 export const CRM_FIELD_DEFINITION_READER = Symbol.for(
   '@pattern-stack/codegen-crm.field-definition-reader',
 );
+
+/** DI token for the CRM `IPicklistReader` (C2). */
+export const CRM_PICKLIST_READER = Symbol.for(
+  '@pattern-stack/codegen-crm.picklist-reader',
+);
+
+/** DI token for the CRM `IAssociationReader` (C3). */
+export const CRM_ASSOCIATION_READER = Symbol.for(
+  '@pattern-stack/codegen-crm.association-reader',
+);
+
+/** DI token for an adapter's `CrmCapabilities` descriptor (C4). */
+export const CRM_CAPABILITIES = Symbol.for(
+  '@pattern-stack/codegen-crm.capabilities',
+);

--- a/src/__tests__/packages/codegen-crm-smoke.test.ts
+++ b/src/__tests__/packages/codegen-crm-smoke.test.ts
@@ -11,10 +11,20 @@
 import { describe, it, expect } from 'bun:test';
 import {
   CRM_FIELD_DEFINITION_READER,
+  CRM_PICKLIST_READER,
+  CRM_ASSOCIATION_READER,
+  CRM_CAPABILITIES,
+  NO_CRM_CAPABILITIES,
   type IFieldDefinitionReader,
+  type IPicklistReader,
+  type IAssociationReader,
   type CrmFieldDescriptor,
   type CrmFieldType,
   type CrmEntity,
+  type CrmEntityType,
+  type CrmPicklistValue,
+  type CrmAssociation,
+  type CrmCapabilities,
 } from '@pattern-stack/codegen-crm';
 
 describe('@pattern-stack/codegen-crm public barrel', () => {
@@ -45,5 +55,68 @@ describe('@pattern-stack/codegen-crm public barrel', () => {
     };
     await expect(reader.list('conn-1', 'opportunity')).resolves.toEqual([descriptor]);
     await expect(reader.list('conn-1', 'account')).resolves.toEqual([]);
+  });
+
+  it('C2 — exports IPicklistReader + CRM_PICKLIST_READER', async () => {
+    expect(CRM_PICKLIST_READER).toBe(
+      Symbol.for('@pattern-stack/codegen-crm.picklist-reader'),
+    );
+    const value: CrmPicklistValue = { value: 'new', label: 'New', active: true };
+    const reader: IPicklistReader = {
+      async values(_id, _entity, _fieldId) {
+        return [value];
+      },
+    };
+    await expect(reader.values('conn-1', 'opportunity', 'StageName')).resolves.toEqual([
+      value,
+    ]);
+  });
+
+  it('C3 — exports IAssociationReader + CRM_ASSOCIATION_READER (CrmEntityType aliases CrmEntity)', async () => {
+    expect(CRM_ASSOCIATION_READER).toBe(
+      Symbol.for('@pattern-stack/codegen-crm.association-reader'),
+    );
+    // CrmEntityType is the same union as CrmEntity — a value typed as one is
+    // assignable to the other (alias, single source of truth).
+    const entity: CrmEntityType = 'contact';
+    const asEntity: CrmEntity = entity;
+    expect(asEntity).toBe('contact');
+
+    const assoc: CrmAssociation = {
+      fromEntity: 'contact',
+      fromId: 'c1',
+      toEntity: 'account',
+      toId: 'a1',
+      primary: true,
+    };
+    const reader: IAssociationReader = {
+      async list(_id, from, _fromId, to) {
+        return from === 'contact' && to === 'account' ? [assoc] : [];
+      },
+    };
+    await expect(reader.list('conn-1', 'contact', 'c1', 'account')).resolves.toEqual([
+      assoc,
+    ]);
+  });
+
+  it('C4 — CrmCapabilities + NO_CRM_CAPABILITIES + CRM_CAPABILITIES token', () => {
+    expect(CRM_CAPABILITIES).toBe(Symbol.for('@pattern-stack/codegen-crm.capabilities'));
+    expect(NO_CRM_CAPABILITIES).toEqual({
+      fieldDefinitions: false,
+      picklists: false,
+      associations: false,
+      entities: [],
+    });
+    const caps: CrmCapabilities = {
+      ...NO_CRM_CAPABILITIES,
+      fieldDefinitions: true,
+      picklists: true,
+      entities: ['account', 'contact', 'opportunity'],
+    };
+    expect(caps.fieldDefinitions).toBe(true);
+    expect(caps.associations).toBe(false); // inherited from NO_CRM_CAPABILITIES
+    expect(caps.entities).toEqual(['account', 'contact', 'opportunity']);
+    // NO_CRM_CAPABILITIES is not mutated by the spread.
+    expect(NO_CRM_CAPABILITIES.entities).toEqual([]);
   });
 });


### PR DESCRIPTION
Implements **#331, #332, #333** in one PR — the remaining CRM L2 ports + the capability descriptor, all added to `@pattern-stack/codegen-crm` following the C1 conventions (`Symbol.for` tokens; vocab lives in codegen-crm, not codegen; ADR-036). Stacked on C1 (#406, merged); rebased onto `origin/main` so the diff is C2–C4 only.

## What landed
- **C2 (#331)** — `src/ports/picklist-reader.port.ts`: `IPicklistReader` + `CrmPicklistValue`; `CRM_PICKLIST_READER` token.
- **C3 (#332)** — `src/ports/association-reader.port.ts`: `IAssociationReader` + `CrmAssociation`; `CRM_ASSOCIATION_READER` token.
- **C4 (#333)** — `src/capabilities.ts`: `CrmCapabilities` + `NO_CRM_CAPABILITIES`; `CRM_CAPABILITIES` token. Includes the scope-amendment `entities: readonly string[]` field.
- `index.ts` re-exports all three; README documents every export + the capability spread pattern + a consumer query example.
- Smoke test extended (now 5 cases): each port implementable, each token a registered `Symbol.for`, `NO_CRM_CAPABILITIES` shape + non-mutating spread.

## Key design point (C4)
`CrmCapabilities.entities` is **runtime coverage data, not a type bound** on the L3 `CrmPort` — the port stays entity-agnostic (ADR-036 §6 / epic #328 locked decision #7). C6's `assertCrmAdapter()` will verify each declared entity resolves via the change-source registry (C7). Per-method capability granularity is explicitly v1-deferred (boolean per-port), per the issue's open question.

## Interpretation call
**`CrmEntityType` (C3) is exported as an alias of the canonical `CrmEntity` (C1).** Both name the union `'account' | 'contact' | 'opportunity'`; C1 shipped `CrmEntity`, the C3 issue's code block names it `CrmEntityType`. Rather than two divergent definitions, there's one source of truth (`CrmEntity`) with `CrmEntityType` as an alias — both names exported, C2's `values()` and C3's association shapes both reference the canonical union. Flag if you'd prefer a single name.

## Tests
`just test-all` green (EXIT=0): 2275 unit (+3 new smoke cases) + baseline + smoke + junction. Package `tsc --noEmit` clean; `tsup` build emits `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)