### PR TITLE
feat(track-c): C6 — CrmPort + assertCrmAdapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
     },
+    "./subsystems": {
+      "types": "./dist/runtime/subsystems/index.d.ts",
+      "default": "./dist/runtime/subsystems/index.js"
+    },
     "./runtime/*": {
       "types": "./dist/runtime/*.d.ts",
       "default": "./dist/runtime/*.js"

--- a/packages/codegen-crm/README.md
+++ b/packages/codegen-crm/README.md
@@ -31,6 +31,9 @@ L3  generated CrmPort             — composes the L2 ports (Track C · C6)
 | `CRM_ASSOCIATION_READER` | DI token (`Symbol.for`) | C3 (#332) |
 | `CrmCapabilities`, `NO_CRM_CAPABILITIES` | per-adapter capability descriptor | C4 (#333) |
 | `CRM_CAPABILITIES` | DI token (`Symbol.for`) | C4 (#333) |
+| `CrmPort` | L3 composing port — the contract an adapter implements (entity-agnostic) | C6 (#337) |
+| `CRM_PORT` | DI token (`Symbol.for`) | C6 (#337) |
+| `assertCrmAdapter` (from `@pattern-stack/codegen-crm/testing`) | conformance helper | C6 (#337) |
 
 > `CrmEntityType` (C3) is an alias of the canonical `CrmEntity` (C1) — the
 > union `'account' | 'contact' | 'opportunity'` has one source of truth; both
@@ -84,9 +87,37 @@ if (caps.fieldDefinitions && caps.entities.includes('lead')) {
 port stays entity-agnostic (ADR-036 §6). C6's `assertCrmAdapter()` checks each
 declared entity resolves via the change-source registry.
 
+## The composing port — `CrmPort`
+
+`CrmPort` is the single L3 contract a provider adapter implements. It composes
+L1 strategies (`auth`, the entity-keyed `sources` registry) and the L2 ports
+(`fields`, `picklists`, `associations`) plus the runtime `capabilities`
+descriptor. It is **entity-agnostic** — no entity name appears in its type;
+entity access goes through `sources.get<T>(entityName)`. Per-consumer typed
+views are codegen-emitted (Track D), not encoded here.
+
+### Conformance testing
+
+`@pattern-stack/codegen-crm/testing` ships `assertCrmAdapter` — a structural
+check for adapter tests:
+
+```ts
+import { assertCrmAdapter } from '@pattern-stack/codegen-crm/testing';
+
+it('hubspot adapter conforms to CrmPort', () => {
+  assertCrmAdapter(hubspotCrmAdapter); // throws AggregateError listing every gap
+});
+```
+
+It verifies required L1 slots resolve, that `capabilities` flags match the
+present ports, and that every `capabilities.entities` entry resolves via
+`sources.has(name)` — so an adapter declaring an entity it can't source fails
+the test rather than failing at runtime.
+
 ## Roadmap
 
-- **C6** — generated `CrmPort` composing port + `assertCrmAdapter`
+- Surface-only `CrmPort` methods — added only when a consumer feature drives one.
+- Track D D3/D4 — codegen-emitted adapter scaffolds + per-consumer typed views.
 
 ## License
 

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -12,12 +12,17 @@
       "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./testing": {
+      "bun": "./src/testing/index.ts",
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
     }
   },
   "files": ["dist", "README.md"],
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --clean --out-dir dist",
+    "build": "tsup",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run build"
   },

--- a/packages/codegen-crm/src/index.ts
+++ b/packages/codegen-crm/src/index.ts
@@ -8,5 +8,10 @@
 export * from './ports/field-definition-reader.port';
 export * from './ports/picklist-reader.port';
 export * from './ports/association-reader.port';
+export * from './ports/crm.port';
 export * from './capabilities';
 export * from './tokens';
+
+// Note: the conformance helper `assertCrmAdapter` is intentionally NOT exported
+// here — it ships from the '@pattern-stack/codegen-crm/testing' subpath so it
+// stays out of production bundles.

--- a/packages/codegen-crm/src/ports/crm.port.ts
+++ b/packages/codegen-crm/src/ports/crm.port.ts
@@ -1,0 +1,52 @@
+/**
+ * CRM L3 composing port (Track C · C6, #337).
+ *
+ * `CrmPort` is the single contract a CRM provider adapter implements. It
+ * composes L1 strategies (auth + the entity-keyed change-source registry) and
+ * the L2 capability ports (fields / picklists / associations) plus the runtime
+ * capability descriptor.
+ *
+ * **Entity-agnostic by design** — no specific entity name appears anywhere in
+ * this type. Entity access goes through `sources.get<T>(entityName)` at runtime;
+ * per-consumer typed views are codegen-emitted by Track D (D3/D4), not encoded
+ * here (epic #328 locked decision #5 / ADR-036).
+ *
+ * The L1 types (`IAuthStrategy`, `IEntityChangeSourceRegistry`) are imported
+ * across the package boundary from `@pattern-stack/codegen/subsystems` — the
+ * first place L2-imports-L1 is exercised. This is a type-only import (erased at
+ * runtime); see the package tsconfig for in-workspace resolution and the
+ * codegen `exports` map for the published resolution.
+ */
+
+import type {
+  IAuthStrategy,
+  IEntityChangeSourceRegistry,
+} from '@pattern-stack/codegen/subsystems';
+import type { IFieldDefinitionReader } from './field-definition-reader.port';
+import type { IPicklistReader } from './picklist-reader.port';
+import type { IAssociationReader } from './association-reader.port';
+import type { CrmCapabilities } from '../capabilities';
+
+export interface CrmPort {
+  /** L1 — auth strategy resolving credentials for this provider. */
+  readonly auth: IAuthStrategy;
+
+  /** L1 — entity-keyed registry of change sources for this provider's CRM entities. */
+  readonly sources: IEntityChangeSourceRegistry;
+
+  /** L2 — custom-field discovery. */
+  readonly fields: IFieldDefinitionReader;
+
+  /** L2 — picklist values discovery. */
+  readonly picklists: IPicklistReader;
+
+  /** L2 — cross-entity association reads. */
+  readonly associations: IAssociationReader;
+
+  /** L2 — runtime capability descriptor (includes entity coverage). */
+  readonly capabilities: CrmCapabilities;
+
+  // Surface-only methods (CRM-specific) start empty: the port ships with the
+  // L1+L2 composition only and accretes a method here ONLY when a consumer use
+  // case in pattern-stack/integration-patterns forces it (epic #328 DoD).
+}

--- a/packages/codegen-crm/src/testing/assert-crm-adapter.ts
+++ b/packages/codegen-crm/src/testing/assert-crm-adapter.ts
@@ -1,0 +1,97 @@
+/**
+ * CRM adapter conformance helper (Track C · C6, #337; ADR-036 §10).
+ *
+ * `assertCrmAdapter` structurally verifies a `CrmPort` implementation so
+ * consumer adapter tests can catch wiring mistakes (a missing port slot, a
+ * capability flag that doesn't match an implemented port, an entity declared in
+ * `capabilities.entities` with no registered change source) at test time rather
+ * than at NestJS boot or first use.
+ *
+ * Shipped from the `@pattern-stack/codegen-crm/testing` subpath — a test-time
+ * helper, kept out of the package's main runtime barrel.
+ */
+
+import type { CrmPort } from '../ports/crm.port';
+
+export interface AssertCrmAdapterOptions {
+  /**
+   * When true (default), a capability flag set to `true` requires the matching
+   * port slot to be present, AND a port slot that IS present requires its
+   * capability flag to be `true` (no silently-undeclared ports). When false,
+   * only the "capability true ⇒ port present" direction is checked.
+   */
+  respectCapabilities?: boolean;
+}
+
+/**
+ * Structurally verify a `CrmPort` implementation. Collects every failure and
+ * throws a single `AggregateError` listing them all (rather than failing on the
+ * first), so a test reports the complete conformance gap in one run.
+ *
+ * Checks:
+ *   1. Required L1 slots (`auth`, `sources`) resolve to non-null objects.
+ *   2. Capability-driven L2 slots: `capabilities.<port>` ⇒ the slot is present;
+ *      and (when `respectCapabilities`) a present slot ⇒ its flag is `true`.
+ *   3. Every `capabilities.entities` entry resolves via `sources.has(name)`.
+ *
+ * @throws AggregateError when any check fails.
+ */
+export function assertCrmAdapter(
+  adapter: CrmPort,
+  opts: AssertCrmAdapterOptions = {},
+): void {
+  const respectCapabilities = opts.respectCapabilities ?? true;
+  const failures: Error[] = [];
+
+  // 1. Required L1 slots.
+  if (!adapter.auth) failures.push(new Error('CrmPort.auth missing'));
+  if (!adapter.sources) failures.push(new Error('CrmPort.sources missing'));
+
+  // 2. Capability-driven L2 slots.
+  const caps = adapter.capabilities;
+  if (!caps) {
+    failures.push(new Error('CrmPort.capabilities missing'));
+  } else {
+    const l2: ReadonlyArray<[keyof CrmPort, keyof typeof caps, string]> = [
+      ['fields', 'fieldDefinitions', 'fields'],
+      ['picklists', 'picklists', 'picklists'],
+      ['associations', 'associations', 'associations'],
+    ];
+    for (const [slot, flag, label] of l2) {
+      const declared = caps[flag] === true;
+      const present = Boolean(adapter[slot]);
+      if (declared && !present) {
+        failures.push(
+          new Error(`caps.${String(flag)}=true but CrmPort.${label} missing`),
+        );
+      }
+      if (respectCapabilities && present && !declared) {
+        failures.push(
+          new Error(
+            `CrmPort.${label} present but caps.${String(flag)} is not true`,
+          ),
+        );
+      }
+    }
+
+    // 3. Entity coverage matches the change-source registry.
+    if (adapter.sources) {
+      for (const entity of caps.entities) {
+        if (!adapter.sources.has(entity)) {
+          failures.push(
+            new Error(
+              `caps.entities lists '${entity}' but sources.has('${entity}') is false`,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `CrmPort conformance failed (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+    );
+  }
+}

--- a/packages/codegen-crm/src/testing/index.ts
+++ b/packages/codegen-crm/src/testing/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @pattern-stack/codegen-crm/testing — test-time helpers.
+ *
+ * Conformance checks for CRM adapter implementations, kept out of the main
+ * runtime barrel so production bundles don't pull in test scaffolding.
+ */
+
+export * from './assert-crm-adapter';

--- a/packages/codegen-crm/src/tokens.ts
+++ b/packages/codegen-crm/src/tokens.ts
@@ -32,3 +32,6 @@ export const CRM_ASSOCIATION_READER = Symbol.for(
 export const CRM_CAPABILITIES = Symbol.for(
   '@pattern-stack/codegen-crm.capabilities',
 );
+
+/** DI token for the composed `CrmPort` adapter (C6). */
+export const CRM_PORT = Symbol.for('@pattern-stack/codegen-crm.port');

--- a/packages/codegen-crm/tsconfig.json
+++ b/packages/codegen-crm/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "//": "Standalone library config. There is no shared library base to extend (the repo-root tsconfig.json extends test/scaffold and carries scaffold-only paths/includes unsuited to a published lib); mirrors the compilerOptions used by tsconfig.build.json. See ADR-036.",
+  "//": "Standalone library config (no shared library base to extend; mirrors tsconfig.build.json compilerOptions). The `paths` entry resolves the L1 import in-workspace: published consumers resolve @pattern-stack/codegen/subsystems via codegen's package.json `exports` map, but here the root @pattern-stack/codegen is the workspace ROOT (not a packages/* member) so it isn't symlinked into node_modules. typecheck points at codegen's BUILT .d.ts — skipLibCheck applies, so codegen's NestJS/drizzle source isn't pulled in — i.e. `bun run build` at the repo root must run before this package's typecheck. The imports are type-only / erased at runtime, so tests need no build. See ADR-036.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "ignoreDeprecations": "6.0",
     "strict": true,
     "skipLibCheck": true,
     "declaration": true,
@@ -12,7 +13,12 @@
     "verbatimModuleSyntax": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "@pattern-stack/codegen/subsystems": [
+        "../../dist/runtime/subsystems/index.d.ts"
+      ]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]

--- a/packages/codegen-crm/tsup.config.ts
+++ b/packages/codegen-crm/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * Local build config for @pattern-stack/codegen-crm. Without this, tsup walks
+ * up and picks the repo-root tsup.config.ts (whose `tsconfig:
+ * tsconfig.build.json` lacks this package's `paths` mapping for the L1 import),
+ * so the DTS step can't resolve `@pattern-stack/codegen/subsystems`. Pinning the
+ * package tsconfig here makes the cross-package type import resolve during the
+ * declaration build.
+ */
+export default defineConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  outDir: 'dist',
+  format: ['esm'],
+  target: 'node20',
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  tsconfig: 'tsconfig.json',
+});

--- a/runtime/subsystems/index.ts
+++ b/runtime/subsystems/index.ts
@@ -50,6 +50,21 @@ export type {
   CursorSnapshot,
 } from './observability';
 
+// Integration — entity change-source registry (C7) + change-source port.
+// Exposed here so L2 surface packages (e.g. @pattern-stack/codegen-crm) can
+// import them across the package boundary via @pattern-stack/codegen/subsystems
+// (Track C C6). Selective re-export (not `export *`) to avoid the
+// IntegrationRunSummary name clash with the observability barrel above.
+export {
+  ENTITY_CHANGE_SOURCE_REGISTRY,
+  MemoryEntityChangeSourceRegistry,
+  UnknownEntityError,
+} from './integration';
+export type {
+  IEntityChangeSourceRegistry,
+  IChangeSource,
+} from './integration';
+
 // Auth
 export {
   ENCRYPTION_KEY,

--- a/src/__tests__/packages/assert-crm-adapter.test.ts
+++ b/src/__tests__/packages/assert-crm-adapter.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for assertCrmAdapter (Track C · C6, #337).
+ *
+ * Imports the helper from the '@pattern-stack/codegen-crm/testing' subpath
+ * (proving that export resolves) and the CrmPort type + NO_CRM_CAPABILITIES
+ * from the package root. Fakes are plain objects cast to CrmPort — no value is
+ * imported from @pattern-stack/codegen (the L1 types are type-only / erased),
+ * so these run without codegen built or linked.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { assertCrmAdapter } from '@pattern-stack/codegen-crm/testing';
+import {
+  NO_CRM_CAPABILITIES,
+  type CrmPort,
+  type CrmCapabilities,
+} from '@pattern-stack/codegen-crm';
+
+/** Minimal fake of IEntityChangeSourceRegistry over a name set. */
+function fakeSources(names: string[]) {
+  const set = new Set(names);
+  return {
+    has: (n: string) => set.has(n),
+    get: () => {
+      throw new Error('not needed for conformance');
+    },
+    entities: () => [...set],
+  };
+}
+
+/** Build a CrmPort fake; override any slot/capability per test. */
+function makeAdapter(
+  overrides: Partial<Record<keyof CrmPort, unknown>> = {},
+  caps: Partial<CrmCapabilities> = {},
+): CrmPort {
+  const capabilities: CrmCapabilities = { ...NO_CRM_CAPABILITIES, ...caps };
+  const base: Record<string, unknown> = {
+    auth: { label: 'fake-auth' },
+    sources: fakeSources(capabilities.entities as string[]),
+    fields: { list: async () => [] },
+    picklists: { values: async () => [] },
+    associations: { list: async () => [] },
+    capabilities,
+    ...overrides,
+  };
+  return base as unknown as CrmPort;
+}
+
+function failures(fn: () => void): string[] {
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(AggregateError);
+    return (err as AggregateError).errors.map((e) => (e as Error).message);
+  }
+  throw new Error('expected assertCrmAdapter to throw');
+}
+
+describe('assertCrmAdapter — conforming adapters', () => {
+  it('passes a fully-implementing adapter with matching capabilities', () => {
+    const adapter = makeAdapter({}, {
+      fieldDefinitions: true,
+      picklists: true,
+      associations: true,
+      entities: ['account', 'contact', 'opportunity'],
+    });
+    expect(() => assertCrmAdapter(adapter)).not.toThrow();
+  });
+
+  it('passes a no-capability adapter (all flags false, no entities)', () => {
+    // respectCapabilities checks that present ports are declared — so a minimal
+    // conforming adapter omits the undeclared L2 ports.
+    const adapter = makeAdapter({
+      fields: undefined,
+      picklists: undefined,
+      associations: undefined,
+    });
+    expect(() => assertCrmAdapter(adapter)).not.toThrow();
+  });
+});
+
+describe('assertCrmAdapter — failure modes', () => {
+  it('throws when auth is missing', () => {
+    const msgs = failures(() => assertCrmAdapter(makeAdapter({ auth: undefined })));
+    expect(msgs).toContain('CrmPort.auth missing');
+  });
+
+  it('throws when sources is missing', () => {
+    const msgs = failures(() =>
+      assertCrmAdapter(makeAdapter({ sources: undefined })),
+    );
+    expect(msgs).toContain('CrmPort.sources missing');
+  });
+
+  it('throws when a declared capability has no matching port', () => {
+    const adapter = makeAdapter({ fields: undefined }, { fieldDefinitions: true });
+    const msgs = failures(() => assertCrmAdapter(adapter));
+    expect(msgs).toContain('caps.fieldDefinitions=true but CrmPort.fields missing');
+  });
+
+  it("throws when caps.entities lists an entity sources can't resolve", () => {
+    // entities includes 'lead' but the registry only knows account/contact.
+    const adapter = makeAdapter(
+      { sources: fakeSources(['account', 'contact']) },
+      { entities: ['account', 'contact', 'lead'] },
+    );
+    const msgs = failures(() => assertCrmAdapter(adapter));
+    expect(msgs).toContain(
+      "caps.entities lists 'lead' but sources.has('lead') is false",
+    );
+  });
+
+  it('respectCapabilities: flags a present port whose capability is not declared', () => {
+    // fields present but fieldDefinitions=false (default).
+    const adapter = makeAdapter({}, { picklists: true, associations: true });
+    const msgs = failures(() => assertCrmAdapter(adapter));
+    expect(msgs).toContain(
+      'CrmPort.fields present but caps.fieldDefinitions is not true',
+    );
+  });
+
+  it('respectCapabilities:false suppresses the present-but-undeclared check', () => {
+    const adapter = makeAdapter({}, { picklists: true, associations: true });
+    // fields/picklists/associations all present; only picklists+associations declared.
+    expect(() =>
+      assertCrmAdapter(adapter, { respectCapabilities: false }),
+    ).not.toThrow();
+  });
+
+  it('aggregates multiple failures into one AggregateError', () => {
+    const adapter = makeAdapter(
+      { auth: undefined, fields: undefined, sources: fakeSources([]) },
+      { fieldDefinitions: true, entities: ['lead'] },
+    );
+    const msgs = failures(() => assertCrmAdapter(adapter));
+    expect(msgs).toContain('CrmPort.auth missing');
+    expect(msgs).toContain('caps.fieldDefinitions=true but CrmPort.fields missing');
+    expect(msgs).toContain(
+      "caps.entities lists 'lead' but sources.has('lead') is false",
+    );
+    expect(msgs.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
Implements **#337** — the L3 composing port. **Completes Track C and unblocks Track D D3/D4/D6.** Stacked on C2–C4 (#407, merged); rebased onto `origin/main` so the diff is C6-only.

## What landed
- **`packages/codegen-crm/src/ports/crm.port.ts`** — `CrmPort`, **entity-agnostic**: composes L1 (`auth: IAuthStrategy`, `sources: IEntityChangeSourceRegistry`) + L2 (`fields`/`picklists`/`associations` + `capabilities: CrmCapabilities`). No entity name appears in the type — verified grep-clean; entity access is via `sources.get<T>(name)`. Surface-only methods start empty (epic #328 DoD).
- **`packages/codegen-crm/src/testing/{assert-crm-adapter,index}.ts`** — `assertCrmAdapter()`: structural conformance (required L1 slots; capability flags ↔ present ports in both directions under `respectCapabilities`; every `capabilities.entities` entry resolves via `sources.has`). Throws `AggregateError` listing every gap. Ships from the **`@pattern-stack/codegen-crm/testing`** subpath (kept out of the main bundle), per the DoD.
- `CRM_PORT` token; main barrel exports `CrmPort` (the helper stays on `/testing`).
- Tests (9 new): conforming adapters pass; each failure mode (missing slot, capability/port mismatch both directions, entity-not-in-registry, multi-failure aggregation) throws with the expected message.

## ⚠️ Export-path finding — the L1↔L2 seam was NOT wired; I made it real
This is the first time L2 imports L1 across the package boundary, and three things were missing:
1. **`runtime/subsystems/index.ts` didn't re-export the integration subsystem** → `IEntityChangeSourceRegistry` was unreachable there (`IAuthStrategy` already was). Added a **selective** re-export (`IEntityChangeSourceRegistry`, `IChangeSource`, `MemoryEntityChangeSourceRegistry`, `UnknownEntityError`, `ENTITY_CHANGE_SOURCE_REGISTRY`) — selective, not `export *`, to avoid the `IntegrationRunSummary` name clash with the observability barrel.
2. **No `./subsystems` export** in codegen's `package.json` → added `"./subsystems"` → `dist/runtime/subsystems/index.{js,d.ts}`. This is the path consumers (and the issue) import.
3. **In-workspace resolution:** the root `@pattern-stack/codegen` is the workspace *root*, not a `packages/*` member, so it isn't symlinked into `node_modules` and `workspace:*` can't reference it. The imports are **type-only (erased at runtime)**, so tests need no linkage. For typecheck I path-map `@pattern-stack/codegen/subsystems` → codegen's **built `.d.ts`** (`skipLibCheck` applies, so codegen's NestJS/drizzle source isn't pulled into this package's typecheck) — i.e. `bun run build` at the repo root precedes the package typecheck (normal L1-before-L2 order). A local `tsup.config.ts` pins the package tsconfig so the DTS build resolves the specifier (otherwise tsup inherits the root config and the declaration build can't resolve it).

## Verified
- Package `tsc --noEmit` clean; `tsup` build emits `dist` + `dist/testing`; `npm publish --dry-run` ships the `testing` subpath (9 files).
- `just test-all` green (EXIT=0): 2284 unit (+9 assertCrmAdapter) + baseline + smoke + junction. Root `tsc` unchanged (the 3 pre-existing junction/barrel errors only).

## Interpretation calls
1. **`assertCrmAdapter` lives only on the `/testing` subpath**, not also re-exported from the main barrel (the issue's `index.ts` snippet showed both). Per your "export from a testing/ subpath" steer + keeping test scaffolding out of production bundles.
2. **`respectCapabilities` is bidirectional** (default true): a declared capability requires its port AND a present port requires its flag. `respectCapabilities:false` drops the second direction. Matches the issue's intent ("flags match port presence"); flag if you want one-directional only.

This is the last Track-C step — **D3 (adapter scaffold emission) is now unblocked.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)