### PR TITLE
chore(release): surface packages 0.14-compat (widen peer + bump)

### DIFF
--- a/packages/codegen-calendar/package.json
+++ b/packages/codegen-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-calendar",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "L2 calendar surface package for @pattern-stack/codegen — the canonical Meeting type, the CalendarPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0"
+    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-mail/package.json
+++ b/packages/codegen-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-mail",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "L2 mail surface package for @pattern-stack/codegen — the canonical Email type, the MailPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0"
+    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-messaging/package.json
+++ b/packages/codegen-messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-messaging",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "L2 messaging surface package for @pattern-stack/codegen — the canonical Channel/Message vocabulary, the MessagingPort composing contract, the bot-user write seam, and DI tokens. See ADR-036 + swe-brain ADR-0008.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0"
+    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-transcript/package.json
+++ b/packages/codegen-transcript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-transcript",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "L2 transcript surface package for @pattern-stack/codegen — the canonical Transcript type, the TranscriptPort composing contract, and DI tokens. See ADR-036.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0"
+    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",


### PR DESCRIPTION
## Surface packages — 0.14 compat (completes the 0.14 release)

The 0.14 release was only half-done: #443 bumped the **root** `@pattern-stack/codegen` to `0.14.0`, but the surface packages still peer-pinned `^0.13.0` — which in 0.x semver means `>=0.13.0 <0.14.0`, i.e. it **excludes 0.14.0**. So any consumer on `0.14.0` (e.g. swe-brain's depend-mode migration) gets unmet peers + surfaces *declaring* incompatibility with the runtime they're running on.

### Changes
- `codegen-calendar` / `codegen-mail` / `codegen-transcript`: `0.2.1 → 0.2.2`
- `codegen-messaging`: `0.1.0 → 0.1.1`
- peer `@pattern-stack/codegen`: `^0.13.0` → `^0.13.0 || ^0.14.0` (keeps 0.13 support, adds 0.14)

### Verified
All surfaces (+ crm) `typecheck` clean against the local `0.14.0` runtime — the widen is real, not just declared. These are type-level over codegen, and 0.14's `Symbol.for` token change keeps the same export names/types, so nothing in them breaks.

### Publish (after merge)
`just publish` — the root `0.14.0` is already live, so this publishes the bumped surfaces (`0.2.2` / `0.1.1`). Confirm `npm whoami` succeeds first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
