### PR TITLE
fix(surfaces): ship src/ so bun→src resolves from the npm tarball (surfaces → 0.2.1)

### DIFF
--- a/packages/codegen-calendar/package.json
+++ b/packages/codegen-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-calendar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "L2 calendar surface package for @pattern-stack/codegen — the canonical Meeting type, the CalendarPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist", "src", "README.md"],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-crm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "L2 CRM surface package for @pattern-stack/codegen — type-shaped CRM ports (field/picklist/association readers) and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist", "src", "README.md"],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",

--- a/packages/codegen-mail/package.json
+++ b/packages/codegen-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-mail",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "L2 mail surface package for @pattern-stack/codegen — the canonical Email type, the MailPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist", "src", "README.md"],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",

--- a/packages/codegen-transcript/package.json
+++ b/packages/codegen-transcript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-transcript",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "L2 transcript surface package for @pattern-stack/codegen — the canonical Transcript type, the TranscriptPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -19,7 +19,7 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": ["dist", "src", "README.md"],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Problem

Published `@pattern-stack/codegen-{mail,calendar,transcript,crm}@0.2.0` declared
`exports.bun → ./src/index.ts`, but `files` shipped only `dist/`. Under Bun the
`bun` condition wins → resolves a file absent from the tarball, so **Bun
consumers (e.g. swe-brain) cannot import the surface packages from npm**.

- **Node / tsc**: unaffected (`import`→`dist` / `types`→`dist`).
- **Monorepo link**: unaffected (`src/` present) — which is why it slipped 0.2.0.

Reproduced live: `import('@pattern-stack/codegen-mail')` under Bun against the
real published tarball → `Cannot find module`.

## Why not just drop the `bun` condition

First attempt did exactly that — and CI caught it: the repo's own
`src/__tests__/packages/*-smoke.test.ts` + `assert-*-adapter.test.ts` import the
**workspace** surface packages and run **from source without building `dist`**.
The `bun`→`src` condition is load-bearing for in-repo dev/CI; removing it gives
`Cannot find module '@pattern-stack/codegen-*'`.

## Fix

Keep the `bun`→`src` condition and **ship `src/` in the tarball** (add `"src"` to
`files`). Then resolution works for every consumer:

| consumer | condition | target |
|---|---|---|
| in-repo dev / CI (Bun) | `bun` | `src/` (workspace) |
| published Bun (swe-brain) | `bun` | `src/` (now in tarball — same as the link) |
| Node | `import` | `dist/` (built by `prepublishOnly`) |
| `tsc` | `types` | `dist/*.d.ts` |

Bump each `0.2.0 → 0.2.1` (the `just publish` flow skips versions already on
npm). Core `@pattern-stack/codegen@0.13.0` was never broken and is unchanged.

## Verification

`npm pack --dry-run` on `codegen-mail` includes the full `src/` tree
(`src/index.ts`, `src/testing/index.ts`, port/canonical/tokens). Diff is the
`version` + `files` line in each of the four surface packages (+8/−8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)