### PR TITLE
feat(events): package-mode consumer events seam (0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-06-02
+
+Package-mode consumer **events** — the seam that lets a project consuming the
+runtime from the package (`runtime: package`, ADR-037) declare its own
+`events/*.yaml`, get a typed `TypedEventBus`, and publish typed domain events.
+Completes the package-mode story alongside 0.14.2's bridge fixes. Vendored mode
+is byte-stable; everything here is additive.
+
+### Added
+
+- **`EventsModuleOptions.typedBus?: Type<unknown>`** — binds a consumer-supplied
+  `TypedEventBus` class to `TYPED_EVENT_BUS` (via `forRoot`). Omitted ⇒ falls
+  back to the bundled `./generated/bus` (which IS the consumer's generated file
+  in a vendored tree), so existing consumers and tests are unaffected. Nest
+  constructs the supplied class with this module's `EVENT_BUS` +
+  `EVENTS_MULTI_TENANT` providers (string-valued tokens match across the package
+  boundary).
+
+### Fixed
+
+- **Event codegen is package-mode-aware.** Previously `entity new --all` in
+  package mode wrote the five generated event files
+  (`types/schemas/registry/bus/index.ts`) into a stray
+  `src/shared/subsystems/events/generated/` tree whose `../event-bus.protocol` /
+  `../events.tokens` / `../events-errors` imports don't exist in package mode —
+  the tree didn't typecheck and was orphaned (the bundled empty `TypedEventBus`
+  won at runtime). Now in package mode the files land in the consumer's
+  `src/generated/events/`, those three runtime imports resolve through the
+  published `@pattern-stack/codegen/runtime/subsystems/events/index` barrel, and
+  the subsystem barrel threads the generated `TypedEventBus` into
+  `EventsModule.forRoot({ typedBus })`. A package-mode consumer's typed
+  `publish<'…'>()` now resolves against THEIR event union and stamps the right
+  `pool` / `direction`.
+- **Scope-entity-type is package-mode-aware** — relocated to
+  `src/generated/scope-entity-type.ts` (a self-contained zod-only union) instead
+  of the stray vendored `jobs/generated/` path.
+- **Package-mode bridge trigger validation now runs.** Because the consumer's
+  event registry now exists at a real path (`src/generated/events/registry.ts`),
+  the bridge registry generator validates `@JobHandler.triggers` event types
+  against it (the 0.14.2 "known gap"). `subsystem install events` drops an
+  empty-set `src/generated/events/` stub so the barrel's `./events/bus` import
+  never dangles before the next `entity new`.
+
 ## [0.14.2] — 2026-06-02
 
 Package-mode bridge fixes — the two gaps that left the event→job bridge wired but

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/events/events.module.ts
+++ b/runtime/subsystems/events/events.module.ts
@@ -44,7 +44,7 @@
  * `new Class()` which silently left `db` / `redisUrl` undefined
  * (issue #108).
  */
-import { Module, type DynamicModule, type Provider } from '@nestjs/common';
+import { Module, type DynamicModule, type Provider, type Type } from '@nestjs/common';
 import {
   EVENT_BUS,
   EVENT_READ_PORT,
@@ -112,6 +112,31 @@ export interface EventsModuleOptions {
    * Defaults to `false`.
    */
   multiTenant?: boolean;
+  /**
+   * The generated `TypedEventBus` class to bind to `TYPED_EVENT_BUS`.
+   *
+   * **Package mode (ADR-037).** When the runtime is imported from
+   * `@pattern-stack/codegen` (not vendored), the bundled `./generated/bus`
+   * `TypedEventBus` is typed to an EMPTY event union and reads the bundled
+   * empty `eventRegistry` — a consumer's `events/*.yaml` are scanned into
+   * `src/generated/events/bus.ts` (typed to THEIR union, reading THEIR
+   * registry), which the package can't import. The generated subsystem barrel
+   * therefore threads that class in here:
+   * `EventsModule.forRoot({ ..., typedBus: TypedEventBus })`. Nest constructs
+   * it with this module's `EVENT_BUS` + `EVENTS_MULTI_TENANT` providers (the
+   * generated class injects the same string-valued tokens, which match across
+   * the package boundary).
+   *
+   * Omitted (vendored mode / tests) ⇒ falls back to the bundled
+   * `./generated/bus`, which in a vendored tree IS the consumer's generated
+   * file. Without this, a package-mode consumer's typed `publish<'…'>()` calls
+   * resolve against the empty union and their events never get the right
+   * `pool` / `direction` stamped.
+   *
+   * Only consulted by `forRoot` (the path the barrel emits); `forRootAsync`
+   * keeps the bundled bus.
+   */
+  typedBus?: Type<unknown>;
 }
 
 export interface EventsModuleAsyncOptions {
@@ -125,10 +150,18 @@ export interface EventsModuleAsyncOptions {
  * binding, and the resolved `EVENTS_MULTI_TENANT` flag. Returned from one
  * place so every `forRoot` branch and `forRootAsync` agree.
  */
-function buildTypedBusProviders(multiTenant: boolean): Provider[] {
+function buildTypedBusProviders(
+  multiTenant: boolean,
+  typedBus?: Type<unknown>,
+): Provider[] {
+  // Package mode threads the consumer's generated `TypedEventBus` (typed to
+  // their event union, reading their registry) via `typedBus`; vendored mode
+  // omits it and we fall back to the bundled `./generated/bus` (which IS the
+  // consumer's generated file in a vendored tree). See `EventsModuleOptions.typedBus`.
+  const BusClass = typedBus ?? TypedEventBus;
   return [
-    TypedEventBus,
-    { provide: TYPED_EVENT_BUS, useExisting: TypedEventBus },
+    BusClass,
+    { provide: TYPED_EVENT_BUS, useExisting: BusClass },
     { provide: EVENTS_MULTI_TENANT, useValue: multiTenant },
   ];
 }
@@ -249,7 +282,7 @@ export class EventsModule {
             },
             inject: [REDIS_URL],
           },
-          ...buildTypedBusProviders(multiTenant),
+          ...buildTypedBusProviders(multiTenant, options.typedBus),
         ],
         exports: [EVENT_BUS, TYPED_EVENT_BUS, EVENTS_MULTI_TENANT],
       };
@@ -270,7 +303,7 @@ export class EventsModule {
         // IEventReadPort on the same instance as EVENT_BUS. The redis
         // backend retains no history and does not provide this token.
         { provide: EVENT_READ_PORT, useExisting: EVENT_BUS },
-        ...buildTypedBusProviders(multiTenant),
+        ...buildTypedBusProviders(multiTenant, options.typedBus),
       ],
       exports: [EVENT_BUS, EVENT_READ_PORT, TYPED_EVENT_BUS, EVENTS_MULTI_TENANT],
     };

--- a/src/__tests__/cli/event-codegen-generator.test.ts
+++ b/src/__tests__/cli/event-codegen-generator.test.ts
@@ -20,6 +20,7 @@ import { spawnSync } from 'node:child_process';
 
 import {
 	buildBusContent,
+	buildEventCodegenContents,
 	buildIndexContent,
 	buildRegistryContent,
 	buildSchemasContent,
@@ -1169,5 +1170,99 @@ payload:
 		const result = collectMergedEvents({ entitiesDir, eventsDir });
 		expect(result.events).toEqual([]);
 		expect(result.issues.some((i) => i.type === 'no_events_dir')).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Package mode (ADR-037) — runtime imports route through the published events
+// index barrel instead of vendored `../` siblings, so the generated files
+// typecheck from the consumer's `src/generated/events/`.
+// ---------------------------------------------------------------------------
+
+const PKG_EVENTS_IMPORT = '@pattern-stack/codegen/runtime/subsystems/events/index';
+
+describe('buildTypesContent — package mode', () => {
+	test('DomainEvent imports from the package events index (non-empty)', () => {
+		const content = buildTypesContent([contactCreated], 'package');
+		expect(content).toContain(
+			`import type { DomainEvent } from '${PKG_EVENTS_IMPORT}';`,
+		);
+		expect(content).not.toContain("'../event-bus.protocol'");
+	});
+
+	test('empty case also routes DomainEvent through the package', () => {
+		const content = buildTypesContent([], 'package');
+		expect(content).toContain(
+			`import type { DomainEvent } from '${PKG_EVENTS_IMPORT}';`,
+		);
+		expect(content).not.toContain("'../event-bus.protocol'");
+	});
+
+	test('vendored (default) is unchanged', () => {
+		expect(buildTypesContent([contactCreated])).toContain(
+			"import type { DomainEvent } from '../event-bus.protocol';",
+		);
+	});
+});
+
+describe('buildBusContent — package mode', () => {
+	test('all three runtime imports route through the package events index', () => {
+		const content = buildBusContent([], 'package');
+		expect(content).toContain(
+			`import { EVENT_BUS, EVENTS_MULTI_TENANT } from '${PKG_EVENTS_IMPORT}';`,
+		);
+		expect(content).toContain(
+			`import { MissingTenantIdError } from '${PKG_EVENTS_IMPORT}';`,
+		);
+		expect(content).toContain(
+			`import type { IEventBus, DrizzleTransaction } from '${PKG_EVENTS_IMPORT}';`,
+		);
+		// No vendored `../` runtime imports survive.
+		expect(content).not.toContain("'../events.tokens'");
+		expect(content).not.toContain("'../events-errors'");
+		expect(content).not.toContain("'../event-bus.protocol'");
+		// Intra-generated sibling imports stay relative.
+		expect(content).toContain("import { eventPayloadSchemas } from './schemas';");
+		expect(content).toContain("import { getEventMetadata } from './registry';");
+	});
+
+	test('vendored (default) keeps the `../` runtime imports', () => {
+		const content = buildBusContent([]);
+		expect(content).toContain(
+			"import { EVENT_BUS, EVENTS_MULTI_TENANT } from '../events.tokens';",
+		);
+		expect(content).toContain(
+			"import { MissingTenantIdError } from '../events-errors';",
+		);
+		// (the HEADER banner legitimately names @pattern-stack/codegen — assert on
+		// the package IMPORT specifier instead)
+		expect(content).not.toContain(PKG_EVENTS_IMPORT);
+	});
+});
+
+describe('buildEventCodegenContents — package mode', () => {
+	test('emits all five files; types/bus carry package imports', () => {
+		const files = buildEventCodegenContents([], 'package');
+		expect(files.map((f) => f.name)).toEqual([
+			'types.ts',
+			'schemas.ts',
+			'registry.ts',
+			'bus.ts',
+			'index.ts',
+		]);
+		const byName = Object.fromEntries(files.map((f) => [f.name, f.content]));
+		expect(byName['types.ts']).toContain(PKG_EVENTS_IMPORT);
+		expect(byName['bus.ts']).toContain(PKG_EVENTS_IMPORT);
+		// schemas/registry/index have no runtime imports → no package import
+		// specifier (the HEADER banner names the package, so check the specifier).
+		expect(byName['schemas.ts']).not.toContain(PKG_EVENTS_IMPORT);
+		expect(byName['registry.ts']).not.toContain(PKG_EVENTS_IMPORT);
+	});
+
+	test('vendored default emits the same five files with `../` imports', () => {
+		const files = buildEventCodegenContents([]);
+		const byName = Object.fromEntries(files.map((f) => [f.name, f.content]));
+		expect(byName['bus.ts']).toContain("'../events.tokens'");
+		expect(byName['bus.ts']).not.toContain(PKG_EVENTS_IMPORT);
 	});
 });

--- a/src/__tests__/cli/subsystem-barrel-generator.test.ts
+++ b/src/__tests__/cli/subsystem-barrel-generator.test.ts
@@ -454,4 +454,35 @@ describe('buildSubsystemBarrel — package mode (ADR-037)', () => {
 			"BridgeModule.forRoot({ backend: 'drizzle', multiTenant: true, registry: bridgeRegistry }),",
 		);
 	});
+
+	// ─── Events seam: package mode threads the consumer's TypedEventBus ──────
+
+	test('package-mode events composer imports ./events/bus and passes typedBus', () => {
+		const out = buildSubsystemBarrel(
+			[inst('events')],
+			{ events: { backend: 'drizzle', multi_tenant: false } },
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain(
+			"import { TypedEventBus } from './events/bus';",
+		);
+		expect(out.content).toContain(
+			"EventsModule.forRoot({ backend: 'drizzle', multiTenant: false, typedBus: TypedEventBus }),",
+		);
+	});
+
+	test('vendored events composer emits no typedBus (uses the runtime bundled bus)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('events')],
+			{ events: { backend: 'drizzle', multi_tenant: false } },
+			subsystemsRel,
+			'vendored',
+		);
+		expect(out.content).toContain(
+			"EventsModule.forRoot({ backend: 'drizzle', multiTenant: false }),",
+		);
+		expect(out.content).not.toContain('typedBus');
+		expect(out.content).not.toContain('./events/bus');
+	});
 });

--- a/src/__tests__/runtime/subsystems/events-module.spec.ts
+++ b/src/__tests__/runtime/subsystems/events-module.spec.ts
@@ -14,7 +14,7 @@
 import 'reflect-metadata';
 import { describe, expect, it } from 'bun:test';
 import { Test } from '@nestjs/testing';
-import { Module } from '@nestjs/common';
+import { Inject, Injectable, Module } from '@nestjs/common';
 import { EventsModule } from '../../../../runtime/subsystems/events/events.module';
 import {
   EVENT_BUS,
@@ -22,6 +22,7 @@ import {
   EVENTS_MULTI_TENANT,
   TYPED_EVENT_BUS,
 } from '../../../../runtime/subsystems/events/events.tokens';
+import type { IEventBus } from '../../../../runtime/subsystems/events/event-bus.protocol';
 import { TypedEventBus } from '../../../../runtime/subsystems/events/generated/bus';
 import { MemoryEventBus } from '../../../../runtime/subsystems/events/event-bus.memory-backend';
 import { MissingTenantIdError } from '../../../../runtime/subsystems/events/events-errors';
@@ -37,6 +38,45 @@ const PAYLOAD = {
   accountId: '22222222-2222-2222-2222-222222222222',
   createdBy: '33333333-3333-3333-3333-333333333333',
 } as const;
+
+// A stand-in for a consumer's generated `TypedEventBus` (package mode, ADR-037):
+// a distinct class with the same DI shape (injects EVENT_BUS + EVENTS_MULTI_TENANT).
+@Injectable()
+class CustomTypedEventBus {
+  constructor(
+    @Inject(EVENT_BUS) readonly bus: IEventBus,
+    @Inject(EVENTS_MULTI_TENANT) readonly multiTenant: boolean,
+  ) {}
+}
+
+describe('EventsModule.forRoot — typedBus override (ADR-037 package mode)', () => {
+  it('binds the supplied typedBus class to TYPED_EVENT_BUS', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRoot({ backend: 'memory', typedBus: CustomTypedEventBus }),
+      ],
+    }).compile();
+
+    // The consumer's generated bus wins over the bundled one.
+    expect(moduleRef.get(TYPED_EVENT_BUS)).toBeInstanceOf(CustomTypedEventBus);
+    // And Nest constructed it with the module's EVENT_BUS + multiTenant providers.
+    expect(moduleRef.get(CustomTypedEventBus).bus).toBe(moduleRef.get(EVENT_BUS));
+    expect(moduleRef.get(CustomTypedEventBus).multiTenant).toBe(false);
+
+    await moduleRef.close();
+  });
+
+  it('falls back to the bundled TypedEventBus when typedBus is omitted', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventsModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    expect(moduleRef.get(TYPED_EVENT_BUS)).toBeInstanceOf(TypedEventBus);
+    expect(moduleRef.get(TYPED_EVENT_BUS)).not.toBeInstanceOf(CustomTypedEventBus);
+
+    await moduleRef.close();
+  });
+});
 
 describe('EventsModule.forRoot({ backend: "memory" })', () => {
   it('resolves EVENT_BUS to MemoryEventBus and TYPED_EVENT_BUS to TypedEventBus', async () => {

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -392,24 +392,35 @@ export class EntityNewCommand extends Command {
 		const architecture = resolveArchitecture(ctx);
 
 		const subsystemsRoot = resolveSubsystemsRoot(ctx);
-		const scopeEntityTypePath = path.resolve(
-			subsystemsRoot,
-			'jobs/generated/scope-entity-type.ts',
-		);
+		// Runtime mode (ADR-037) drives WHERE consumer-specific generated code
+		// lands. Vendored mode keeps the legacy `<subsystemsRoot>/<name>/generated`
+		// tree (next to the runtime it imports). Package mode has no vendored tree,
+		// so the generated event files + scope union + bridge registry land beside
+		// the other `src/generated/*` barrels, with runtime imports routed through
+		// the published `@pattern-stack/codegen` subpaths.
+		const runtimeMode = resolveRuntimeMode(ctx.config);
+
+		// Scope-entity-type union (jobs). Self-contained (zod-only), so package
+		// mode just relocates it to `src/generated/scope-entity-type.ts`.
+		const scopeEntityTypePath =
+			runtimeMode === 'package'
+				? path.resolve(generatedDir, 'scope-entity-type.ts')
+				: path.resolve(subsystemsRoot, 'jobs/generated/scope-entity-type.ts');
 
 		const eventsDir = resolveEventsDir(ctx);
-		const eventCodegenOutputDir = path.resolve(
-			subsystemsRoot,
-			'events/generated',
-		);
+		// Event codegen output. Package mode → `src/generated/events/` (the 5 files
+		// import the events runtime via the package subpath); also the dir the
+		// bridge registry validates trigger events against (so package-mode trigger
+		// validation now works).
+		const eventCodegenOutputDir =
+			runtimeMode === 'package'
+				? path.resolve(generatedDir, 'events')
+				: path.resolve(subsystemsRoot, 'events/generated');
 		// Bridge registry output is mode-aware (ADR-037). Vendored mode writes
 		// `registry.ts` into the vendored `bridge/generated/` tree (next to the
-		// runtime it types against). Package mode has no vendored tree, so the
-		// registry lands beside the other `src/generated/*` barrels as
-		// `bridge-registry.ts` and is threaded into `BridgeModule.forRoot` by the
-		// subsystem barrel. `mode`/`bridgeInstalled` are passed to the generator,
-		// which picks the filename + type-import accordingly.
-		const runtimeMode = resolveRuntimeMode(ctx.config);
+		// runtime it types against). Package mode lands `bridge-registry.ts` beside
+		// the other `src/generated/*` barrels, threaded into `BridgeModule.forRoot`
+		// by the subsystem barrel.
 		const bridgeInstalledForRegistry = configuredSubsystemNames(
 			ctx.config as Record<string, unknown> | null | undefined,
 		).includes('bridge');
@@ -489,6 +500,7 @@ export class EntityNewCommand extends Command {
 				entitiesDir,
 				eventsDir,
 				outputDir: eventCodegenOutputDir,
+				mode: runtimeMode,
 				dryRun: true,
 			});
 
@@ -703,6 +715,7 @@ export class EntityNewCommand extends Command {
 				entitiesDir,
 				eventsDir,
 				outputDir: eventCodegenOutputDir,
+				mode: runtimeMode,
 			});
 			if (!isJsonMode()) {
 				for (const issue of eventCodegenResult.issues) {

--- a/src/cli/shared/event-codegen-generator.ts
+++ b/src/cli/shared/event-codegen-generator.ts
@@ -32,6 +32,50 @@ import type {
 	EventFieldType,
 	EventPayloadField,
 } from '../../schema/event-definition.schema.js';
+import type { RuntimeMode } from './runtime-import.js';
+
+// ---------------------------------------------------------------------------
+// Mode-aware runtime imports (ADR-037)
+// ---------------------------------------------------------------------------
+
+/**
+ * The generated event files import three things from the events RUNTIME:
+ * `DomainEvent` / `IEventBus` / `DrizzleTransaction` (the protocol), the
+ * `EVENT_BUS` / `EVENTS_MULTI_TENANT` tokens, and `MissingTenantIdError`.
+ *
+ * In vendored mode those sit as siblings of the generated dir
+ * (`../event-bus.protocol`, `../events.tokens`, `../events-errors`). In package
+ * mode the generated files land in the consumer's `src/generated/events/`,
+ * which has no relative line of sight to the package-internal runtime — so all
+ * three resolve through the published events index barrel (which re-exports
+ * every one of those symbols).
+ */
+const PACKAGE_EVENTS_RUNTIME_IMPORT =
+	'@pattern-stack/codegen/runtime/subsystems/events/index';
+
+interface EventsRuntimeImports {
+	/** `DomainEvent`, `IEventBus`, `DrizzleTransaction`. */
+	protocol: string;
+	/** `EVENT_BUS`, `EVENTS_MULTI_TENANT`. */
+	tokens: string;
+	/** `MissingTenantIdError`. */
+	errors: string;
+}
+
+function eventsRuntimeImports(mode: RuntimeMode): EventsRuntimeImports {
+	if (mode === 'package') {
+		return {
+			protocol: PACKAGE_EVENTS_RUNTIME_IMPORT,
+			tokens: PACKAGE_EVENTS_RUNTIME_IMPORT,
+			errors: PACKAGE_EVENTS_RUNTIME_IMPORT,
+		};
+	}
+	return {
+		protocol: '../event-bus.protocol',
+		tokens: '../events.tokens',
+		errors: '../events-errors',
+	};
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,6 +88,14 @@ export interface EventCodegenGeneratorOptions {
 	eventsDir: string;
 	/** Absolute path to the generator's output directory. */
 	outputDir: string;
+	/**
+	 * Runtime mode (ADR-037). Defaults to `'vendored'` so existing callers/tests
+	 * and the vendored emission are byte-stable. In `'package'` mode the three
+	 * runtime imports (`protocol` / `tokens` / `errors`) resolve through the
+	 * published events index barrel instead of vendored `../` siblings — the
+	 * consumer's generated files then typecheck from `src/generated/events/`.
+	 */
+	mode?: RuntimeMode;
 	/** If true, compute content but don't write to disk. */
 	dryRun?: boolean;
 }
@@ -308,14 +360,18 @@ export function collectMergedEvents(
 // Content builder: types.ts
 // ---------------------------------------------------------------------------
 
-export function buildTypesContent(events: EventDefinition[]): string {
+export function buildTypesContent(
+	events: EventDefinition[],
+	mode: RuntimeMode = 'vendored',
+): string {
 	const sorted = [...events].sort((a, b) => a.type.localeCompare(b.type));
+	const protocolImport = eventsRuntimeImports(mode).protocol;
 
 	if (sorted.length === 0) {
 		return (
 			HEADER +
 			'\n' +
-			`import type { DomainEvent } from '../event-bus.protocol';\n` +
+			`import type { DomainEvent } from '${protocolImport}';\n` +
 			'\n' +
 			`export type AppDomainEvent = never;\n` +
 			'\n' +
@@ -333,7 +389,7 @@ export function buildTypesContent(events: EventDefinition[]): string {
 	const chunks: string[] = [];
 	chunks.push(HEADER);
 	chunks.push('');
-	chunks.push(`import type { DomainEvent } from '../event-bus.protocol';`);
+	chunks.push(`import type { DomainEvent } from '${protocolImport}';`);
 	chunks.push('');
 
 	for (const ev of sorted) {
@@ -669,10 +725,23 @@ export class TypedEventBus {
 }
 `;
 
-export function buildBusContent(_events: EventDefinition[]): string {
+export function buildBusContent(
+	_events: EventDefinition[],
+	mode: RuntimeMode = 'vendored',
+): string {
 	// Body is identical for empty and non-empty projects; the behaviour
-	// difference lives in registry.ts (empty throws on any lookup).
-	return HEADER + '\n' + BUS_BODY;
+	// difference lives in registry.ts (empty throws on any lookup). Only the
+	// three runtime imports are mode-dependent (ADR-037) — in package mode they
+	// resolve through the published events index barrel. Vendored mode returns
+	// BUS_BODY untouched (byte-stable).
+	let body = BUS_BODY;
+	if (mode === 'package') {
+		body = body
+			.replace(`from '../events.tokens'`, `from '${PACKAGE_EVENTS_RUNTIME_IMPORT}'`)
+			.replace(`from '../events-errors'`, `from '${PACKAGE_EVENTS_RUNTIME_IMPORT}'`)
+			.replace(`from '../event-bus.protocol'`, `from '${PACKAGE_EVENTS_RUNTIME_IMPORT}'`);
+	}
+	return HEADER + '\n' + body;
 }
 
 // ---------------------------------------------------------------------------
@@ -702,10 +771,30 @@ const OUTPUT_FILE_NAMES = [
 	'index.ts',
 ] as const;
 
+/**
+ * Build all five generated file contents for an event set, mode-aware (ADR-037).
+ * Pure — no fs. Shared by the entrypoint and the subsystem-barrel stub writer
+ * (package mode) so the empty-set output is identical in both. `types.ts` /
+ * `bus.ts` thread `mode` (their runtime imports differ); the other three have
+ * no runtime imports and ignore it.
+ */
+export function buildEventCodegenContents(
+	events: EventDefinition[],
+	mode: RuntimeMode = 'vendored',
+): Array<{ name: (typeof OUTPUT_FILE_NAMES)[number]; content: string }> {
+	return [
+		{ name: 'types.ts', content: buildTypesContent(events, mode) },
+		{ name: 'schemas.ts', content: buildSchemasContent(events) },
+		{ name: 'registry.ts', content: buildRegistryContent(events) },
+		{ name: 'bus.ts', content: buildBusContent(events, mode) },
+		{ name: 'index.ts', content: buildIndexContent(events) },
+	];
+}
+
 export async function generateEventCodegen(
 	opts: EventCodegenGeneratorOptions,
 ): Promise<EventCodegenResult> {
-	const { entitiesDir, eventsDir, outputDir, dryRun = false } = opts;
+	const { entitiesDir, eventsDir, outputDir, mode = 'vendored', dryRun = false } = opts;
 
 	// 1–3. Load + merge via the shared helper. `no_events_dir` / `no_files`
 	// warnings are retained — the generator still emits stub files, matching
@@ -715,23 +804,14 @@ export async function generateEventCodegen(
 		eventsDir,
 	});
 
-	// 4. Build all file contents.
-	const builders: Record<
-		(typeof OUTPUT_FILE_NAMES)[number],
-		(events: EventDefinition[]) => string
-	> = {
-		'types.ts': buildTypesContent,
-		'schemas.ts': buildSchemasContent,
-		'registry.ts': buildRegistryContent,
-		'bus.ts': buildBusContent,
-		'index.ts': buildIndexContent,
-	};
-
-	const files: EventCodegenFileOutput[] = OUTPUT_FILE_NAMES.map((name) => ({
-		name,
-		outputPath: path.join(outputDir, name),
-		content: builders[name](merged),
-	}));
+	// 4. Build all file contents (mode-aware import resolution).
+	const files: EventCodegenFileOutput[] = buildEventCodegenContents(merged, mode).map(
+		({ name, content }) => ({
+			name,
+			outputPath: path.join(outputDir, name),
+			content,
+		}),
+	);
 
 	// 5. Write (or not) — fail-loud on `severity: 'error'` issues.
 	const hasError = issues.some((i) => i.severity === 'error');

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -36,6 +36,7 @@ import {
 	buildBridgeRegistryContent,
 	PACKAGE_BRIDGE_TYPE_IMPORT,
 } from './bridge-registry-generator.js';
+import { buildEventCodegenContents } from './event-codegen-generator.js';
 
 // ---------------------------------------------------------------------------
 // Options + result types
@@ -185,13 +186,29 @@ function workerPoolsClause(
 }
 
 const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
-	events: ({ moduleImport, cfg }) => {
+	events: ({ moduleImport, cfg, mode }) => {
 		const backend = (cfg?.backend as string | undefined) ?? 'drizzle';
 		const multiTenant = Boolean(cfg?.multi_tenant);
+		const imports = [
+			`import { EventsModule } from '${moduleImport('events', 'events.module')}';`,
+		];
+		// Package mode (ADR-037): the consumer's `events/*.yaml` are scanned into
+		// `src/generated/events/bus.ts` (a `TypedEventBus` typed to THEIR event
+		// union, reading THEIR registry). Thread it through `forRoot({ typedBus })`
+		// or the bundled empty-union bus wins and typed publishes resolve against
+		// `never`. Vendored mode omits it — the runtime's own `./generated/bus` IS
+		// the consumer's generated file there.
+		if (mode === 'package') {
+			imports.push(`import { TypedEventBus } from './events/bus';`);
+			return {
+				imports,
+				calls: [
+					`\tEventsModule.forRoot({ backend: '${backend}', multiTenant: ${multiTenant}, typedBus: TypedEventBus }),`,
+				],
+			};
+		}
 		return {
-			imports: [
-				`import { EventsModule } from '${moduleImport('events', 'events.module')}';`,
-			],
+			imports,
 			calls: [
 				`\tEventsModule.forRoot(${quoteOpts({ backend, multiTenant })}),`,
 			],
@@ -463,6 +480,22 @@ export async function regenerateSubsystemBarrel(
 					registryPath,
 					buildBridgeRegistryContent([], PACKAGE_BRIDGE_TYPE_IMPORT),
 				);
+			}
+		}
+
+		// Same guard for the events composer: package mode imports
+		// `./events/bus`. The real 5-file set is emitted by `entity new --all`
+		// (which scans events/*.yaml); `subsystem install events` regenerates the
+		// barrel without that scan, so drop an empty-set stub iff the dir is
+		// absent — never clobber a previously-generated set (byte-identical to the
+		// generator's own empty-case output, so no churn).
+		if (mode === 'package' && emitted.includes('events')) {
+			const eventsDir = path.resolve(generatedDir, 'events');
+			if (!fs.existsSync(path.resolve(eventsDir, 'bus.ts'))) {
+				fs.mkdirSync(eventsDir, { recursive: true });
+				for (const { name, content } of buildEventCodegenContents([], 'package')) {
+					fs.writeFileSync(path.resolve(eventsDir, name), content);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Completes the package-mode (`runtime: package`, ADR-037) story after #448's bridge fixes: a package-mode consumer can now declare its own `events/*.yaml`, get a typed `TypedEventBus`, and publish typed domain events — and the stray `src/shared/subsystems/{events,jobs}/generated` tree that every package-mode regen used to spew (the 0.14.2 known follow-on) is gone.

## The gap
Unlike the bridge (which takes a data registry), `EventsModule`/`TypedEventBus` always read the package's **bundled empty** `./generated/bus` — no seam for consumer events. And event codegen wrote its 5 files to a vendored path whose `../event-bus.protocol` / `../events.tokens` / `../events-errors` imports don't exist in package mode → the tree didn't typecheck and was orphaned.

## What
- **`EventsModuleOptions.typedBus?: Type<unknown>`** (runtime) — binds a consumer-supplied `TypedEventBus` to `TYPED_EVENT_BUS` via `forRoot`; omitted ⇒ bundled fallback (vendored / back-compat). Nest constructs it with the module's `EVENT_BUS` + `EVENTS_MULTI_TENANT` providers.
- **event-codegen mode-aware** — package mode emits the 5 files to `src/generated/events/`, routing the three runtime imports through `@pattern-stack/codegen/runtime/subsystems/events/index` (which re-exports all of them).
- **scope-entity-type mode-aware** — relocated to `src/generated/scope-entity-type.ts`.
- **subsystem barrel** — events composer imports `./events/bus` + threads `typedBus: TypedEventBus`; stub-if-missing keeps `subsystem install events` from dangling the import.
- **entity.ts** — wires mode + output paths; the bridge's `eventsGeneratedDir` now follows to `src/generated/events`, so **package-mode trigger validation runs** (closes the 0.14.2 known gap).

Vendored mode byte-stable.

## Verification
- typecheck clean · **2485** main-tree unit tests (incl. ~10 new seam tests + a runtime `typedBus`-override test)
- `test-baseline` (vendored event-codegen byte-stable), vendored **subsystems smoke** (boot-verify), `smoke-integration` — all green; build clean
- **Validated end-to-end in a real package-mode consumer (swe-brain) via local link**: declared a typed `test_ping` event → generated files land in `src/generated/events/`, package imports resolve, typed union + registry generated, `typedBus` wired, no stray tree, **zero seam typecheck errors** (the only link-time errors were a `bun link` drizzle-orm duplicate-type artifact, absent with the published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)