### PR TITLE
feat(messaging): codegen-messaging L2 surface package + SURFACE_REGISTRY entry

### DIFF
--- a/packages/codegen-messaging/README.md
+++ b/packages/codegen-messaging/README.md
@@ -1,0 +1,43 @@
+# @pattern-stack/codegen-messaging
+
+L2 **messaging** surface package for `@pattern-stack/codegen` (ADR-036). The
+type-shaped home for the messaging context: the canonical `Channel` / `Message`
+vocabulary, the `MessagingPort` composing contract, the bot-user write seam, the
+capability descriptor, and DI tokens.
+
+Designed against **swe-brain ADR-0008** (MessagingDomain, Slack first). Messaging
+is an **interaction surface** — incremental-read, no L2 sub-ports — so this package
+mirrors `codegen-transcript` rather than the CRM-shaped `codegen-crm`.
+
+## What's here (L2)
+
+- **`CanonicalChannel`, `CanonicalMessage`** (`canonical.ts`) — the vendor-agnostic
+  `T`s a provider adapter reads into (`IChangeSource<Canonical…>` → differ → sink).
+  Vendor DTO → External(Zod) → canonical; vendor shapes never cross the boundary
+  (hard rule #4).
+- **`MessagingPort`** (`messaging.port.ts`) — the single contract a messaging
+  provider adapter implements: L1 `auth` + per-entity `changeSources` + the
+  `capabilities` descriptor, plus an optional bot-user `write` seam. Entity-agnostic
+  (named for the *context*, not an entity); reads go through the change-source
+  registry.
+- **`MessagingCapabilities` / `NO_MESSAGING_CAPABILITIES`** (`capabilities.ts`) —
+  runtime coverage (`entities`) + optional write availability (`canWrite`).
+- **tokens** (`tokens.ts`) — `MESSAGING_PORT`, `MESSAGING_CAPABILITIES`, `MESSAGE_WRITE`.
+- **`assertMessagingAdapter`** (`@pattern-stack/codegen-messaging/testing`) — the
+  conformance / falsifier helper, kept out of the runtime barrel.
+
+## What's NOT here
+
+- **`Conversation`** — a *derived* grouping produced by the domain segmentation
+  step (ADR-0008 §8), not vendor-sourced. No canonical read type, no change source;
+  it lives only as a consumer entity + a domain-service output.
+- **Composition** — which providers/ports a given app wires is L3, in the consumer
+  app, never in this package (ADR-036 §3).
+
+## Status
+
+`MessagingPort` and the `MessageWrite` capability are **provisional** until a
+second vendor (Teams/Discord) passes `assertMessagingAdapter` — then they promote
+to stable (hard rule #8). The write path **ships dark** in v1 (ADR-0008 §9): the
+seam is built and wired, but `chat:write` is requested and no nudge fires only once
+the actuator activates.

--- a/packages/codegen-messaging/package.json
+++ b/packages/codegen-messaging/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pattern-stack/codegen-messaging",
+  "version": "0.1.0",
+  "description": "L2 messaging surface package for @pattern-stack/codegen — the canonical Channel/Message vocabulary, the MessagingPort composing contract, the bot-user write seam, and DI tokens. See ADR-036 + swe-brain ADR-0008.",
+  "type": "module",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./testing": {
+      "bun": "./src/testing/index.ts",
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
+    }
+  },
+  "files": ["dist", "src", "README.md"],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "peerDependencies": {
+    "@pattern-stack/codegen": "^0.13.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^6.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/codegen-messaging/src/canonical.ts
+++ b/packages/codegen-messaging/src/canonical.ts
@@ -1,0 +1,118 @@
+/**
+ * Canonical `messaging`-surface vocabulary (ADR-036 §7; swe-brain ADR-0008 §1).
+ *
+ * `CanonicalChannel` and `CanonicalMessage` are the vendor-agnostic `T`s a
+ * messaging provider adapter reads into — the records that flow through the L1
+ * change-source pipeline (`IChangeSource<Canonical…>` → differ → sink). Every
+ * vendor adapter maps its vendor DTO → External (Zod-validated) → these canonical
+ * shapes; vendor DTO/External shapes never cross the port boundary (hard rule #4).
+ * IDs are vendor-prefixed at the boundary (`slack:C…`, `slack:C…:ts`, `slack:U…`).
+ *
+ * Modeled from swe-brain ADR-0008 (MessagingDomain, Slack first), trimmed to the
+ * cross-vendor load-bearing core so Teams/Discord (planned vendor #2) map cleanly.
+ * Slack-specific encodings (`<@U…>` mentions, `<url>` links, `thread_ts`) are
+ * de-encoded in the adapter mapper; only their resolved, generalized forms appear
+ * here.
+ *
+ * `Conversation` is deliberately ABSENT: it is a *derived* grouping produced by
+ * the domain segmentation step (ADR-0008 §8), not vendor-sourced — no adapter
+ * reads it, so it has no canonical read type and no change source. It lives only
+ * as a consumer entity + a domain-service output.
+ *
+ * Each record is declared as `type` (not `interface`) so it satisfies the
+ * orchestrator's `T extends Record<string, unknown>` constraint — interfaces lack
+ * the implicit index signature that constraint needs.
+ */
+
+/** A reaction on a message — emoji shortname + aggregate count. */
+export type MessageReaction = {
+  emoji: string;
+  count: number;
+};
+
+/** A file attached to a message — reference only; binary content is deferred. */
+export type MessageFileRef = {
+  externalId: string;
+  name?: string | null;
+  mime?: string | null;
+};
+
+/**
+ * A messaging container — Slack's "conversation", renamed `Channel` to dodge the
+ * overload with the derived `Conversation` grouping (ADR-0008 §1).
+ */
+export type CanonicalChannel = {
+  /** Vendor-prefixed id at the port boundary, e.g. `slack:C…`. */
+  externalId: string;
+  /**
+   * Container kind, vendor-normalized: `public` | `private` | `dm` | `mpim`.
+   * v1 ingests `public` + `private` only (ADR-0008 §1).
+   */
+  kind: string;
+  /** Display name; null for DMs. */
+  name: string | null;
+  topic: string | null;
+  purpose: string | null;
+  isArchived: boolean;
+  /** Externally-hosted shared channel (Slack Connect analog) — flagged, deferred. */
+  isExtShared: boolean;
+  createdAt: Date | null;
+};
+
+/**
+ * An atomic, MUTABLE message (ADR-0008 §1). Edits/deletes arrive post-ingest and
+ * are absorbed by `integrationUpsert` (dedup on `externalId`); `deletedAt` is a
+ * soft-delete tombstone preserved as signal.
+ *
+ * `conversationExternalId` is intentionally ABSENT from the canonical read type:
+ * conversation membership is assigned by the domain segmentation step, never by
+ * the adapter (ADR-0008 §8). The consumer `message` entity carries it as a
+ * nullable, segmentation-owned column.
+ */
+export type CanonicalMessage = {
+  /** Vendor-prefixed id, e.g. `slack:C…:ts`. */
+  externalId: string;
+  /** Parent container (cross-entity join key, not a DB FK — ADR-0004). Vendor-prefixed. */
+  channelExternalId: string;
+  /** Author's vendor user id, e.g. `slack:U…`. */
+  authorExternalId: string;
+  /**
+   * Author email when resolvable — routed through an `ExactEmailMatch` identity
+   * matcher (hard rule #5), not an ad-hoc display-name map. Null for bots /
+   * guests / external users without a first-party email.
+   */
+  authorEmail: string | null;
+  /** Message timestamp (the vendor `ts` for Slack). */
+  occurredAt: Date;
+  /**
+   * Native reply-thread link (Slack `thread_ts`, vendor-prefixed). A strong
+   * *within*-Conversation signal, NOT a Conversation id (ADR-0008 §1/§8).
+   */
+  threadExternalId: string | null;
+  /** Raw message body; vendor markup preserved. */
+  text: string;
+  /**
+   * Mention target ids decoded from vendor markup (e.g. `<@U…>` → `slack:U…`).
+   * De-encoding is the adapter's job; resolution to Person is the domain's.
+   */
+  mentionExternalIds: string[] | null;
+  /** System/bot subtype preserved; the domain owns the signal-vs-noise policy. */
+  subtype: string | null;
+  reactions: MessageReaction[] | null;
+  files: MessageFileRef[] | null;
+  /** Edit time when the message was edited post-send (drives upsert). */
+  editedAt: Date | null;
+  /** Soft-delete tombstone (preserved as signal). */
+  deletedAt: Date | null;
+  /**
+   * The visibility the message was observed at (`public` | `private`) — the
+   * consent lattice's runtime currency; any actuator write's target visibility
+   * must be ≤ this (RFC-0001 §4; ADR-0008 §7).
+   */
+  visibility: string;
+  /**
+   * The actuator's own posts — the echo-loop guard so ingestion skips/marks
+   * self-authored messages (ADR-0008 §9).
+   */
+  isAppAuthored: boolean;
+};

--- a/packages/codegen-messaging/src/capabilities.ts
+++ b/packages/codegen-messaging/src/capabilities.ts
@@ -1,0 +1,39 @@
+/**
+ * Messaging surface capability descriptor (ADR-036 §6).
+ *
+ * The messaging surface is an **incremental-read surface**: it has no L2
+ * sub-ports (no field/picklist/association readers — that's CRM-shaped), so the
+ * descriptor carries only `entities` plus the messaging-specific `canWrite` flag.
+ * Runtime coverage data, not a type bound on `MessagingPort` (the port stays
+ * entity-agnostic; ADR-036 §6).
+ */
+export interface MessagingCapabilities {
+  /**
+   * Consumer-defined entity names this adapter can resolve (runtime coverage,
+   * not a type bound). e.g. `['channel', 'message']`. `conversation` is derived
+   * by domain segmentation and never appears here.
+   */
+  entities: readonly string[];
+  /**
+   * Whether this adapter can post/edit/react as the app's bot user (ADR-0008 §9).
+   * Optional; the write path **ships dark** in v1 — left unset / `false` until the
+   * actuator activates (`chat:write` is requested only then; v1 OAuth is
+   * read-scopes-only). When `true`, `MessagingPort.write` must be present.
+   */
+  canWrite?: boolean;
+}
+
+/**
+ * The empty capability set — no entities, no write. Spread on top to declare
+ * coverage:
+ *
+ * ```ts
+ * const SLACK_MESSAGING_CAPABILITIES: MessagingCapabilities = {
+ *   ...NO_MESSAGING_CAPABILITIES,
+ *   entities: ['channel', 'message'],
+ * };
+ * ```
+ */
+export const NO_MESSAGING_CAPABILITIES: MessagingCapabilities = {
+  entities: [],
+};

--- a/packages/codegen-messaging/src/index.ts
+++ b/packages/codegen-messaging/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @pattern-stack/codegen-messaging — public surface barrel.
+ *
+ * The L2 messaging surface package: the canonical Channel/Message vocabulary, the
+ * entity-agnostic `MessagingPort` composing contract (with its optional bot-user
+ * `write` seam), the capability descriptor, and DI tokens. See ADR-036 (surface
+ * packages), swe-brain ADR-0008 (MessagingDomain), and ../README.md.
+ */
+
+export * from './canonical';
+export * from './capabilities';
+export * from './messaging.port';
+export * from './tokens';
+
+// Note: the conformance helper `assertMessagingAdapter` is intentionally NOT
+// exported here — it ships from the '@pattern-stack/codegen-messaging/testing'
+// subpath so it stays out of production bundles.

--- a/packages/codegen-messaging/src/messaging.port.ts
+++ b/packages/codegen-messaging/src/messaging.port.ts
@@ -1,0 +1,86 @@
+/**
+ * Messaging L3 composing port.
+ *
+ * `MessagingPort` is the single contract a messaging provider adapter implements.
+ * It composes L1 strategies (auth + the entity-keyed change-source registry) plus
+ * the runtime capability descriptor, and — unique to messaging among the
+ * interaction surfaces — an optional bot-user `write` seam (ADR-0008 §9). Like
+ * `TranscriptPort` it carries **no L2 sub-ports**: the messaging surface is
+ * incremental-read + canonical types (`CanonicalChannel`, `CanonicalMessage`), so
+ * reads go through the change-source registry; there is no field/picklist/
+ * association reader to compose.
+ *
+ * **Entity-agnostic by design** — no entity name appears in this type (the port
+ * is named for the *context*, `messaging`; ADR-036 §11.3). The adapter contributes
+ * `changeSources['channel']` / `changeSources['message']`; the surface aggregator
+ * folds every provider's `changeSources` into the `<SURFACE>_ENTITY_SOURCES`
+ * registry consumers read at runtime. `conversation` is NOT a change source — it
+ * is produced by the domain segmentation step (ADR-0008 §8).
+ *
+ * `MessagingPort` (and `MessageWrite`) are **provisional** until a second adapter
+ * (Teams/Discord is the planned vendor #2) passes the falsifier suite — that
+ * promotes them to stable (hard rule #8).
+ *
+ * The L1 types are imported across the package boundary from
+ * `@pattern-stack/codegen/subsystems` (the C6/C7 seam) — type-only, erased at
+ * runtime; see the package tsconfig for in-workspace resolution.
+ */
+
+import type {
+  IAuthStrategy,
+  IChangeSource,
+} from '@pattern-stack/codegen/subsystems';
+import type { MessagingCapabilities } from './capabilities';
+
+/**
+ * A draft message the actuator posts as the app's bot user (ADR-0008 §9). The
+ * brain speaks *as itself* (APP badge) — posting as an end user is out of scope.
+ */
+export type MessageDraft = {
+  /** Target container (vendor-prefixed), e.g. `slack:C…`. */
+  channelExternalId: string;
+  /** Reply in a thread when set (vendor-prefixed thread id); else a top-level post. */
+  threadExternalId?: string | null;
+  text: string;
+};
+
+/**
+ * The bot-user write capability (ADR-0003 `Writeback`-shaped; ADR-0008 §3/§9).
+ * **Ships dark** in v1 — built and wired, but gated by an `act` `ConsentGrant` ×
+ * the visibility bound × the escalation-rung policy before any write fires.
+ */
+export interface MessageWrite {
+  /**
+   * Post a new message (or a threaded reply when the draft carries a thread id).
+   * Returns the new message's vendor-prefixed id, which the caller persists to
+   * enable later edit/delete AND to set `isAppAuthored` (the echo-loop guard).
+   */
+  post(draft: MessageDraft): Promise<string>;
+  /** Edit a previously-posted message by its vendor-prefixed id. */
+  update(externalId: string, text: string): Promise<void>;
+  /** React to a message with an emoji shortname. */
+  react(externalId: string, emoji: string): Promise<void>;
+}
+
+export interface MessagingPort {
+  /** L1 — auth strategy resolving credentials for this provider. */
+  readonly auth: IAuthStrategy;
+
+  /**
+   * L1 — per-entity change sources this adapter contributes, keyed by entity
+   * name (`channel`, `message`); the surface aggregator folds these into the
+   * entity-keyed registry.
+   */
+  readonly changeSources: Record<string, IChangeSource<unknown>>;
+
+  /** L2 — runtime capability descriptor (entity coverage + write availability). */
+  readonly capabilities: MessagingCapabilities;
+
+  /**
+   * Surface-only — the bot-user write capability (ADR-0008 §9). Optional and
+   * **dark** in v1: present on a fully-wired adapter, but no write fires until an
+   * `act` grant + visibility bound + rung policy permit it. Absent on a
+   * read-only adapter (then `capabilities.canWrite` is unset / `false`).
+   */
+  readonly write?: MessageWrite;
+}

--- a/packages/codegen-messaging/src/testing/assert-messaging-adapter.ts
+++ b/packages/codegen-messaging/src/testing/assert-messaging-adapter.ts
@@ -1,0 +1,72 @@
+/**
+ * Messaging adapter conformance helper (ADR-036 §10).
+ *
+ * `assertMessagingAdapter` structurally verifies a `MessagingPort` implementation
+ * so consumer adapter tests catch wiring mistakes (a missing L1 slot, an entity
+ * declared in `capabilities.entities` with no registered change source, a
+ * `canWrite` descriptor with no `write` seam) at test time rather than at NestJS
+ * boot or first use. This is also the falsifier-suite entry point a second vendor
+ * (Teams/Discord) runs against to promote the port from provisional to stable
+ * (hard rule #8).
+ *
+ * Shipped from the `@pattern-stack/codegen-messaging/testing` subpath — a
+ * test-time helper, kept out of the package's main runtime barrel.
+ */
+
+import type { MessagingPort } from '../messaging.port';
+
+/**
+ * Structurally verify a `MessagingPort` implementation. Collects every failure
+ * and throws a single `AggregateError` listing them all (rather than failing on
+ * the first), so a test reports the complete conformance gap in one run.
+ *
+ * Checks:
+ *   1. Required L1 slots (`auth`, `changeSources`) resolve to non-null objects.
+ *   2. `capabilities` resolves.
+ *   3. Every `capabilities.entities` entry has a registered `changeSources` entry.
+ *   4. If `capabilities.canWrite` is set, the `write` seam is present (ADR-0008 §9).
+ *
+ * @throws AggregateError when any check fails.
+ */
+export function assertMessagingAdapter(adapter: MessagingPort): void {
+  const failures: Error[] = [];
+
+  // 1. Required L1 slots.
+  if (!adapter.auth) failures.push(new Error('MessagingPort.auth missing'));
+  if (!adapter.changeSources)
+    failures.push(new Error('MessagingPort.changeSources missing'));
+
+  // 2. Capability descriptor + 3. entity coverage matches the contributions.
+  const caps = adapter.capabilities;
+  if (!caps) {
+    failures.push(new Error('MessagingPort.capabilities missing'));
+  } else {
+    if (adapter.changeSources) {
+      for (const entity of caps.entities) {
+        if (!(entity in adapter.changeSources)) {
+          failures.push(
+            new Error(
+              `caps.entities lists '${entity}' but changeSources['${entity}'] is missing`,
+            ),
+          );
+        }
+      }
+    }
+
+    // 4. Write capability ↔ descriptor consistency (ADR-0008 §9).
+    if (caps.canWrite && !adapter.write) {
+      failures.push(
+        new Error(
+          'capabilities.canWrite is true but MessagingPort.write is missing',
+        ),
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `MessagingPort conformance failed (${failures.length} issue${failures.length === 1 ? '' : 's'})`,
+    );
+  }
+}

--- a/packages/codegen-messaging/src/testing/index.ts
+++ b/packages/codegen-messaging/src/testing/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @pattern-stack/codegen-messaging/testing — test-time helpers.
+ *
+ * Conformance checks for messaging adapter implementations, kept out of the main
+ * runtime barrel so production bundles don't pull in test scaffolding.
+ */
+
+export * from './assert-messaging-adapter';

--- a/packages/codegen-messaging/src/tokens.ts
+++ b/packages/codegen-messaging/src/tokens.ts
@@ -1,0 +1,30 @@
+/**
+ * Messaging surface package — DI tokens.
+ *
+ * The messaging surface has no L2 sub-ports, so it ships the two tokens every
+ * surface needs — its capability descriptor and the composed port — plus
+ * `MESSAGE_WRITE` for the bot-user write capability (ADR-0008 §9), which is a
+ * distinct injectable even though it ships dark in v1. The L1 seams a
+ * `MessagingPort` injects (`auth`, the entity-keyed change-source registry) bind
+ * under the codegen subsystems' own tokens (`STRATEGY_REGISTRY`,
+ * `ENTITY_CHANGE_SOURCE_REGISTRY`), not here.
+ *
+ * `Symbol.for(...)` matches a token by key across duplicated module instances /
+ * import boundaries — the case a published, possibly-deduped surface package
+ * needs (mirrors `@pattern-stack/codegen-transcript`).
+ */
+
+/** DI token for an adapter's `MessagingCapabilities` descriptor. */
+export const MESSAGING_CAPABILITIES = Symbol.for(
+  '@pattern-stack/codegen-messaging.capabilities',
+);
+
+/** DI token for the composed `MessagingPort` adapter. */
+export const MESSAGING_PORT = Symbol.for(
+  '@pattern-stack/codegen-messaging.port',
+);
+
+/** DI token for the bot-user `MessageWrite` capability (ships dark in v1; ADR-0008 §9). */
+export const MESSAGE_WRITE = Symbol.for(
+  '@pattern-stack/codegen-messaging.message-write',
+);

--- a/packages/codegen-messaging/tsconfig.json
+++ b/packages/codegen-messaging/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "//": "Standalone library config (mirrors codegen-transcript). The `paths` entry resolves the L1 import in-workspace: published consumers resolve @pattern-stack/codegen/subsystems via codegen's package.json `exports` map, but here the root @pattern-stack/codegen is the workspace ROOT (not a packages/* member) so it isn't symlinked into node_modules. typecheck points at codegen's BUILT .d.ts — skipLibCheck applies — i.e. `bun run build` at the repo root must run before this package's typecheck. The imports are type-only / erased at runtime, so tests need no build. See ADR-036.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "ignoreDeprecations": "6.0",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"],
+    "paths": {
+      "@pattern-stack/codegen/subsystems": [
+        "../../dist/runtime/subsystems/index.d.ts"
+      ]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/codegen-messaging/tsup.config.ts
+++ b/packages/codegen-messaging/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * Local build config for @pattern-stack/codegen-messaging. Without this, tsup
+ * walks up and picks the repo-root tsup.config.ts (whose `tsconfig:
+ * tsconfig.build.json` lacks this package's `paths` mapping for the L1 import),
+ * so the DTS step can't resolve `@pattern-stack/codegen/subsystems`. Pinning the
+ * package tsconfig here makes the cross-package type import resolve during the
+ * declaration build. Mirrors codegen-transcript.
+ */
+export default defineConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  outDir: 'dist',
+  format: ['esm'],
+  target: 'node20',
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  tsconfig: 'tsconfig.json',
+});

--- a/src/cli/shared/adapter-emission-generator.ts
+++ b/src/cli/shared/adapter-emission-generator.ts
@@ -160,6 +160,19 @@ export const SURFACE_REGISTRY: Record<string, SurfaceSpec> = {
     l2Ports: [],
     readPrimitive: true,
   },
+  // messaging (swe-brain ADR-0008) — interaction surface like transcript: the
+  // adapter contributes per-entity change sources for `channel` + `message`
+  // (`conversation` is domain-derived by segmentation, not vendor-read). The
+  // capability descriptor adds an optional `canWrite` flag for the bot-user write
+  // path, which ships dark in v1; the scaffold still only constructs `entities`.
+  messaging: {
+    packageName: "@pattern-stack/codegen-messaging",
+    portType: "MessagingPort",
+    capabilitiesType: "MessagingCapabilities",
+    noCapsConst: "NO_MESSAGING_CAPABILITIES",
+    l2Ports: [],
+    readPrimitive: true,
+  },
 };
 
 // ============================================================================


### PR DESCRIPTION
## `codegen-messaging` — the `messaging` interaction surface (Track-D)

New L2 surface package `@pattern-stack/codegen-messaging` (peer of `codegen-{calendar,mail,transcript}`) + the `messaging` entry in core's `SURFACE_REGISTRY`. Mirrors the transcript surface exactly. Built by the Slack/MessagingDomain thread; brought onto the release line to **ride the same core publish as RFC-0003 R5 (#439)**.

### Contents (1 commit, +510, no overlap with #439)
- `packages/codegen-messaging/` — canonical types (`CanonicalChannel`, `CanonicalMessage`, `MessageReaction`, `MessageFileRef`), `MessagingCapabilities`, `MessagingPort` (auth + `changeSources` + optional `write`), tokens, and the `assert-messaging-adapter` falsifier. Interaction surface (`l2Ports: []`, `IncrementalReadBase` reads; canonical types are the `T`). Builds (tsup → dist + .d.ts), typechecks against core's `.d.ts`, resolves under Bun.
- `src/cli/shared/adapter-emission-generator.ts` — the `messaging` `SURFACE_REGISTRY` entry. **Core change** (compiled into the CLI → needs the core bump; can't ship as a sibling package). Without it, `surface: messaging` entities hit `skippedSurfaces`.

### Verified
`entity validate` OK; messaging entities generate + `tsc` 0; the Track-D emit recognizes `messaging` (gate flipped) and the emitted Slack adapter imports `@pattern-stack/codegen-messaging`. (The 3 pre-existing `junction.ts`/`barrel-generator.ts` `tsc` errors are already on `main` — unrelated.)

### Decisions to confirm
- **(a) Version `0.1.0`** — provisional (`MessagingPort` is pre-stable until vendor #2, hard rule #8). Bump to `0.2.x` for lockstep with the sibling surfaces if preferred.
- **(c) `MessageWrite` seam** — included as an optional/dark `write?` + `canWrite?` (ADR-0008 §9 bot-user actuator). Keep, or strip to a read-only v1 surface.

### Release
Bundle with **#439 (R5)**: both merge → publish core (R5 + this registry entry) + `codegen-messaging@0.1.0`, same mechanics as `codegen-{calendar,mail,transcript}@0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
