### PR TITLE
chore(release): 0.12.0 — Track C/D integration codegen + surface packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-05-31
+
+Integration codegen retarget (RFC-0001): a **provider/adapter/surface** model
+for integration codegen, plus a **surface-package framework**. Additive over
+0.11.0 — new declarative inputs and emitted artifacts; existing entity codegen
+is unchanged. The one breaking item (the ADR-033.2 per-entity provider tuples)
+has no consumers. Consumers adopt by adding `definitions/providers/*.yaml` and
+regenerating. Ships alongside four independently-versioned **surface packages**
+(`@pattern-stack/codegen-{crm,calendar,mail,transcript}`) publishing fresh at
+`0.1.0`.
+
+### ⚠ BREAKING CHANGES
+
+- **ADR-033.2 per-entity provider tuples removed.** The
+  `<entity>-integration-source.providers.ts` emission (`<ENTITY>_PROVIDERS`
+  const + `<Entity>Provider` type) is deleted. Its replacement is the
+  surface-scoped, codegen-owned typed view at
+  `src/integrations/<surface>/types.generated.ts` (`<Surface>Provider` /
+  `<Surface>Entity` unions + a `(provider, entity)` validity map) — a single
+  source of provider truth. ADR-033.2 is superseded by RFC-0001. No published
+  consumers depend on the tuples.
+
+### Added
+
+- **Track C — surface-package framework (ADR-036).** First-class L2 *surface
+  packages* shipping type-shaped ports + DI tokens + an L3 composing port per
+  integration surface:
+  - **L1** — `IEntityChangeSourceRegistry` (entity-keyed change-source
+    resolver) + `MemoryEntityChangeSourceRegistry` + the
+    `ENTITY_CHANGE_SOURCE_REGISTRY` token, in the integration subsystem;
+    exported across the package boundary via `@pattern-stack/codegen/subsystems`.
+  - **`@pattern-stack/codegen-crm`** — L2 CRM ports (`IFieldDefinitionReader`,
+    `IPicklistReader`, `IAssociationReader`), the `CrmCapabilities` descriptor,
+    and the L3 entity-agnostic **`CrmPort`** composing port + `assertCrmAdapter`
+    conformance helper (on the `/testing` subpath).
+  - **`@pattern-stack/codegen-{calendar,mail,transcript}`** — incremental-read
+    interaction surfaces (`CalendarPort` / `MailPort` / `TranscriptPort`,
+    canonical types, capability descriptors). Independently versioned (`0.1.0`).
+- **Track D — provider/adapter integration codegen (RFC-0001).**
+  - `definitions/providers/<provider>.yaml` — providers as first-class
+    declarative artifacts (slug, auth strategy, client, surfaces); Zod schema +
+    validator with a **pre-flight import-path check** (a missing
+    strategy/client export fails `cdp gen`, not NestJS boot), surface
+    cross-check, and slug-uniqueness.
+  - Emits, per provider × surface: a `<provider>.provider.module.ts`, an
+    **emit-once** `<provider>-<surface>.adapter.ts` scaffold (sentinel-guarded,
+    author-owned after first emit), fully codegen-owned adapter modules +
+    barrels, a per-surface registry (`<SURFACE>_ADAPTER_CONTRIBUTIONS` →
+    `<SURFACE>_ENTITY_SOURCES`, folding into the L1 registry), and the
+    `types.generated.ts` typed view.
+  - Optional entity-YAML **`surface:`** field — the declarative input the
+    provider/adapter emission groups entities by.
+- **`context:` output-folder grouping (#403).** An optional top-level entity
+  `context:` nests its generated module folder under that segment
+  (`<modules>/<context>/<plural>/`); no context → flat (byte-identical to
+  before).
+- **Multi-package release.** `just publish` publishes the root plus every
+  opted-in `packages/*` (those declaring `publishConfig.access: public`) at its
+  own independent version, skipping versions already on npm.
+
 ## [0.11.0] — 2026-05-30
 
 Vocabulary rename per **ADR-0005 (swe-brain `.ai-docs/decisions/ADR-0005-rename-sync-to-integration.md`)**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/packages/codegen-calendar/package.json
+++ b/packages/codegen-calendar/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.11.0"
+    "@pattern-stack/codegen": "^0.12.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.11.0"
+    "@pattern-stack/codegen": "^0.12.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-mail/package.json
+++ b/packages/codegen-mail/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.11.0"
+    "@pattern-stack/codegen": "^0.12.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-transcript/package.json
+++ b/packages/codegen-transcript/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.11.0"
+    "@pattern-stack/codegen": "^0.12.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",


### PR DESCRIPTION
Root bump **0.11.0 → 0.12.0** so the Track C/D work merged since 0.11.0 actually ships. As my publish-pipeline report surfaced: the trunk and npm are both still `0.11.0`, so a `just publish` would push the 4 surface packages but **skip the root** (npm-view guard, unchanged version) → the Track-C/D codegen never reaches npm and swe-brain can't consume the provider/adapter emission or the `surface:` / `context:` fields. This bump fixes that.

**Minor (additive).** RFC-0001 integration codegen retarget + the ADR-036 surface-package framework. The one breaking item — the ADR-033.2 per-entity provider-tuple removal — has **no published consumers**; minor is appropriate pre-1.0 (consistent with how 0.11.0 went out).

## Changes
- `package.json` `0.11.0` → `0.12.0`.
- The 4 surface packages' `peerDependency` `@pattern-stack/codegen` `^0.11.0` → `^0.12.0` — they require the **0.12.0 `./subsystems` export** (`IAuthStrategy` + `IEntityChangeSourceRegistry`) that the L3 ports compose; `^0.11.0` (which caret-pins the 0.x minor) wouldn't admit 0.12.0. Their own versions stay `0.1.0` (fresh, never published).
- `CHANGELOG.md` `## [0.12.0]` — Track C (surface-package framework), Track D (provider/adapter codegen + registry + typed views), `context:` grouping (#403), multi-package publish; `BREAKING` flagged only on the ADR-033.2 tuple removal. Surface packages noted as independently versioned (`0.1.0`).

## Dry-run (no live publish)
- `@pattern-stack/codegen@0.12.0` packs — 840 files, 2.4 MB.
- `@pattern-stack/codegen-{crm,calendar,mail,transcript}@0.1.0` pack — dist + types + `/testing` subpath.
- `just test-all` green (EXIT=0): 2333 unit + baseline + smoke + junction + 3 integration-emit, 0 fail.

## After merge
The human runs `just publish`: root `0.12.0` (new → publishes) + the 4 surface packages `0.1.0` (fresh → publish). No live publish here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)