### PR TITLE
chore(release): surface packages 0.1.1 (peer ^0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ for integration codegen, plus a **surface-package framework**. Additive over
 is unchanged. The one breaking item (the ADR-033.2 per-entity provider tuples)
 has no consumers. Consumers adopt by adding `definitions/providers/*.yaml` and
 regenerating. Ships alongside four independently-versioned **surface packages**
-(`@pattern-stack/codegen-{crm,calendar,mail,transcript}`) publishing fresh at
-`0.1.0`.
+(`@pattern-stack/codegen-{crm,calendar,mail,transcript}`) at `0.1.1`. (Their
+initial `0.1.0` release peer-depended on `@pattern-stack/codegen` `^0.11.0`,
+which predates the `./subsystems` export they require; `0.1.1` corrects the peer
+to `^0.12.0`. The peer source fix merged with 0.12.0 but the version bump was
+missed — this completes it.)
 
 ### ⚠ BREAKING CHANGES
 
@@ -41,7 +44,7 @@ regenerating. Ships alongside four independently-versioned **surface packages**
     conformance helper (on the `/testing` subpath).
   - **`@pattern-stack/codegen-{calendar,mail,transcript}`** — incremental-read
     interaction surfaces (`CalendarPort` / `MailPort` / `TranscriptPort`,
-    canonical types, capability descriptors). Independently versioned (`0.1.0`).
+    canonical types, capability descriptors). Independently versioned (`0.1.1`).
 - **Track D — provider/adapter integration codegen (RFC-0001).**
   - `definitions/providers/<provider>.yaml` — providers as first-class
     declarative artifacts (slug, auth strategy, client, surfaces); Zod schema +

--- a/packages/codegen-calendar/package.json
+++ b/packages/codegen-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-calendar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "L2 calendar surface package for @pattern-stack/codegen — the canonical Meeting type, the CalendarPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-crm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "L2 CRM surface package for @pattern-stack/codegen — type-shaped CRM ports (field/picklist/association readers) and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",

--- a/packages/codegen-mail/package.json
+++ b/packages/codegen-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-mail",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "L2 mail surface package for @pattern-stack/codegen — the canonical Email type, the MailPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",

--- a/packages/codegen-transcript/package.json
+++ b/packages/codegen-transcript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-transcript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "L2 transcript surface package for @pattern-stack/codegen — the canonical Transcript type, the TranscriptPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Completes the peer correction that **0.12.0 (#421) intended but only half-landed**: the `@pattern-stack/codegen` peerDependency source fix (`^0.11.0` → `^0.12.0`) merged with 0.12.0, but the surface packages' **version bump did not** (the merge landed before the bump commit). So the trunk has them at `0.1.0` — already immutable on npm with the stale `^0.11.0` — and the publish guard would **skip** them, leaving the drift + an unmet-peer warning for any consumer on `codegen@0.12.0`.

## Change
- Bump `@pattern-stack/codegen-{crm,calendar,mail,transcript}` **0.1.0 → 0.1.1** so a release republishes them with the corrected `^0.12.0` peer and moves `latest`.
- Peer ranges are **already `^0.12.0`** on the trunk (the source fix merged) — left as-is.
- One CHANGELOG note under `## [0.12.0]` (surface packages at 0.1.1, peer-correction rationale, completing the missed bump). Root stays **0.12.0**.

## Verified (no live publish)
- Dry-run packs all four surface packages at **0.1.1** (dist + types + `/testing`); peer `^0.12.0`.
- `just test-all` green (EXIT=0): 2333 unit + baseline + smoke + junction + 3 integration-emit, 0 fail.

## After merge
The human runs `just publish`: root `0.12.0` already on npm → skipped; the four surface packages `0.1.1` → publish (new) → `latest` resolves to the good peer. Warning gone, drift fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)