### PR TITLE
chore(release): 0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Version bump `0.14.0 → 0.14.1`. Ships:
- **#445** — package-mode subsystem support (config-driven barrel, no-revendor install, schema-barrel auto-emit) + the `ModuleRef` DI fix.
- **#446** — de-flake `getStatusHistogram` boundary test (injectable clock).

Backward-compatible (vendored mode unchanged). Publish is manual after merge (`npm publish` → `prepublishOnly: tsup`). Unblocks the swe-brain dogfood to drop its interim hand-wiring + boot the jobs worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)