### PR TITLE
docs(RFC-0003): resolve R3 build forks §4 — Option B typing + static-const filter threading

### DIFF
--- a/docs/rfcs/RFC-0003-incremental-read-enumerate-hydrate.md
+++ b/docs/rfcs/RFC-0003-incremental-read-enumerate-hydrate.md
@@ -154,16 +154,32 @@ Per-ref cursors fix the silent-tail-skip — a crash at page 80 of a backfill re
 
 ```ts
 // <CODEGEN-SCAFFOLD-V1>   ← still emit-once; regen skips if present
+// fork #2: the entity's `detection.filters` emitted verbatim as a static const.
+const EMAIL_DETECTION_FILTERS: ResolvedFilter[] = [ /* from entity `detection:` YAML */ ];
+
 export class GoogleEmailIncrementalRead
-  extends IncrementalReadBase<CanonicalEmail, EmailFilter, EmailRefMeta> {
+  extends IncrementalReadBase<CanonicalEmail, ResolvedFilter[]> {   // F = uniform runtime filter; M defaults (author narrows)
   readonly label = 'google-mail-email';
   protected override filterPushdown = true;                 // Gmail q= takes the predicate
 
-  protected async *enumerate(mode, filter) { /* TODO: messages.list / history.list → Ref pages */ }
+  protected async *enumerate(mode, filter: ResolvedFilter[]) { /* TODO: messages.list / history.list → Ref pages */ }
   protected async hydrate(ids)  { /* TODO: messages.get (override: /batch) → Map<id, raw> */ }
   protected toCanonical(raw)    { /* TODO: External(Zod) → CanonicalEmail */ }
+
+  // fork #2: filterFor returns the static const — 2-arg `(auth, client)` construction preserved.
+  protected override filterFor(_sub: IntegrationSubscriptionView): ResolvedFilter[] {
+    return EMAIL_DETECTION_FILTERS;
+  }
 }
 ```
+
+> **R3 typing + threading — RESOLVED (2026-05-31, Doug).** Two R3-build forks (separate from §7's Q1/Q3/Q4) are now locked:
+>
+> **Fork #1 — subclass typing (Option B).** Emit `IncrementalReadBase<CanonicalEmail, ResolvedFilter[]>`: **T** = the surface package's canonical type; **F** = the *existing uniform* `ResolvedFilter[]` (from `DetectionConfig.filters`) — not a bespoke per-entity `EmailFilter`; **M** = the base default (`Record<string, unknown>`), which the author narrows in the emit-once scaffold (it's the vendor list-stub shape — author knowledge). This gives free compile-time filter typing with zero new types and no surface-package coupling. The earlier `<…, EmailFilter, EmailRefMeta>` bespoke shape is **superseded** — codegen-owned bespoke F/M types roll up into RFC-0004 ("B", the canonical-model RFC), not R3.
+>
+> **Fork #2 — filter threading (static const).** `IntegrationSubscriptionView` is only `{ id, domain, externalRef }` — it does NOT carry filters. So codegen emits the entity's `detection.filters` as a static module-level `ResolvedFilter[]` const and `filterFor()` returns it. This preserves the post-E0 2-arg `(auth, client)` construction (no DI of a never-changing value). Dynamic stays open two ways: a direct `read(ReadRequest<F>)` caller passes runtime filters, and an author can override `filterFor(sub)` (emit-once) to derive per-subscription.
+>
+> **Named caveat:** this assumes filters are **entity-level config, not per-subscription**. If two subscriptions of one entity ever need different filters, revisit via the `filterFor(sub)` author override — keep the `subscription` param in the emitted signature so that escape hatch stays free.
 
 and the adapter's container becomes:
 


### PR DESCRIPTION
## Resolve the two R3 build forks in §4 (Doug's call)

Locks the R3-implementation forks the stream flagged as deferred, and **corrects RFC-0003 §4**, which still prescribed the *superseded* bespoke typing (`IncrementalReadBase<CanonicalEmail, EmailFilter, EmailRefMeta>`). Left as-is, the RFC would lead R3 to build the wrong type signature.

### Fork #1 — subclass typing → **Option B**
`IncrementalReadBase<CanonicalEmail, ResolvedFilter[]>`:
- **T** = surface-package canonical type.
- **F** = the *existing uniform* `ResolvedFilter[]` (what `DetectionConfig.filters` already produces) — **not** a bespoke per-entity `EmailFilter`. Free compile-time filter typing, zero new types, no surface-package coupling.
- **M** = base default (`Record<string, unknown>`); the author narrows it in the emit-once scaffold (it's the vendor list-stub shape — their knowledge).

Bespoke/codegen-owned `F`/`M` types roll up into **RFC-0004 ("B")**, not R3.

### Fork #2 — filter threading → **static const**
`IntegrationSubscriptionView` is only `{ id, domain, externalRef }` — it doesn't carry filters. So codegen emits the entity's `detection.filters` as a static module-level `ResolvedFilter[]` const and `filterFor()` returns it. **Preserves the post-E0 2-arg `(auth, client)` construction** — no DI of a never-changing value. Dynamic stays open (direct `read(ReadRequest<F>)`, or author override of `filterFor(sub)`).

**Named caveat:** assumes filters are *entity-level config, not per-subscription*. If that changes, it's an author `filterFor(sub)` override — keep the `subscription` param in the emitted signature.

### Coordination
Targeted **into your branch**, non-destructive — merge on your schedule. **If you've already applied Option B to §4 as part of in-flight R3, just close this** (same decision). Also captured in shared project memory (`project_r3_typing_decision`) so a fresh session recalls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
