### PR TITLE
feat(integration): RFC-0003 R5 — per-run ReadContext threaded into the read body

### DIFF
--- a/.claude/skills/integration/protocols-and-ports.md
+++ b/.claude/skills/integration/protocols-and-ports.md
@@ -115,6 +115,16 @@ withheld and only the final record carries the token, so the orchestrator's pers
 never persists an unresumable mid-walk value (resumes all-or-nothing; bound the backfill blast
 radius with `ReadRequest.pageSize`).
 
+**Per-connection auth + raw landing — `ReadContext` (R5).** `enumerate`/`hydrate`/`get`/`read`
+take an optional `ctx?: ReadContext` carrying the run's `subscription`; `listChanges` builds
+`{ subscription }` and threads it down. A **multi-account** provider (per-connection tokens, not
+one provider-level token) resolves credentials in the fetch from `ctx?.subscription?.externalRef`
+— assert its presence (`if (!ctx?.subscription) throw …`); a singleton change source can't hold
+connection-scoped auth any other way. `ctx` is also the natural place to **land raw** (ADR-0001):
+`hydrate` has both the raw payloads and `ctx.subscription.id`, so inject a raw-objects repo and
+land there (only kept refs hydrate ⇒ only kept records' raw lands). Provider-level-auth adapters
+ignore `ctx`. (Optional everywhere = the core contract; a direct `get(id)` "fill on click" may omit it.)
+
 **Codegen emits the subclass.** For interaction surfaces, `codegen entity new --all` emits a
 per-entity `IncrementalReadBase<Canonical<Entity>, ResolvedFilter[]>` subclass (emit-once,
 author-owned) registered in the adapter's `changeSources` — you fill `enumerate`/`hydrate`/

--- a/docs/rfcs/RFC-0003-incremental-read-enumerate-hydrate.md
+++ b/docs/rfcs/RFC-0003-incremental-read-enumerate-hydrate.md
@@ -1,6 +1,6 @@
 # RFC-0003 — `IncrementalRead`: enumerate/hydrate read primitive + the scaffold body it emits (Track D round-3)
 
-**Status:** Accepted — Gate 1.5 PASS_WITH_NOTES (rev 2); **R1–R4 landed** (manifest dropped on architectural grounds; optional runtime-telemetry follow-up noted in §Sequencing R4)
+**Status:** Accepted — Gate 1.5 PASS_WITH_NOTES (rev 2); **R1–R4 landed** (manifest dropped on architectural grounds; optional runtime-telemetry follow-up noted in §Sequencing R4); **R5 (per-run `ReadContext`) in progress** — runtime threaded; emitter + snapshot pending (see §Amendment R5)
 **Date:** 2026-05-31
 **Owner:** Doug
 **Related:** RFC-0001 (provider/adapter emission — *this RFC reshapes the read-side `changeSources` body it emits*), RFC-0002 (module assembly emission — **disjoint surface; composes, does not collide — see §6**), ADR-033/033.1 (`detection:` config + `PollChangeSource`), Track C #329 (surface packages), swe-brain ADR-0002/ADR-0003 (the capability-primitive model this promotes), `runtime/subsystems/integration/` (the `IChangeSource` / `PollChangeSource` / orchestrator this builds on).
@@ -290,3 +290,24 @@ _All rev-1 notes also addressed substantively:_ `SourcedRecord<T>` is now formal
 - [Status line] Header still reads "Draft — Gate 1.5 critique addressed (rev 2); pending re-critique." On merge, flip to "Accepted (Gate 1.5: PASS_WITH_NOTES)" so the doc state matches the verdict.
 
 **Reviewed by:** reviewer agent · 2026-05-31T00:00:00Z (rev 2)
+
+---
+
+## Amendment — 2026-05-31 — R5: per-run `ReadContext` (the credential/raw-landing seam)
+
+**Surfaced by swe-brain (dogfood #2).** R1–R4 shipped the read primitive and swe-brain became the first app to drive the *generated* read path against a **multi-account** provider (Google Workspace: tokens are per-connection, not per-provider). Two things the pre-0.13 hand-rolled L7 fetch did have **no home** in the new model:
+
+1. **Per-connection auth.** The old fetch resolved credentials per run from `subscription.externalRef` (the connection id) — `surfaceFactory.forIntegration(connectionId)`. In the R1–R4 base the subscription reaches only `filterFor(subscription)`; it is **not** forwarded to `enumerate`/`hydrate`. A singleton change source therefore cannot hold connection-scoped credentials, and `hydrate(ids)` — where the vendor call happens — had no way to know *which* connection it was fetching for. (dealbrain, the first dogfood, never hit this: it builds its adapter stack **per connection in a harness**, sidestepping the generated singleton path. swe-brain is the first to exercise the generated path with per-connection auth.)
+2. **Raw landing (ADR-0001).** The same old fetch landed the raw vendor payload (`rawObjects.land(...)`). `listChanges` adapts `read()`→`Change<T>` and drops `raw`, so persisted raw landing also lost its seam.
+
+**The gap is narrow.** The context already arrives at `listChanges(subscription, cursor)`; the base simply failed to forward it past `filterFor`. So the fix is surgical, not a rewrite.
+
+**Fix (runtime — landed on this branch).** A `ReadContext` (carrying the run `subscription`), threaded **optional** through `read(req, ctx)` → `enumerate(…, ctx)` + `hydrate(ids, ctx)` and `get(id, ctx)`; `listChanges` builds `{ subscription }` and passes it down. Optional throughout = the core contract (a direct `read()`/`get()` "fill on click" may omit it; a per-connection adapter reads `ctx?.subscription?.externalRef` and asserts presence; a provider-level-auth adapter ignores it). Exported `ReadContext` from the integration + top subsystems barrels. **No back-compat shim** (per CLAUDE.md): existing 3-param `enumerate` / 1-arg `hydrate` overrides still satisfy the widened abstract signatures (TS allows fewer-param overrides), so this is additive, not breaking.
+
+**Raw landing becomes author-side, no `Change<T>` change.** With `ctx.subscription` available in `hydrate` (where the raw payloads are fetched, keyed by `subscription.id`), an adapter that injects a raw-objects repo lands raw there — better than before (only kept refs hydrate, so only kept records' raw lands). `Change<T>` stays clean.
+
+**Remaining build step (not yet done — tracked):**
+- **Emitter** — `generateAdapterScaffold` (`src/cli/shared/adapter-emission-generator.ts`) should emit the `ctx?: ReadContext` parameter on the scaffold's `enumerate`/`hydrate` so authors see the seam, plus the import. Then **rebaseline the template-emission snapshot** (§8 — not `just test-baseline`).
+- **Falsifier (optional)** — extend `incremental-read.spec.ts` with a `ReadContext`-passthrough assertion (a `ctx` handed to `read`/`listChanges` reaches `enumerate`/`hydrate` unchanged).
+
+**Open (Q5).** `ReadContext` currently carries only `subscription` (all that reaches `listChanges`). Threading `userId`/`provider`/`tenantId` would require widening `IChangeSource.listChanges` + the orchestrator's call — deferred until an adapter needs more than `subscription.externalRef`.

--- a/runtime/subsystems/index.ts
+++ b/runtime/subsystems/index.ts
@@ -80,6 +80,7 @@ export {
 export type {
   IncrementalRead,
   RandomRead,
+  ReadContext,
   ReadMode,
   ReadRequest,
   Ref,

--- a/runtime/subsystems/integration/incremental-read.ts
+++ b/runtime/subsystems/integration/incremental-read.ts
@@ -80,6 +80,26 @@ export interface ReadRequest<F = unknown> {
 }
 
 /**
+ * Per-run context threaded from `listChanges` into the vendor read body (R5).
+ *
+ * Carries the `subscription` framing the run so `enumerate`/`hydrate` can resolve
+ * **per-connection credentials** (and raw-landing keys) from
+ * `subscription.externalRef` — the gap a multi-account consumer surfaced: a
+ * singleton change source cannot hold connection-scoped auth, and before R5 the
+ * base forwarded the subscription only into `filterFor`, never into the fetch.
+ *
+ * Optional throughout (the core contract): a direct `read()` / `get()` call — the
+ * query surface's "fill one record on click" — may omit it. An adapter that needs
+ * per-connection auth reads `ctx?.subscription?.externalRef` and asserts its
+ * presence; a provider-level-auth adapter ignores it.
+ */
+export interface ReadContext {
+  /** The subscription framing this run; `externalRef` is the upstream scope /
+   *  connection id the adapter resolves credentials + raw-landing keys from. */
+  readonly subscription?: IntegrationSubscriptionView;
+}
+
+/**
  * The `read()`-side envelope: canonical record + the raw vendor payload it came
  * from + the originating external id + the per-ref cursor.
  *
@@ -101,7 +121,7 @@ export interface SourcedRecord<T> {
  * hydration, and cursor emission are the providing base's concern.
  */
 export interface IncrementalRead<T, F = unknown> {
-  read(req: ReadRequest<F>): AsyncIterable<SourcedRecord<T>>;
+  read(req: ReadRequest<F>, ctx?: ReadContext): AsyncIterable<SourcedRecord<T>>;
 }
 
 /**
@@ -111,7 +131,7 @@ export interface IncrementalRead<T, F = unknown> {
  * surface.
  */
 export interface RandomRead<T> {
-  get(id: string): Promise<T | null>;
+  get(id: string, ctx?: ReadContext): Promise<T | null>;
 }
 
 // ============================================================================
@@ -208,11 +228,16 @@ export abstract class IncrementalReadBase<T, F = unknown, M = Record<string, unk
    * `pageSize` (from `ReadRequest`) is the adapter's requested vendor page size
    * — also the atomic-cursor backfill blast-radius bound (§ `cursorDivisible`).
    * Honor it as a hint; vendors that cap page size clamp it.
+   *
+   * `ctx?.subscription` (R5) carries the run's subscription, so a per-connection
+   * adapter resolves credentials / upstream scope from `externalRef` here; absent
+   * on a direct `read()` with no run subscription.
    */
   protected abstract enumerate(
     mode: ReadMode,
     filter?: F,
     pageSize?: number,
+    ctx?: ReadContext,
   ): AsyncIterable<Ref<M>[]>;
 
   /**
@@ -221,8 +246,12 @@ export abstract class IncrementalReadBase<T, F = unknown, M = Record<string, unk
    * alignment. Write it over `mapConcurrent(ids, (id) => this.fetchOne(id),
    * this.hydrateConcurrency)`; override with a real `/batch` call or a
    * passthrough (full-object list) where the vendor allows.
+   *
+   * `ctx?.subscription` (R5) carries the run's subscription for per-connection
+   * credential resolution (the fetch is where the vendor call happens) and is the
+   * natural place to land raw payloads keyed by `subscription.id`.
    */
-  protected abstract hydrate(ids: string[]): Promise<Map<string, unknown>>;
+  protected abstract hydrate(ids: string[], ctx?: ReadContext): Promise<Map<string, unknown>>;
 
   /** Provider payload → canonical record. Return `null` to drop a record. */
   protected abstract toCanonical(raw: unknown): T | null;
@@ -256,11 +285,14 @@ export abstract class IncrementalReadBase<T, F = unknown, M = Record<string, unk
    * adapter cannot hydrate-then-discard. A hydrate miss (deleted mid-run) is
    * skipped, never fabricated.
    */
-  async *read(req: ReadRequest<F>): AsyncIterable<SourcedRecord<T>> {
-    for await (const refPage of this.enumerate(req.mode, req.filter, req.pageSize)) {
+  async *read(req: ReadRequest<F>, ctx?: ReadContext): AsyncIterable<SourcedRecord<T>> {
+    for await (const refPage of this.enumerate(req.mode, req.filter, req.pageSize, ctx)) {
       const kept = refPage.filter((ref) => this.matchesRef(ref, req.filter));
       if (kept.length === 0) continue;
-      const raws = await this.hydrate(kept.map((ref) => ref.externalId));
+      const raws = await this.hydrate(
+        kept.map((ref) => ref.externalId),
+        ctx,
+      );
       for (const ref of kept) {
         const raw = raws.get(ref.externalId);
         if (raw === undefined || raw === null) continue; // deleted mid-run → skip
@@ -277,8 +309,8 @@ export abstract class IncrementalReadBase<T, F = unknown, M = Record<string, unk
    * `toCanonical ∘ hydrate([id])`. Reuses the adapter's batched fetch + miss
    * tolerance; returns `null` for a missing or undecodable record.
    */
-  async get(id: string): Promise<T | null> {
-    const raws = await this.hydrate([id]);
+  async get(id: string, ctx?: ReadContext): Promise<T | null> {
+    const raws = await this.hydrate([id], ctx);
     const raw = raws.get(id);
     if (raw === undefined || raw === null) return null;
     return this.toCanonical(raw);
@@ -308,7 +340,9 @@ export abstract class IncrementalReadBase<T, F = unknown, M = Record<string, unk
         ? { kind: 'full' }
         : { kind: 'delta', cursor };
     const filter = this.filterFor(subscription);
-    const stream = this.read({ mode, filter });
+    // R5: thread the run's subscription into the read body so `enumerate`/`hydrate`
+    // can resolve per-connection credentials (and raw-landing keys) from it.
+    const stream = this.read({ mode, filter }, { subscription });
 
     if (this.cursorDivisible) {
       for await (const sourced of stream) {

--- a/runtime/subsystems/integration/index.ts
+++ b/runtime/subsystems/integration/index.ts
@@ -101,6 +101,7 @@ export {
   mapConcurrent,
   type IncrementalRead,
   type RandomRead,
+  type ReadContext,
   type ReadMode,
   type ReadRequest,
   type Ref,


### PR DESCRIPTION
## RFC-0003 R5 — thread a per-run `ReadContext` into the read body

R1–R4 shipped the enumerate/hydrate read primitive. R5 closes a gap the swe-brain dogfood surfaced as the **first app to drive the generated read path with per-connection (multi-account) auth**.

### The gap
`IncrementalReadBase` forwarded the `subscription` only into `filterFor` — `enumerate`/`hydrate` (where the vendor call happens) got **no run context**. So a per-connection adapter had no concurrency-safe seam to resolve credentials, and raw landing (which lived in the old hand-rolled fetch) had nowhere to go. (dealbrain never hit it — it builds its adapter stack per-connection in a harness, sidestepping the generated singleton path.)

### The fix (additive — no back-compat shim)
- `ReadContext { subscription? }`, threaded **optional** through `read` / `enumerate` / `hydrate` / `get`; `listChanges` builds `{ subscription }` from the subscription it already receives.
- Optional = the core contract: a per-connection adapter reads `ctx?.subscription?.externalRef` and asserts presence; a provider-level-auth adapter ignores it.
- `ReadContext` exported from the integration + top subsystems barrels.
- Existing 3-param `enumerate` / 1-arg `hydrate` overrides still satisfy the widened abstract signatures (TS allows fewer-param overrides).

### Validated by a real consumer
swe-brain's transcript/calendar/mail adapters consume it: `listChanges → ctx → auth.resolve(subscription.externalRef) → per-connection token on every vendor call`. Live vs. real Google: calendar 250, email 413, transcript clean — **0 failures**. The existing `incremental-read` spec is **24/24** green (the change is additive).

### Docs (same change, per CLAUDE.md)
RFC-0003 §Amendment R5 + the integration skill (`protocols-and-ports.md`).

### Remaining R5 step (follow-on — tracked in the amendment)
The **emitter** should emit `ctx` on the scaffold's `enumerate`/`hydrate` + a registry-backed, client-less provider module for per-connection surfaces, then rebaseline the template-emission snapshot. Until then the consumer hand-stopgaps the generated provider module.

### Release
Ride the next core publish — **bundle with `@pattern-stack/codegen-messaging@0.1.0`** (sibling Track-D surface) so the consumer's migration takes one core bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
