### PR TITLE
fix(track-d): consumer CLI — surface/context in entity block + exclude providers dir (0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.2] — 2026-05-31
+
+Track D consumer-CLI fix. The 0.12.0/0.12.1 generator was correct in the
+hermetic D7 path but broke for real consumers driving it through the CLI. Two
+schema/loader bugs plus a DX gap that masked the first. No swe-brain YAML change
+is required — consumer YAML already wrote the keys in the natural place; the
+schema is now corrected to match.
+
+### Fixed
+
+- **`entity.surface` / `entity.context` schema level.** `surface:` and
+  `context:` were defined at the ROOT of `EntityDefinitionSchema` (sibling of
+  `entity:`/`fields:`), but consumers naturally write them INSIDE the `entity:`
+  block (next to `pattern:`/`name:`/`table:`). Because the `entity:` block is
+  `.strict()`, those YAMLs were rejected with "Unrecognized key(s) in object:
+  'surface' at 'entity'". The fields now live in `EntityConfigSchema` and are
+  read as `entity.surface` / `entity.context`. Clean break — root-level
+  placement no longer validates. Read sites updated:
+  `collectEntitySurfaces` (`validate-providers.ts`), `collectEntitiesBySurface`
+  (`adapter-emission-generator.ts`), the provider surface cross-check
+  (`entity.ts`), and the clean-lite-ps output-subfolder consumer
+  (`prompt-extension.js` `buildCleanLitePsLocals`).
+- **Entity `--all` discovery no longer globs `definitions/providers/`.** With
+  `entities_dir: definitions`, the recursive YAML walk pulled provider files
+  into the entity loader, where they fail entity validation. Entity discovery
+  (`findYamlFiles`, `loadEntities`, `listEntityYamls`) now excludes the
+  configured providers dir (`paths.providers`, default `definitions/providers`).
+  Provider files route only through `ProviderDefinitionSchema`.
+
+### Changed
+
+- **`entity new --dry-run` surfaces the Zod detail.** The failure path printed
+  only "Validation failed for <file>"; it now emits the same per-issue Zod
+  diagnostics as `entity validate`, so a misplaced key reports which key/level
+  is wrong (the DX gap that hid the `entity.surface` rejection).
+
 ## [0.12.1] — 2026-05-31
 
 Track D (provider/adapter integration codegen) discoverability fix. The 0.12.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/clean-lite-ps/context-output-subfolder.test.ts
+++ b/src/__tests__/clean-lite-ps/context-output-subfolder.test.ts
@@ -18,13 +18,18 @@ import { buildCleanLitePsLocals } from '../../../templates/entity/new/clean-lite
 
 const SRC = 'app/backend/src';
 
-function localsFor(extra: Record<string, unknown>) {
+function localsFor(entityExtra: Record<string, unknown>) {
 	const definition = {
-		entity: { name: 'transcript', plural: 'transcripts', table: 'transcripts' },
+		entity: {
+			name: 'transcript',
+			plural: 'transcripts',
+			table: 'transcripts',
+			// #403: `context:` lives inside the `entity:` block (0.12.2).
+			...entityExtra,
+		},
 		fields: { title: { type: 'string', required: true } },
 		relationships: {},
 		behaviors: ['timestamps'],
-		...extra,
 	};
 	return buildCleanLitePsLocals(definition, { backendSrc: SRC });
 }

--- a/src/__tests__/cli/adapter-emission-generator.test.ts
+++ b/src/__tests__/cli/adapter-emission-generator.test.ts
@@ -32,10 +32,10 @@ function loadDef(name: string) {
 }
 
 const ENTITIES = [
-  { entity: { name: 'deal' }, surface: 'crm' },
-  { entity: { name: 'account' }, surface: 'crm' },
-  { entity: { name: 'calendar_event' }, surface: 'calendar' },
-  { entity: { name: 'email' }, surface: 'mail' },
+  { entity: { name: 'deal', surface: 'crm' } },
+  { entity: { name: 'account', surface: 'crm' } },
+  { entity: { name: 'calendar_event', surface: 'calendar' } },
+  { entity: { name: 'email', surface: 'mail' } },
   { entity: { name: 'no_surface' } },
 ];
 

--- a/src/__tests__/cli/barrel-generator.test.ts
+++ b/src/__tests__/cli/barrel-generator.test.ts
@@ -43,8 +43,8 @@ function mkProject(opts: {
 				`  name: ${ent.name}`,
 				`  plural: ${ent.plural}`,
 				`  table: ${ent.plural}`,
-				// #403: top-level `context:` nests the module folder.
-				...(ent.context ? [`context: ${ent.context}`] : []),
+				// #403: `entity.context:` nests the module folder.
+				...(ent.context ? [`  context: ${ent.context}`] : []),
 				'fields:',
 				'  id:',
 				'    type: uuid',

--- a/src/__tests__/parser/fixtures/entities/calendar-event.yaml
+++ b/src/__tests__/parser/fixtures/entities/calendar-event.yaml
@@ -2,7 +2,7 @@ entity:
   name: calendar_event
   plural: calendar_events
   table: calendar_events
-surface: calendar
+  surface: calendar
 fields:
   title:
     type: string

--- a/src/__tests__/parser/fixtures/entities/deal.yaml
+++ b/src/__tests__/parser/fixtures/entities/deal.yaml
@@ -2,7 +2,7 @@ entity:
   name: deal
   plural: deals
   table: deals
-surface: crm
+  surface: crm
 fields:
   name:
     type: string

--- a/src/__tests__/parser/fixtures/entities/email.yaml
+++ b/src/__tests__/parser/fixtures/entities/email.yaml
@@ -2,7 +2,7 @@ entity:
   name: email
   plural: emails
   table: emails
-surface: mail
+  surface: mail
 fields:
   subject:
     type: string

--- a/src/__tests__/parser/fixtures/entities/meeting.yaml
+++ b/src/__tests__/parser/fixtures/entities/meeting.yaml
@@ -2,7 +2,7 @@ entity:
   name: meeting
   plural: meetings
   table: meetings
-surface: transcript
+  surface: transcript
 fields:
   title:
     type: string

--- a/src/__tests__/parser/track-d-consumer-cli.test.ts
+++ b/src/__tests__/parser/track-d-consumer-cli.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Track D consumer-CLI regression tests (0.12.2).
+ *
+ * Mirrors the swe-brain consumer layout that broke under 0.12.0/0.12.1, at the
+ * loader level the D7 hermetic test bypassed:
+ *
+ *   1. `surface:` / `context:` live INSIDE the `entity:` block (next to
+ *      `pattern:`/`name:`/`table:`), which is where consumers naturally write
+ *      them. The `entity:` block is `.strict()`, so before the fix these keys
+ *      were rejected ("Unrecognized key(s) in object: 'surface' at 'entity'").
+ *      Root-level placement is a clean break — it no longer validates.
+ *
+ *   2. With `entities_dir: definitions`, the recursive YAML walk used to pull in
+ *      `definitions/providers/*.yaml` and run them through the ENTITY loader,
+ *      where they fail validation. Entity discovery must exclude the providers
+ *      subtree; provider files route ONLY through ProviderDefinitionSchema.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { findYamlFiles } from '../../utils/find-yaml-files';
+import { loadEntities } from '../../parser/load-entities';
+import { loadEntityFromYaml, loadProviderFromYaml } from '../../utils/yaml-loader';
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), 'track-d-cli-'));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function write(rel: string, content: string): string {
+	const full = join(dir, rel);
+	mkdirSync(join(full, '..'), { recursive: true });
+	writeFileSync(full, content);
+	return resolve(full);
+}
+
+// A swe-brain-shaped entity: `surface:`/`context:` inside the `entity:` block.
+const ENTITY_WITH_SURFACE = `entity:
+  name: transcript
+  plural: transcripts
+  table: transcripts
+  surface: transcript
+  context: integration
+fields:
+  title:
+    type: string
+    required: true
+`;
+
+const PROVIDER_YAML = `slug: google
+display_name: Google
+auth:
+  type: oauth2
+  strategy: '@app/integrations/providers/google/google-oauth.strategy#GoogleOAuthStrategy'
+  scopes:
+    - https://www.googleapis.com/auth/gmail.readonly
+client:
+  class: '@app/integrations/providers/google/google.client#GoogleClient'
+  base_url: https://www.googleapis.com
+surfaces: [transcript]
+`;
+
+describe('Track D · entity.surface / entity.context (0.12.2)', () => {
+	it('validates an entity with surface: + context: inside the entity: block', () => {
+		const file = write('definitions/transcript.yaml', ENTITY_WITH_SURFACE);
+		const result = loadEntityFromYaml(file);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.definition.entity.surface).toBe('transcript');
+			expect(result.definition.entity.context).toBe('integration');
+		}
+	});
+
+	it('rejects root-level surface:/context: with an actionable Zod detail', () => {
+		const file = write(
+			'definitions/bad.yaml',
+			`entity:
+  name: transcript
+  plural: transcripts
+  table: transcripts
+surface: transcript
+fields:
+  title:
+    type: string
+    required: true
+`,
+		);
+		const result = loadEntityFromYaml(file);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			// The DX miss: `entity new` now surfaces this detail too, not just the
+			// short "Validation failed" line.
+			expect(result.details && result.details.length > 0).toBe(true);
+		}
+	});
+});
+
+describe('Track D · entity discovery excludes the providers subtree (0.12.2)', () => {
+	it('findYamlFiles({ excludeDirs }) omits definitions/providers/*.yaml', () => {
+		write('definitions/transcript.yaml', ENTITY_WITH_SURFACE);
+		write('definitions/providers/google.yaml', PROVIDER_YAML);
+
+		const entitiesDir = join(dir, 'definitions');
+		const providersDir = join(dir, 'definitions', 'providers');
+
+		const all = findYamlFiles(entitiesDir);
+		expect(all.some((f) => f.includes('/providers/'))).toBe(true);
+
+		const entityOnly = findYamlFiles(entitiesDir, {
+			excludeDirs: [providersDir],
+		});
+		expect(entityOnly.some((f) => f.includes('/providers/'))).toBe(false);
+		expect(entityOnly).toHaveLength(1);
+	});
+
+	it('loadEntities({ excludeDirs }) does NOT validate provider files as entities', () => {
+		write('definitions/transcript.yaml', ENTITY_WITH_SURFACE);
+		write('definitions/providers/google.yaml', PROVIDER_YAML);
+
+		const entitiesDir = join(dir, 'definitions');
+		const providersDir = join(dir, 'definitions', 'providers');
+
+		// Without exclusion the provider file is loaded as an entity and fails.
+		const naive = loadEntities(entitiesDir);
+		expect(naive.issues.some((i) => i.severity === 'error')).toBe(true);
+
+		// With exclusion the load is clean: only the real entity is parsed.
+		const scoped = loadEntities(entitiesDir, { excludeDirs: [providersDir] });
+		expect(scoped.issues.some((i) => i.severity === 'error')).toBe(false);
+		expect(scoped.entities).toHaveLength(1);
+		expect(scoped.entities[0]!.name).toBe('transcript');
+	});
+
+	it('provider YAML routes cleanly through ProviderDefinitionSchema', () => {
+		const file = write('definitions/providers/google.yaml', PROVIDER_YAML);
+
+		// It is NOT a valid entity...
+		expect(loadEntityFromYaml(file).success).toBe(false);
+		// ...but IS a valid provider.
+		const provider = loadProviderFromYaml(file);
+		expect(provider.success).toBe(true);
+		if (provider.success) {
+			expect(provider.definition.slug).toBe('google');
+			expect(provider.definition.surfaces).toContain('transcript');
+		}
+	});
+});

--- a/src/__tests__/parser/validate-providers.test.ts
+++ b/src/__tests__/parser/validate-providers.test.ts
@@ -62,9 +62,9 @@ describe('collectEntitySurfaces', () => {
 
 	it('ignores entities without a surface', () => {
 		const surfaces = collectEntitySurfaces([
-			{ surface: 'crm' },
-			{},
-			{ surface: undefined },
+			{ entity: { surface: 'crm' } },
+			{ entity: {} },
+			{ entity: { surface: undefined } },
 		]);
 		expect([...surfaces]).toEqual(['crm']);
 	});

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -462,33 +462,74 @@ describe('scopeable flag', () => {
 	});
 });
 
-describe('context flag (#403)', () => {
+describe('context flag (#403) — inside entity: block (0.12.2)', () => {
 	const base = {
 		entity: { name: 'transcript', plural: 'transcripts', table: 'transcripts' },
 		fields: { id: { type: 'uuid', required: true } },
 	};
 
-	it('accepts a top-level context: <snake_case> — the key no longer trips .strict()', () => {
-		const result = EntityDefinitionSchema.safeParse({ ...base, context: 'integration' });
+	it('accepts entity.context: <snake_case>', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, context: 'integration' },
+		});
 		expect(result.success).toBe(true);
-		expect(result.data!.context).toBe('integration');
+		expect(result.data!.entity.context).toBe('integration');
 	});
 
 	it('context is optional — omitting it is valid (flat output preserved)', () => {
 		const result = EntityDefinitionSchema.safeParse(base);
 		expect(result.success).toBe(true);
-		expect(result.data!.context).toBeUndefined();
+		expect(result.data!.entity.context).toBeUndefined();
 	});
 
 	it('rejects non-snake_case context (uppercase / hyphen / leading digit)', () => {
 		for (const bad of ['Integration', 'my-context', '1context', '_x']) {
-			const result = EntityDefinitionSchema.safeParse({ ...base, context: bad });
+			const result = EntityDefinitionSchema.safeParse({
+				...base,
+				entity: { ...base.entity, context: bad },
+			});
 			expect(result.success).toBe(false);
 		}
 	});
 
 	it('rejects non-string context', () => {
-		const result = EntityDefinitionSchema.safeParse({ ...base, context: 123 });
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, context: 123 },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects root-level context: — clean break, no root placement', () => {
+		const result = EntityDefinitionSchema.safeParse({ ...base, context: 'integration' });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('surface flag (RFC-0001) — inside entity: block (0.12.2)', () => {
+	const base = {
+		entity: { name: 'transcript', plural: 'transcripts', table: 'transcripts' },
+		fields: { id: { type: 'uuid', required: true } },
+	};
+
+	it('accepts entity.surface: <string>', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, surface: 'transcript' },
+		});
+		expect(result.success).toBe(true);
+		expect(result.data!.entity.surface).toBe('transcript');
+	});
+
+	it('surface is optional — omitting it is valid', () => {
+		const result = EntityDefinitionSchema.safeParse(base);
+		expect(result.success).toBe(true);
+		expect(result.data!.entity.surface).toBeUndefined();
+	});
+
+	it('rejects root-level surface: — clean break, no root placement', () => {
+		const result = EntityDefinitionSchema.safeParse({ ...base, surface: 'transcript' });
 		expect(result.success).toBe(false);
 	});
 });

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -63,9 +63,33 @@ import type { NounModule } from '../noun-module.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function listEntityYamls(dir: string): string[] {
+/**
+ * Resolve the provider-definitions directory from config (`paths.providers`,
+ * default `definitions/providers`). Provider YAML validates against
+ * `ProviderDefinitionSchema` — it must be excluded from entity discovery so the
+ * recursive `definitions` walk never feeds `definitions/providers/*.yaml` to the
+ * entity loader (where it fails entity validation).
+ */
+function resolveProvidersDir(ctx: Context): string {
+	const fromConfig = (
+		ctx.config as { paths?: { providers?: string } } | null | undefined
+	)?.paths?.providers;
+	return fromConfig != null
+		? path.resolve(ctx.cwd, fromConfig)
+		: path.resolve(ctx.cwd, 'definitions/providers');
+}
+
+/**
+ * List entity YAML files under `dir`, excluding the provider-definitions
+ * subtree. When the entities dir IS the `definitions` root, the recursive walk
+ * would otherwise pull in `definitions/providers/*.yaml`; passing the providers
+ * dir as an exclusion keeps entity discovery to entity files only.
+ */
+function listEntityYamls(dir: string, providersDir?: string): string[] {
 	if (!fs.existsSync(dir)) return [];
-	return findYamlFiles(dir);
+	return findYamlFiles(dir, {
+		excludeDirs: providersDir ? [providersDir] : [],
+	});
 }
 
 interface EntitySummaryRow {
@@ -135,7 +159,7 @@ async function summary(ctx: Context): Promise<PaneOutput> {
 		};
 	}
 
-	const files = listEntityYamls(ctx.entitiesDir);
+	const files = listEntityYamls(ctx.entitiesDir, resolveProvidersDir(ctx));
 	const rows = files.map(summarizeEntityFile).filter((r): r is EntitySummaryRow => r !== null);
 
 	const patterns = new Set(rows.map((r) => r.pattern));
@@ -256,7 +280,7 @@ export class EntityNewCommand extends Command {
 		let targets: string[] = [];
 		if (this.all) {
 			const dir = ctx.entitiesDir ?? path.resolve(ctx.cwd, 'entities');
-			targets = listEntityYamls(dir);
+			targets = listEntityYamls(dir, resolveProvidersDir(ctx));
 			if (targets.length === 0) {
 				printError(`No entity YAML files found in ${dir}`);
 				return 1;
@@ -268,21 +292,29 @@ export class EntityNewCommand extends Command {
 			return 2;
 		}
 
-		// Pre-flight: validate each YAML.
+		// Pre-flight: validate each YAML. Capture the Zod `details` alongside the
+		// short message so `entity new` surfaces the SAME per-issue diagnostics as
+		// `entity validate` — otherwise a failing YAML prints only "Validation
+		// failed for <file>" with no clue which key/level is wrong (the DX miss
+		// that masked Bug 1: `entity.surface` rejected with no actionable detail).
 		const validated: Array<{ file: string; name: string }> = [];
-		const invalid: Array<{ file: string; message: string }> = [];
+		const invalid: Array<{ file: string; message: string; details?: string[] }> =
+			[];
 		for (const file of targets) {
 			const result = loadEntityFromYaml(file);
 			if (result.success) {
 				validated.push({ file, name: result.definition.entity.name });
 			} else {
-				invalid.push({ file, message: result.error });
+				invalid.push({ file, message: result.error, details: result.details });
 			}
 		}
 
 		if (invalid.length > 0 && !this.continueOnError) {
 			for (const i of invalid) {
 				printError(`${path.basename(i.file)} — ${i.message}`);
+				for (const detail of i.details ?? []) {
+					printError(`   • ${detail}`);
+				}
 			}
 			if (!isJsonMode()) {
 				return 1;
@@ -297,7 +329,9 @@ export class EntityNewCommand extends Command {
 		const entitiesDirForEmits =
 			ctx.entitiesDir ?? path.resolve(ctx.cwd, 'entities');
 		const eventsDirForEmits = resolveEventsDir(ctx);
-		const allEntitiesForEmits = loadEntities(entitiesDirForEmits).entities;
+		const allEntitiesForEmits = loadEntities(entitiesDirForEmits, {
+			excludeDirs: [resolveProvidersDir(ctx)],
+		}).entities;
 		const validatedNames = new Set(validated.map((v) => v.name));
 		const emitsTargetEntities = allEntitiesForEmits.filter((e) =>
 			validatedNames.has(e.name),
@@ -707,14 +741,7 @@ export class EntityNewCommand extends Command {
 		// integrations see no change. Blocking issues ⇒ nothing is written.
 		let providerResult: ReturnType<typeof generateProviderModules> | null = null;
 		try {
-			const providersDir =
-				(ctx.config as { paths?: { providers?: string } } | null | undefined)
-					?.paths?.providers != null
-					? path.resolve(
-							ctx.cwd,
-							(ctx.config as { paths: { providers: string } }).paths.providers,
-						)
-					: path.resolve(ctx.cwd, 'definitions/providers');
+			const providersDir = resolveProvidersDir(ctx);
 			const providerOutputRoot = path.resolve(
 				ctx.cwd,
 				backendSrcForHandlers,
@@ -722,9 +749,9 @@ export class EntityNewCommand extends Command {
 			);
 			const entitySurfaces = fs.existsSync(entitiesDir)
 				? collectEntitySurfaces(
-						loadEntitiesFromYaml(findYamlFiles(entitiesDir)).successes.map(
-							(s) => s.definition,
-						),
+						loadEntitiesFromYaml(
+							findYamlFiles(entitiesDir, { excludeDirs: [providersDir] }),
+						).successes.map((s) => s.definition),
 					)
 				: new Set<string>();
 			const tsAliases = resolveTsconfigAliases(ctx.cwd);
@@ -774,9 +801,9 @@ export class EntityNewCommand extends Command {
 					'integrations',
 				);
 				const entityDefs = fs.existsSync(entitiesDir)
-					? loadEntitiesFromYaml(findYamlFiles(entitiesDir)).successes.map(
-							(s) => s.definition,
-						)
+					? loadEntitiesFromYaml(
+							findYamlFiles(entitiesDir, { excludeDirs: [providersDir] }),
+						).successes.map((s) => s.definition)
 					: [];
 				const loadedProviders = loadProvidersFromYaml(
 					findYamlFiles(providersDir),
@@ -944,7 +971,7 @@ export class EntityListCommand extends Command {
 			return 1;
 		}
 
-		const files = listEntityYamls(ctx.entitiesDir);
+		const files = listEntityYamls(ctx.entitiesDir, resolveProvidersDir(ctx));
 		const rows = files
 			.map(summarizeEntityFile)
 			.filter((r): r is EntitySummaryRow => r !== null)

--- a/src/cli/shared/adapter-emission-generator.ts
+++ b/src/cli/shared/adapter-emission-generator.ts
@@ -158,14 +158,15 @@ function generatedBanner(sourceDesc: string): string {
  * union per surface populates each adapter's `capabilities.entities`.
  */
 export function collectEntitiesBySurface(
-  entities: Iterable<{ entity: { name: string }; surface?: string }>,
+  entities: Iterable<{ entity: { name: string; surface?: string } }>,
 ): Map<string, string[]> {
   const bySurface = new Map<string, string[]>();
   for (const e of entities) {
-    if (!e.surface) continue;
-    const list = bySurface.get(e.surface) ?? [];
+    const surface = e.entity.surface;
+    if (!surface) continue;
+    const list = bySurface.get(surface) ?? [];
     list.push(e.entity.name);
-    bySurface.set(e.surface, list);
+    bySurface.set(surface, list);
   }
   // Deterministic order within each surface.
   for (const [surface, list] of bySurface) {

--- a/src/cli/shared/barrel-generator.ts
+++ b/src/cli/shared/barrel-generator.ts
@@ -138,8 +138,8 @@ function collectEntities(entitiesDir: string): EntityInfo[] {
 		entities.push({
 			name: def.entity.name,
 			plural: def.entity.plural,
-			// #403: top-level `context:` nests the module folder; undefined → flat.
-			context: def.context,
+			// #403: `entity.context:` nests the module folder; undefined → flat.
+			context: def.entity.context,
 		});
 	}
 	// Deterministic: sort by singular name.

--- a/src/parser/load-entities.ts
+++ b/src/parser/load-entities.ts
@@ -208,16 +208,21 @@ function loadErrorToIssue(error: LoadError): AnalysisIssue[] {
 /**
  * Load all entity YAML files from a directory
  */
-export function loadEntities(entitiesDir: string): LoadEntitiesResult {
+export function loadEntities(
+	entitiesDir: string,
+	opts?: { excludeDirs?: string[] },
+): LoadEntitiesResult {
 	const entities: ParsedEntity[] = [];
 	const issues: AnalysisIssue[] = [];
 
 	const resolvedDir = resolve(entitiesDir);
 
-	// Get all YAML files
+	// Get all YAML files. `excludeDirs` keeps the provider-definitions subtree
+	// (`definitions/providers/*.yaml`) out — those validate against
+	// ProviderDefinitionSchema, not the entity loader.
 	let files: string[];
 	try {
-		files = findYamlFiles(resolvedDir);
+		files = findYamlFiles(resolvedDir, { excludeDirs: opts?.excludeDirs });
 	} catch (err) {
 		issues.push({
 			severity: 'error',

--- a/src/parser/validate-providers.ts
+++ b/src/parser/validate-providers.ts
@@ -77,11 +77,11 @@ export interface ValidateProvidersOptions {
  * contribute nothing.
  */
 export function collectEntitySurfaces(
-  entities: Iterable<{ surface?: string }>,
+  entities: Iterable<{ entity: { surface?: string } }>,
 ): Set<string> {
   const surfaces = new Set<string>();
   for (const e of entities) {
-    if (e.surface) surfaces.add(e.surface);
+    if (e.entity.surface) surfaces.add(e.entity.surface);
   }
   return surfaces;
 }

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -497,6 +497,41 @@ const EntityConfigSchema = z
     // Drives the generated ScopeEntityType union in
     // runtime/subsystems/jobs/generated/scope-entity-type.ts.
     scopeable: z.boolean().optional(),
+
+    // RFC-0001 §1/§8: the integration *surface* this entity belongs to
+    // (e.g. 'calendar', 'mail', 'crm'). Surfaces span provider contexts
+    // (ADR-0006) — one Google OAuth feeds calendar+mail+transcript. The union
+    // of `surface:` values across all entity YAML is the closed set that a
+    // provider's `surfaces:` must be a subset of (cross-checked in
+    // src/parser/validate-providers.ts). Optional: entities without an
+    // integration surface omit it. The surface-package *emission* convention
+    // is Track C (#329); this field is only the declarative input both tracks
+    // read. Lives inside the `entity:` block (next to `pattern:`/`name:`/`table:`).
+    surface: z.string().optional(),
+
+    // Bounded-context declaration (ADR-0004) — "which bounded context this
+    // entity belongs to". This is the DURABLE decision; it is a plain
+    // bounded-context slug, NOT a folder knob. Different features consume it:
+    //
+    //   - #403 (the FIRST consumer): drives the generated code's
+    //     module output folder. clean-lite-ps nests the entity's module under
+    //     `<modules>/<context>/<entity>/` so same-context entities group
+    //     together; untagged entities stay flat (`<modules>/<entity>/`).
+    //   - ADR-0004 (deferred): a later `naming: prefix | schema` knob reads
+    //     this SAME field to drive the Postgres physical layout —
+    //     `prefix` → `pgTable('<context>__<table>')`, then the flip to
+    //     `schema` → `pgSchema('<context>').table('<table>')`. NOT wired here.
+    //
+    // Sibling to `surface:` and orthogonal to it (ADR-0006): context = model
+    // cohesion (which domain), surface = vendor composition (which integration).
+    // Lives inside the `entity:` block (next to `pattern:`/`name:`/`table:`).
+    context: z
+      .string()
+      .regex(
+        /^[a-z][a-z0-9_]*$/,
+        "context must be lowercase snake_case (e.g. 'integration')",
+      )
+      .optional(),
   })
   .strict()
   .refine((d) => !(d.pattern && d.patterns), {
@@ -807,40 +842,11 @@ export const EntityDefinitionSchema = z
     // `EntityDefinitionSchema` below.
     detection: z.record(z.string(), DetectionConfigSchema).optional(),
 
-    // RFC-0001 §1/§8: the integration *surface* this entity belongs to
-    // (e.g. 'calendar', 'mail', 'crm'). Surfaces span provider contexts
-    // (ADR-0006) — one Google OAuth feeds calendar+mail+transcript. The union
-    // of `surface:` values across all entity YAML is the closed set that a
-    // provider's `surfaces:` must be a subset of (cross-checked in
-    // src/parser/validate-providers.ts). Optional: entities without an
-    // integration surface omit it. The surface-package *emission* convention
-    // is Track C (#329); this field is only the declarative input both tracks
-    // read.
-    surface: z.string().optional(),
-
-    // Bounded-context declaration (ADR-0004) — "which bounded context this
-    // entity belongs to". This is the DURABLE decision; it is a plain
-    // bounded-context slug, NOT a folder knob. Different features consume it:
-    //
-    //   - #403 (this PR, the FIRST consumer): drives the generated code's
-    //     module output folder. clean-lite-ps nests the entity's module under
-    //     `<modules>/<context>/<entity>/` so same-context entities group
-    //     together; untagged entities stay flat (`<modules>/<entity>/`).
-    //   - ADR-0004 (deferred): a later `naming: prefix | schema` knob reads
-    //     this SAME field to drive the Postgres physical layout —
-    //     `prefix` → `pgTable('<context>__<table>')`, then the flip to
-    //     `schema` → `pgSchema('<context>').table('<table>')`. NOT wired here;
-    //     #403 makes no table/column/schema changes.
-    //
-    // Sibling to `surface:` and orthogonal to it (ADR-0006): context = model
-    // cohesion (which domain), surface = vendor composition (which integration).
-    context: z
-      .string()
-      .regex(
-        /^[a-z][a-z0-9_]*$/,
-        "context must be lowercase snake_case (e.g. 'integration')",
-      )
-      .optional(),
+    // NOTE: `surface:` and `context:` moved INTO EntityConfigSchema (the
+    // `entity:` block) in 0.12.2 — consumers write them next to
+    // `pattern:`/`name:`/`table:`, which is the natural place. They are
+    // read via `entity.surface` / `entity.context`. Clean break: no
+    // root-level placement is accepted.
 
     // v2: Domain event declarations (CODEGEN-EVOLUTION-PLAN Phase 2)
     // Generates typed event classes, handlers, and queue registration

--- a/src/utils/find-yaml-files.ts
+++ b/src/utils/find-yaml-files.ts
@@ -31,18 +31,29 @@ function isYaml(name: string): boolean {
  * Recursively collect every `.yaml`/`.yml` file under `dir`.
  *
  * @param dir Directory to walk (relative paths are resolved against cwd).
+ * @param opts.excludeDirs Absolute directory paths to skip entirely (and their
+ *   subtrees). Used by entity discovery to keep `definitions/providers/*.yaml`
+ *   out of the entity glob — provider files validate against
+ *   `ProviderDefinitionSchema`, not `EntityDefinitionSchema`, so they must never
+ *   reach the entity loader. Paths are compared after `resolve`.
  * @returns Absolute file paths, sorted lexicographically. Throws if `dir`
  *   does not exist.
  */
-export function findYamlFiles(dir: string): string[] {
+export function findYamlFiles(
+	dir: string,
+	opts?: { excludeDirs?: string[] },
+): string[] {
 	const root = resolve(dir);
 	const out: string[] = [];
+	const excluded = new Set((opts?.excludeDirs ?? []).map((d) => resolve(d)));
 
 	const walk = (current: string): void => {
 		for (const entry of readdirSync(current, { withFileTypes: true })) {
 			if (entry.isDirectory()) {
 				if (entry.name.startsWith('.')) continue;
-				walk(join(current, entry.name));
+				const child = join(current, entry.name);
+				if (excluded.has(resolve(child))) continue;
+				walk(child);
 			} else if (isYaml(entry.name)) {
 				out.push(join(current, entry.name));
 			}

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -1008,14 +1008,14 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const entityNamePlural = entity.plural || pluralize(entityName);
   const entityNamePluralPascal = pascalCase(entityNamePlural);
 
-  // #403: bounded-context folder grouping. A top-level `context:` nests this
+  // #403: bounded-context folder grouping. `entity.context:` nests this
   // entity's module folder under that segment so same-context entities group
   // together (`<modules>/<context>/<plural>/`); no context → flat
   // (`<modules>/<plural>/`, byte-identical to pre-#403). Emit-folder-only —
   // every intra-module import is folder-relative and therefore unaffected, and
   // the generated barrel recomputes its import paths from the full file paths
   // below. The module-folder base used by every clpOutputPaths entry:
-  const entityContext = definition.context || null;
+  const entityContext = entity.context || null;
   const moduleGroupDir = entityContext
     ? `${srcRoot}/modules/${entityContext}`
     : `${srcRoot}/modules`;

--- a/test/fixtures/integration-patterns/definitions/entities/account.yaml
+++ b/test/fixtures/integration-patterns/definitions/entities/account.yaml
@@ -4,7 +4,7 @@ entity:
   name: account
   plural: accounts
   table: accounts
-surface: crm
+  surface: crm
 fields:
   name:
     type: string

--- a/test/fixtures/integration-patterns/definitions/entities/contact.yaml
+++ b/test/fixtures/integration-patterns/definitions/entities/contact.yaml
@@ -2,7 +2,7 @@ entity:
   name: contact
   plural: contacts
   table: contacts
-surface: crm
+  surface: crm
 fields:
   email:
     type: string

--- a/test/fixtures/integration-patterns/definitions/entities/email.yaml
+++ b/test/fixtures/integration-patterns/definitions/entities/email.yaml
@@ -2,7 +2,7 @@ entity:
   name: email
   plural: emails
   table: emails
-surface: mail
+  surface: mail
 fields:
   subject:
     type: string

--- a/test/fixtures/integration-patterns/definitions/entities/meeting.yaml
+++ b/test/fixtures/integration-patterns/definitions/entities/meeting.yaml
@@ -2,7 +2,7 @@ entity:
   name: meeting
   plural: meetings
   table: meetings
-surface: calendar
+  surface: calendar
 fields:
   title:
     type: string

--- a/test/fixtures/integration-patterns/definitions/entities/opportunity.yaml
+++ b/test/fixtures/integration-patterns/definitions/entities/opportunity.yaml
@@ -2,7 +2,7 @@ entity:
   name: opportunity
   plural: opportunities
   table: opportunities
-surface: crm
+  surface: crm
 fields:
   name:
     type: string

--- a/test/fixtures/integration-patterns/definitions/entities/transcript.yaml
+++ b/test/fixtures/integration-patterns/definitions/entities/transcript.yaml
@@ -2,7 +2,7 @@ entity:
   name: transcript
   plural: transcripts
   table: transcripts
-surface: transcript
+  surface: transcript
 fields:
   body:
     type: string


### PR DESCRIPTION
## Track D consumer-CLI fix (0.12.2)

Track D's generator path is correct and shipped, but the **consumer CLI** path broke in 0.12.0/0.12.1. The hermetic D7 test bypassed the CLI, so CI missed it. Diagnosed against the running tool (swe-brain). Two real bugs + one DX gap.

### Bug 1 — `surface:`/`context:` were at the wrong schema level
Defined at the ROOT of `EntityDefinitionSchema` (sibling of `entity:`/`fields:`), but consumers write them INSIDE the `entity:` block (next to `pattern:`/`name:`/`table:` — the natural place). The `entity:` block is `.strict()`, so those YAMLs were rejected: *"Unrecognized key(s) in object: 'surface' at 'entity'"*.

**Fix:** moved both fields into `EntityConfigSchema`; read as `entity.surface` / `entity.context`. Clean break — root-level placement no longer validates. Read sites updated:
- `collectEntitySurfaces` (`src/parser/validate-providers.ts`)
- `collectEntitiesBySurface` (`src/cli/shared/adapter-emission-generator.ts`)
- provider surface cross-check (`src/cli/commands/entity.ts`)
- clean-lite-ps output-subfolder consumer (`templates/entity/new/clean-lite-ps/prompt-extension.js` `buildCleanLitePsLocals`)
- `src/cli/shared/barrel-generator.ts` (#403 context-folder consumer)

### Bug 2 — entity `--all` discovery globbed `definitions/providers/`
With `entities_dir: definitions`, the recursive walk pulled `definitions/providers/*.yaml` into the entity loader, where they fail entity validation. `findYamlFiles`/`loadEntities` now take `excludeDirs`; `entity.ts` excludes `paths.providers` (default `definitions/providers`). Provider files route only through `ProviderDefinitionSchema`.

### DX miss — `entity new --dry-run` swallowed the Zod detail
Printed only "Validation failed for <file>"; now surfaces the same per-issue Zod diagnostics as `entity validate` (the gap that masked Bug 1).

### Tests
- New repro at `src/__tests__/parser/track-d-consumer-cli.test.ts` (swe-brain-shaped): `entity.surface`/`entity.context` validate; provider subtree excluded from entity discovery; provider YAML routes to `ProviderDefinitionSchema`. Plus a clean-break test asserting root-level placement is rejected.
- `just test-all` green: unit (2342 pass), baseline, smoke.

### Consumer impact
**No swe-brain YAML change required** — consumer YAML already wrote the keys in the natural place; the schema is now corrected to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
