### PR TITLE
feat(codegen): context: drives generated module output subfolder

### DIFF
--- a/.claude/skills/codegen/SKILL.md
+++ b/.claude/skills/codegen/SKILL.md
@@ -154,6 +154,7 @@ relationships:
     foreign_key: account_id
 
 # Optional top-level flags (PR #52 / #53 / #55)
+context: integration                     # ADR-0004 bounded-context slug; #403 wires it to nest modules/<context>/<plural>/
 eav: true                                # emit paired reads + compound-write use cases for EAV
 eav_value_table: true                    # THIS entity IS the EAV value table
 eav_definition_table: field_definition   # where the value table resolves keys → ids
@@ -171,6 +172,42 @@ queries:
     search: name                         # ilike column
     paginate: true                       # returns { items, total, limit, offset }
 ```
+
+### `context:` — bounded-context declaration (ADR-0004)
+
+Optional top-level `context:` (lowercase snake_case) declares **which bounded
+context this entity belongs to** — e.g. `integration`, `crm`, `identity`. This
+is the *durable* decision (ADR-0004); it's a plain bounded-context slug, not a
+folder switch. Multiple features read the same field:
+
+- **Code-folder grouping (#403, wired today):** under `clean-lite-ps`, a
+  context-tagged entity's module folder nests under the context segment.
+
+  | YAML | clean-lite-ps emit dir |
+  |------|------------------------|
+  | _(no `context:`)_ | `modules/<plural>/` |
+  | `context: integration` | `modules/integration/<plural>/` |
+
+  So integration entities group together
+  (`modules/integration/{transcripts,connections,…}/`) while untagged entities
+  stay flat. The regenerated barrel (`<generated>/modules.ts`) recomputes its
+  import paths automatically, so import aliases resolve without further wiring.
+
+- **Physical DB layout (ADR-0004, deferred — NOT wired here):** a later
+  `naming: prefix | schema` knob will read this *same* `context:` to drive the
+  Postgres layout — `prefix` → `pgTable('<context>__<table>')`, then the flip
+  to `schema` → `pgSchema('<context>').table('<table>')`. **#403 makes no
+  table/column/schema changes**; table names are unchanged regardless of
+  `context:`.
+
+`context:` is orthogonal to `surface:` (ADR-0006): context = model cohesion
+(which domain), surface = vendor composition (which integration).
+
+> The code-folder nesting applies to the `clean-lite-ps` architecture
+> (self-contained `modules/<plural>/` folders). For the full `clean`
+> architecture — whose layers are split across shared `domain/`,
+> `application/`, `infrastructure/` dirs with cross-layer relative imports —
+> context-subfolder nesting is **not yet wired** (#403 scope).
 
 ### `eav: true` — auto-generated EAV routes on a consumer entity
 

--- a/src/__tests__/clean-lite-ps/context-output-subfolder.test.ts
+++ b/src/__tests__/clean-lite-ps/context-output-subfolder.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #403 — `context:` drives the generated module output subfolder (clean-lite-ps).
+ *
+ * Verifies the central resolver (`buildCleanLitePsLocals` →
+ * `clpOutputPaths` + `moduleGroupDir`):
+ *   - A top-level `context:` nests EVERY module file under
+ *     `<src>/modules/<context>/<plural>/…`.
+ *   - An untagged entity stays flat (`<src>/modules/<plural>/…`) — byte-identical
+ *     to pre-#403 output (baseline protection).
+ *   - `clpContext` is surfaced for templates (null when untagged).
+ *
+ * Folder-grouping ONLY: this exercise asserts paths, not table/column names —
+ * those are unchanged by `context:` (ADR-0004's prefix→schema flip stays deferred).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite-ps/prompt-extension.js';
+
+const SRC = 'app/backend/src';
+
+function localsFor(extra: Record<string, unknown>) {
+	const definition = {
+		entity: { name: 'transcript', plural: 'transcripts', table: 'transcripts' },
+		fields: { title: { type: 'string', required: true } },
+		relationships: {},
+		behaviors: ['timestamps'],
+		...extra,
+	};
+	return buildCleanLitePsLocals(definition, { backendSrc: SRC });
+}
+
+describe('#403 clean-lite-ps — context nests module output paths', () => {
+	it('prefixes every clpOutputPaths entry with modules/<context>/<plural>/', () => {
+		const { clpOutputPaths, clpContext } = localsFor({ context: 'integration' });
+
+		expect(clpContext).toBe('integration');
+
+		const base = `${SRC}/modules/integration/transcripts`;
+		expect(clpOutputPaths.entity).toBe(`${base}/transcript.entity.ts`);
+		expect(clpOutputPaths.repository).toBe(`${base}/transcript.repository.ts`);
+		expect(clpOutputPaths.service).toBe(`${base}/transcript.service.ts`);
+		expect(clpOutputPaths.controller).toBe(`${base}/transcript.controller.ts`);
+		expect(clpOutputPaths.module).toBe(`${base}/transcripts.module.ts`);
+		expect(clpOutputPaths.index).toBe(`${base}/index.ts`);
+		expect(clpOutputPaths.findByIdUseCase).toBe(
+			`${base}/use-cases/find-transcript-by-id.use-case.ts`,
+		);
+		expect(clpOutputPaths.createDto).toBe(`${base}/dto/create-transcript.dto.ts`);
+
+		// Every emitted path lives under the context subfolder — no leaks to flat.
+		for (const p of Object.values(clpOutputPaths)) {
+			if (typeof p === 'string') {
+				expect(p.startsWith(`${SRC}/modules/integration/`)).toBe(true);
+			}
+		}
+	});
+
+	it('untagged entity stays flat (modules/<plural>/) — baseline unchanged', () => {
+		const { clpOutputPaths, clpContext } = localsFor({});
+
+		expect(clpContext).toBeNull();
+
+		const base = `${SRC}/modules/transcripts`;
+		expect(clpOutputPaths.entity).toBe(`${base}/transcript.entity.ts`);
+		expect(clpOutputPaths.module).toBe(`${base}/transcripts.module.ts`);
+		expect(clpOutputPaths.createDto).toBe(`${base}/dto/create-transcript.dto.ts`);
+
+		// No `/modules/<context>/` segment ever appears for an untagged entity.
+		for (const p of Object.values(clpOutputPaths)) {
+			if (typeof p === 'string') {
+				expect(p.startsWith(`${SRC}/modules/transcripts/`)).toBe(true);
+			}
+		}
+	});
+});

--- a/src/__tests__/cli/barrel-generator.test.ts
+++ b/src/__tests__/cli/barrel-generator.test.ts
@@ -27,7 +27,7 @@ import { loadContext } from '../../cli/shared/context.js';
 const tempDirs: string[] = [];
 
 function mkProject(opts: {
-	entities: Array<{ name: string; plural: string; file?: string }>;
+	entities: Array<{ name: string; plural: string; file?: string; context?: string }>;
 	config?: string;
 }): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'barrel-'));
@@ -43,6 +43,8 @@ function mkProject(opts: {
 				`  name: ${ent.name}`,
 				`  plural: ${ent.plural}`,
 				`  table: ${ent.plural}`,
+				// #403: top-level `context:` nests the module folder.
+				...(ent.context ? [`context: ${ent.context}`] : []),
 				'fields:',
 				'  id:',
 				'    type: uuid',
@@ -112,6 +114,67 @@ describe('buildModulesBarrel — content shape', () => {
 		const out = buildModulesBarrel([], 'src/generated/modules.ts', 'clean-lite-ps');
 		expect(out).toContain('export const GENERATED_MODULES = [] as const;');
 		expect(out).not.toContain('import {');
+	});
+});
+
+describe('#403 — context: nests the module folder', () => {
+	test('clean-lite-ps: context entity imports from modules/<context>/<plural>/', () => {
+		const entities = [
+			{ name: 'transcript', plural: 'transcripts', context: 'integration' },
+			{ name: 'account', plural: 'accounts' }, // untagged → flat
+		];
+		const out = buildModulesBarrel(entities, 'src/generated/modules.ts', 'clean-lite-ps');
+
+		// Context-tagged entity nests under the context segment.
+		expect(out).toContain(
+			"import { TranscriptsModule } from '../../app/backend/src/modules/integration/transcripts/transcripts.module';"
+		);
+		// Untagged entity stays flat — byte-identical to pre-#403.
+		expect(out).toContain(
+			"import { AccountsModule } from '../../app/backend/src/modules/accounts/accounts.module';"
+		);
+	});
+
+	test('clean-lite-ps schema barrel nests the context entity too', () => {
+		const entities = [
+			{ name: 'transcript', plural: 'transcripts', context: 'integration' },
+			{ name: 'account', plural: 'accounts' },
+		];
+		const out = buildSchemaBarrel(entities, 'src/generated/schema.ts', 'clean-lite-ps');
+
+		expect(out).toContain(
+			"export * from '../../app/backend/src/modules/integration/transcripts/transcript.entity';"
+		);
+		expect(out).toContain(
+			"export * from '../../app/backend/src/modules/accounts/account.entity';"
+		);
+	});
+
+	test('end-to-end: context entity YAML validates and lands under the context subfolder', async () => {
+		const root = mkProject({
+			entities: [
+				{ name: 'transcript', plural: 'transcripts', context: 'integration' },
+				{ name: 'account', plural: 'accounts' },
+			],
+		});
+		const ctx = await loadContext({ cwd: root, skipDetection: true });
+
+		const result = await regenerateBarrels({
+			ctx,
+			entitiesDir: path.join(root, 'entities'),
+			generatedDir: path.join(root, 'src/generated'),
+			architecture: 'clean-lite-ps',
+		});
+
+		// Both entities discovered (YAML with context: validated — schema accepts it).
+		expect(result.entityCount).toBe(2);
+		const modulesContent = fs.readFileSync(result.modulesBarrel, 'utf-8');
+		expect(modulesContent).toContain(
+			"from '../../app/backend/src/modules/integration/transcripts/transcripts.module'"
+		);
+		expect(modulesContent).toContain(
+			"from '../../app/backend/src/modules/accounts/accounts.module'"
+		);
 	});
 });
 

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -462,6 +462,37 @@ describe('scopeable flag', () => {
 	});
 });
 
+describe('context flag (#403)', () => {
+	const base = {
+		entity: { name: 'transcript', plural: 'transcripts', table: 'transcripts' },
+		fields: { id: { type: 'uuid', required: true } },
+	};
+
+	it('accepts a top-level context: <snake_case> — the key no longer trips .strict()', () => {
+		const result = EntityDefinitionSchema.safeParse({ ...base, context: 'integration' });
+		expect(result.success).toBe(true);
+		expect(result.data!.context).toBe('integration');
+	});
+
+	it('context is optional — omitting it is valid (flat output preserved)', () => {
+		const result = EntityDefinitionSchema.safeParse(base);
+		expect(result.success).toBe(true);
+		expect(result.data!.context).toBeUndefined();
+	});
+
+	it('rejects non-snake_case context (uppercase / hyphen / leading digit)', () => {
+		for (const bad of ['Integration', 'my-context', '1context', '_x']) {
+			const result = EntityDefinitionSchema.safeParse({ ...base, context: bad });
+			expect(result.success).toBe(false);
+		}
+	});
+
+	it('rejects non-string context', () => {
+		const result = EntityDefinitionSchema.safeParse({ ...base, context: 123 });
+		expect(result.success).toBe(false);
+	});
+});
+
 // ============================================================================
 // Strict mode — unknown keys still rejected
 // ============================================================================

--- a/src/cli/shared/barrel-generator.ts
+++ b/src/cli/shared/barrel-generator.ts
@@ -89,6 +89,13 @@ export interface BarrelResult {
 interface EntityInfo {
 	name: string;
 	plural: string;
+	/**
+	 * #403: bounded-context segment. When set, the entity's clean-lite-ps
+	 * module folder is nested under `modules/<context>/<plural>/` so the barrel
+	 * import path must include it. Relationships and junctions never carry a
+	 * context, so they stay flat.
+	 */
+	context?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +138,8 @@ function collectEntities(entitiesDir: string): EntityInfo[] {
 		entities.push({
 			name: def.entity.name,
 			plural: def.entity.plural,
+			// #403: top-level `context:` nests the module folder; undefined → flat.
+			context: def.context,
 		});
 	}
 	// Deterministic: sort by singular name.
@@ -245,11 +254,15 @@ function entityFilePaths(
 		// templates/entity/new/clean-lite-ps/prompt-extension.js — `srcRoot`).
 		// The barrel must match that on-disk layout.
 		const prefix = backendSrc && backendSrc !== '.' ? `${backendSrc}/` : '';
+		// #403: a bounded-context entity nests under `modules/<context>/<plural>/`
+		// — must mirror `moduleGroupDir` in the clean-lite-ps prompt-extension.
+		// Untagged entities stay flat (`modules/<plural>/`).
+		const ctxSeg = info.context ? `${info.context}/` : '';
 		return {
-			moduleFile: `${prefix}modules/${plural}/${plural}.module.ts`,
+			moduleFile: `${prefix}modules/${ctxSeg}${plural}/${plural}.module.ts`,
 			moduleClass: `${toPascalCase(plural)}Module`,
 			// Drizzle entity schema lives alongside the entity file in clean-lite-ps.
-			schemaFile: `${prefix}modules/${plural}/${name}.entity.ts`,
+			schemaFile: `${prefix}modules/${ctxSeg}${plural}/${name}.entity.ts`,
 		};
 	}
 

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -818,6 +818,30 @@ export const EntityDefinitionSchema = z
     // read.
     surface: z.string().optional(),
 
+    // Bounded-context declaration (ADR-0004) — "which bounded context this
+    // entity belongs to". This is the DURABLE decision; it is a plain
+    // bounded-context slug, NOT a folder knob. Different features consume it:
+    //
+    //   - #403 (this PR, the FIRST consumer): drives the generated code's
+    //     module output folder. clean-lite-ps nests the entity's module under
+    //     `<modules>/<context>/<entity>/` so same-context entities group
+    //     together; untagged entities stay flat (`<modules>/<entity>/`).
+    //   - ADR-0004 (deferred): a later `naming: prefix | schema` knob reads
+    //     this SAME field to drive the Postgres physical layout —
+    //     `prefix` → `pgTable('<context>__<table>')`, then the flip to
+    //     `schema` → `pgSchema('<context>').table('<table>')`. NOT wired here;
+    //     #403 makes no table/column/schema changes.
+    //
+    // Sibling to `surface:` and orthogonal to it (ADR-0006): context = model
+    // cohesion (which domain), surface = vendor composition (which integration).
+    context: z
+      .string()
+      .regex(
+        /^[a-z][a-z0-9_]*$/,
+        "context must be lowercase snake_case (e.g. 'integration')",
+      )
+      .optional(),
+
     // v2: Domain event declarations (CODEGEN-EVOLUTION-PLAN Phase 2)
     // Generates typed event classes, handlers, and queue registration
     events: z.array(EventDeclarationSchema).optional(),

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -1008,6 +1008,18 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const entityNamePlural = entity.plural || pluralize(entityName);
   const entityNamePluralPascal = pascalCase(entityNamePlural);
 
+  // #403: bounded-context folder grouping. A top-level `context:` nests this
+  // entity's module folder under that segment so same-context entities group
+  // together (`<modules>/<context>/<plural>/`); no context → flat
+  // (`<modules>/<plural>/`, byte-identical to pre-#403). Emit-folder-only —
+  // every intra-module import is folder-relative and therefore unaffected, and
+  // the generated barrel recomputes its import paths from the full file paths
+  // below. The module-folder base used by every clpOutputPaths entry:
+  const entityContext = definition.context || null;
+  const moduleGroupDir = entityContext
+    ? `${srcRoot}/modules/${entityContext}`
+    : `${srcRoot}/modules`;
+
   // Generation toggles — `generate.writes` defaults to true so consumers who
   // regenerate pick up create/update/delete use cases without YAML changes.
   // Set `generate.writes: false` in YAML to suppress write-side emission
@@ -1207,44 +1219,47 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
 
   // Output paths
   const outputPaths = {
-    entity: `${srcRoot}/modules/${entityNamePlural}/${entityName}.entity.ts`,
-    repository: `${srcRoot}/modules/${entityNamePlural}/${entityName}.repository.ts`,
-    service: `${srcRoot}/modules/${entityNamePlural}/${entityName}.service.ts`,
-    controller: `${srcRoot}/modules/${entityNamePlural}/${entityName}.controller.ts`,
-    module: `${srcRoot}/modules/${entityNamePlural}/${entityNamePlural}.module.ts`,
-    index: `${srcRoot}/modules/${entityNamePlural}/index.ts`,
-    findByIdUseCase: `${srcRoot}/modules/${entityNamePlural}/use-cases/find-${entityName}-by-id.use-case.ts`,
-    listUseCase: `${srcRoot}/modules/${entityNamePlural}/use-cases/list-${entityNamePlural}.use-case.ts`,
+    entity: `${moduleGroupDir}/${entityNamePlural}/${entityName}.entity.ts`,
+    repository: `${moduleGroupDir}/${entityNamePlural}/${entityName}.repository.ts`,
+    service: `${moduleGroupDir}/${entityNamePlural}/${entityName}.service.ts`,
+    controller: `${moduleGroupDir}/${entityNamePlural}/${entityName}.controller.ts`,
+    module: `${moduleGroupDir}/${entityNamePlural}/${entityNamePlural}.module.ts`,
+    index: `${moduleGroupDir}/${entityNamePlural}/index.ts`,
+    findByIdUseCase: `${moduleGroupDir}/${entityNamePlural}/use-cases/find-${entityName}-by-id.use-case.ts`,
+    listUseCase: `${moduleGroupDir}/${entityNamePlural}/use-cases/list-${entityNamePlural}.use-case.ts`,
     findByIdWithFieldsUseCase: eavEnabled
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/find-${entityName}-by-id-with-fields.use-case.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/find-${entityName}-by-id-with-fields.use-case.ts`
       : null,
     listWithFieldsUseCase: eavEnabled
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/list-${entityNamePlural}-with-fields.use-case.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/list-${entityNamePlural}-with-fields.use-case.ts`
       : null,
     createUseCase: generateWrites
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/create-${entityName}.use-case.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/create-${entityName}.use-case.ts`
       : null,
     updateUseCase: generateWrites
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/update-${entityName}.use-case.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/update-${entityName}.use-case.ts`
       : null,
     deleteUseCase: generateWrites
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/delete-${entityName}.use-case.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/delete-${entityName}.use-case.ts`
       : null,
-    createDto: `${srcRoot}/modules/${entityNamePlural}/dto/create-${entityName}.dto.ts`,
-    updateDto: `${srcRoot}/modules/${entityNamePlural}/dto/update-${entityName}.dto.ts`,
-    outputDto: `${srcRoot}/modules/${entityNamePlural}/dto/${entityName}-output.dto.ts`,
+    createDto: `${moduleGroupDir}/${entityNamePlural}/dto/create-${entityName}.dto.ts`,
+    updateDto: `${moduleGroupDir}/${entityNamePlural}/dto/update-${entityName}.dto.ts`,
+    outputDto: `${moduleGroupDir}/${entityNamePlural}/dto/${entityName}-output.dto.ts`,
     searchUseCase: searchQueryResolved
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/search-${entityNamePlural}.use-case.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/search-${entityNamePlural}.use-case.ts`
       : null,
     searchController: searchQueryResolved
-      ? `${srcRoot}/modules/${entityNamePlural}/${entityName}-search.controller.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/${entityName}-search.controller.ts`
       : null,
     declarativeQueries: hasDeclarativeQueries
-      ? `${srcRoot}/modules/${entityNamePlural}/use-cases/declarative-queries.ts`
+      ? `${moduleGroupDir}/${entityNamePlural}/use-cases/declarative-queries.ts`
       : null,
     // ADR-033.1 §8 — integration-source module emission for clean-lite-ps. Co-located
     // with the entity feature module under src/modules/<plural>/. Closes #267.
-    integrationSourceModule: `${srcRoot}/modules/${entityNamePlural}/${entityName}-integration-source.module.ts`,
+    // #403: routed through moduleGroupDir so a `context:`-tagged entity nests the
+    // integration-source module under its context segment (untagged → flat, the
+    // same `${srcRoot}/modules/<plural>/…` path as before).
+    integrationSourceModule: `${moduleGroupDir}/${entityNamePlural}/${entityName}-integration-source.module.ts`,
     // ADR-033.2's per-entity provider tuples (`<entity>-integration-source.providers.ts`)
     // are removed by RFC-0001 §8 (D4). The surface-scoped typed view
     // (`src/integrations/<surface>/types.generated.ts`) is the single source of
@@ -1402,6 +1417,10 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     searchQuery: searchQueryResolved,
     hasSearchQuery: !!searchQueryResolved,
 
+
+    // #403: bounded-context segment (null when untagged). Drives the
+    // module-folder nesting reflected in clpOutputPaths above.
+    clpContext: entityContext,
 
     // Output paths
     clpOutputPaths: outputPaths,


### PR DESCRIPTION
Closes #403.

## What

Add optional top-level `context:` to the entity schema as **ADR-0004's durable bounded-context declaration** ("which bounded context this entity belongs to" — e.g. `integration`, `crm`, `identity`), and wire its **first consumer**: the generated **module output folder**. A context-tagged entity nests under `<modules>/<context>/<plural>/` so same-context entities group together; untagged entities stay flat (`<modules>/<plural>/`) — byte-identical to before.

`context:` is defined as a plain bounded-context slug, not a folder knob — so it composes cleanly with the deferred ADR-0004 DB-layout work (see below).

## `context:` is the durable field; #403 is one use of it

| Consumer | Status | Effect |
|----------|--------|--------|
| **Code-folder grouping (#403, this PR)** | wired | clean-lite-ps nests the module folder under `<modules>/<context>/<plural>/` |
| **Physical DB layout (ADR-0004)** | deferred | a later `naming: prefix \| schema` knob reads the *same* `context:` → `pgTable('<context>__<table>')`, then the flip → `pgSchema('<context>').table('<table>')` |

**This PR makes no table/column/schema changes** — table names are unchanged regardless of `context:`. The future `__`→`.` schema flip stays a clean knob-flip on this same field.

## Changes

- **Schema** (`src/schema/entity-definition.schema.ts`): added optional top-level `context: string` (`^[a-z][a-z0-9_]*$`), sibling to `surface:`, documented as the ADR-0004 bounded-context declaration. `.strict()` now validates it — closes the `entity validate` failure swe-brain hit.
- **Resolver** (`templates/entity/new/clean-lite-ps/prompt-extension.js`): introduced `moduleGroupDir` (`<src>/modules/<context>` when tagged, else `<src>/modules`) and routed **every** `clpOutputPaths` entry through it — entity/repository/service/controller/module/index/use-cases/dto/search/integration-source all nest together. Surfaces `clpContext`.
- **Barrel** (`src/cli/shared/barrel-generator.ts`): threaded `context` through `EntityInfo` → `entityFilePaths` so the regenerated `src/generated/modules.ts` + `schema.ts` emit correct relative imports to the nested folder automatically. Relationships/junctions never carry a context → stay flat.
- **Docs**: `.claude/skills/codegen/SKILL.md` documents `context:` as the bounded-context declaration with a pointer to ADR-0004 (code-folder use wired, prefix/schema use deferred).

## Resolver insertion point

The clean-lite-ps output paths are built in the template's `buildCleanLitePsLocals` (`clpOutputPaths`), **not** `paths.mjs getDynamicPaths` (that feeds the full clean-arch pipeline). I applied the single-segment prefix at `moduleGroupDir`, the shared base for all `clpOutputPaths` entries, so one change nests the whole module folder. The barrel recomputes its imports from the full file paths, so import aliases resolve with no extra wiring.

## Interpretation call — clean-arch deferred (flagged)

Code-folder nesting is implemented for **clean-lite-ps** only (the architecture swe-brain uses; the `modules/integration/*` target IS that self-contained-folder layout). For the full **clean** architecture I deliberately did **not** prefix: its layers are split across shared `domain/`, `application/`, `infrastructure/modules/`, … dirs with cross-layer relative imports keyed to fixed depths — prefixing only `modules/` would break those imports, and prefixing every layer is a cross-cutting refactor beyond #403's scope. Documented as a known limitation. Cross-context FK/join semantics (e.g. `has_many` import paths to a target in a different context) also stay out of scope per the issue.

## Tests (`just test-all` green)

- `src/__tests__/clean-lite-ps/context-output-subfolder.test.ts` — `context: integration` nests every `clpOutputPaths` entry; untagged entity stays flat (baseline protection).
- `src/__tests__/cli/barrel-generator.test.ts` — context entity imports from `modules/integration/<plural>/`, untagged flat, end-to-end barrel regen.
- `src/__tests__/schema/schema-v2.test.ts` — `entity validate` accepts `context:`; optional; rejects non-snake_case / non-string.

> Two pre-existing failures in `subsystem-install.observability.test.ts` ("— real" live-`bun add` tests) are environmental link races (`Failed to link ejs: EEXIST`), unrelated to this diff — it touches neither subsystem install nor config injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)