### PR TITLE
chore(release): bump core 0.13.0 to 0.13.1 (R5 + messaging registry)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bumps `@pattern-stack/codegen` to **0.13.1** so the merged **#439 (RFC-0003 R5 `ReadContext`)** + **#440 (messaging `SURFACE_REGISTRY` entry)** reach npm.

The prior `just publish` skipped the core (version unchanged → already on npm), so npm still serves 0.13.0 **without R5**. swe-brain #26 consumes R5 and its clean-install CI fails against published 0.13.0. After this merges: `just publish` pushes 0.13.1 with R5; then swe-brain bumps its pin off 0.13.0, drops the local link → #26 green.

One-line version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)