### PR TITLE
fix(events): package-mode bridge/trigger event typing (0.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.1] — 2026-06-02
+
+Package-mode **bridge/trigger event typing** — the fourth and final package-mode
+seam (after 0.14.1 subsystems, 0.14.2 bridge, 0.15.0 events). Lets a package-mode
+consumer (`runtime: package`, ADR-037) author a `@JobHandler({ triggers: [{ event:
+'<their_event>', map, when }] })` on their OWN event and have it typecheck with
+full per-event payload typing. Vendored mode is byte-stable; everything here is
+additive.
+
+### Fixed
+
+- **`@JobHandler.triggers` and the generated `bridge-registry.ts` now accept a
+  package-mode consumer's own events.** Previously the bridge + job-trigger types
+  (`BridgeRegistry`, `BridgeTriggerEntry<T>`, `JobTrigger<TInput>`) keyed off
+  `EventTypeName` imported from the bundled `events/generated/types.ts` — which
+  in the published package is codegen-patterns' OWN test-fixture union
+  (`contact_created`, `deal_created`, …). A consumer's
+  `'inbound_webhook_received'` trigger therefore failed to typecheck
+  (`'inbound_webhook_received' is not assignable to '"contact_created" | …'`) and
+  their generated `bridge-registry.ts` reported "does not exist in type
+  'BridgeRegistry'". The bridge/trigger types now key off an **augmentable
+  `DomainEventRegistry`** (see below) instead of the bundled fixture union, so in
+  the consumer's tsc program they resolve THEIR event union with full
+  `EventOfType<T>` payload typing (`e.payload.<field>` is typed, not `unknown`).
+  The bundled fixture-based runtime tests stay green: the bundled `TypedEventBus`
+  still keys off its local `events/generated/types.ts`, and the fixtures are
+  never registered into `DomainEventRegistry`, so they never leak into a
+  consumer's `EventTypeName`.
+
+### Added
+
+- **`DomainEventRegistry` — an augmentable, empty event registry interface**
+  (`runtime/subsystems/events/event-registry.ts`, re-exported from the events
+  index barrel). `EventTypeName` now derives from it
+  (`keyof DomainEventRegistry extends never ? string : keyof DomainEventRegistry &
+  string`) and `EventOfType<T>` resolves a registered event's concrete interface
+  (falling back to the structural `DomainEvent` base otherwise). Empty in the
+  package and in any no-events project ⇒ `EventTypeName` degrades to `string` and
+  the bridge/trigger types stay sound (`Record<string, …>` / `(e: DomainEvent) =>
+  …`) — exactly the loose shape the package's own fixture tests rely on. The five
+  bridge/jobs runtime files that consumed `EventTypeName` / `EventOfType` from the
+  bundled `events/generated/types` (`bridge.protocol`, `job-handler.base`,
+  `event-flow.service`, `bridge-outbox-drain-hook`, `bridge-delivery-handler`) now
+  import them from this augmentable seam.
+- **Event codegen emits a package-mode `declare module` augmentation.** In
+  package mode the generated `src/generated/events/types.ts` now appends a
+  `declare module '@pattern-stack/codegen/runtime/subsystems/events/index' {
+  interface DomainEventRegistry { '<type>': <Type>Event; … } }` block that
+  declaration-merges the consumer's events into the runtime's registry through
+  the events index module specifier (the stable, public augmentation target).
+  Gated on `mode === 'package'` and a non-empty event set; vendored mode emits
+  nothing (the bridge/job types import the consumer's vendored `./generated/types`
+  directly), so vendored output is byte-stable. Proven end-to-end with a real
+  cross-`node_modules` consumer typecheck (declaration merging across the package
+  boundary is finicky and is covered by a real-tsc unit test, not string
+  assertions alone): an unregistered event type is rejected, and a registered
+  one's trigger `map` reads `e.payload.<field>` fully typed.
+
 ## [0.15.0] — 2026-06-02
 
 Package-mode consumer **events** — the seam that lets a project consuming the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/bridge/bridge-delivery-handler.ts
+++ b/runtime/subsystems/bridge/bridge-delivery-handler.ts
@@ -64,7 +64,7 @@ import {
 
 import { EVENT_BUS } from '../events/events.tokens';
 import type { IEventBus, DomainEvent } from '../events/event-bus.protocol';
-import type { EventTypeName } from '../events/generated/types';
+import type { EventTypeName } from '../events/event-registry';
 
 import {
   BRIDGE_DELIVERY_REPO,

--- a/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
+++ b/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
@@ -45,7 +45,7 @@ import type {
   IBridgeOutboxDrainHook,
 } from './bridge.protocol';
 import { BRIDGE_DELIVERY_JOB_TYPE } from './bridge-delivery-handler';
-import type { EventTypeName } from '../events/generated/types';
+import type { EventTypeName } from '../events/event-registry';
 
 /** Reserved pools the wrapper rows route into; ADR-022 / ADR-024. */
 const POOL_BY_DIRECTION: Record<string, string> = {

--- a/runtime/subsystems/bridge/bridge.protocol.ts
+++ b/runtime/subsystems/bridge/bridge.protocol.ts
@@ -29,7 +29,7 @@ import type { DrizzleTransaction, DomainEvent } from '../events/event-bus.protoc
 import type {
   EventOfType,
   EventTypeName,
-} from '../events/generated/types';
+} from '../events/event-registry';
 
 import type {
   BridgeDeliveryRecord,

--- a/runtime/subsystems/bridge/event-flow.service.ts
+++ b/runtime/subsystems/bridge/event-flow.service.ts
@@ -52,7 +52,7 @@ import type {
 import type {
   EventOfType,
   EventTypeName,
-} from '../events/generated/types';
+} from '../events/event-registry';
 
 import { JOB_ORCHESTRATOR } from '../jobs/jobs-domain.tokens';
 import type { IJobOrchestrator } from '../jobs/job-orchestrator.protocol';

--- a/runtime/subsystems/events/event-registry.ts
+++ b/runtime/subsystems/events/event-registry.ts
@@ -1,0 +1,77 @@
+/**
+ * Augmentable domain-event registry (ADR-037, package-mode trigger typing).
+ *
+ * This is the seam that lets the bridge + job-trigger types see a PACKAGE-MODE
+ * consumer's OWN events with full per-event payload typing — without the
+ * package shipping (and leaking) its internal test-fixture event union.
+ *
+ * ── The problem ──────────────────────────────────────────────────────────────
+ * In vendored mode, `bridge.protocol.ts` / `job-handler.base.ts` could import
+ * `EventTypeName` / `EventOfType` straight from the consumer's vendored
+ * `./generated/types` (a sibling file). In package mode the runtime is consumed
+ * from the published `@pattern-stack/codegen`, whose bundled
+ * `events/generated/types.ts` is the codegen-patterns repo's OWN fixture union
+ * (`contact_created`, `deal_created`, …). Keying the bridge/trigger types off
+ * THAT union rejects the consumer's events (`'inbound_webhook_received' is not
+ * assignable to '"contact_created" | …'`).
+ *
+ * ── The fix ──────────────────────────────────────────────────────────────────
+ * `EventTypeName` (as used by the bridge/trigger types) derives from an EMPTY,
+ * augmentable `DomainEventRegistry` interface instead of the bundled concrete
+ * union. A package-mode consumer's generated events code emits a
+ * `declare module '@pattern-stack/codegen/runtime/subsystems/events/index' {
+ *    interface DomainEventRegistry { <their_event>: <TheirEvent>; … } }`
+ * augmentation, so in the consumer's tsc program `keyof DomainEventRegistry`
+ * picks up THEIR events and `EventOfType<T>` resolves THEIR concrete payloads.
+ *
+ * In the package's OWN program (and any consumer that authors no events) the
+ * interface is never augmented, so `keyof DomainEventRegistry` is `never` and
+ * `EventTypeName` falls back to `string` — the bridge/trigger types degrade to
+ * `Record<string, …>` / `(event: DomainEvent) => …`, exactly the loose-but-
+ * sound shape that keeps the package's fixture-based runtime tests green.
+ *
+ * The bundled `events/generated/{types,bus,schemas}.ts` keep their concrete
+ * fixture union locally (the bundled `TypedEventBus` keys off `./types`, NOT
+ * this file), so they do NOT augment `DomainEventRegistry` and never leak the
+ * fixtures into a consumer's `EventTypeName` — even though the consumer pulls
+ * `generated/types.d.ts` in transitively via the events index barrel.
+ */
+import type { DomainEvent } from './event-bus.protocol';
+
+/**
+ * Empty marker interface, augmented by a consumer's generated events code via
+ * declaration merging on the events index module specifier
+ * (`@pattern-stack/codegen/runtime/subsystems/events/index`). Each key is an
+ * event `type` literal; each value is the event's concrete interface (extends
+ * `DomainEvent`). Empty in the package and in any project that declares no
+ * `events/*.yaml`.
+ *
+ * Intentionally NOT augmented by the package's own bundled
+ * `events/generated/types.ts` — those fixtures stay local to the bundled
+ * `TypedEventBus` so they never widen a consumer's `EventTypeName`.
+ *
+ * Must be an `interface` (only interfaces merge across module boundaries) and
+ * empty by design — a consumer augments it via declaration merging.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface DomainEventRegistry {}
+
+/**
+ * Union of registered event `type` literals. When the registry is augmented
+ * (package-mode consumer with events) this is their event-type union; when it's
+ * empty (the package itself, or a no-events project) it falls back to `string`
+ * so the bridge/trigger types stay sound rather than collapsing to `never`.
+ */
+export type EventTypeName = keyof DomainEventRegistry extends never
+  ? string
+  : keyof DomainEventRegistry & string;
+
+/**
+ * The concrete event interface for a given `type`. Resolves to the consumer's
+ * registered interface when the registry knows `T`; otherwise (the fallback
+ * `string` case, or an unregistered literal) widens to the structural
+ * `DomainEvent` base so `event.type` / `event.id` / `event.payload` are still
+ * typed (payloads as `Record<string, unknown>`).
+ */
+export type EventOfType<T extends EventTypeName> =
+  T extends keyof DomainEventRegistry ? DomainEventRegistry[T] : DomainEvent;

--- a/runtime/subsystems/events/index.ts
+++ b/runtime/subsystems/events/index.ts
@@ -4,6 +4,18 @@
  * Import the module in AppModule, inject the bus via EVENT_BUS token.
  */
 export type { DomainEvent, IEventBus, DrizzleTransaction } from './event-bus.protocol';
+// Augmentable event registry (ADR-037, package-mode trigger typing). A
+// package-mode consumer's generated events code augments `DomainEventRegistry`
+// via `declare module '@pattern-stack/codegen/runtime/subsystems/events/index'`
+// so the bridge + job-trigger types pick up THEIR events with full payload
+// typing. `EventTypeName` / `EventOfType` are re-exported here (the public
+// barrel is the stable augmentation target); they derive from the registry, NOT
+// the bundled fixture union the generated `./generated/types` re-export carries.
+export type {
+  DomainEventRegistry,
+  EventTypeName,
+  EventOfType,
+} from './event-registry';
 export type {
   IEventReadPort,
   ListEventsQuery,

--- a/runtime/subsystems/jobs/job-handler.base.ts
+++ b/runtime/subsystems/jobs/job-handler.base.ts
@@ -17,7 +17,7 @@
 // TODO(logging-subsystem): swap to ILogger once ADR-028 lands
 import type { Logger } from '@nestjs/common';
 import { tokenKey } from '../token-key';
-import type { EventOfType, EventTypeName } from '../events/generated/types';
+import type { EventOfType, EventTypeName } from '../events/event-registry';
 import type { JobRun } from './job-orchestrator.protocol';
 
 // ─── ParentClosePolicy ──────────────────────────────────────────────────────

--- a/src/__tests__/cli/event-codegen-generator.test.ts
+++ b/src/__tests__/cli/event-codegen-generator.test.ts
@@ -263,6 +263,59 @@ describe('buildTypesContent — multi-event ordering', () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Package-mode `DomainEventRegistry` augmentation (ADR-037, trigger typing).
+//
+// In package mode the bridge + `@JobHandler({ triggers })` types key off the
+// published runtime's augmentable `DomainEventRegistry` (not the consumer's
+// local `EventTypeName`). The generated `types.ts` must emit a `declare module`
+// block that merges the project's events into that interface so triggers see
+// them with full payload typing. Vendored mode must NOT emit it (byte-stable).
+// ---------------------------------------------------------------------------
+
+describe('buildTypesContent — package-mode DomainEventRegistry augmentation', () => {
+	test('package mode emits a declare-module augmentation on the events index barrel', () => {
+		const content = buildTypesContent(
+			[contactCreated, stripePaymentReceived],
+			'package',
+		);
+		// Targets the EXACT module specifier the consumer imports the bridge/event
+		// types from — declaration merging only flows through the same specifier.
+		expect(content).toContain(
+			"declare module '@pattern-stack/codegen/runtime/subsystems/events/index' {",
+		);
+		expect(content).toContain('interface DomainEventRegistry {');
+		// Each event registered as `'<type>': <Pascal>Event;`, alphabetical.
+		expect(content).toContain("'contact_created': ContactCreatedEvent;");
+		expect(content).toContain(
+			"'stripe_payment_received': StripePaymentReceivedEvent;",
+		);
+		const contactIdx = content.indexOf("'contact_created': ContactCreatedEvent;");
+		const stripeIdx = content.indexOf(
+			"'stripe_payment_received': StripePaymentReceivedEvent;",
+		);
+		expect(stripeIdx).toBeGreaterThan(contactIdx);
+	});
+
+	test('vendored mode emits NO augmentation block (byte-stable)', () => {
+		const content = buildTypesContent([contactCreated], 'vendored');
+		expect(content).not.toContain('declare module');
+		expect(content).not.toContain('DomainEventRegistry');
+	});
+
+	test('default mode (no arg) is vendored — no augmentation', () => {
+		const content = buildTypesContent([contactCreated]);
+		expect(content).not.toContain('declare module');
+	});
+
+	test('empty event set in package mode emits no augmentation (string fallback stands)', () => {
+		const content = buildTypesContent([], 'package');
+		expect(content).not.toContain('declare module');
+		// Empty case still degrades EventTypeName to string (unchanged).
+		expect(content).toContain('export type EventTypeName = string;');
+	});
+});
+
 describe('buildTypesContent — empty payload', () => {
 	test('emits Record<string, never> for a payload-less event', () => {
 		const ev: EventDefinition = {
@@ -764,6 +817,236 @@ describe('emitted generated/* typechecks under strict + noUncheckedIndexedAccess
 			throw new Error(`tsc exited ${exitCode}:\n${output}`);
 		}
 		expect(exitCode).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Package-mode trigger typing — REAL cross-package declaration-merging proof
+// (ADR-037, 0.15.1). Mirrors how a package-mode consumer's `bridge-registry.ts`
+// and `@JobHandler({ triggers })` see THEIR events: the published runtime keys
+// the bridge/trigger types off an augmentable `DomainEventRegistry`, and the
+// consumer's generated `types.ts` augments it through the events INDEX module
+// specifier. This must be PROVEN with a real tsc against a faithful copy of the
+// runtime's augmentable types — cross-`node_modules` declaration merging is too
+// finicky to assert on string content alone.
+// ---------------------------------------------------------------------------
+
+describe('package-mode trigger typing — cross-package declaration merging (real tsc)', () => {
+	/**
+	 * Build a tiny fake `@pattern-stack/codegen` whose `event-registry` /
+	 * `bridge.protocol` types are byte-faithful to the shipped runtime, drop the
+	 * consumer's `buildTypesContent(events, 'package')` output beside it, plus a
+	 * `bridge-registry.ts` that keys off the package's `BridgeRegistry`. `extra`
+	 * is appended to the consumer's bridge-registry file to add inline
+	 * assertions (`@ts-expect-error`, typed reads) that fail the build if the
+	 * augmentation did NOT take effect.
+	 */
+	function runPackageAugmentationTsc(
+		events: EventDefinition[],
+		extra: string,
+	): { exitCode: number; output: string } {
+		const repoRoot = path.resolve(import.meta.dirname, '..', '..', '..');
+		const tmpBase = path.join(repoRoot, 'test', 'tmp', 'evt-pkg-aug-tsc');
+		fs.mkdirSync(tmpBase, { recursive: true });
+		const dir = fs.mkdtempSync(path.join(tmpBase, 'case-'));
+		tempDirs.push(dir);
+
+		// --- Fake package: node_modules/@pattern-stack/codegen/runtime/... -----
+		const pkgEvents = path.join(
+			dir,
+			'node_modules',
+			'@pattern-stack',
+			'codegen',
+			'runtime',
+			'subsystems',
+			'events',
+		);
+		const pkgBridge = path.join(
+			dir,
+			'node_modules',
+			'@pattern-stack',
+			'codegen',
+			'runtime',
+			'subsystems',
+			'bridge',
+		);
+		fs.mkdirSync(pkgEvents, { recursive: true });
+		fs.mkdirSync(pkgBridge, { recursive: true });
+
+		fs.writeFileSync(
+			path.join(pkgEvents, 'event-bus.protocol.ts'),
+			[
+				'export interface DomainEvent {',
+				'  readonly id: string;',
+				'  readonly type: string;',
+				'  readonly payload: Record<string, unknown>;',
+				'}',
+			].join('\n') + '\n',
+		);
+		// Byte-faithful copy of the shipped runtime/.../events/event-registry.ts core.
+		fs.writeFileSync(
+			path.join(pkgEvents, 'event-registry.ts'),
+			[
+				"import type { DomainEvent } from './event-bus.protocol';",
+				// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+				'export interface DomainEventRegistry {}',
+				'export type EventTypeName = keyof DomainEventRegistry extends never',
+				'  ? string',
+				'  : keyof DomainEventRegistry & string;',
+				'export type EventOfType<T extends EventTypeName> =',
+				'  T extends keyof DomainEventRegistry ? DomainEventRegistry[T] : DomainEvent;',
+			].join('\n') + '\n',
+		);
+		// Index barrel re-exports the augmentable types (the augmentation target).
+		fs.writeFileSync(
+			path.join(pkgEvents, 'index.ts'),
+			[
+				"export type { DomainEvent } from './event-bus.protocol';",
+				"export type { DomainEventRegistry, EventTypeName, EventOfType } from './event-registry';",
+			].join('\n') + '\n',
+		);
+		// Bridge protocol keys off event-registry (faithful to the shipped file).
+		fs.writeFileSync(
+			path.join(pkgBridge, 'bridge.protocol.ts'),
+			[
+				"import type { EventOfType, EventTypeName } from '../events/event-registry';",
+				'export interface BridgeTriggerEntry<T extends EventTypeName = EventTypeName> {',
+				'  triggerId: string;',
+				'  jobType: string;',
+				'  map: (event: EventOfType<T>) => unknown;',
+				'  when?: (event: EventOfType<T>) => boolean;',
+				'}',
+				'export type BridgeRegistry = {',
+				'  [T in EventTypeName]?: BridgeTriggerEntry<T>[];',
+				'};',
+			].join('\n') + '\n',
+		);
+		fs.writeFileSync(
+			path.join(pkgBridge, 'index.ts'),
+			"export type { BridgeRegistry, BridgeTriggerEntry } from './bridge.protocol';\n",
+		);
+
+		// --- Consumer: generated events types (package mode) + bridge-registry --
+		const gen = path.join(dir, 'src', 'generated');
+		fs.mkdirSync(path.join(gen, 'events'), { recursive: true });
+		fs.writeFileSync(
+			path.join(gen, 'events', 'types.ts'),
+			buildTypesContent(events, 'package'),
+		);
+		// The augmentation lives in events/types.ts; import it for side effects so
+		// the declare-module merges into the consumer's program.
+		fs.writeFileSync(
+			path.join(gen, 'bridge-registry.ts'),
+			[
+				"import type { BridgeRegistry } from '@pattern-stack/codegen/runtime/subsystems/bridge/index';",
+				"import './events/types';",
+				'',
+				'export const bridgeRegistry: BridgeRegistry = {',
+				extra,
+				'};',
+			].join('\n') + '\n',
+		);
+
+		fs.writeFileSync(
+			path.join(dir, 'tsconfig.json'),
+			JSON.stringify(
+				{
+					compilerOptions: {
+						target: 'ESNext',
+						module: 'ESNext',
+						moduleResolution: 'bundler',
+						noEmit: true,
+						strict: true,
+						skipLibCheck: true,
+						types: [],
+					},
+					include: ['src/**/*'],
+				},
+				null,
+				2,
+			),
+		);
+		fs.writeFileSync(
+			path.join(dir, 'package.json'),
+			'{"name":"evt-pkg-aug-tsc"}\n',
+		);
+
+		const res = spawnSync('bunx', ['--bun', 'tsc', '--noEmit', '-p', dir], {
+			cwd: repoRoot,
+			encoding: 'utf-8',
+			timeout: 60_000,
+		});
+		return {
+			exitCode: res.status ?? -1,
+			output: (res.stdout ?? '') + (res.stderr ?? ''),
+		};
+	}
+
+	// A consumer event with a typed payload field we can read in the trigger map.
+	const inboundWebhookReceived: EventDefinition = {
+		type: 'inbound_webhook_received',
+		direction: 'inbound',
+		source: 'webhook',
+		version: 1,
+		description: 'A verified inbound webhook item was staged.',
+		payload: {
+			staging_id: { type: 'uuid', nullable: false },
+			provider: { type: 'string', nullable: false },
+		},
+		retry: { attempts: 5, backoff: 'exponential' },
+		pool: 'events_inbound',
+	};
+
+	test("consumer's own event type is accepted by BridgeRegistry with full payload typing", () => {
+		// A trigger keyed by the consumer's event, reading a typed payload field.
+		// If the augmentation did NOT merge, EventTypeName would be the package's
+		// `string` fallback (key accepted but `e.payload.stagingId` is `unknown`)
+		// OR the package's fixture union (key REJECTED). The `: string` binding on
+		// the typed read forces the strong-typing assertion.
+		const extra = [
+			"  'inbound_webhook_received': [",
+			'    {',
+			"      triggerId: 'inbound-sync#0',",
+			"      jobType: 'inbound-sync',",
+			'      map: (e) => {',
+			'        const sid: string = e.payload.stagingId;',
+			'        const prov: string = e.payload.provider;',
+			'        return { sid, prov };',
+			'      },',
+			'      when: () => true,',
+			'    },',
+			'  ],',
+		].join('\n');
+		const { exitCode, output } = runPackageAugmentationTsc(
+			[inboundWebhookReceived],
+			extra,
+		);
+		if (exitCode !== 0) {
+			throw new Error(`tsc exited ${exitCode}:\n${output}`);
+		}
+		expect(exitCode).toBe(0);
+	});
+
+	test('an unregistered event type is REJECTED (proves it is not the loose string fallback)', () => {
+		// `nope_event` is not in the augmented registry. With a real `EventTypeName`
+		// union this key is a type error; with the `string` fallback it would be
+		// accepted. We assert tsc FAILS — proving the union narrowed.
+		const extra = [
+			"  'nope_event': [",
+			'    {',
+			"      triggerId: 'x#0',",
+			"      jobType: 'x',",
+			'      map: () => ({}),',
+			'    },',
+			'  ],',
+		].join('\n');
+		const { exitCode, output } = runPackageAugmentationTsc(
+			[inboundWebhookReceived],
+			extra,
+		);
+		expect(exitCode).not.toBe(0);
+		// The error must be about the unknown key, not some unrelated breakage.
+		expect(output).toContain('nope_event');
 	});
 });
 

--- a/src/cli/shared/event-codegen-generator.ts
+++ b/src/cli/shared/event-codegen-generator.ts
@@ -53,6 +53,47 @@ import type { RuntimeMode } from './runtime-import.js';
 const PACKAGE_EVENTS_RUNTIME_IMPORT =
 	'@pattern-stack/codegen/runtime/subsystems/events/index';
 
+/**
+ * Build the package-mode `DomainEventRegistry` augmentation block (ADR-037,
+ * package-mode trigger typing). Emitted ONLY in package mode and ONLY when the
+ * project declares at least one event.
+ *
+ * The published runtime keys the bridge + job-trigger types off an EMPTY,
+ * augmentable `DomainEventRegistry` interface (events/event-registry.ts), so
+ * `EventTypeName` defaults to `string` until a consumer fills it in. This block
+ * declaration-merges the consumer's events into that interface via the events
+ * INDEX module specifier — the public, stable augmentation target the runtime
+ * re-exports the interface from. After this merges, the consumer's
+ * `bridge-registry.ts` and their `@JobHandler({ triggers })` see their own
+ * `EventTypeName` union with full `EventOfType<T>` payload typing.
+ *
+ * In vendored mode this is unnecessary (the bridge/job types import the
+ * consumer's vendored `./generated/types` directly) and not emitted, so
+ * vendored output stays byte-stable.
+ */
+function buildRegistryAugmentationBlock(events: EventDefinition[]): string {
+	const sorted = [...events].sort((a, b) => a.type.localeCompare(b.type));
+	const chunks: string[] = [];
+	chunks.push(
+		`// Package-mode trigger typing (ADR-037): merge these events into the runtime's`,
+	);
+	chunks.push(
+		`// augmentable \`DomainEventRegistry\` so the bridge + \`@JobHandler({ triggers })\``,
+	);
+	chunks.push(
+		`// types (which key off the published \`EventTypeName\`) see THIS project's events`,
+	);
+	chunks.push(`// with full \`EventOfType<T>\` payload typing.`);
+	chunks.push(`declare module '${PACKAGE_EVENTS_RUNTIME_IMPORT}' {`);
+	chunks.push(`\tinterface DomainEventRegistry {`);
+	for (const ev of sorted) {
+		chunks.push(`\t\t'${ev.type}': ${toPascalCase(ev.type)}Event;`);
+	}
+	chunks.push(`\t}`);
+	chunks.push(`}`);
+	return chunks.join('\n');
+}
+
 interface EventsRuntimeImports {
 	/** `DomainEvent`, `IEventBus`, `DrizzleTransaction`. */
 	protocol: string;
@@ -435,6 +476,16 @@ export function buildTypesContent(
 		`export type PayloadOfType<T extends EventTypeName> = EventOfType<T>['payload'];`,
 	);
 	chunks.push('');
+
+	// Package-mode augmentation (ADR-037): in package mode the bridge + trigger
+	// types key off the published runtime's augmentable `DomainEventRegistry`,
+	// not the consumer's local `EventTypeName` above. Emit a `declare module`
+	// block so they pick up this project's events. Vendored mode imports the
+	// local types directly and needs no augmentation (byte-stable).
+	if (mode === 'package') {
+		chunks.push(buildRegistryAugmentationBlock(sorted));
+		chunks.push('');
+	}
 
 	return chunks.join('\n');
 }


### PR DESCRIPTION
## The gap

A **package-mode** consumer (`runtime: package`, ADR-037) authoring a bridge
trigger on their OWN event:

```ts
@JobHandler('inbound-sync', {
  triggers: [{ event: 'inbound_webhook_received', map: e => ..., when: ... }],
})
```

failed to typecheck. The bridge + job-trigger types (`BridgeRegistry`,
`BridgeTriggerEntry<T>`, `JobTrigger<TInput>`) keyed off `EventTypeName` imported
from the bundled `events/generated/types.ts` — which in the **published** package
is codegen-patterns' OWN test-fixture union (`contact_created`, `deal_created`,
…, committed because the runtime tests depend on them). So:

- the consumer's generated `src/generated/bridge-registry.ts` reported
  `'inbound_webhook_received' does not exist in type 'BridgeRegistry'`, and
- their `@JobHandler` trigger reported `'inbound_webhook_received' is not
  assignable to '"contact_created" | …'`.

Vendored mode was fine (the bridge/job types could import the consumer's vendored
`./generated/types` directly); only package mode was broken.

## The fix — augmentable `DomainEventRegistry` (declaration merging)

- New **augmentable, empty** interface `DomainEventRegistry`
  (`runtime/subsystems/events/event-registry.ts`, re-exported from the events
  index barrel). `EventTypeName` derives from it:

  ```ts
  export interface DomainEventRegistry {}                 // empty in the package
  export type EventTypeName = keyof DomainEventRegistry extends never
    ? string
    : keyof DomainEventRegistry & string;
  export type EventOfType<T extends EventTypeName> =
    T extends keyof DomainEventRegistry ? DomainEventRegistry[T] : DomainEvent;
  ```

- The five bridge/jobs runtime files that consumed `EventTypeName`/`EventOfType`
  from the bundled fixture union (`bridge.protocol`, `job-handler.base`,
  `event-flow.service`, `bridge-outbox-drain-hook`, `bridge-delivery-handler`)
  now import them from this seam.

- In **package mode** the generated `src/generated/events/types.ts` appends a
  `declare module '@pattern-stack/codegen/runtime/subsystems/events/index' {
  interface DomainEventRegistry { '<type>': <Type>Event; … } }` block that
  declaration-merges the consumer's events into the runtime's registry through
  the events index module specifier (the stable, public augmentation target).
  Gated on `mode === 'package'` + a non-empty event set — vendored mode emits
  nothing, so vendored output is **byte-stable**.

### Why the package's own fixture tests stay green

The package's program never augments `DomainEventRegistry`, so there
`EventTypeName` falls back to `string` and the bridge/trigger types degrade to
`Record<string, …>` / `(e: DomainEvent) => …` — the loose-but-sound shape the
fixture tests rely on. The bundled `TypedEventBus` still keys off its LOCAL
`events/generated/types.ts` concrete union (so `typed.publish('contact_created',
…)` typechecks). The fixtures are never registered into `DomainEventRegistry`, so
they never leak into a consumer's `EventTypeName` even though the consumer pulls
`generated/types.d.ts` in transitively via the events index barrel.

## Validation

- **codegen-patterns**: `bun run typecheck` clean (only the 3 unrelated
  pre-existing `junction.ts` / `barrel-generator.ts:212` errors remain); full
  unit suite **2491 pass / 0 fail**; `test-baseline` (vendored byte-stability)
  green; `test-smoke-subsystems` green (consumer tree typechecks + boots);
  `bun run build` clean.
- **Cross-package declaration merging is PROVEN, not assumed.** New real-tsc unit
  tests build a faithful fake `@pattern-stack/codegen` under `node_modules/` and
  typecheck a consumer that augments via the index specifier: a registered
  event's trigger `map` reads `e.payload.<field>` fully typed, and an
  unregistered event type is **rejected** (proving the union narrowed, not the
  loose `string` fallback).
- **End-to-end in swe-brain** (package-mode dogfood) via local `bun link` +
  `entity new --all --force` + `just typecheck`: `src/generated/events`,
  `src/generated/bridge-registry.ts`, and the `@JobHandler` trigger have **zero**
  errors. A throwaway probe confirmed full payload typing now works
  (`e.payload.stagingId: string` with no cast). The only remaining swe-brain
  errors are `bun link` drizzle dual-package artifacts (two physically-distinct
  `drizzle-orm@0.45.2` copies → `PgTable`/`SQL` identity mismatch) which vanish
  with the real published package — same artifact the 0.15.0 validation hit.

## Release

`0.15.0` → `0.15.1` (package.json + CHANGELOG). Additive; vendored mode
byte-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)