### PR TITLE
chore(release): multi-package publish for surface packages

### DIFF
--- a/justfile
+++ b/justfile
@@ -201,8 +201,19 @@ release:
     git push origin "v${version}"
     echo "Tagged and pushed v${version}"
 
-# Publish current origin/main to npm (clean worktree, no branch-state assumptions)
-publish:
+# Publish origin/main to npm: the root @pattern-stack/codegen + every opted-in
+# workspace package (clean worktree, no branch-state assumptions).
+#
+# Multi-package (ADR-036 §8 — independent versioning): the root publishes first
+# (its build emits dist/, which the surface packages' .d.ts builds resolve the
+# @pattern-stack/codegen/subsystems import against), then each publishable
+# packages/* publishes at its OWN version. A package opts in by declaring
+# `publishConfig.access: public` (the 4 surface packages do); private or
+# unmarked packages (graph-components, generated api/db) are skipped.
+#
+# Pass `--dry-run` to pack + validate every tarball WITHOUT uploading:
+#   just publish --dry-run
+publish *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -218,8 +229,9 @@ publish:
     fi
 
     workdir="/tmp/codegen-publish-${version}-$$"
-    echo "Publishing @pattern-stack/codegen@${version} from origin/main"
+    echo "Publishing @pattern-stack/codegen@${version} (+ surface packages) from origin/main"
     echo "Worktree: ${workdir}"
+    [ -n "{{flags}}" ] && echo "Flags: {{flags}}"
 
     trap 'cd /; git worktree remove --force "${workdir}" 2>/dev/null || true' EXIT
 
@@ -235,9 +247,46 @@ publish:
     mise install
 
     mise exec -- bun install
-    mise exec -- npm publish
 
-    echo "✓ Published @pattern-stack/codegen@${version}"
+    # Always build the root first — its dist/ is what the surface packages'
+    # declaration (.d.ts) builds resolve `@pattern-stack/codegen/subsystems`
+    # against, whether or not the root itself is (re)published this run.
+    mise exec -- bun run build
+
+    # Publish one package iff its version isn't already on npm — independent
+    # versioning (ADR-036 §8), so releasing one surface package doesn't force a
+    # root or sibling bump. Already-published versions are skipped, not errors.
+    publish_pkg() {
+        local dir="$1" name="$2" ver="$3" on_npm
+        on_npm=$( ( cd "${dir}" && mise exec -- npm view "${name}@${ver}" version 2>/dev/null ) || true )
+        if [ "${on_npm}" = "${ver}" ]; then
+            echo "↷ skip ${name}@${ver} (already on npm)"
+            return 0
+        fi
+        echo "Publishing ${name}@${ver} from ${dir}"
+        ( cd "${dir}" && mise exec -- npm publish {{flags}} )
+        echo "✓ ${name}@${ver}"
+    }
+
+    # 1. Root package.
+    publish_pkg "." "@pattern-stack/codegen" "${version}"
+
+    # 2. Each opted-in workspace package (publishConfig.access: public), at its
+    #    own version. Private / unmarked (graph-components, generated api/db) skip.
+    for pkgjson in packages/*/package.json; do
+        dir=$(dirname "${pkgjson}")
+        name=$(jq -r '.name' "${pkgjson}")
+        ver=$(jq -r '.version' "${pkgjson}")
+        priv=$(jq -r '.private // false' "${pkgjson}")
+        access=$(jq -r '.publishConfig.access // ""' "${pkgjson}")
+        if [ "${priv}" = "true" ] || [ "${access}" != "public" ]; then
+            echo "↷ skip ${name} (not opted in: private=${priv} access=${access:-none})"
+            continue
+        fi
+        publish_pkg "${dir}" "${name}" "${ver}"
+    done
+
+    echo "✓ Done."
 
 # ─── Install Skill ────────────────────────────────────────────────────────────
 

--- a/packages/codegen-calendar/src/calendar.port.ts
+++ b/packages/codegen-calendar/src/calendar.port.ts
@@ -23,7 +23,7 @@ import type {
   IAuthStrategy,
   IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
-import type { CalendarCapabilities } from '../capabilities';
+import type { CalendarCapabilities } from './capabilities';
 
 export interface CalendarPort {
   /** L1 — auth strategy resolving credentials for this provider. */

--- a/packages/codegen-mail/src/mail.port.ts
+++ b/packages/codegen-mail/src/mail.port.ts
@@ -22,7 +22,7 @@ import type {
   IAuthStrategy,
   IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
-import type { MailCapabilities } from '../capabilities';
+import type { MailCapabilities } from './capabilities';
 
 export interface MailPort {
   /** L1 — auth strategy resolving credentials for this provider. */

--- a/packages/codegen-transcript/src/transcript.port.ts
+++ b/packages/codegen-transcript/src/transcript.port.ts
@@ -30,7 +30,7 @@ import type {
   IAuthStrategy,
   IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
-import type { TranscriptCapabilities } from '../capabilities';
+import type { TranscriptCapabilities } from './capabilities';
 
 export interface TranscriptPort {
   /** L1 — auth strategy resolving credentials for this provider. */


### PR DESCRIPTION
swe-brain needs the 4 surface packages on npm to consume the generated integration wiring, but `just publish` only published the root `@pattern-stack/codegen`. This extends the **existing** release mechanism (the manual, human-cut `just publish` — there is **no CI publish**; `ci.yml` runs tests only) to be multi-package.

## How the repo publishes (what I found)
`just publish` is the release trigger: it fetches the trunk, spins an ephemeral worktree at it, `mise install` + `bun install`, then `npm publish` (root only). `just bump`/`just release` are version + tag helpers. 0.11.0 reached npm this way. No GitHub Actions publish.

## What changed
- **`just publish` → `publish *flags`**, multi-package:
  - **always builds the root first** — its `dist/` is what the surface packages' `.d.ts` builds resolve `@pattern-stack/codegen/subsystems` against, whether or not root is re-published.
  - publishes the root, then **each opted-in `packages/*` at its own independent version** (ADR-036 §8). Opt-in = `publishConfig.access: public` (the 4 surface packages all declare it); graph-components (no `publishConfig`) and generated `api`/`db` are skipped. A **workspace loop**, not N hardcoded recipes.
  - **publishes a package iff its version isn't already on npm** (`npm view` guard) — releasing one surface package doesn't force a root/sibling bump, and re-running is safe (no `set -e` abort on an already-published version).
  - `just publish --dry-run` threads `--dry-run` to every tarball.
- **Build-blocker fix in the interaction packages** (regression from #416's single-port collapse): `calendar`/`mail`/`transcript` port files imported `from '../capabilities'` — valid when the port lived in `src/ports/`, but after the collapse to `src/<surface>.port.ts` the sibling is `./capabilities`. It's a **type-only import (erased at runtime), so tests stayed green**, but the `.d.ts` build (tsup/tsc) — i.e. publish — failed. Fixed to `./capabilities`; all three now build + typecheck clean.

## Dry-run results (verified, no live publish)
| package | result |
|---|---|
| `@pattern-stack/codegen` (root) | ↷ skipped — 0.11.0 already on npm (npm-view guard) |
| `@pattern-stack/codegen-crm@0.1.0` | ✓ packs (dist + types + `/testing` subpath), 8.7 kB |
| `@pattern-stack/codegen-calendar@0.1.0` | ✓ packs, 5.5 kB |
| `@pattern-stack/codegen-mail@0.1.0` | ✓ packs, 5.6 kB |
| `@pattern-stack/codegen-transcript@0.1.0` | ✓ packs, 6.3 kB |
| `@pattern-stack/graph-components` | ↷ skipped — no `publishConfig.access` (not opted in) |

`just test-all` green (EXIT=0): 2333 unit + baseline + smoke + junction + 3 integration-emit, 0 fail. (The import fix is type-only, so runtime/tests are unchanged.)

## Does a release/version bump need to happen to actually push them?
**No bump needed for the surface packages** — they're at `0.1.0` and have **never been published**, so the first `just publish` (cut by the human after this merges) publishes all four fresh. The **root is skipped** (0.11.0 already on npm) unless its code changes and gets bumped — which is correct; swe-brain only needs the surface packages. Changesets is **not** warranted: independent per-package versions + the npm-view guard cover the multi-package case without coordinated-versioning tooling.

**No live `npm publish` run here** — only `--dry-run`. The actual publish is the human's release trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)