### PR TITLE
fix(bridge): package-mode worker pools + registry binding (0.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.2] — 2026-06-02
+
+Package-mode bridge fixes — the two gaps that left the event→job bridge wired but
+inert when the runtime is consumed from the package (`runtime: package`, ADR-037)
+rather than vendored. Both are follow-ons to 0.14.1's package-mode subsystem
+support. Vendored mode is unchanged; these are additive.
+
+### Fixed
+
+- **Embedded worker now drains the reserved `events_*` bridge pools.** The
+  subsystem barrel emitted `JobWorkerModule.forRoot({ mode: 'embedded' })` with no
+  pool list, so the in-process worker polled only `interactive` + `batch` and
+  bridge wrappers sat pending forever (the BRIDGE-8 footgun, just past the boot
+  guard). When `bridge` is in `subsystems.install`, the embedded worker now
+  defaults to `allPools: true` (every lane in-process — exactly the knob
+  `BridgeModule`'s reserved-pool guard short-circuits on).
+- **A package-mode consumer's `@JobHandler.triggers` now bind.** Previously
+  `BridgeModule` hardwired the bundled `./generated/registry` placeholder (frozen
+  `{}` inside the package), and the registry generator skipped entirely in package
+  mode (it gated on a vendored `bridge.protocol.ts` that doesn't exist), so no
+  event ever routed to a job. The registry is now generated into the consumer's
+  `src/generated/bridge-registry.ts` (type imported from
+  `@pattern-stack/codegen/runtime/subsystems/bridge/index`, install gated on
+  `subsystems.install`) and threaded into `BridgeModule.forRoot({ registry })` by
+  the barrel. `subsystem install bridge` drops an empty-registry stub so the
+  import never dangles before the next `entity new`.
+
+### Added
+
+- **`BridgeModuleOptions.registry?: BridgeRegistry`** — lets the generated barrel
+  supply the consumer's scanned registry. Omitted ⇒ falls back to the bundled
+  `./generated/registry` (which IS the consumer's generated file in vendored
+  mode), so existing consumers and tests are unaffected.
+- **`jobs.worker_pools: string[]` and `jobs.all_pools: true`** config knobs on the
+  embedded worker. Precedence: explicit `worker_pools` (→ `pools: [...]`) >
+  `all_pools` (→ `allPools: true`) > bridge-installed default (`allPools: true`) >
+  the non-reserved default (unchanged).
+
+### Known gaps
+
+- Package-mode trigger-event **validation** against the events registry is skipped
+  (the event codegen generator is not yet mode-aware, so its registry isn't found
+  under the package-mode generated path). Triggers still generate and bind; only
+  the build-time "unknown event" check is inert. Tracked for a follow-on.
+
 ## [0.13.0] — 2026-05-31
 
 Track D round-2/3 — the integration codegen now emits the **full** integration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/bridge/bridge.module.ts
+++ b/runtime/subsystems/bridge/bridge.module.ts
@@ -70,6 +70,7 @@ import { BridgeOutboxDrainHook } from './bridge-outbox-drain-hook';
 import { EventFlowService } from './event-flow.service';
 import { BridgeDeliveryHandler } from './bridge-delivery-handler';
 import { bridgeRegistry } from './generated/registry';
+import type { BridgeRegistry } from './bridge.protocol';
 import { BRIDGE_RESERVED_POOLS } from './reserved-pools';
 
 export interface BridgeModuleOptions {
@@ -87,6 +88,26 @@ export interface BridgeModuleOptions {
    * `null` always passes (cross-tenant work). Defaults to `false`.
    */
   multiTenant?: boolean;
+  /**
+   * The codegen-emitted `Record<EventTypeName, BridgeTriggerEntry[]>` that
+   * drives outbox-drain trigger lookup (BRIDGE-4) and the facade's Case B
+   * dedup (BRIDGE-7).
+   *
+   * **Package mode (ADR-037).** When the runtime is imported from
+   * `@pattern-stack/codegen` (not vendored), the bundled
+   * `./generated/registry` is a frozen empty placeholder (`{}`) — a
+   * consumer's `@JobHandler.triggers` are scanned into a registry that lives
+   * in THEIR `src/generated/bridge-registry.ts`, which the package can't
+   * import. The generated subsystem barrel therefore threads that registry in
+   * here: `BridgeModule.forRoot({ ..., registry: bridgeRegistry })`. Omitted
+   * (vendored mode / tests) ⇒ falls back to the bundled `./generated/registry`,
+   * which in vendored mode IS the consumer's freshly-generated file.
+   *
+   * Without this, package-mode consumers' triggers never bind and the bridge
+   * routes nothing (the "wrappers sit pending" footgun's silent twin —
+   * nothing is ever enqueued in the first place).
+   */
+  registry?: BridgeRegistry;
 }
 
 @Module({})
@@ -108,7 +129,11 @@ export class BridgeModule implements OnModuleInit {
       providers: [
         { provide: BRIDGE_MODULE_OPTIONS, useValue: opts },
         { provide: BRIDGE_MULTI_TENANT, useValue: opts.multiTenant ?? false },
-        { provide: BRIDGE_REGISTRY, useValue: bridgeRegistry },
+        // Package mode threads the consumer's generated registry through
+        // `opts.registry`; vendored mode omits it and we fall back to the
+        // bundled `./generated/registry` (which IS the consumer's generated
+        // file in a vendored tree). See `BridgeModuleOptions.registry`.
+        { provide: BRIDGE_REGISTRY, useValue: opts.registry ?? bridgeRegistry },
         repoProvider,
         // Drain hook — always wired; `DrizzleEventBus` consumes it via
         // `@Optional()`, so non-bridge mounts simply see `undefined`.

--- a/src/__tests__/cli/bridge-registry-generator.test.ts
+++ b/src/__tests__/cli/bridge-registry-generator.test.ts
@@ -700,3 +700,127 @@ describe('validateNoDuplicateTriggers (BRIDGE-7 follow-up)', () => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 });
+
+// ─── Package mode (ADR-037) ──────────────────────────────────────────────────
+//
+// In package mode the bridge runtime lives in node_modules (read-only), so the
+// generated registry lands beside the consumer's other `src/generated/*`
+// barrels as `bridge-registry.ts`, imports the `BridgeRegistry` TYPE off the
+// published runtime subpath (not a vendored `../bridge.protocol` that doesn't
+// exist), and the "is bridge installed" gate is decided by the caller
+// (`bridgeInstalled`, read from `subsystems.install`) — there is no
+// `bridge.protocol.ts` file to probe.
+describe('generateBridgeRegistry — package mode (ADR-037)', () => {
+  let root: string;
+  let handlersDir: string;
+  let outputDir: string;
+  const PKG_TYPE_IMPORT =
+    '@pattern-stack/codegen/runtime/subsystems/bridge/index';
+
+  beforeEach(() => {
+    root = makeTmpDir('pkg');
+    handlersDir = path.join(root, 'src/jobs');
+    // Package mode writes into the consumer's `src/generated/` — NOT a vendored
+    // subsystems tree. No `bridge.protocol.ts` exists anywhere.
+    outputDir = path.join(root, 'src/generated');
+    fs.mkdirSync(handlersDir, { recursive: true });
+    fs.mkdirSync(outputDir, { recursive: true });
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('writes bridge-registry.ts (not registry.ts) with the package type import', async () => {
+    writeHandler(handlersDir, 'welcome.ts', HANDLER_TEMPLATE('send_welcome_email', `
+  triggers: [
+    { event: 'contact_created', map: (e) => ({ contactId: e.aggregateId }) },
+  ],
+`));
+    const eventsGeneratedDir = writeEventsRegistry(root, ['contact_created']);
+    const result = await generateBridgeRegistry({
+      handlersDir,
+      eventsGeneratedDir,
+      outputDir,
+      mode: 'package',
+      bridgeInstalled: true,
+    });
+    expect(result.skipped).toBe(false);
+    expect(result.written).toBe(true);
+    expect(result.triggerCount).toBe(1);
+    // The mode-specific filename.
+    expect(result.files[0]!.name).toBe('bridge-registry.ts');
+    expect(fs.existsSync(path.join(outputDir, 'bridge-registry.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, 'registry.ts'))).toBe(false);
+    const out = fs.readFileSync(path.join(outputDir, 'bridge-registry.ts'), 'utf8');
+    // Type import resolves off the published runtime subpath, NOT the vendored
+    // relative protocol path.
+    expect(out).toContain(
+      `import type { BridgeRegistry } from '${PKG_TYPE_IMPORT}';`,
+    );
+    expect(out).not.toContain("from '../bridge.protocol'");
+    expect(out).toContain("'send_welcome_email#0'");
+  });
+
+  it('emits an empty registry (still package-shaped) when there are no triggers', async () => {
+    const result = await generateBridgeRegistry({
+      handlersDir,
+      outputDir,
+      mode: 'package',
+      bridgeInstalled: true,
+    });
+    expect(result.skipped).toBe(false);
+    const out = fs.readFileSync(path.join(outputDir, 'bridge-registry.ts'), 'utf8');
+    expect(out).toContain('bridgeRegistry: BridgeRegistry = {};');
+    expect(out).toContain(
+      `import type { BridgeRegistry } from '${PKG_TYPE_IMPORT}';`,
+    );
+  });
+
+  it('skips + cleans up a stray bridge-registry.ts when bridge not in install set', async () => {
+    const stray = path.join(outputDir, 'bridge-registry.ts');
+    fs.writeFileSync(stray, '// stale');
+    writeHandler(handlersDir, 'a.ts', HANDLER_TEMPLATE('a_job', `
+  triggers: [{ event: 'evt_x', map: (e) => ({}) }],
+`));
+    const result = await generateBridgeRegistry({
+      handlersDir,
+      outputDir,
+      mode: 'package',
+      bridgeInstalled: false,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.written).toBe(false);
+    expect(fs.existsSync(stray)).toBe(false);
+  });
+
+  it('does NOT consult bridge.protocol.ts in package mode (gate is config-driven)', async () => {
+    // No bridge.protocol.ts anywhere, yet bridgeInstalled:true ⇒ it generates.
+    // (Vendored mode would skip here.)
+    const result = await generateBridgeRegistry({
+      handlersDir,
+      outputDir,
+      mode: 'package',
+      bridgeInstalled: true,
+    });
+    expect(result.skipped).toBe(false);
+    expect(fs.existsSync(path.join(outputDir, 'bridge-registry.ts'))).toBe(true);
+  });
+});
+
+describe('buildBridgeRegistryContent — type import is parameterized', () => {
+  it('defaults to the vendored ../bridge.protocol specifier', () => {
+    const out = buildBridgeRegistryContent([]);
+    expect(out).toContain("import type { BridgeRegistry } from '../bridge.protocol';");
+  });
+
+  it('honors a package type-import specifier', () => {
+    const out = buildBridgeRegistryContent(
+      [],
+      '@pattern-stack/codegen/runtime/subsystems/bridge/index',
+    );
+    expect(out).toContain(
+      "import type { BridgeRegistry } from '@pattern-stack/codegen/runtime/subsystems/bridge/index';",
+    );
+    expect(out).not.toContain("'../bridge.protocol'");
+  });
+});

--- a/src/__tests__/cli/subsystem-barrel-generator.test.ts
+++ b/src/__tests__/cli/subsystem-barrel-generator.test.ts
@@ -221,6 +221,107 @@ describe('buildSubsystemBarrel', () => {
 			"EventsModule.forRoot({ backend: 'drizzle', multiTenant: false }),",
 		);
 	});
+
+	// ─── Gate 1: embedded worker pool clause (BRIDGE-8) ──────────────────────
+
+	test("embedded worker + bridge installed defaults to `allPools: true` (drains reserved events_* lanes)", () => {
+		const out = buildSubsystemBarrel(
+			[inst('events'), inst('jobs'), inst('bridge')],
+			{
+				events: {},
+				jobs: { backend: 'drizzle', worker_mode: 'embedded' },
+				bridge: {},
+			},
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"JobWorkerModule.forRoot({ mode: 'embedded', allPools: true }),",
+		);
+	});
+
+	test("embedded worker WITHOUT bridge stays `{ mode: 'embedded' }` (no pool clause)", () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{ jobs: { backend: 'drizzle', worker_mode: 'embedded' } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain("JobWorkerModule.forRoot({ mode: 'embedded' }),");
+		expect(out.content).not.toContain('allPools');
+		expect(out.content).not.toContain('pools:');
+	});
+
+	test('explicit `jobs.worker_pools` wins over the bridge default → emits `pools: [...]`', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs'), inst('bridge')],
+			{
+				jobs: {
+					backend: 'drizzle',
+					worker_mode: 'embedded',
+					worker_pools: ['interactive', 'batch', 'events_inbound'],
+				},
+				bridge: {},
+			},
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"JobWorkerModule.forRoot({ mode: 'embedded', pools: ['interactive', 'batch', 'events_inbound'] }),",
+		);
+		expect(out.content).not.toContain('allPools');
+	});
+
+	test('explicit `jobs.all_pools: true` emits `allPools: true` (even without bridge)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{ jobs: { backend: 'drizzle', worker_mode: 'embedded', all_pools: true } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"JobWorkerModule.forRoot({ mode: 'embedded', allPools: true }),",
+		);
+	});
+
+	test('bullmq embedded + bridge appends the pool clause after backend/extensions', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs'), inst('bridge')],
+			{
+				jobs: {
+					backend: 'bullmq',
+					worker_mode: 'embedded',
+					extensions: { bullmq: { redis_url: 'redis://localhost:16379' } },
+				},
+				bridge: {},
+			},
+			subsystemsRel,
+		);
+		expect(out.content).toContain("backend: 'bullmq'");
+		expect(out.content).toContain('domainModuleExtensions: { bullmq:');
+		expect(out.content).toContain('allPools: true }),');
+	});
+
+	test('standalone worker + bridge does NOT emit a worker (pool clause is embedded-only)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs'), inst('bridge')],
+			{ jobs: { backend: 'drizzle', worker_mode: 'standalone' }, bridge: {} },
+			subsystemsRel,
+		);
+		expect(out.content).not.toContain('JobWorkerModule');
+		expect(out.content).not.toContain('allPools');
+	});
+
+	// ─── Gate 2b: vendored mode passes NO registry (runtime uses its own) ────
+
+	test('vendored bridge composer emits no `registry` option (falls back to bundled)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('bridge')],
+			{ bridge: { backend: 'drizzle', multi_tenant: false } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"BridgeModule.forRoot({ backend: 'drizzle', multiTenant: false }),",
+		);
+		expect(out.content).not.toContain('registry:');
+		expect(out.content).not.toContain('bridge-registry');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -300,6 +401,57 @@ describe('buildSubsystemBarrel — package mode (ADR-037)', () => {
 			.filter((l) => l.startsWith('import '));
 		expect(importLines.some((l) => l.includes('@pattern-stack/codegen'))).toBe(
 			false,
+		);
+	});
+
+	// ─── Gate 2b: package mode threads the consumer's generated registry ─────
+
+	test('package-mode bridge composer imports ./bridge-registry and passes it to forRoot', () => {
+		const out = buildSubsystemBarrel(
+			[inst('bridge')],
+			{ bridge: { backend: 'drizzle', multi_tenant: false } },
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain(
+			"import { bridgeRegistry } from './bridge-registry';",
+		);
+		expect(out.content).toContain(
+			"BridgeModule.forRoot({ backend: 'drizzle', multiTenant: false, registry: bridgeRegistry }),",
+		);
+	});
+
+	test('package-mode embedded worker + bridge: allPools AND registry both emitted', () => {
+		const out = buildSubsystemBarrel(
+			[inst('events'), inst('jobs'), inst('bridge')],
+			{
+				events: {},
+				jobs: { backend: 'drizzle', worker_mode: 'embedded' },
+				bridge: { backend: 'drizzle', multi_tenant: false },
+			},
+			subsystemsRel,
+			'package',
+		);
+		// Gate 1 — the embedded worker drains every lane (reserved included).
+		expect(out.content).toContain(
+			"JobWorkerModule.forRoot({ mode: 'embedded', allPools: true }),",
+		);
+		// Gate 2b — the consumer registry is threaded in.
+		expect(out.content).toContain(
+			"import { bridgeRegistry } from './bridge-registry';",
+		);
+		expect(out.content).toContain('registry: bridgeRegistry }),');
+	});
+
+	test('package-mode `multi_tenant: true` survives the manual registry literal', () => {
+		const out = buildSubsystemBarrel(
+			[inst('bridge')],
+			{ bridge: { backend: 'drizzle', multi_tenant: true } },
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain(
+			"BridgeModule.forRoot({ backend: 'drizzle', multiTenant: true, registry: bridgeRegistry }),",
 		);
 	});
 });

--- a/src/__tests__/runtime/subsystems/bridge.module.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge.module.spec.ts
@@ -41,6 +41,7 @@ import {
   MemoryBridgeDeliveryRepo,
   MissingTenantIdError,
   type BridgeDeliveryInsert,
+  type BridgeRegistry,
 } from '../../../../runtime/subsystems/bridge';
 import { EventsModule } from '../../../../runtime/subsystems/events/events.module';
 import { JobsDomainModule } from '../../../../runtime/subsystems/jobs/jobs-domain.module';
@@ -185,6 +186,53 @@ describe('BridgeModule.forRoot({ backend: "memory" })', () => {
     }).compile();
 
     expect(moduleRef.get(BRIDGE_MULTI_TENANT)).toBe(false);
+
+    await moduleRef.close();
+  });
+});
+
+// ─── Registry override (ADR-037 package mode) ────────────────────────────────
+//
+// Package-mode consumers can't reach the bundled `./generated/registry`
+// placeholder ({}), so the generated subsystem barrel threads their scanned
+// registry in via `forRoot({ registry })`. The provider must prefer that over
+// the bundle; omitting it must still resolve (vendored / tests fall back to the
+// bundled empty registry).
+describe('BridgeModule.forRoot — registry override', () => {
+  const customRegistry = {
+    contact_created: [
+      {
+        triggerId: 'send_welcome_email#0',
+        jobType: 'send_welcome_email',
+        map: (e: unknown) => e,
+      },
+    ],
+  } as unknown as BridgeRegistry;
+
+  it('binds the supplied registry to BRIDGE_REGISTRY (package mode path)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ...siblingsMemory(),
+        BridgeModule.forRoot({ backend: 'memory', registry: customRegistry }),
+      ],
+    }).compile();
+
+    expect(moduleRef.get(BRIDGE_REGISTRY)).toBe(customRegistry);
+
+    await moduleRef.close();
+  });
+
+  it('falls back to the bundled empty registry when `registry` is omitted', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ...siblingsMemory(),
+        BridgeModule.forRoot({ backend: 'memory' }),
+      ],
+    }).compile();
+
+    // Bundled placeholder is `{}` — resolvable + empty (NOT the custom one).
+    expect(moduleRef.get(BRIDGE_REGISTRY)).toEqual({});
+    expect(moduleRef.get(BRIDGE_REGISTRY)).not.toBe(customRegistry);
 
     await moduleRef.close();
   });

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -46,6 +46,7 @@ import {
 } from '../shared/provider-module-generator.js';
 import { emitAdapters } from '../shared/adapter-emission-generator.js';
 import { resolveRuntimeMode } from '../shared/runtime-import.js';
+import { configuredSubsystemNames } from '../shared/subsystem-detect.js';
 import { loadProvidersFromYaml } from '../../utils/yaml-loader.js';
 import { loadEntities } from '../../parser/load-entities.js';
 import { findYamlFiles } from '../../utils/find-yaml-files.js';
@@ -401,10 +402,21 @@ export class EntityNewCommand extends Command {
 			subsystemsRoot,
 			'events/generated',
 		);
-		const bridgeRegistryOutputDir = path.resolve(
-			subsystemsRoot,
-			'bridge/generated',
-		);
+		// Bridge registry output is mode-aware (ADR-037). Vendored mode writes
+		// `registry.ts` into the vendored `bridge/generated/` tree (next to the
+		// runtime it types against). Package mode has no vendored tree, so the
+		// registry lands beside the other `src/generated/*` barrels as
+		// `bridge-registry.ts` and is threaded into `BridgeModule.forRoot` by the
+		// subsystem barrel. `mode`/`bridgeInstalled` are passed to the generator,
+		// which picks the filename + type-import accordingly.
+		const runtimeMode = resolveRuntimeMode(ctx.config);
+		const bridgeInstalledForRegistry = configuredSubsystemNames(
+			ctx.config as Record<string, unknown> | null | undefined,
+		).includes('bridge');
+		const bridgeRegistryOutputDir =
+			runtimeMode === 'package'
+				? generatedDir
+				: path.resolve(subsystemsRoot, 'bridge/generated');
 		// Handlers dir resolves under `paths.backend_src` (matching where the
 		// rest of the backend tree lives) with `src` as final fallback — the
 		// same default `subsystems-path.ts` uses for `subsystems` root.
@@ -413,9 +425,9 @@ export class EntityNewCommand extends Command {
 			(ctx.config as { paths?: { backend_src?: string } } | null | undefined)
 				?.paths?.backend_src ?? 'src';
 
-		// Runtime mode (ADR-037) — drives every runtime import specifier the
+		// `runtimeMode` (ADR-037) is resolved above — it drives the bridge
+		// registry output (mode-aware) plus every runtime import specifier the
 		// integration emitters write. Defaults to `package` (the new default).
-		const runtimeMode = resolveRuntimeMode(ctx.config);
 		const bridgeHandlersDir = path.resolve(
 			ctx.cwd,
 			backendSrcForHandlers,
@@ -484,6 +496,8 @@ export class EntityNewCommand extends Command {
 				handlersDir: bridgeHandlersDir,
 				eventsGeneratedDir: eventCodegenOutputDir,
 				outputDir: bridgeRegistryOutputDir,
+				mode: runtimeMode,
+				bridgeInstalled: bridgeInstalledForRegistry,
 				dryRun: true,
 			});
 
@@ -715,6 +729,8 @@ export class EntityNewCommand extends Command {
 				handlersDir: bridgeHandlersDir,
 				eventsGeneratedDir: eventCodegenOutputDir,
 				outputDir: bridgeRegistryOutputDir,
+				mode: runtimeMode,
+				bridgeInstalled: bridgeInstalledForRegistry,
 			});
 			if (bridgeRegistryResult.skipped && !isJsonMode()) {
 				printInfo(

--- a/src/cli/shared/bridge-registry-generator.ts
+++ b/src/cli/shared/bridge-registry-generator.ts
@@ -35,6 +35,31 @@ import fs from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 
+import type { RuntimeMode } from './runtime-import.js';
+
+// ---------------------------------------------------------------------------
+// Mode-aware emission constants (ADR-037)
+// ---------------------------------------------------------------------------
+
+/**
+ * The `BridgeRegistry` type-import specifier the package-mode registry uses.
+ * The file lands in the consumer's `src/generated/`, so it can't reach the
+ * package-internal `bridge.protocol`; it imports the type off the published
+ * per-subsystem runtime index (the same subpath the subsystem schema barrel
+ * uses).
+ */
+export const PACKAGE_BRIDGE_TYPE_IMPORT =
+  '@pattern-stack/codegen/runtime/subsystems/bridge/index';
+
+/** Output filename per mode. Package mode co-locates with the other
+ * `src/generated/*` barrels (and must NOT collide with a vendored
+ * `registry.ts`); vendored mode keeps the legacy name inside the vendored
+ * `bridge/generated/` dir. */
+const OUTPUT_FILE_BY_MODE: Record<RuntimeMode, string> = {
+  vendored: 'registry.ts',
+  package: 'bridge-registry.ts',
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -48,8 +73,27 @@ export interface BridgeRegistryGeneratorOptions {
    * `undefined` ⇒ skip validation (fixtures, tests).
    */
   eventsGeneratedDir?: string;
-  /** Absolute path to the bridge generated/ output directory. */
+  /** Absolute path to the output directory. Vendored mode: the vendored
+   * `bridge/generated/`. Package mode: the consumer's `src/generated/`. */
   outputDir: string;
+  /**
+   * Runtime mode (ADR-037). Defaults to `'vendored'` so the existing
+   * (fixture/test) callers and the legacy vendored emission are byte-stable.
+   *   - vendored → writes `registry.ts` with a `'../bridge.protocol'` type
+   *     import; "is bridge installed" is decided by the `bridge.protocol.ts`
+   *     sibling check (a vendored tree means the runtime was vendored).
+   *   - package  → writes `bridge-registry.ts` with the package type import;
+   *     there is nothing vendored on disk, so installation is decided by the
+   *     caller via `bridgeInstalled` (read from `subsystems.install`).
+   */
+  mode?: RuntimeMode;
+  /**
+   * Package-mode installation gate. Ignored in vendored mode (which uses the
+   * `bridge.protocol.ts` sibling check). When `mode: 'package'` and this is
+   * falsy, generation is skipped and any stray output file is removed —
+   * mirroring the vendored "no bridge.protocol ⇒ skip" behavior.
+   */
+  bridgeInstalled?: boolean;
   /** If true, compute content but don't write to disk. */
   dryRun?: boolean;
 }
@@ -489,11 +533,23 @@ export function validateAgainstEventRegistry(
 // Content builder
 // ---------------------------------------------------------------------------
 
-export function buildBridgeRegistryContent(triggers: ScannedTrigger[]): string {
+export function buildBridgeRegistryContent(
+  triggers: ScannedTrigger[],
+  /**
+   * Where the `BridgeRegistry` type is imported FROM, mode-aware (ADR-037):
+   *   - vendored → `'../bridge.protocol'` (the file sits in the vendored
+   *     `bridge/generated/` dir, one level under the protocol). Default, so
+   *     existing callers/tests are byte-stable.
+   *   - package  → `'@pattern-stack/codegen/runtime/subsystems/bridge/index'`
+   *     (the file lands in the consumer's `src/generated/`, which has no
+   *     relative line of sight to the package-internal protocol).
+   */
+  typeImport = '../bridge.protocol',
+): string {
   const chunks: string[] = [];
   chunks.push(HEADER);
   chunks.push('');
-  chunks.push(`import type { BridgeRegistry } from '../bridge.protocol';`);
+  chunks.push(`import type { BridgeRegistry } from '${typeImport}';`);
   chunks.push('');
 
   if (triggers.length === 0) {
@@ -539,23 +595,35 @@ export function buildBridgeRegistryContent(triggers: ScannedTrigger[]): string {
 // Public entrypoint
 // ---------------------------------------------------------------------------
 
-const OUTPUT_FILE_NAME = 'registry.ts';
-
 export async function generateBridgeRegistry(
   opts: BridgeRegistryGeneratorOptions,
 ): Promise<BridgeRegistryResult> {
-  const { handlersDir, eventsGeneratedDir, outputDir, dryRun = false } = opts;
+  const {
+    handlersDir,
+    eventsGeneratedDir,
+    outputDir,
+    mode = 'vendored',
+    bridgeInstalled = false,
+    dryRun = false,
+  } = opts;
 
-  // 0. Gate on bridge subsystem installation (issue #191). The emitted
-  //    `registry.ts` imports `../bridge.protocol`, which only exists
-  //    after `codegen subsystem install bridge` has vendored the runtime
-  //    files. Consumers with a `bridge:` block in `codegen.config.yaml`
-  //    but no installed subsystem would otherwise end up with a broken
-  //    file on every `entity new --all`. Skip entirely and clean up any
-  //    stray artifact from a previous run.
-  const bridgeProtocolPath = path.resolve(outputDir, '..', 'bridge.protocol.ts');
-  if (!fs.existsSync(bridgeProtocolPath)) {
-    const strayPath = path.join(outputDir, OUTPUT_FILE_NAME);
+  const outputFileName = OUTPUT_FILE_BY_MODE[mode];
+  const typeImport =
+    mode === 'package' ? PACKAGE_BRIDGE_TYPE_IMPORT : '../bridge.protocol';
+
+  // 0. Gate on bridge subsystem installation (issue #191). The emitted file
+  //    imports the `BridgeRegistry` type; in vendored mode that type comes
+  //    from `../bridge.protocol`, which only exists after `subsystem install
+  //    bridge` vendored the runtime — so the file's presence IS the gate. In
+  //    package mode nothing is vendored on disk, so the caller decides via
+  //    `bridgeInstalled` (from `subsystems.install`). Either way: not
+  //    installed ⇒ skip and clean up any stray artifact from a prior run.
+  const installed =
+    mode === 'package'
+      ? bridgeInstalled
+      : fs.existsSync(path.resolve(outputDir, '..', 'bridge.protocol.ts'));
+  if (!installed) {
+    const strayPath = path.join(outputDir, outputFileName);
     if (!dryRun && fs.existsSync(strayPath)) {
       fs.rmSync(strayPath);
     }
@@ -588,10 +656,10 @@ export async function generateBridgeRegistry(
   validateNoAuditTriggers(triggers, eventTiers);
 
   // 3. Build content.
-  const content = buildBridgeRegistryContent(triggers);
+  const content = buildBridgeRegistryContent(triggers, typeImport);
   const file: BridgeRegistryFileOutput = {
-    name: OUTPUT_FILE_NAME,
-    outputPath: path.join(outputDir, OUTPUT_FILE_NAME),
+    name: outputFileName,
+    outputPath: path.join(outputDir, outputFileName),
     content,
   };
 

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -32,6 +32,10 @@ import {
 } from './subsystem-detect.js';
 import { resolveSubsystemsRoot } from './subsystems-path.js';
 import { resolveRuntimeMode, type RuntimeMode } from './runtime-import.js';
+import {
+	buildBridgeRegistryContent,
+	PACKAGE_BRIDGE_TYPE_IMPORT,
+} from './bridge-registry-generator.js';
 
 // ---------------------------------------------------------------------------
 // Options + result types
@@ -76,6 +80,14 @@ interface ComposerInput {
 	moduleImport: (subsystem: SubsystemName, moduleBasename: string) => string;
 	/** Per-subsystem config block from codegen.config.yaml (snake_case keys). */
 	cfg: Record<string, unknown> | undefined;
+	/** Resolved runtime mode (ADR-037). The `bridge` composer threads the
+	 * consumer's generated registry only in `package` mode. */
+	mode: RuntimeMode;
+	/** Whether `bridge` is in the (actable) install set. The `jobs` composer
+	 * uses this to default the embedded worker to `allPools: true` so the
+	 * reserved `events_*` bridge lanes are drained (otherwise wrappers sit
+	 * pending forever — the BRIDGE-8 footgun). */
+	bridgeInstalled: boolean;
 }
 
 interface ComposerOutput {
@@ -140,6 +152,38 @@ function quoteBullmqDomainOpts(input: {
 	return `{ ${parts.join(', ')} }`;
 }
 
+/**
+ * JOB-7 / BRIDGE-8 — resolve the embedded worker's pool clause as a TS object
+ * fragment (e.g. `pools: ['interactive', 'batch']` or `allPools: true`), or
+ * `''` when none applies. Precedence (mirrors `JobWorkerOrchestrator`'s own
+ * `pools > allPools > default`):
+ *
+ *   1. explicit `jobs.worker_pools: [...]` ⇒ `pools: [...]`
+ *   2. explicit `jobs.all_pools: true`     ⇒ `allPools: true`
+ *   3. `bridge` installed (no explicit knob) ⇒ `allPools: true` — the embedded
+ *      worker runs every lane in-process, so it MUST drain the reserved
+ *      `events_*` bridge pools or `BridgeModule`'s onModuleInit guard throws
+ *      `BridgeReservedPoolsNotPolledError` at boot. `allPools` is exactly the
+ *      knob that guard short-circuits on.
+ *   4. otherwise ⇒ `''` (worker drains the non-reserved default — unchanged).
+ */
+function workerPoolsClause(
+	cfg: Record<string, unknown> | undefined,
+	bridgeInstalled: boolean,
+): string {
+	const explicit = cfg?.worker_pools;
+	if (Array.isArray(explicit) && explicit.length > 0) {
+		const list = explicit
+			.filter((p): p is string => typeof p === 'string')
+			.map((p) => `'${p}'`)
+			.join(', ');
+		if (list.length > 0) return `pools: [${list}]`;
+	}
+	if (cfg?.all_pools === true) return 'allPools: true';
+	if (bridgeInstalled) return 'allPools: true';
+	return '';
+}
+
 const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 	events: ({ moduleImport, cfg }) => {
 		const backend = (cfg?.backend as string | undefined) ?? 'drizzle';
@@ -154,7 +198,7 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 		};
 	},
 
-	jobs: ({ moduleImport, cfg }) => {
+	jobs: ({ moduleImport, cfg, bridgeInstalled }) => {
 		const backend = (cfg?.backend as string | undefined) ?? 'drizzle';
 		const multiTenant = Boolean(cfg?.multi_tenant);
 		const workerMode = ((cfg?.worker_mode as string | undefined) ?? 'standalone').trim();
@@ -178,26 +222,47 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 			imports.push(
 				`import { JobWorkerModule } from '${moduleImport('jobs', 'job-worker.module')}';`
 			);
-			// BULLMQ-1: forward backend + bullmq extensions to the embedded worker
-			// so it spawns BullMQ (not Drizzle) workers when configured.
-			const workerOpts =
-				backend === 'bullmq'
-					? `{ mode: 'embedded', backend: 'bullmq'${
-							bullExt ? `, domainModuleExtensions: { bullmq: ${jsonToTs(bullExt)} }` : ''
-						} }`
-					: `{ mode: 'embedded' }`;
-			calls.push(`\tJobWorkerModule.forRoot(${workerOpts}),`);
+			// Assemble the worker options literal piecewise. `mode` is always
+			// first; BULLMQ-1 forwards the backend + extensions; BRIDGE-8 appends
+			// the pool clause (`pools` / `allPools`) so the embedded worker drains
+			// the reserved `events_*` bridge lanes when bridge is installed.
+			const parts = [`mode: 'embedded'`];
+			if (backend === 'bullmq') {
+				parts.push(`backend: 'bullmq'`);
+				if (bullExt) {
+					parts.push(`domainModuleExtensions: { bullmq: ${jsonToTs(bullExt)} }`);
+				}
+			}
+			const poolsClause = workerPoolsClause(cfg, bridgeInstalled);
+			if (poolsClause) parts.push(poolsClause);
+			calls.push(`\tJobWorkerModule.forRoot({ ${parts.join(', ')} }),`);
 		}
 		return { imports, calls };
 	},
 
-	bridge: ({ moduleImport, cfg }) => {
+	bridge: ({ moduleImport, cfg, mode }) => {
 		const backend = (cfg?.backend as string | undefined) ?? 'drizzle';
 		const multiTenant = Boolean(cfg?.multi_tenant);
+		const imports = [
+			`import { BridgeModule } from '${moduleImport('bridge', 'bridge.module')}';`,
+		];
+		// Package mode (ADR-037): the consumer's `@JobHandler.triggers` are
+		// scanned into `<generated>/bridge-registry.ts` (co-located with this
+		// barrel), since the bundled `./generated/registry` inside the package is
+		// a frozen empty placeholder. Thread it through `forRoot({ registry })`
+		// or the triggers never bind. Vendored mode omits it — the runtime's own
+		// `./generated/registry` IS the consumer's generated file there.
+		if (mode === 'package') {
+			imports.push(`import { bridgeRegistry } from './bridge-registry';`);
+			return {
+				imports,
+				calls: [
+					`\tBridgeModule.forRoot({ backend: '${backend}', multiTenant: ${multiTenant}, registry: bridgeRegistry }),`,
+				],
+			};
+		}
 		return {
-			imports: [
-				`import { BridgeModule } from '${moduleImport('bridge', 'bridge.module')}';`,
-			],
+			imports,
 			calls: [
 				`\tBridgeModule.forRoot(${quoteOpts({ backend, multiTenant })}),`,
 			],
@@ -295,6 +360,7 @@ export function buildSubsystemBarrel(
 	// builder.
 	const actable = installed.filter((i) => i.status !== 'incomplete');
 	const installedNames = new Set(actable.map((i) => i.name));
+	const bridgeInstalled = installedNames.has('bridge');
 	const emitted: SubsystemName[] = [];
 	const skipped: SubsystemName[] = [];
 
@@ -309,7 +375,7 @@ export function buildSubsystemBarrel(
 			continue;
 		}
 		const cfg = (config?.[name] as Record<string, unknown> | undefined) ?? undefined;
-		const out = composer({ moduleImport, cfg });
+		const out = composer({ moduleImport, cfg, mode, bridgeInstalled });
 		allImports.push(...out.imports);
 		allCalls.push(...out.calls);
 		emitted.push(name);
@@ -382,6 +448,23 @@ export async function regenerateSubsystemBarrel(
 		fs.mkdirSync(path.dirname(barrelAbs), { recursive: true });
 		fs.writeFileSync(barrelAbs, content);
 		written = true;
+
+		// Package mode: the bridge composer imports `./bridge-registry`. The real
+		// registry is emitted by `entity new --all` (which scans handlers); but
+		// `subsystem install bridge` regenerates this barrel WITHOUT running that
+		// scan, which would dangle the import until the next `entity new`. Drop an
+		// empty-registry stub iff the file is absent — never clobber a
+		// previously-generated registry (idempotent: byte-identical to the
+		// generator's own empty-case output, so no churn).
+		if (mode === 'package' && emitted.includes('bridge')) {
+			const registryPath = path.resolve(generatedDir, 'bridge-registry.ts');
+			if (!fs.existsSync(registryPath)) {
+				fs.writeFileSync(
+					registryPath,
+					buildBridgeRegistryContent([], PACKAGE_BRIDGE_TYPE_IMPORT),
+				);
+			}
+		}
 	}
 
 	return {


### PR DESCRIPTION
## Why

Under `runtime: package` (ADR-037), the event→job **bridge** was wired but inert — two gaps (0.14.1 follow-ons) that block swe-brain's real-time inbound spine:

1. **Worker pools** — the subsystem barrel emitted `JobWorkerModule.forRoot({ mode: 'embedded' })` with no pool list, so the in-process worker polled only `interactive`+`batch` and bridge wrappers sat pending forever (the BRIDGE-8 footgun, just past the boot guard).
2. **Registry binding** — `BridgeModule` hardwired the bundled empty `./generated/registry` placeholder, and the registry generator skipped in package mode (it gated on a vendored `bridge.protocol.ts` that doesn't exist). A consumer's `@JobHandler.triggers` never bound → nothing routed.

## What

**Gate 1 — embedded worker drains reserved pools** (`subsystem-barrel-generator.ts`)
- When `bridge ∈ subsystems.install`, the embedded worker defaults to `allPools: true` (the knob `BridgeModule`'s reserved-pool guard short-circuits on).
- New `jobs.worker_pools: string[]` / `jobs.all_pools: true` knobs. Precedence: `worker_pools` (`pools:[…]`) > `all_pools` (`allPools:true`) > bridge-default (`allPools:true`) > non-reserved default (unchanged).

**Gate 2a — runtime accepts a consumer registry** (`bridge.module.ts`)
- `BridgeModuleOptions.registry?: BridgeRegistry`; provider is `opts.registry ?? bridgeRegistry`. Omitted ⇒ vendored fallback (back-compat).

**Gate 2b — package-mode registry generation + wiring** (`bridge-registry-generator.ts`, `entity.ts`, barrel)
- Generator is mode-aware: package mode writes `src/generated/bridge-registry.ts`, type-imported from `@pattern-stack/codegen/runtime/subsystems/bridge/index`, install-gated on `subsystems.install`.
- The barrel's bridge composer threads `registry: bridgeRegistry`; a stub-if-missing write keeps `subsystem install bridge` from dangling the import before the next `entity new`.

Vendored mode is byte-stable; all changes are additive.

## Tests
- **84** focused unit tests across the three areas (Gate 1 / 2a / 2b)
- Full main-tree unit suite (**2474** pass), `test-baseline`, all smoke tests green — incl. **`test-smoke-subsystems`** boot-verify: *"bridge guard passed; pools wired or allPools"*
- `tsup` build + typecheck clean

## Known gap
Package-mode trigger-event **validation** against the events registry is skipped (event codegen isn't mode-aware yet, so its registry isn't found under the package-mode path). Triggers still generate + bind; only the build-time "unknown event" check is inert. Follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)