### PR TITLE
fix(bridge): de-flake getStatusHistogram boundary test (injectable clock)

### DIFF
--- a/runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
+++ b/runtime/subsystems/bridge/bridge-delivery.memory-backend.ts
@@ -116,12 +116,19 @@ export class MemoryBridgeDeliveryRepo implements IJobBridge {
   async getStatusHistogram(
     windowHours: number,
     tenantId?: string | null,
+    // Reference instant for the window cutoff. Defaults to the wall clock; exposed
+    // as a test-injection seam so a caller can pin the cutoff to the same `now` it
+    // positioned a boundary row from. Without it the cutoff is re-sampled here a few
+    // ms later, pushing an "exactly at the boundary" row just below the window
+    // (the OBS-3 boundary test flake). The drizzle backend has no analogue — it
+    // evaluates the cutoff once in SQL via `now()`.
+    nowMs: number = Date.now(),
   ): Promise<StatusHistogram> {
     if (!Number.isFinite(windowHours) || windowHours <= 0) {
       throw new RangeError('windowHours must be positive');
     }
 
-    const cutoffMs = Date.now() - windowHours * 3_600_000;
+    const cutoffMs = nowMs - windowHours * 3_600_000;
     const histogram: StatusHistogram = {
       pending: 0,
       delivered: 0,

--- a/src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-delivery.memory-backend.spec.ts
@@ -233,16 +233,18 @@ describe('MemoryBridgeDeliveryRepo — getStatusHistogram (OBS-3)', () => {
   });
 
   it('includes deliveries exactly at the boundary (>= cutoff)', async () => {
-    // Freeze the comparison: put the delivery at exactly cutoff by using
-    // an attemptedAt that is `now - windowHours * 3_600_000` — this is
-    // the precise boundary. We rely on the implementation using `<`
-    // (strict) to exclude BELOW cutoff, so equal should be INCLUDED.
+    // Put the delivery at exactly cutoff and pin the histogram to the SAME `now`,
+    // so the row sits precisely on the boundary deterministically. (Previously the
+    // test sampled `now` here and the impl re-sampled its own a few ms later, sliding
+    // the cutoff past the row → intermittent exclusion under CI timing.) The impl
+    // includes `>= cutoff`, so a row exactly at cutoff must be counted.
     const windowHours = 1;
-    const boundary = new Date(Date.now() - windowHours * 3_600_000);
+    const now = Date.now();
+    const boundary = new Date(now - windowHours * 3_600_000);
     await repo.insertDelivery(
       row(EVENT_A, 'boundary#0', { attemptedAt: boundary }),
     );
-    const h = await repo.getStatusHistogram(windowHours);
+    const h = await repo.getStatusHistogram(windowHours, undefined, now);
     expect(h.pending).toBe(1);
   });
 


### PR DESCRIPTION
## What
`MemoryBridgeDeliveryRepo — getStatusHistogram (OBS-3) > includes deliveries exactly at the boundary (>= cutoff)` intermittently reddened CI (surfaced on #445's first run; passed on re-run).

## Why it flaked
Two independently-sampled clocks the test assumed were equal:
- **Test** sampled `Date.now()` to position a delivery at `now − windowHours`.
- **Memory backend** re-sampled its *own* `Date.now()` a few ms later to compute `cutoff = now − windowHours`.

Since the backend's `now` is later, `cutoff` slides just past the boundary row → it falls below the window → `pending = 0` instead of 1. Only passes when both samples land in the same millisecond (usually true locally, intermittently false under CI scheduling). The `>= cutoff` (inclusive) semantics were already correct — only the test's clock assumption was broken.

## Fix
Added an optional `nowMs` seam to the memory backend's `getStatusHistogram` (defaults to `Date.now()`); the test pins both the boundary and the cutoff to the same `now`. The **drizzle backend needs no change** — it evaluates the cutoff once in SQL via `now()`. **Protocol unchanged** (the param is an optional implementation extension). Deterministic across 10+ runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)