### PR TITLE
chore(release): 0.13.0 prep — version bumps + integration-codegen docs/skills

### DIFF
--- a/.claude/skills/codegen/SKILL.md
+++ b/.claude/skills/codegen/SKILL.md
@@ -1,6 +1,6 @@
 # @pattern-stack/codegen
 
-Code generation CLI for NestJS + Drizzle applications. Generates entities, repositories, services, controllers, DTOs, use cases, OAuth-ready integrations, and infrastructure subsystems from YAML definitions.
+Code generation CLI for NestJS + Drizzle applications. Generates entities, repositories, services, controllers, DTOs, use cases, OAuth-ready integrations, the full vendor-integration layer (provider/adapter read side + module assembly write side + the `IncrementalRead` read primitive — Track D, RFC-0001/0002/0003), and infrastructure subsystems from YAML definitions.
 
 ## When to Use This Skill
 
@@ -39,6 +39,8 @@ After every generation run, barrel files are regenerated:
 - `src/generated/schema.ts` — re-exports all entity Drizzle schemas
 
 The user wires these into `app.module.ts` once; codegen never touches that file again.
+
+For entities tagged with `surface:` (when `definitions/providers/*.yaml` exist), `entity new` also runs the Track D integration post-step — emitting the provider/adapter read side, the per-entity module assembly (binds change source + sink + a tokened `ExecuteIntegrationUseCase`), the emit-once default sink, and the `IncrementalReadBase` read-body scaffold inside the adapter's `changeSources`. There is no standalone `provider`/`integration`/`gen` command. The surface ports declare `readonly changeSources: Record<string, IChangeSource<unknown>>` (not the old `sources` registry — the folded `<SURFACE>_ENTITY_SOURCES` registry is the surface aggregator's output). See the `integration` skill (`protocols-and-ports.md`, `SKILL.md`) for the port shapes, output paths, and skip conditions.
 
 ### Subsystem Commands
 

--- a/.claude/skills/integration/SKILL.md
+++ b/.claude/skills/integration/SKILL.md
@@ -31,6 +31,29 @@ new` whenever `definitions/providers/*.yaml` exist. See
 output paths, and skip conditions before telling anyone the CLI wiring is
 missing.
 
+0.13.0 extends Track D to emit the **full** integration layer, not just the
+read side:
+- **Module assembly (RFC-0002).** Per `(surface, provider, entity)` codegen now
+  emits the per-entity `<entity>-integration.module.ts` (binds
+  `INTEGRATION_CHANGE_SOURCE` = `adapter.changeSources['<entity>']` +
+  `INTEGRATION_SINK`, provides a local `ExecuteIntegrationUseCase`, exports it
+  under a unique `<ENTITY>_INTEGRATION_USE_CASE__<PROVIDER>` token), an
+  emit-once default sink scaffold over the `Integrated` repo (`pattern:
+  Integrated` only — hard-errors otherwise), a surface integration aggregator,
+  and a tokens file. This is the *generated* form of swe-brain's hand-rolled
+  `*_integration` feature modules.
+- **Read primitive (RFC-0003).** For interaction surfaces (mail/calendar/
+  transcript) the adapter's `changeSources` entries are emitted as emit-once
+  `IncrementalReadBase<Canonical<Entity>, ResolvedFilter[]>` subclasses — the
+  enumerate/hydrate read-body scaffold. The base owns streaming,
+  filter-before-hydrate, bounded-concurrency hydration, and per-ref cursor
+  emission; the author fills only `enumerate` / `hydrate` / `toCanonical`.
+- **Port shape (post-E0).** The surface ports declare `readonly changeSources:
+  Record<string, IChangeSource<unknown>>` (what the adapter *contributes*), NOT
+  the old `readonly sources: IEntityChangeSourceRegistry`. The folded,
+  entity-keyed `<SURFACE>_ENTITY_SOURCES` registry is the surface aggregator's
+  output (surface-module concern), no longer injected into the adapter.
+
 ## Mental model
 
 **Integration vs. jobs vs. events — three domains, one codebase:**
@@ -235,7 +258,18 @@ Files that ship to the consumer app (not templates):
   `mode: 'poll' | 'webhook'`; flat-AND `ResolvedFilter` triples
   (`eq | neq | in | nin | gt | gte | lt | lte`); `CursorStrategy`
   tagged union (`systemModstamp | replayId | timestamp | eventId`);
-  `poll.provenance: 'cdc'` knob (ADR-033)
+  `poll.provenance: 'cdc'` knob (ADR-033). The `CursorStrategy` union also
+  carries the atomic opaque-token kinds `historyId` / `syncToken` (RFC-0003 R2),
+  with divisibility exposed via `CURSOR_DIVISIBILITY` / `isDivisibleCursor`.
+- `runtime/subsystems/integration/incremental-read.ts` — `IncrementalRead<T, F>`
+  / `RandomRead<T>` / `IncrementalReadBase` + `SourcedRecord` / `Ref` /
+  `ReadMode` / `ReadRequest` / `mapConcurrent` (RFC-0003 R1). The universal
+  enumerate/hydrate read primitive: the base decomposes the read into
+  `enumerate(mode, filter) → AsyncIterable<Ref>` + `hydrate(ids) → Map<id, raw>`
+  and owns drain, filter-before-hydrate, bounded-concurrency hydrate, per-ref
+  cursor emission (gated by `cursorDivisible` for atomic strategies), and the
+  `listChanges` adaptation. `get` (RandomRead) is provided free as
+  `toCanonical ∘ hydrate([id])`. Exported from `@pattern-stack/codegen/subsystems`.
 - `runtime/subsystems/integration/integration-middleware.protocol.ts` —
   `ChangeIterator<T>` + `ChangeMiddleware<T>` types; the universal
   composition seam consumed by primitives (loopback ships here in

--- a/.claude/skills/integration/consumer-patterns.md
+++ b/.claude/skills/integration/consumer-patterns.md
@@ -48,6 +48,21 @@ putting the orchestrator in `IntegrationModule` would require those tokens
 globally, which fails until the feature module is imported. The
 `IntegrationModule` header documents this with a worked example.
 
+> **This feature module is now codegen-generated for `surface:` entities (0.13.0,
+> RFC-0002).** When the entity carries a `surface:` tag and a provider YAML
+> exists, the `entity new` post-step emits the per-entity assembly module
+> (`<surface>/modules/<provider>/<entity>-integration.module.ts`) — `@generated`,
+> binding `INTEGRATION_CHANGE_SOURCE = adapter.changeSources['<entity>']` +
+> `INTEGRATION_SINK`, providing a local `ExecuteIntegrationUseCase`, and exporting
+> it under a unique `<ENTITY>_INTEGRATION_USE_CASE__<PROVIDER>` token. The default
+> sink is an emit-once scaffold over the entity's `Integrated` repo. You do NOT
+> hand-write this module for generated surfaces — you fill the adapter's
+> `changeSources` read body (RFC-0003: `enumerate` / `hydrate` / `toCanonical`)
+> and any non-generic sink write logic, then grab the exported token from your
+> trigger (cron/job/CLI/webhook). The hand-written shape below is the predecessor
+> the generated assembly replaces — keep it as the mental model for what the
+> generator emits and for non-surface entities you still wire by hand.
+
 ## Writing an `IChangeSource<T>`
 
 ```ts

--- a/.claude/skills/integration/orchestrator-flow.md
+++ b/.claude/skills/integration/orchestrator-flow.md
@@ -86,6 +86,15 @@ network error, upstream rate-limit), the orchestrator catches,
 marks the run `status='failed'`, persists `latestCursor`, and runs
 `completeRun` in the finally clause.
 
+> **Atomic-cursor caveat (RFC-0003 R2).** The orchestrator persists
+> last-yielded unconditionally — which is correct *only* for divisible
+> cursors. For atomic opaque tokens (Gmail `historyId`, Calendar
+> `syncToken`) an `IncrementalReadBase` subclass with
+> `cursorDivisible = false` **withholds** the per-ref cursor until a safe
+> boundary (end-of-walk), so the orchestrator never persists an
+> unresumable mid-walk token. The gating lives in the base, not here —
+> the orchestrator lifecycle is unchanged.
+
 Consequence: partial runs don't lose progress. Re-running resumes
 from the last successful yield.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-05-31
+
+Track D round-2/3 — the integration codegen now emits the **full** integration
+layer. Where 0.12.x stopped at the read side (provider module, adapter scaffold,
+registry, typed views), 0.13.0 adds the **module assembly** (the write/run side —
+RFC-0002) and reshapes the read body into the **`IncrementalRead` primitive**
+(RFC-0003). After this release the author fills only the irreducible vendor seam:
+the `enumerate` / `hydrate` / `toCanonical` read methods and any non-generic sink
+write logic.
+
+Core and the four surface packages (`codegen-{mail,calendar,transcript,crm}`)
+**release together** — the surfaces carry the BREAKING port change below and
+require the matching core (peer dep `^0.13.0`).
+
+### BREAKING
+
+- **Surface ports declare `changeSources`, not `sources`.** The four surface
+  ports (`MailPort` / `CalendarPort` / `TranscriptPort` / `CrmPort`) now require
+  `readonly changeSources: Record<string, IChangeSource<unknown>>` — the
+  per-entity change sources the adapter *contributes*, keyed by entity name —
+  instead of the old `readonly sources: IEntityChangeSourceRegistry`. The folded,
+  entity-keyed registry (`<SURFACE>_ENTITY_SOURCES`) is now the **surface
+  module's** concern: the surface aggregator folds every provider's
+  `changeSources` into it, and entity-agnostic consumers read it at runtime. This
+  drops a vestigial registry injection from the adapter (it was read by nothing
+  and formed a latent DI cycle — RFC-0002 §3 E0), making the adapter
+  standalone-importable. The four surface packages bump to **0.2.0**; their peer
+  dep on `@pattern-stack/codegen` moves to **^0.13.0**. Conformance helpers
+  (`assert<Surface>Adapter`) check `changeSources` membership accordingly.
+
+### Added
+
+- **Integration module assembly emission (RFC-0002).** Per `(surface, provider,
+  entity-with-surface)`, codegen now emits the assembly that turns a registry of
+  change sources into a runnable integration per entity:
+  - `<surface>/modules/<provider>/<entity>-integration.module.ts` — `@generated`
+    per-entity feature module binding `INTEGRATION_CHANGE_SOURCE`
+    (= `adapter.changeSources['<entity>']`, Option A) + `INTEGRATION_SINK`, a
+    local `ExecuteIntegrationUseCase`, and a uniquely-tokened handle
+    (`<ENTITY>_INTEGRATION_USE_CASE__<PROVIDER>`) a trigger can grab.
+  - `<surface>/sinks/<entity>.sink.ts` — emit-once **default sink** scaffold
+    (`// <CODEGEN-SCAFFOLD-V1>`) over the entity's generated `Integrated`
+    repository (`pattern: Integrated` only — hard-errors otherwise); author fills
+    any non-generic `canonical ↔ local` mapping.
+  - `<surface>/<surface>-integration.module.ts` — `@generated` aggregator over
+    the per-entity modules.
+  - `<surface>/<surface>-integration.tokens.ts` — `@generated` use-case tokens.
+- **`IncrementalRead` read primitive (RFC-0003).** A universal read capability
+  (`IncrementalRead<T, F>` / `RandomRead<T>` / `IncrementalReadBase` +
+  `SourcedRecord` / `Ref` / `ReadMode` / `ReadRequest` / `mapConcurrent`) in
+  `runtime/subsystems/integration/`, exported from
+  `@pattern-stack/codegen/subsystems`. The base decomposes the read into
+  `enumerate(mode, filter) → AsyncIterable<Ref>` (cheap delta/backfill walk) and
+  `hydrate(ids) → Map<id, raw>` (batched fetch-by-id), and owns the orchestration
+  (drain, **filter-before-hydrate**, bounded-concurrency hydrate, per-ref cursor
+  emission, `listChanges` adaptation). Cursor divisibility is kind-keyed
+  (`CURSOR_DIVISIBILITY` / `isDivisibleCursor`); atomic strategies (`historyId` /
+  `syncToken`) withhold the per-ref cursor until a safe boundary so an
+  interrupted backfill never persists an unresumable token.
+- **Read-side scaffold reshape.** For interaction surfaces (mail / calendar /
+  transcript), `generateAdapterScaffold` now emits each `changeSources` entry as
+  an emit-once `IncrementalReadBase<Canonical<Entity>, ResolvedFilter[]>`
+  subclass — the buffer-all/serial/run-final-cursor regression becomes
+  structurally unwritable. CRM keeps its author-filled `changeSources` seam
+  (field-reader model, no single canonical `T`).
+
 ## [0.12.2] — 2026-05-31
 
 Track D consumer-CLI fix. The 0.12.0/0.12.1 generator was correct in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,16 @@ Five subsystems following Protocol → Backend → Factory pattern:
 
 All use `DynamicModule.forRoot({ backend })` with `global: true`.
 
+### Integration Codegen (RFC-0001/0002/0003)
+
+For entities tagged with `surface:` (when `definitions/providers/*.yaml` exist), the `entity new` post-step emits the **full** integration layer per `(surface, provider, entity)`, not just the read side:
+
+- **Read side** (RFC-0001) — provider module (auth + client), adapter scaffold whose `changeSources: Record<string, IChangeSource<unknown>>` the adapter *contributes* (keyed by entity), the surface aggregator that folds those into the `<SURFACE>_ENTITY_SOURCES` registry, and typed views. The adapter holds the contributions; the folded registry is the surface module's concern (post-E0 — the adapter no longer injects the registry).
+- **Read primitive** (RFC-0003) — for interaction surfaces (mail/calendar/transcript), each `changeSources` entry is emitted as an emit-once `IncrementalReadBase<Canonical<Entity>, ResolvedFilter[]>` subclass (the enumerate/hydrate read-body scaffold). The base owns streaming, filter-before-hydrate, bounded-concurrency hydration, and per-ref cursor emission; the author fills only `enumerate` / `hydrate` / `toCanonical`. Lives in `runtime/subsystems/integration/`, exported from `@pattern-stack/codegen/subsystems`.
+- **Module assembly** (RFC-0002) — the write/run side: per-entity `<entity>-integration.module.ts` binding `INTEGRATION_CHANGE_SOURCE` (= `adapter.changeSources['<entity>']`) + `INTEGRATION_SINK` + a local `ExecuteIntegrationUseCase` exported under a unique `<ENTITY>_INTEGRATION_USE_CASE__<PROVIDER>` token; an emit-once default sink scaffold over the `Integrated` repo (`pattern: Integrated` only); a surface integration aggregator; and a tokens file.
+
+The author seam is just the vendor read methods plus any non-generic sink write logic.
+
 ### Entity Families
 
 Base classes in `runtime/base-classes/`:

--- a/README.md
+++ b/README.md
@@ -138,6 +138,50 @@ modules/{plural}/
   use-cases/                       FindById, List, declarative queries
 ```
 
+## Integration Codegen (provider/adapter + assembly + read primitive)
+
+When an entity carries a `surface:` tag and `definitions/providers/*.yaml` exist,
+re-running `codegen entity new` emits the **full** integration layer for each
+`(surface, provider, entity)` — not just the read side. The author fills only the
+irreducible vendor seam: the `enumerate` / `hydrate` / `toCanonical` read methods
+and any non-generic sink write logic.
+
+**Read side** (provider/adapter — RFC-0001):
+```
+integrations/providers/<provider>/      Auth strategy + client (provider module)
+integrations/<surface>/adapters/<provider>/  Adapter scaffold: changeSources container
+integrations/<surface>/<surface>-adapters.module.ts  Aggregator → <SURFACE>_ENTITY_SOURCES registry
+integrations/<surface>/types.generated.ts            Typed views
+```
+
+The adapter *contributes* `changeSources` (per-entity, keyed by entity name); the
+aggregator folds every provider's contributions into the entity-keyed
+`<SURFACE>_ENTITY_SOURCES` registry consumers read at runtime.
+
+**Read primitive** (RFC-0003): for interaction surfaces (mail / calendar /
+transcript) each `changeSources` entry is emitted as an emit-once
+`IncrementalReadBase<Canonical<Entity>, ResolvedFilter[]>` subclass — the
+enumerate/hydrate read capability (`@pattern-stack/codegen/subsystems`). The base
+owns streaming, **filter-before-hydrate**, bounded-concurrency hydration, and
+per-ref cursor emission, so the buffer-all/serial/run-final-cursor regression is
+structurally unwritable; the author fills only `enumerate` / `hydrate` /
+`toCanonical`.
+
+**Write/run side** (assembly — RFC-0002):
+```
+integrations/<surface>/modules/<provider>/<entity>-integration.module.ts  @generated per-entity assembly
+integrations/<surface>/sinks/<entity>.sink.ts            emit-once default sink scaffold
+integrations/<surface>/<surface>-integration.module.ts   @generated aggregator
+integrations/<surface>/<surface>-integration.tokens.ts   @generated use-case tokens
+```
+
+Each per-entity module binds `INTEGRATION_CHANGE_SOURCE`
+(= `adapter.changeSources['<entity>']`) + `INTEGRATION_SINK`, provides a local
+`ExecuteIntegrationUseCase`, and exports a uniquely-tokened handle
+(`<ENTITY>_INTEGRATION_USE_CASE__<PROVIDER>`) a trigger grabs to run a sync. The
+default sink scaffolds over the entity's generated `Integrated` repository
+(`pattern: Integrated` only); the author overrides any non-generic write logic.
+
 ## Entity Families
 
 Families provide pre-built base classes with domain-specific query patterns:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/packages/codegen-calendar/README.md
+++ b/packages/codegen-calendar/README.md
@@ -42,28 +42,40 @@ import {
 } from '@pattern-stack/codegen-calendar';
 ```
 
-## The read primitive — registry, not a bespoke `pull`
+## The read primitive — `changeSources`, not a bespoke `pull`
 
-`CalendarPort` composes the L1 `sources: IEntityChangeSourceRegistry` (the C6/C7
-seam). Incremental reads go through `sources.get<CanonicalMeeting>('meeting')`,
-which resolves an `IChangeSource<CanonicalMeeting>` — the generic L1 read with
-cursor-by-value. The port carries **no** entity-specific `pull*` method. (The
-swe-brain prototype used a transitional flat `pullEvents({ syncToken })` because
-L1 `IncrementalRead<T>` wasn't minted yet; the codegen package skips that and
-uses the registry pattern directly, consistent with `CrmPort`.)
+`CalendarPort` composes the L1 `changeSources: Record<string, IChangeSource<unknown>>`
+(the C6/C7 seam) — the per-entity change sources the adapter *contributes*, keyed
+by entity name. Each entry resolves an `IChangeSource<CanonicalMeeting>` — the
+generic L1 read with cursor-by-value. The surface aggregator (a surface-module
+concern, not the adapter's) folds every provider's `changeSources` into the
+`CALENDAR_ENTITY_SOURCES` registry (an `IEntityChangeSourceRegistry`) that
+entity-agnostic consumers read at runtime. The port carries **no** entity-specific
+`pull*` method. (The swe-brain prototype used a transitional flat
+`pullEvents({ syncToken })` because L1 `IncrementalRead<T>` wasn't minted yet; the
+codegen package skips that and uses the `changeSources` pattern directly,
+consistent with `CrmPort`.)
+
+Codegen reshapes the read body inside each `changeSources` entry to an
+`IncrementalReadBase<CanonicalMeeting, ResolvedFilter[]>` subclass (RFC-0003) —
+the enumerate/hydrate read primitive. The author fills only `enumerate` /
+`hydrate` / `toCanonical`; the base owns streaming, filter-before-hydrate,
+bounded-concurrency hydration, and per-ref cursor emission.
 
 ## The composing port — `CalendarPort`
 
 ```ts
 export interface CalendarPort {
-  readonly auth: IAuthStrategy;                    // L1
-  readonly sources: IEntityChangeSourceRegistry;   // L1
-  readonly capabilities: CalendarCapabilities;     // L2
+  readonly auth: IAuthStrategy;                                  // L1
+  readonly changeSources: Record<string, IChangeSource<unknown>>; // L1
+  readonly capabilities: CalendarCapabilities;                   // L2
 }
 ```
 
-Entity-agnostic — no entity name appears in its type; entity access goes through
-`sources.get<T>(entityName)`. Per-consumer typed views are codegen-emitted
+Entity-agnostic — no entity name appears in its type. The adapter contributes
+`changeSources['meeting']`; the surface aggregator folds every provider's
+contributions into the entity-keyed `CALENDAR_ENTITY_SOURCES` registry that
+consumers read at runtime. Per-consumer typed views are codegen-emitted
 (Track D), not encoded here.
 
 ## Declaring capabilities
@@ -91,8 +103,8 @@ it('google calendar adapter conforms to CalendarPort', () => {
 ```
 
 Verifies the required L1 slots resolve and every `capabilities.entities` entry
-resolves via `sources.has(name)` — so an adapter declaring an entity it can't
-source fails the test rather than failing at runtime.
+has a registered `changeSources` entry — so an adapter declaring an entity it
+can't source fails the test rather than failing at runtime.
 
 ## License
 

--- a/packages/codegen-calendar/package.json
+++ b/packages/codegen-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-calendar",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "L2 calendar surface package for @pattern-stack/codegen — the canonical Meeting type, the CalendarPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.12.0"
+    "@pattern-stack/codegen": "^0.13.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-crm/README.md
+++ b/packages/codegen-crm/README.md
@@ -85,16 +85,18 @@ if (caps.fieldDefinitions && caps.entities.includes('lead')) {
 
 `entities` is runtime coverage data, not a type bound on the L3 `CrmPort` — the
 port stays entity-agnostic (ADR-036 §6). C6's `assertCrmAdapter()` checks each
-declared entity resolves via the change-source registry.
+declared entity has a registered `changeSources` entry.
 
 ## The composing port — `CrmPort`
 
 `CrmPort` is the single L3 contract a provider adapter implements. It composes
-L1 strategies (`auth`, the entity-keyed `sources` registry) and the L2 ports
-(`fields`, `picklists`, `associations`) plus the runtime `capabilities`
-descriptor. It is **entity-agnostic** — no entity name appears in its type;
-entity access goes through `sources.get<T>(entityName)`. Per-consumer typed
-views are codegen-emitted (Track D), not encoded here.
+L1 strategies (`auth`, the per-entity `changeSources` contributions) and the L2
+ports (`fields`, `picklists`, `associations`) plus the runtime `capabilities`
+descriptor. It is **entity-agnostic** — no entity name appears in its type. The
+adapter contributes `changeSources[entityName]`; the surface aggregator folds
+every provider's contributions into the entity-keyed `CRM_ENTITY_SOURCES`
+registry that consumers read at runtime. Per-consumer typed views are
+codegen-emitted (Track D), not encoded here.
 
 ### Conformance testing
 
@@ -110,8 +112,8 @@ it('hubspot adapter conforms to CrmPort', () => {
 ```
 
 It verifies required L1 slots resolve, that `capabilities` flags match the
-present ports, and that every `capabilities.entities` entry resolves via
-`sources.has(name)` — so an adapter declaring an entity it can't source fails
+present ports, and that every `capabilities.entities` entry has a registered
+`changeSources` entry — so an adapter declaring an entity it can't source fails
 the test rather than failing at runtime.
 
 ## Roadmap

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-crm",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "L2 CRM surface package for @pattern-stack/codegen — type-shaped CRM ports (field/picklist/association readers) and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.12.0"
+    "@pattern-stack/codegen": "^0.13.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-mail/README.md
+++ b/packages/codegen-mail/README.md
@@ -42,29 +42,41 @@ import {
 } from '@pattern-stack/codegen-mail';
 ```
 
-## The read primitive — registry, not a bespoke `pull`
+## The read primitive — `changeSources`, not a bespoke `pull`
 
-`MailPort` composes the L1 `sources: IEntityChangeSourceRegistry` (the C6/C7
-seam). Incremental reads go through `sources.get<CanonicalEmail>('email')`,
-which resolves an `IChangeSource<CanonicalEmail>` — the generic L1 read with
-cursor-by-value. The port carries **no** entity-specific `pull*` method. (The
-swe-brain prototype used a transitional flat `pullMessages({ historyId })`
-because L1 `IncrementalRead<T>` wasn't minted yet; the codegen package skips that
-and uses the registry pattern directly, consistent with `CrmPort`.)
+`MailPort` composes the L1 `changeSources: Record<string, IChangeSource<unknown>>`
+(the C6/C7 seam) — the per-entity change sources the adapter *contributes*, keyed
+by entity name. Each entry resolves an `IChangeSource<CanonicalEmail>` — the
+generic L1 read with cursor-by-value. The surface aggregator (a surface-module
+concern, not the adapter's) folds every provider's `changeSources` into the
+`MAIL_ENTITY_SOURCES` registry (an `IEntityChangeSourceRegistry`) that
+entity-agnostic consumers read at runtime. The port carries **no** entity-specific
+`pull*` method. (The swe-brain prototype used a transitional flat
+`pullMessages({ historyId })` because L1 `IncrementalRead<T>` wasn't minted yet;
+the codegen package skips that and uses the `changeSources` pattern directly,
+consistent with `CrmPort`.)
+
+Codegen reshapes the read body inside each `changeSources` entry to an
+`IncrementalReadBase<CanonicalEmail, ResolvedFilter[]>` subclass (RFC-0003) — the
+enumerate/hydrate read primitive. The author fills only `enumerate` / `hydrate` /
+`toCanonical`; the base owns streaming, filter-before-hydrate, bounded-concurrency
+hydration, and per-ref cursor emission.
 
 ## The composing port — `MailPort`
 
 ```ts
 export interface MailPort {
-  readonly auth: IAuthStrategy;                    // L1
-  readonly sources: IEntityChangeSourceRegistry;   // L1
-  readonly capabilities: MailCapabilities;         // L2
+  readonly auth: IAuthStrategy;                                  // L1
+  readonly changeSources: Record<string, IChangeSource<unknown>>; // L1
+  readonly capabilities: MailCapabilities;                       // L2
 }
 ```
 
-Entity-agnostic — no entity name appears in its type; entity access goes through
-`sources.get<T>(entityName)`. Per-consumer typed views are codegen-emitted
-(Track D), not encoded here.
+Entity-agnostic — no entity name appears in its type. The adapter contributes
+`changeSources['email']`; the surface aggregator folds every provider's
+contributions into the entity-keyed `MAIL_ENTITY_SOURCES` registry that consumers
+read at runtime. Per-consumer typed views are codegen-emitted (Track D), not
+encoded here.
 
 ## Declaring capabilities
 
@@ -91,8 +103,8 @@ it('gmail adapter conforms to MailPort', () => {
 ```
 
 Verifies the required L1 slots resolve and every `capabilities.entities` entry
-resolves via `sources.has(name)` — so an adapter declaring an entity it can't
-source fails the test rather than failing at runtime.
+has a registered `changeSources` entry — so an adapter declaring an entity it
+can't source fails the test rather than failing at runtime.
 
 ## License
 

--- a/packages/codegen-mail/package.json
+++ b/packages/codegen-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-mail",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "L2 mail surface package for @pattern-stack/codegen — the canonical Email type, the MailPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.12.0"
+    "@pattern-stack/codegen": "^0.13.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-transcript/README.md
+++ b/packages/codegen-transcript/README.md
@@ -45,28 +45,40 @@ import {
 } from '@pattern-stack/codegen-transcript';
 ```
 
-## The read primitive — registry, not a bespoke `pull`
+## The read primitive — `changeSources`, not a bespoke `pull`
 
-`TranscriptPort` composes the L1 `sources: IEntityChangeSourceRegistry` (the
-C6/C7 seam). Incremental reads go through
-`sources.get<CanonicalTranscript>('transcript')`, which resolves an
-`IChangeSource<CanonicalTranscript>` — the generic L1 read with cursor-by-value.
-The port carries **no** entity-specific `pull*` method; the Meet REST nested pull
-(conference records → transcripts → entries) is absorbed inside the adapter's
-change source, with the nesting encoded in the opaque cursor (ADR-0007 §3).
+`TranscriptPort` composes the L1 `changeSources: Record<string, IChangeSource<unknown>>`
+(the C6/C7 seam) — the per-entity change sources the adapter *contributes*, keyed
+by entity name. Each entry resolves an `IChangeSource<CanonicalTranscript>` — the
+generic L1 read with cursor-by-value. The surface aggregator (a surface-module
+concern, not the adapter's) folds every provider's `changeSources` into the
+`TRANSCRIPT_ENTITY_SOURCES` registry (an `IEntityChangeSourceRegistry`) that
+entity-agnostic consumers read at runtime. The port carries **no** entity-specific
+`pull*` method; the Meet REST nested pull (conference records → transcripts →
+entries) is absorbed inside the adapter's change source, with the nesting encoded
+in the opaque cursor (ADR-0007 §3).
+
+Codegen reshapes the read body inside each `changeSources` entry to an
+`IncrementalReadBase<CanonicalTranscript, ResolvedFilter[]>` subclass (RFC-0003) —
+the enumerate/hydrate read primitive that absorbs the nested-list drain. The
+author fills only `enumerate` / `hydrate` / `toCanonical`; the base owns
+streaming, filter-before-hydrate, bounded-concurrency hydration, and per-ref
+cursor emission.
 
 ## The composing port — `TranscriptPort`
 
 ```ts
 export interface TranscriptPort {
-  readonly auth: IAuthStrategy;                    // L1
-  readonly sources: IEntityChangeSourceRegistry;   // L1
-  readonly capabilities: TranscriptCapabilities;   // L2
+  readonly auth: IAuthStrategy;                                  // L1
+  readonly changeSources: Record<string, IChangeSource<unknown>>; // L1
+  readonly capabilities: TranscriptCapabilities;                 // L2
 }
 ```
 
-Entity-agnostic — no entity name appears in its type; entity access goes through
-`sources.get<T>(entityName)`. Per-consumer typed views are codegen-emitted
+Entity-agnostic — no entity name appears in its type. The adapter contributes
+`changeSources['transcript']`; the surface aggregator folds every provider's
+contributions into the entity-keyed `TRANSCRIPT_ENTITY_SOURCES` registry that
+consumers read at runtime. Per-consumer typed views are codegen-emitted
 (Track D), not encoded here.
 
 > **Provisional.** `TranscriptPort` stays provisional until a second adapter
@@ -98,8 +110,8 @@ it('google meet adapter conforms to TranscriptPort', () => {
 ```
 
 Verifies the required L1 slots resolve and every `capabilities.entities` entry
-resolves via `sources.has(name)` — so an adapter declaring an entity it can't
-source fails the test rather than failing at runtime.
+has a registered `changeSources` entry — so an adapter declaring an entity it
+can't source fails the test rather than failing at runtime.
 
 ## License
 

--- a/packages/codegen-transcript/package.json
+++ b/packages/codegen-transcript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-transcript",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "L2 transcript surface package for @pattern-stack/codegen — the canonical Transcript type, the TranscriptPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.12.0"
+    "@pattern-stack/codegen": "^0.13.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",


### PR DESCRIPTION
Release-prep for **0.13.0** — version bumps + documentation/skill updates for the Track D round-2/3 work on `main`: integration **module assembly emission** (RFC-0002) + the **`IncrementalRead` enumerate/hydrate read primitive** (RFC-0003), plus the **BREAKING** surface-port change. Publish is the human's, separately — this PR does not tag or publish.

## Version bumps

| Package | From | To | Bump |
|---|---|---|---|
| `@pattern-stack/codegen` (core) | 0.12.2 | **0.13.0** | minor |
| `@pattern-stack/codegen-mail` | 0.1.1 | **0.2.0** | breaking |
| `@pattern-stack/codegen-calendar` | 0.1.1 | **0.2.0** | breaking |
| `@pattern-stack/codegen-transcript` | 0.1.1 | **0.2.0** | breaking |
| `@pattern-stack/codegen-crm` | 0.1.1 | **0.2.0** | breaking |
| surface `peerDependencies["@pattern-stack/codegen"]` (×4) | ^0.12.0 | **^0.13.0** | — |

No other workspace package bumped. Core + the 4 surface packages release **together** — the surfaces carry the breaking port change and require the matching core.

## Breaking change

The four surface **ports** (`MailPort` / `CalendarPort` / `TranscriptPort` / `CrmPort`) now declare `readonly changeSources: Record<string, IChangeSource<unknown>>` — the per-entity change sources the adapter *contributes*, keyed by entity name — instead of the old `readonly sources: IEntityChangeSourceRegistry`. The folded, entity-keyed `<SURFACE>_ENTITY_SOURCES` registry is now the surface aggregator's output (a surface-module concern), no longer injected into the adapter (post-E0: drops a vestigial injection that was read by nothing and formed a latent DI cycle — RFC-0002 §3). This PR corrects the docs that still described the old shape.

## Doc/skill files touched

- `packages/codegen-mail/README.md` — `sources` → `changeSources` (port block, read-primitive prose, conformance prose) + `IncrementalRead` note
- `packages/codegen-calendar/README.md` — same
- `packages/codegen-transcript/README.md` — same
- `packages/codegen-crm/README.md` — `sources.get`/`sources.has` → `changeSources` (port composition + conformance prose)
- `CHANGELOG.md` — `0.13.0` entry: assembly emission + `IncrementalRead` primitive + BREAKING port change + release-together note
- `README.md` — new "Integration Codegen" section (read side + read primitive + write/run assembly)
- `CLAUDE.md` — architecture note: integration codegen now emits the full layer (assembly + read-body scaffold)
- `.claude/skills/integration/SKILL.md` — Track D 0.13.0 paragraph (assembly + read primitive + `changeSources` port shape) + runtime-snapshot entry for `incremental-read.ts` + atomic cursor kinds
- `.claude/skills/integration/consumer-patterns.md` — callout that the feature module is now codegen-generated for `surface:` entities
- `.claude/skills/integration/orchestrator-flow.md` — atomic-cursor token-withholding caveat (RFC-0003 R2)
- `.claude/skills/codegen/SKILL.md` — capability line + Track D post-step note (assembly/read primitive/`changeSources` port shape)

`.claude/skills/integration/protocols-and-ports.md` was already R1–R4-updated and consistent with `main` — left untouched per scope.

## Verification

- `bun run typecheck` — only the pre-existing #399 junction/barrel errors; no new errors.
- `bun test src/__tests__/packages/` — 39 pass / 0 fail (conformance tests confirm the doc edits match the real `*.port.ts` shape on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
