### PR TITLE
feat(track-d): E0 — drop registry back-edge from adapter scaffold (RFC-0002)

### DIFF
--- a/src/__tests__/cli/adapter-emission-generator.test.ts
+++ b/src/__tests__/cli/adapter-emission-generator.test.ts
@@ -78,12 +78,18 @@ describe('generateAdapterScaffold', () => {
     expect(out).toContain('...NO_CRM_CAPABILITIES');
   });
 
-  it('injects L1 strategy + client + entity sources registry', () => {
+  it('injects L1 strategy + client (no registry back-edge)', () => {
     expect(out).toContain('@Inject(HUBSPOT_AUTH_STRATEGY) readonly auth: IAuthStrategy');
     expect(out).toContain('@Inject(HUBSPOT_CLIENT) private readonly client: HubspotClient');
-    expect(out).toContain(
-      '@Inject(CRM_ENTITY_SOURCES) readonly sources: IEntityChangeSourceRegistry',
-    );
+    // E0: the vestigial registry back-edge is gone — the adapter no longer
+    // injects CRM_ENTITY_SOURCES / IEntityChangeSourceRegistry, nor imports
+    // the registry type or the *-adapters.tokens module. (The descriptive
+    // changeSources doc comment still names the registry it feeds — that prose
+    // is accurate and is not the back-edge.)
+    expect(out).not.toContain('@Inject(CRM_ENTITY_SOURCES)');
+    expect(out).not.toContain('readonly sources: IEntityChangeSourceRegistry');
+    expect(out).not.toContain("from '../../crm-adapters.tokens'");
+    expect(out).not.toMatch(/import[^;]*IEntityChangeSourceRegistry/);
   });
 
   it('stubs every L2 method with a not-implemented throw', () => {
@@ -158,8 +164,9 @@ describe('emitAdapters — orchestration', () => {
     expect(calendar).not.toContain('IFieldDefinitionReader');
     expect(calendar).not.toContain('not implemented');
     expect(calendar).not.toContain('fieldDefinitions: true');
-    // still injects L1 + sources + exposes changeSources
-    expect(calendar).toContain('readonly sources: IEntityChangeSourceRegistry');
+    // still injects L1 + exposes changeSources (no registry back-edge — E0)
+    expect(calendar).not.toContain('readonly sources: IEntityChangeSourceRegistry');
+    expect(calendar).not.toMatch(/import[^;]*IEntityChangeSourceRegistry/);
     expect(calendar).toContain('readonly changeSources: Record<string, IChangeSource<unknown>>');
   });
 

--- a/src/cli/shared/adapter-emission-generator.ts
+++ b/src/cli/shared/adapter-emission-generator.ts
@@ -221,8 +221,8 @@ function names(providerSlug: string, surface: string): Names {
 
 /**
  * The emit-once adapter scaffold. Implements the surface port, injects L1
- * (auth strategy + client) and the entity sources registry, declares
- * capabilities (entities from `surface:`), and stubs the L2 port methods.
+ * (auth strategy + client), declares capabilities (entities from `surface:`),
+ * and stubs the L2 port methods.
  */
 export function generateAdapterScaffold(
   def: ProviderDefinition,
@@ -282,11 +282,9 @@ import { ${spec.noCapsConst} } from '${spec.packageName}';
 import type {
   IAuthStrategy,
   IChangeSource,
-  IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
 import type { ${client.exportName} } from '${client.path}';
 import { ${n.strategyToken}, ${n.clientToken} } from '../../../providers/${def.slug}/${def.slug}.provider.module';
-import { ${n.entitySourcesToken} } from '../../${surface}-adapters.tokens';
 
 @Injectable()
 export class ${n.adapterClass} implements ${spec.portType} {
@@ -298,7 +296,6 @@ ${capabilityBody}
   constructor(
     @Inject(${n.strategyToken}) readonly auth: IAuthStrategy,
     @Inject(${n.clientToken}) private readonly client: ${client.exportName},
-    @Inject(${n.entitySourcesToken}) readonly sources: IEntityChangeSourceRegistry,
   ) {}
 ${l2Section}
   /**

--- a/test/integration-emit/__snapshots__/snapshot.test.ts.snap
+++ b/test/integration-emit/__snapshots__/snapshot.test.ts.snap
@@ -29,11 +29,9 @@ import { NO_CALENDAR_CAPABILITIES } from '@pattern-stack/codegen-calendar';
 import type {
   IAuthStrategy,
   IChangeSource,
-  IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
 import type { GoogleClient } from '@app/integrations/providers/google/google.client';
 import { GOOGLE_AUTH_STRATEGY, GOOGLE_CLIENT } from '../../../providers/google/google.provider.module';
-import { CALENDAR_ENTITY_SOURCES } from '../../calendar-adapters.tokens';
 
 @Injectable()
 export class GoogleCalendarAdapter implements CalendarPort {
@@ -46,7 +44,6 @@ export class GoogleCalendarAdapter implements CalendarPort {
   constructor(
     @Inject(GOOGLE_AUTH_STRATEGY) readonly auth: IAuthStrategy,
     @Inject(GOOGLE_CLIENT) private readonly client: GoogleClient,
-    @Inject(CALENDAR_ENTITY_SOURCES) readonly sources: IEntityChangeSourceRegistry,
   ) {}
 
   /**
@@ -206,11 +203,9 @@ import { NO_CRM_CAPABILITIES } from '@pattern-stack/codegen-crm';
 import type {
   IAuthStrategy,
   IChangeSource,
-  IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
 import type { SalesforceClient } from '@app/integrations/providers/salesforce/salesforce.client';
 import { SALESFORCE_AUTH_STRATEGY, SALESFORCE_CLIENT } from '../../../providers/salesforce/salesforce.provider.module';
-import { CRM_ENTITY_SOURCES } from '../../crm-adapters.tokens';
 
 @Injectable()
 export class SalesforceCrmAdapter implements CrmPort {
@@ -226,7 +221,6 @@ export class SalesforceCrmAdapter implements CrmPort {
   constructor(
     @Inject(SALESFORCE_AUTH_STRATEGY) readonly auth: IAuthStrategy,
     @Inject(SALESFORCE_CLIENT) private readonly client: SalesforceClient,
-    @Inject(CRM_ENTITY_SOURCES) readonly sources: IEntityChangeSourceRegistry,
   ) {}
 
   /** L2 — fill in the provider-specific implementation. */
@@ -394,11 +388,9 @@ import { NO_MAIL_CAPABILITIES } from '@pattern-stack/codegen-mail';
 import type {
   IAuthStrategy,
   IChangeSource,
-  IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
 import type { GoogleClient } from '@app/integrations/providers/google/google.client';
 import { GOOGLE_AUTH_STRATEGY, GOOGLE_CLIENT } from '../../../providers/google/google.provider.module';
-import { MAIL_ENTITY_SOURCES } from '../../mail-adapters.tokens';
 
 @Injectable()
 export class GoogleMailAdapter implements MailPort {
@@ -411,7 +403,6 @@ export class GoogleMailAdapter implements MailPort {
   constructor(
     @Inject(GOOGLE_AUTH_STRATEGY) readonly auth: IAuthStrategy,
     @Inject(GOOGLE_CLIENT) private readonly client: GoogleClient,
-    @Inject(MAIL_ENTITY_SOURCES) readonly sources: IEntityChangeSourceRegistry,
   ) {}
 
   /**
@@ -641,11 +632,9 @@ import { NO_TRANSCRIPT_CAPABILITIES } from '@pattern-stack/codegen-transcript';
 import type {
   IAuthStrategy,
   IChangeSource,
-  IEntityChangeSourceRegistry,
 } from '@pattern-stack/codegen/subsystems';
 import type { GoogleClient } from '@app/integrations/providers/google/google.client';
 import { GOOGLE_AUTH_STRATEGY, GOOGLE_CLIENT } from '../../../providers/google/google.provider.module';
-import { TRANSCRIPT_ENTITY_SOURCES } from '../../transcript-adapters.tokens';
 
 @Injectable()
 export class GoogleTranscriptAdapter implements TranscriptPort {
@@ -658,7 +647,6 @@ export class GoogleTranscriptAdapter implements TranscriptPort {
   constructor(
     @Inject(GOOGLE_AUTH_STRATEGY) readonly auth: IAuthStrategy,
     @Inject(GOOGLE_CLIENT) private readonly client: GoogleClient,
-    @Inject(TRANSCRIPT_ENTITY_SOURCES) readonly sources: IEntityChangeSourceRegistry,
   ) {}
 
   /**


### PR DESCRIPTION
## E0 — adapter-edge fix (RFC-0002 Track D round-2)

First step of the integration **module-assembly** emission (RFC-0002, Gate 1.5 cleared). Surgical prep change: removes a vestigial registry injection from the emitted adapter scaffold so the assembly module (E2) can import the adapter standalone.

### What & why
`generateAdapterScaffold` emitted a third constructor injection — `@Inject(<SURFACE>_ENTITY_SOURCES) readonly sources: IEntityChangeSourceRegistry` — that is **read by nothing** in the scaffold and forms a **latent DI cycle**: adapter → `<SURFACE>_ENTITY_SOURCES` → surface-aggregator contributions fold → adapter. The D7 snapshot only diffs emitted text (never boots a Nest container) and swe-brain still runs hand-rolled modules, so this wiring has never been instantiated. The Gate 1.5 critique surfaced it before E2 would have hit it at runtime.

Removing the back-edge makes the adapter **standalone-importable**, which is the precondition for RFC-0002 Option A (the assembly binds `INTEGRATION_CHANGE_SOURCE = adapter.changeSources['<entity>']` by importing the adapter module directly, without pulling in the throw-on-collision aggregator fold).

### Scope
- **generator** — drop the `IEntityChangeSourceRegistry` type import, the `*-adapters.tokens` import, the constructor arg, and the stale doc-comment clause. `generateSurfaceAggregator` / `generateSurfaceTokens` / `generateAdapterModule` **untouched** — the aggregator still emits `<SURFACE>_ENTITY_SOURCES` one-directionally; the registry + its C6 `CrmPort` consumer are unaffected.
- **tests** — flip the two adapter-injection assertions to assert the back-edge is gone; aggregator-fold assertions unchanged.
- **snapshot** — rebaselined; diff is exactly 3 deletions × 4 surfaces (calendar/crm/mail/transcript), no other changes.

### Verification
- `bun test src/__tests__/cli/adapter-emission-generator.test.ts` → 24 pass
- `bun test test/integration-emit/` → 3 pass (snapshot stable)
- Pre-existing reds (schema-v2, junction typecheck #399) confirmed not introduced by this change.

Part of the RFC-0002 stack: **E0** → E1 (default sink) → E2 (assembly module) → E3 (surface aggregator) → E4 (snapshot + tests). Base is the epic branch carrying the RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
