### PR TITLE
chore(release): bump core 0.13.1 -> 0.14.0 (runtime mode + Symbol.for tokens + R5, ADR-037)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Release 0.14.0

Bumps `@pattern-stack/codegen` `0.13.1 → 0.14.0` to publish the work merged in #442 (the merge carried no version bump, so `0.13.1` on `main` already == the published version — nothing new could ship until this).

### What's in 0.14.0 (#442, ADR-037)
- **Runtime mode (`package` | `vendored`)** — consumers choose whether generated code imports the runtime from the npm package or a vendored `src/shared` copy. One `runtimeImport()` helper; every generator (entity + integration) honors it; `init` vendors only in `vendored` mode. **Default: `package`.**
- **Namespaced `Symbol.for()` DI tokens** — all subsystem injection tokens keyed via a single `tokenKey('<area>', '<token>')` helper (also the future version seam), so vendored and package copies of the runtime resolve the **same** token (fixes the dual-package hazard).
- **RFC-0003 R5 emitter follow-on** — `ctx?: ReadContext` threaded onto emitted reads; registry-backed, client-less provider modules for per-connection (`readPrimitive`) surfaces; biome-clean emitted output.

### ⚠️ Migration for existing vendored consumers
The default flips to `package` and token identities move to `Symbol.for`. Existing vendored projects must set `runtime: vendored` explicitly and refresh shims (`codegen init`), or the default flip + new token identities will mismatch a stale vendored copy. (ADR-037 §Consequences.)

### Publish (after merge)
`just release` (tags `v0.14.0` + pushes) → `scripts/publish.sh`. Confirm `npm whoami` succeeds first — an auth/OTP failure is the likely reason an earlier publish no-op'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
