### PR TITLE
fix(track-d): surface provider/adapter codegen in CLI help + skill (0.12.1)

### DIFF
--- a/.claude/skills/integration/SKILL.md
+++ b/.claude/skills/integration/SKILL.md
@@ -24,6 +24,13 @@ and `<ENTITY>_CHANGE_SOURCES: ReadonlyMap<string, IChangeSource<T>>`
 (factory output via `buildChangeSource`). Webhook-side codegen + CDC
 streaming emission are deferred.
 
+Track D (provider modules + adapter scaffolds, RFC-0001) shipped in 0.12.0.
+**It has no command of its own** — it runs as a post-step of `codegen entity
+new` whenever `definitions/providers/*.yaml` exist. See
+`protocols-and-ports.md` → "Driving Track D codegen" for the invocation,
+output paths, and skip conditions before telling anyone the CLI wiring is
+missing.
+
 ## Mental model
 
 **Integration vs. jobs vs. events — three domains, one codebase:**

--- a/.claude/skills/integration/protocols-and-ports.md
+++ b/.claude/skills/integration/protocols-and-ports.md
@@ -67,6 +67,38 @@ surface port stays entity-agnostic. Use `MemoryEntityChangeSourceRegistry`
 registry is Track D (RFC-0001 §3); full authoring coverage lives in the C5
 surface-authoring guide.
 
+### Driving Track D codegen — there is no `provider`/`integration`/`gen` command
+
+Provider + adapter emission is **a post-step of `codegen entity new`**, not a
+standalone command. The CLI exposes no `provider`, `integration`, `surface`, or
+`gen` verb — searching `--help` for one and finding nothing is expected, not a
+publish gap. The wiring lives in `EntityNewCommand.execute()`
+(`src/cli/commands/entity.ts`), after event/bridge/orchestration codegen.
+
+To regenerate:
+
+```bash
+codegen entity new --all      # cdp is the alias bin; `just gen-all` wraps this
+```
+
+The step:
+
+1. Looks for `definitions/providers/*.yaml` (override via `paths.providers` in
+   `codegen.config.yaml`; default `definitions/providers`). **No providers dir ⇒
+   the whole step is silently skipped** — the usual reason "nothing happened."
+2. Runs the D1 cross-validator (slug/surface always; import-path check only when
+   a consumer tsconfig resolves path aliases — this is the "`cdp gen` failing on
+   bad import paths" seen in release notes). Blocking issues ⇒ nothing written.
+3. Emits one provider module per YAML → `<backendSrc>/integrations/providers/`.
+4. **Only if provider emission succeeded with zero issues**, runs `emitAdapters`
+   → `<backendSrc>/integrations/` (emit-once author-owned scaffolds +
+   `@generated` files). A provider surface with no Track C surface package is
+   skipped with a warning, not an error.
+
+The generated scaffold is the ground truth for the adapter's port shape: the
+emitted `<Surface>Port` / `IChangeSource<T>` + registry wiring is what adapters
+must implement — read it rather than inferring the shape from `.d.ts`.
+
 ## `IIntegrationSink<T>` — the write surface
 
 One sink per canonical entity. Speaks canonical externally; internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-05-31
+
+Track D (provider/adapter integration codegen) discoverability fix. The 0.12.0
+generator wiring is correct and shipped — provider + adapter emission runs as a
+post-step of `codegen entity new` whenever `definitions/providers/*.yaml` exist
+— but nothing in the CLI surfaced that, so consumers searched `--help` for a
+`provider` / `integration` / `gen` command, found none, and mistook a working
+feature for a publish gap. Docs-and-help only; no generator behavior changed.
+
+### Changed
+
+- **`codegen entity new --help`** now documents every post-generation step it
+  runs (event / bridge / orchestration / **provider + adapter (Track D)**
+  codegen), including Track D's trigger (`definitions/providers/*.yaml`), output
+  paths (`<backendSrc>/integrations/{providers,}`), emit-once semantics, and an
+  explicit note that there is no standalone `provider` / `integration` / `gen`
+  command — Track D is driven entirely by re-running `entity new`.
+- **`codegen entity` summary hints** now surface a Track D regen hint when the
+  project has a providers directory — a discoverability path that does not
+  require reading `entity new --help`.
+- **Integration domain skill** (`protocols-and-ports.md`, `SKILL.md`) documents
+  the Track D invocation, the skip-when-no-providers-dir behavior, and that the
+  generated scaffold (not the `.d.ts`) is ground truth for adapter port shape.
+
 ## [0.12.0] — 2026-05-31
 
 Integration codegen retarget (RFC-0001): a **provider/adapter/surface** model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -171,12 +171,33 @@ async function hints(ctx: Context): Promise<Hint[]> {
 			},
 		];
 	}
-	return [
+	const baseHints: Hint[] = [
 		{ command: 'codegen entity new <file>', description: 'Generate one entity' },
 		{ command: 'codegen entity new --all', description: 'Regenerate all entities' },
 		{ command: 'codegen entity validate', description: 'Validate YAML definitions' },
 		{ command: 'codegen entity list', description: 'List entities as a table' },
 	];
+
+	// Track D (RFC-0001): provider/adapter codegen has no command of its own —
+	// it is a post-step of `entity new`. Surface that here when the project has
+	// provider definitions, so the only discoverability path doesn't depend on
+	// reading `entity new --help`.
+	const providersDir =
+		(ctx.config as { paths?: { providers?: string } } | null | undefined)?.paths
+			?.providers != null
+			? path.resolve(
+					ctx.cwd,
+					(ctx.config as { paths: { providers: string } }).paths.providers,
+				)
+			: path.resolve(ctx.cwd, 'definitions/providers');
+	if (fs.existsSync(providersDir)) {
+		baseHints.push({
+			command: 'codegen entity new --all',
+			description: 'Regenerate provider modules + adapter scaffolds (Track D)',
+		});
+	}
+
+	return baseHints;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,9 +208,23 @@ export class EntityNewCommand extends Command {
 	static paths = [['entity', 'new']];
 	static usage = Command.Usage({
 		description: 'Generate code for one or more entities from YAML',
+		details: `
+			Generates Clean Architecture code for the named entity (or all entities with \`--all\`), then runs the post-generation codegen steps that share this entrypoint:
+
+			- **Event codegen** — \`AppDomainEvent\` union + typed bus from \`events/*.yaml\`.
+			- **Bridge registry** — when the bridge subsystem is installed.
+			- **Orchestration modules** — from orchestration patterns.
+			- **Provider + adapter codegen (Track D, RFC-0001)** — when \`definitions/providers/*.yaml\` exist, emits one provider module per file into \`<backendSrc>/integrations/providers/\` and the matching adapter scaffolds + \`@generated\` files into \`<backendSrc>/integrations/\`. Author-owned scaffolds are emit-once (never overwritten); \`@generated\` files re-emit each run. With no providers dir the step is silently skipped.
+
+			There is no separate \`provider\`, \`integration\`, or \`gen\` command — Track D codegen is driven entirely by re-running \`entity new\`. The \`just gen\` / \`just gen-all\` recipes are thin wrappers over it.
+		`,
 		examples: [
 			['Generate a single entity', 'codegen entity new entities/contact.yaml'],
 			['Regenerate all entities', 'codegen entity new --all'],
+			[
+				'Regenerate everything incl. provider/adapter codegen',
+				'codegen entity new --all',
+			],
 			['Preview without writing', 'codegen entity new entities/contact.yaml --dry-run'],
 		],
 	});


### PR DESCRIPTION
## Why

A consuming agent on 0.12.0 reported what looked like a publish gap: Track D (provider/adapter integration codegen) shipped per the CHANGELOG, but `--help` exposed no `provider`, `integration`, `surface`, or `gen` command, and `codegen integration` errored. They couldn't find the invocation.

It's **not a gap**. I packed the published `@pattern-stack/codegen@0.12.0` tarball and confirmed the generator wiring is present (`generateProviderModules` / `emitAdapters`, 8 hits in `dist/src/cli/index.js`). Track D runs as a **post-step of `codegen entity new`** whenever `definitions/providers/*.yaml` exist — there is no standalone command by design. The CLI just never surfaced that, so a working feature read as missing.

This PR closes the discoverability gap. **Docs-and-help only — no generator behavior changed.**

## Changes

- **`codegen entity new --help`** — new `details:` block documenting every post-generation step (`event` / `bridge` / `orchestration` / **provider + adapter (Track D)** codegen): the trigger (`definitions/providers/*.yaml`), output paths (`<backendSrc>/integrations/{providers,}`), emit-once scaffold semantics, and an explicit *"there is no separate `provider` / `integration` / `gen` command"* note.
- **`codegen entity` summary hints** — when the project has a providers dir, append a Track D regen hint. This is the discoverability path that does **not** require reading `entity new --help`.
- **Integration domain skill** (`protocols-and-ports.md`, `SKILL.md`) — document the invocation, the skip-when-no-providers-dir behavior, the D1 import-path gate, and that the generated scaffold (not the `.d.ts`) is ground truth for adapter port shape.
- **Version** bumped `0.12.0 → 0.12.1` + CHANGELOG entry.

## Verification

- `codegen entity new --help` renders the new Details/Examples cleanly (ANSI-stripped check).
- `codegen entity` hints show the Track D line only when a providers dir is present.
- CLI test suite: **758 pass / 0 fail**. (Pre-existing failures in `worktrees/pr-271/` are another branch's WIP swept up by `bun`; confirmed identical with this branch stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
