### PR TITLE
fix(build): dedupe JOB_HANDLER_REGISTRY singleton across dist chunks (0.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.2] — 2026-06-03
+
+Package-mode **bridge *delivery*** — the first time a `runtime: package` consumer
+(ADR-037) drives a real event→bridge→job round-trip end to end (webhook →
+`domain_events` outbox → `bridge_delivery` → wrapper `@framework/bridge_delivery`
+run → user `@JobHandler`). Three latent defects only this path exercises (codegen's
+own tests are vendored — a single `tsc` compilation, a single in-memory Map, and a
+mocked `tx` that never touches a real FK — so none of them ever surfaced). All three
+fixes are framework-only; vendored mode is unaffected.
+
+### Fixed
+
+- **Stateful module-singletons are no longer duplicated across dist entry
+  chunks** (`tsup.config.ts`: `splitting: false` → `splitting: true`). The
+  published bundle is ESM and multi-entry — `runtime/**/*.ts` each emit a physical
+  `dist/runtime/.../x.js` so the `./runtime/*` wildcard `exports` map resolves 1:1.
+  With splitting off, esbuild INLINED every shared module into each importing entry
+  chunk. Harmless for pure functions, but a correctness bug for a stateful
+  singleton: `runtime/subsystems/jobs/job-handler.base`'s `JOB_HANDLER_REGISTRY`
+  Map (and its `HandlerRegistry` read facade), which the `@JobHandler` decorator
+  mutates at import time, got a **second copy** inlined into the `bridge/*` chunk.
+  The framework's own `@JobHandler('@framework/bridge_delivery')`
+  (`BridgeDeliveryHandler`, bridge chunk) registered into the BRIDGE copy while the
+  jobs `JobWorker` read the JOBS copy → the worker never upserted the wrapper's
+  `job` row → the bridge's outbox-drain couldn't spawn the wrapper `job_run` (its
+  `job_type` FKs `job(type)`), so the `bridge_delivery` insert violated its
+  `wrapper_run_id → job_run` FK and looped forever. `splitting: true` hoists each
+  shared module into a SINGLE shared chunk that every entry imports, collapsing the
+  registry back to one Map. The named per-entry output files are preserved (each
+  entry stays a physical `dist/runtime/.../x.js`), so the wildcard `exports` map and
+  the deep consumer subpaths (`…/subsystems/jobs/index`, `…/bridge/index`,
+  `./subsystems`) still resolve. ESM-only build ⇒ no CJS output to regress. Guarded
+  by a new dist-grep regression test.
+- **`BridgeOutboxDrainHook` now inserts the wrapper `job_run` BEFORE the
+  `bridge_delivery` that references it** (`bridge-outbox-drain-hook.ts`).
+  `bridge_delivery.wrapper_run_id → job_run(id)` is a plain (non-deferrable) FK, so
+  the referenced wrapper run must exist before the delivery row is inserted —
+  otherwise Postgres rejects the delivery insert immediately. The drain previously
+  inserted the delivery (with `wrapper_run_id` set) first, then the wrapper run; the
+  unit tests mocked `tx`, so the ordering was never validated against a real FK.
+  Idempotency is preserved: the delivery keeps its `ON CONFLICT (event_id,
+  trigger_id) DO NOTHING RETURNING`, and when it conflicts (outbox replay or
+  facade-eager Case B) the speculatively-inserted wrapper run is DELETEd in the same
+  tx, so a skipped delivery leaves no orphan `job_run`.
+- **`JobWorker.nextStepSeq` no longer array-destructures the raw `db.execute()`
+  result** (`job-worker.ts`). `db.execute(sql\`…\`)` is driver-shape-dependent and
+  not uniformly array-iterable: `drizzle-orm/node-postgres` returns the pg `Result`
+  OBJECT (`{ rows, rowCount, … }`), so `const [row] = await this.db.execute(...)`
+  threw `TypeError: {} is not iterable`. Every wrapper `@framework/bridge_delivery`
+  run calls `ctx.step` → `nextStepSeq`, so the delivery failed on every attempt. The
+  result is now normalised to a row array before reading, tolerating both the
+  node-postgres `{ rows }` shape and a plain-array shape. Guarded by a new unit test.
+
 ## [0.15.1] — 2026-06-02
 
 Package-mode **bridge/trigger event typing** — the fourth and final package-mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
+++ b/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
@@ -32,6 +32,7 @@
  */
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
 
 import type { DomainEvent, DrizzleTransaction } from '../events/event-bus.protocol';
 import { bridgeDelivery } from './bridge-delivery.schema';
@@ -143,7 +144,38 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
       const deliveryId = randomUUID();
       const wrapperRunId = randomUUID();
 
-      // 1. bridge_delivery insert with ON CONFLICT DO NOTHING + RETURNING.
+      // FK ORDER (BRIDGE / 0.15.2): `bridge_delivery.wrapper_run_id` REFERENCES
+      // `job_run(id)` is a plain (non-deferrable) FK, so the referenced
+      // wrapper `job_run` MUST exist before the delivery row that points at it
+      // is inserted — otherwise Postgres rejects the delivery insert
+      // immediately. (The codegen unit tests mock `tx`, so they never
+      // exercised this ordering against a real FK; package-mode bridge
+      // deliveries are the first to do so.) We therefore insert the wrapper
+      // run FIRST, then the delivery. Idempotency is unchanged: the delivery
+      // keeps its `ON CONFLICT (event_id, trigger_id) DO NOTHING RETURNING`,
+      // and when the delivery conflicts (outbox replay or facade-eager Case B)
+      // we DELETE the just-inserted orphan wrapper run in the same tx, so a
+      // skipped delivery leaves no stray `job_run` for a worker to claim.
+
+      // 1. Wrapper job_run insert. We carry the deliveryId into the wrapper
+      //    input so BridgeDeliveryHandler.run(ctx) can locate the row via
+      //    repo.findDeliveryById(ctx.input.deliveryId).
+      await (tx as unknown as { insert: typeof client.insert })
+        .insert(jobRuns)
+        .values({
+          id: wrapperRunId,
+          jobType: BRIDGE_DELIVERY_JOB_TYPE,
+          jobVersion: 1,
+          rootRunId: wrapperRunId,
+          pool: wrapperPool,
+          status: 'pending',
+          input: { deliveryId },
+          triggerSource: 'event',
+          triggerRef: event.id,
+          tenantId,
+        });
+
+      // 2. bridge_delivery insert with ON CONFLICT DO NOTHING + RETURNING.
       const inserted = await (tx as unknown as {
         insert: typeof client.insert;
       })
@@ -162,29 +194,20 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
         .returning({ id: bridgeDelivery.id });
 
       if (inserted.length === 0) {
-        // Case B (facade pre-wrote `delivered`) or drain replay — skip
-        // wrapper insert for this trigger. Sibling triggers still fire.
+        // Case B (facade pre-wrote `delivered`) or drain replay — the delivery
+        // already exists, so this trigger is a no-op. Remove the orphan wrapper
+        // run we speculatively inserted above so no worker claims it. Sibling
+        // triggers still fire.
+        await (tx as unknown as {
+          delete: (table: unknown) => {
+            where: (cond: unknown) => Promise<unknown>;
+          };
+        })
+          .delete(jobRuns)
+          .where(eq(jobRuns.id, wrapperRunId));
         dedupSkips++;
         continue;
       }
-
-      // 2. Wrapper job_run insert. We carry the deliveryId into the
-      //    wrapper input so BridgeDeliveryHandler.run(ctx) can locate
-      //    the row via repo.findDeliveryById(ctx.input.deliveryId).
-      await (tx as unknown as { insert: typeof client.insert })
-        .insert(jobRuns)
-        .values({
-          id: wrapperRunId,
-          jobType: BRIDGE_DELIVERY_JOB_TYPE,
-          jobVersion: 1,
-          rootRunId: wrapperRunId,
-          pool: wrapperPool,
-          status: 'pending',
-          input: { deliveryId },
-          triggerSource: 'event',
-          triggerRef: event.id,
-          tenantId,
-        });
 
       delivered++;
     }

--- a/runtime/subsystems/jobs/job-worker.ts
+++ b/runtime/subsystems/jobs/job-worker.ts
@@ -609,19 +609,25 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
    * worker resumes via stale-claim sweep).
    */
   private async nextStepSeq(runId: string): Promise<number> {
-    const [row] = await this.db.execute(
+    const result = await this.db.execute(
       sql`SELECT COALESCE(MAX(seq), 0) + 1 AS next FROM job_step WHERE job_run_id = ${runId}`,
-    ) as unknown as Array<{ next: number }>;
-    // pg driver returns { rows: [...] } for raw execute; tolerate both shapes.
+    );
+    // Driver shape varies and is NOT uniformly array-iterable, so we must
+    // never array-destructure the raw result (that throws `{} is not iterable`
+    // on the node-postgres `Result` object, which exposes `.rows` instead of
+    // being an array — first hit by package-mode bridge deliveries on
+    // `drizzle-orm/node-postgres`). Normalise to a row array first, then read.
+    //   - node-postgres `db.execute(sql)` → `{ rows: [{ next }], ... }`
+    //   - some drivers / future shapes → a plain `[{ next }]` array
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const maybeRows = (row as any)?.rows;
-    if (Array.isArray(maybeRows) && maybeRows.length > 0) {
-      return Number(maybeRows[0].next ?? 1);
-    }
-    if (row && typeof (row as { next?: unknown }).next !== 'undefined') {
-      return Number((row as { next: unknown }).next);
-    }
-    return 1;
+    const raw = result as any;
+    const rows: Array<{ next?: unknown }> = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.rows)
+        ? raw.rows
+        : [];
+    const next = rows[0]?.next;
+    return typeof next === 'undefined' ? 1 : Number(next);
   }
 
   // ============================================================================

--- a/src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts
@@ -23,34 +23,44 @@ import type { DomainEvent } from '../../../../runtime/subsystems/events/event-bu
 // ─── Fluent insert mock ─────────────────────────────────────────────────────
 
 type InsertCall = { table: string; values: Record<string, unknown> };
+type DeleteCall = { table: string };
+
+function tableName(table: unknown): string {
+  // Drizzle's `pgTable` exposes the table name via the
+  // `Symbol(drizzle:Name)` Symbol-keyed property. Look it up
+  // generically rather than relying on the public surface.
+  const sym = Object.getOwnPropertySymbols(table as object).find(
+    (s) => String(s) === 'Symbol(drizzle:Name)',
+  );
+  return sym ? ((table as Record<symbol, unknown>)[sym] as string) : 'unknown';
+}
 
 function makeTx(insertedIdResults: Array<string[]>) {
   // `insertedIdResults[i]` controls what the i-th INSERT-with-RETURNING
   // returns (`[id]` for "row inserted", `[]` for "ON CONFLICT skipped").
   // INSERTs without `.returning` are wrapper job_run inserts; they
   // don't consume a slot from this list.
+  //
+  // FK-order note (0.15.2): the hook now inserts the wrapper `job_run`
+  // FIRST, then the `bridge_delivery` (so the non-deferrable
+  // `wrapper_run_id → job_run` FK is satisfied), and on an ON-CONFLICT
+  // delivery it DELETEs the speculative wrapper run. `calls` records inserts
+  // in fire order; `deletes` records orphan-wrapper cleanups.
   const calls: InsertCall[] = [];
+  const deletes: DeleteCall[] = [];
   let returningCallIdx = 0;
 
   const tx = {
     insert(table: unknown) {
-      // Drizzle's `pgTable` exposes the table name via the
-      // `Symbol(drizzle:Name)` Symbol-keyed property. Look it up
-      // generically rather than relying on the public surface.
-      const sym = Object.getOwnPropertySymbols(table as object).find(
-        (s) => String(s) === 'Symbol(drizzle:Name)',
-      );
-      const name = sym
-        ? ((table as Record<symbol, unknown>)[sym] as string)
-        : 'unknown';
+      const name = tableName(table);
       const builder = {
         values(v: Record<string, unknown>) {
           calls.push({ table: name, values: v });
           // Return both shapes: with onConflictDoNothing for the
           // delivery insert, and a plain promise for the wrapper insert.
           // The bridge hook consistently chains:
-          //   .insert(bridgeDelivery).values(...).onConflictDoNothing(...).returning(...)
           //   .insert(jobRuns).values(...)            ← awaited as Promise
+          //   .insert(bridgeDelivery).values(...).onConflictDoNothing(...).returning(...)
           const chain = {
             onConflictDoNothing(_opts: unknown) {
               return {
@@ -75,8 +85,17 @@ function makeTx(insertedIdResults: Array<string[]>) {
       };
       return builder;
     },
+    delete(table: unknown) {
+      const name = tableName(table);
+      return {
+        where(_cond: unknown) {
+          deletes.push({ table: name });
+          return Promise.resolve([]);
+        },
+      };
+    },
   };
-  return { tx, calls };
+  return { tx, calls, deletes };
 }
 
 function event(overrides: Partial<DomainEvent> = {}): DomainEvent {
@@ -157,23 +176,24 @@ describe('BridgeOutboxDrainHook — happy path', () => {
       auditBlocked: 0,
     });
 
-    // Expect 4 inserts: 2 delivery + 2 wrapper, interleaved.
+    // Expect 4 inserts: per trigger the wrapper job_run FIRST, then the
+    // bridge_delivery (FK order). No orphan deletes on the happy path.
     expect(calls).toHaveLength(4);
-    expect(calls[0]!.table).toBe('bridge_delivery');
-    expect(calls[1]!.table).toBe('job_run');
-    expect(calls[2]!.table).toBe('bridge_delivery');
-    expect(calls[3]!.table).toBe('job_run');
+    expect(calls[0]!.table).toBe('job_run');
+    expect(calls[1]!.table).toBe('bridge_delivery');
+    expect(calls[2]!.table).toBe('job_run');
+    expect(calls[3]!.table).toBe('bridge_delivery');
 
     // Wrappers route into events_change (matches event direction).
-    expect(calls[1]!.values['pool']).toBe('events_change');
-    expect(calls[3]!.values['pool']).toBe('events_change');
-    expect(calls[1]!.values['jobType']).toBe('@framework/bridge_delivery');
-    expect(calls[1]!.values['triggerSource']).toBe('event');
-    expect(calls[1]!.values['triggerRef']).toBe('evt-1');
+    expect(calls[0]!.values['pool']).toBe('events_change');
+    expect(calls[2]!.values['pool']).toBe('events_change');
+    expect(calls[0]!.values['jobType']).toBe('@framework/bridge_delivery');
+    expect(calls[0]!.values['triggerSource']).toBe('event');
+    expect(calls[0]!.values['triggerRef']).toBe('evt-1');
 
     // bridge_delivery rows carry trigger_id from the registry entry.
-    expect(calls[0]!.values['triggerId']).toBe('send_welcome_email#0');
-    expect(calls[2]!.values['triggerId']).toBe('integration_contact_to_hubspot#0');
+    expect(calls[1]!.values['triggerId']).toBe('send_welcome_email#0');
+    expect(calls[3]!.values['triggerId']).toBe('integration_contact_to_hubspot#0');
   });
 
   it('routes wrapper pool by event direction (inbound/change/outbound)', async () => {
@@ -204,11 +224,11 @@ describe('BridgeOutboxDrainHook — happy path', () => {
 });
 
 describe('BridgeOutboxDrainHook — Case B / replay dedup', () => {
-  it('skips wrapper insert for the trigger whose delivery insert hit ON CONFLICT', async () => {
+  it('rolls back the speculative wrapper for the trigger whose delivery hit ON CONFLICT', async () => {
     const hook = new BridgeOutboxDrainHook(REGISTRY_TWO_TRIGGERS);
     // First delivery insert returns empty (ON CONFLICT — facade pre-write
     // or replay); second succeeds.
-    const { tx, calls } = makeTx([[], ['del-2']]);
+    const { tx, calls, deletes } = makeTx([[], ['del-2']]);
 
     const result = await hook.processEvent(event(), tx as never);
 
@@ -219,20 +239,25 @@ describe('BridgeOutboxDrainHook — Case B / replay dedup', () => {
       auditBlocked: 0,
     });
 
-    // 1 dedup-skipped delivery insert + 1 successful delivery insert + 1
-    // wrapper insert = 3 calls total. The first trigger's wrapper is
-    // skipped; the second still fires.
-    expect(calls).toHaveLength(3);
-    expect(calls[0]!.table).toBe('bridge_delivery'); // skipped
-    expect(calls[1]!.table).toBe('bridge_delivery'); // succeeded
-    expect(calls[2]!.table).toBe('job_run');
+    // FK order: each trigger inserts wrapper job_run THEN delivery. The first
+    // trigger's delivery conflicts → its speculative wrapper is DELETEd; the
+    // second trigger delivers normally (no delete).
+    expect(calls).toHaveLength(4);
+    expect(calls[0]!.table).toBe('job_run'); // trigger 1 wrapper (rolled back)
+    expect(calls[1]!.table).toBe('bridge_delivery'); // trigger 1 delivery (skipped)
+    expect(calls[2]!.table).toBe('job_run'); // trigger 2 wrapper (kept)
+    expect(calls[3]!.table).toBe('bridge_delivery'); // trigger 2 delivery (succeeded)
     expect(calls[2]!.values['pool']).toBe('events_change');
-    expect(calls[1]!.values['triggerId']).toBe('integration_contact_to_hubspot#0');
+    expect(calls[3]!.values['triggerId']).toBe('integration_contact_to_hubspot#0');
+
+    // Exactly one orphan wrapper run cleaned up (the skipped trigger's).
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]!.table).toBe('job_run');
   });
 
-  it('all triggers ON CONFLICT → all wrappers skipped; no job_run inserts', async () => {
+  it('all triggers ON CONFLICT → every speculative wrapper rolled back; net zero job_run rows', async () => {
     const hook = new BridgeOutboxDrainHook(REGISTRY_TWO_TRIGGERS);
-    const { tx, calls } = makeTx([[], []]);
+    const { tx, calls, deletes } = makeTx([[], []]);
     const result = await hook.processEvent(event(), tx as never);
     expect(result).toEqual({
       delivered: 0,
@@ -240,7 +265,9 @@ describe('BridgeOutboxDrainHook — Case B / replay dedup', () => {
       triggerCount: 2,
       auditBlocked: 0,
     });
-    expect(calls.filter((c) => c.table === 'job_run')).toHaveLength(0);
+    // Both wrappers were speculatively inserted then deleted → net zero.
+    expect(calls.filter((c) => c.table === 'job_run')).toHaveLength(2);
+    expect(deletes.filter((d) => d.table === 'job_run')).toHaveLength(2);
   });
 });
 

--- a/src/__tests__/runtime/subsystems/dist-singleton-dedup.spec.ts
+++ b/src/__tests__/runtime/subsystems/dist-singleton-dedup.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Dist-singleton dedup regression (0.15.2).
+ *
+ * The published bundle is ESM, multi-entry (`runtime/**\/*.ts` each become a
+ * physical `dist/runtime/.../x.js` so the `./runtime/*` wildcard `exports` map
+ * resolves 1:1). Before 0.15.2 the build ran with `splitting: false`, so esbuild
+ * INLINED every shared module into each entry chunk that imported it. For pure
+ * functions / types that is harmless, but for a STATEFUL module-singleton it is
+ * a correctness bug: `runtime/subsystems/jobs/job-handler.base`'s
+ * `JOB_HANDLER_REGISTRY` Map (mutated at import time by the `@JobHandler`
+ * decorator) was duplicated across the `jobs/*` and `bridge/*` entry chunks. The
+ * framework's own `@JobHandler('@framework/bridge_delivery')` (in the bridge
+ * chunk) then registered into the BRIDGE copy while the jobs `JobWorker` read the
+ * JOBS copy → the worker never upserted the wrapper's `job` row → package-mode
+ * bridge deliveries deadlocked on the `job_run.job_type → job(type)` FK.
+ *
+ * `tsup.config.ts` now sets `splitting: true`, which hoists each such shared
+ * module into a SINGLE shared chunk that every entry imports. This test guards
+ * that invariant against the BUILT dist: there must be exactly one
+ * `JOB_HANDLER_REGISTRY = new Map()` definition and one `HandlerRegistry`
+ * read-facade implementation across all emitted `.js`.
+ *
+ * Skips when `dist/` is absent (e.g. a fresh checkout before `bun run build`) so
+ * `bun test` stays green without a prior build; CI builds before testing.
+ */
+import { describe, it, expect } from 'bun:test';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DIST = join(import.meta.dir, '../../../../dist');
+
+/** All `.js` files under dist (excludes `.js.map`, which embed source text). */
+function distJsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...distJsFiles(full));
+    } else if (entry.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function countMatches(files: string[], pattern: RegExp): number {
+  let n = 0;
+  for (const f of files) {
+    const src = readFileSync(f, 'utf8');
+    const m = src.match(pattern);
+    if (m) n += m.length;
+  }
+  return n;
+}
+
+const describeOrSkip = existsSync(DIST) ? describe : describe.skip;
+
+describeOrSkip('dist singleton dedup (0.15.2 — splitting hoists shared state)', () => {
+  const files = existsSync(DIST) ? distJsFiles(DIST) : [];
+
+  it('emits exactly ONE JOB_HANDLER_REGISTRY Map across the whole bundle', () => {
+    // The decorator's write target. >1 copy ⇒ register-vs-read split the Map.
+    const count = countMatches(files, /JOB_HANDLER_REGISTRY = (?:\/\* @__PURE__ \*\/ )?new Map/g);
+    expect(count).toBe(1);
+  });
+
+  it('emits exactly ONE HandlerRegistry read-facade implementation', () => {
+    // `HandlerRegistry.getAll()` is backed by `Array.from(JOB_HANDLER_REGISTRY.values())`.
+    // A duplicated impl ⇒ a second namespace over a second Map.
+    const count = countMatches(
+      files,
+      /Array\.from\(JOB_HANDLER_REGISTRY\.values\(\)\)/g,
+    );
+    expect(count).toBe(1);
+  });
+
+  it('shares that singleton chunk between the jobs worker and the bridge handler', () => {
+    // Both the @JobHandler-decorated BridgeDeliveryHandler (bridge entry) and the
+    // JobWorker (jobs entry) must import the SAME chunk that defines the Map.
+    const registryChunk = files.find((f) =>
+      /JOB_HANDLER_REGISTRY = (?:\/\* @__PURE__ \*\/ )?new Map/.test(
+        readFileSync(f, 'utf8'),
+      ),
+    );
+    expect(registryChunk).toBeDefined();
+    const chunkBase = registryChunk!.split('/').pop()!;
+
+    const bridgeHandler = readFileSync(
+      join(DIST, 'runtime/subsystems/bridge/bridge-delivery-handler.js'),
+      'utf8',
+    );
+    const jobWorker = readFileSync(
+      join(DIST, 'runtime/subsystems/jobs/job-worker.js'),
+      'utf8',
+    );
+    expect(bridgeHandler).toContain(chunkBase);
+    expect(jobWorker).toContain(chunkBase);
+  });
+});

--- a/src/__tests__/runtime/subsystems/job-worker.next-step-seq.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-worker.next-step-seq.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * `JobWorker.nextStepSeq` driver-shape regression (0.15.2).
+ *
+ * `nextStepSeq` allocates the next `job_step.seq` for a run via a raw
+ * `this.db.execute(sql\`SELECT COALESCE(MAX(seq),0)+1 ...\`)`. The result shape
+ * of `db.execute(sql)` is driver-dependent and NOT uniformly array-iterable:
+ * `drizzle-orm/node-postgres` returns the pg `Result` OBJECT (`{ rows, rowCount,
+ * ... }`), which is not an array. The original code array-destructured the raw
+ * result (`const [row] = await this.db.execute(...)`), so under node-postgres it
+ * threw `TypeError: {} is not iterable` — first hit by package-mode bridge
+ * deliveries, whose wrapper `@framework/bridge_delivery` run calls `ctx.step`
+ * (→ `nextStepSeq`) and so failed every attempt, deadlocking the delivery.
+ *
+ * The fix normalises the result to a row array BEFORE reading, so both the
+ * node-postgres `{ rows }` shape and a plain-array shape work. These tests pin
+ * that `nextStepSeq` is shape-tolerant and never array-destructures the raw
+ * result.
+ */
+import 'reflect-metadata';
+import { describe, expect, it } from 'bun:test';
+
+import { JobWorker } from '../../../../runtime/subsystems/jobs/job-worker';
+
+/**
+ * Build a `JobWorker` with a stub `db` whose `execute` returns `shape`. Only
+ * `nextStepSeq` (which reads `this.db.execute`) is exercised; the worker's
+ * polling/sweeper timers are never started (we don't call `onModuleInit`).
+ */
+function workerWithExecuteResult(shape: unknown): JobWorker {
+  const db = {
+    execute: () => Promise.resolve(shape),
+  } as unknown as ConstructorParameters<typeof JobWorker>[0];
+  // The remaining constructor args are unused by nextStepSeq.
+  return new JobWorker(
+    db,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    {} as never,
+  );
+}
+
+/** Invoke the private `nextStepSeq` without widening its visibility in source. */
+function nextStepSeq(worker: JobWorker, runId: string): Promise<number> {
+  return (
+    worker as unknown as { nextStepSeq(id: string): Promise<number> }
+  ).nextStepSeq(runId);
+}
+
+describe('JobWorker.nextStepSeq — driver-shape tolerance (0.15.2)', () => {
+  it('reads the next seq from the node-postgres { rows: [...] } result (no `{} is not iterable`)', async () => {
+    const worker = workerWithExecuteResult({ rows: [{ next: 7 }], rowCount: 1 });
+    await expect(nextStepSeq(worker, 'run-1')).resolves.toBe(7);
+  });
+
+  it('reads the next seq from a plain-array result shape', async () => {
+    const worker = workerWithExecuteResult([{ next: 4 }]);
+    await expect(nextStepSeq(worker, 'run-1')).resolves.toBe(4);
+  });
+
+  it('defaults to 1 when the result is an empty { rows: [] }', async () => {
+    const worker = workerWithExecuteResult({ rows: [] });
+    await expect(nextStepSeq(worker, 'run-1')).resolves.toBe(1);
+  });
+
+  it('does not throw on a non-iterable empty-object result (the original bug)', async () => {
+    const worker = workerWithExecuteResult({});
+    await expect(nextStepSeq(worker, 'run-1')).resolves.toBe(1);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,24 @@ import { defineConfig } from "tsup";
  *
  * ESM-only output targeting Node 20+. Bun runs ESM natively. CJS consumers
  * are out of scope — @pattern-stack/codegen is a 2026-era tool.
+ *
+ * `splitting: true` (0.15.2): esbuild ESM code-splitting hoists any module
+ * imported by >1 entry into a single SHARED chunk that those entries import,
+ * instead of INLINING a fresh copy into every entry. This is required for
+ * correctness, not just size: stateful module-singletons — chiefly
+ * `runtime/subsystems/jobs/job-handler.base`'s `JOB_HANDLER_REGISTRY` Map and
+ * its `HandlerRegistry` namespace, mutated at import time by the `@JobHandler`
+ * decorator — were being duplicated across the `jobs/*` and `bridge/*` entry
+ * chunks. The framework's own `@JobHandler('@framework/bridge_delivery')`
+ * registered into the bridge chunk's copy while the jobs `JobWorker` read the
+ * jobs chunk's copy, so the worker never upserted the handler's `job` row and
+ * package-mode bridge *deliveries* deadlocked on the `wrapper_run_id` FK.
+ * Splitting collapses these to one shared chunk → one Map. The named per-entry
+ * output files are preserved (each entry stays a physical `dist/runtime/.../x.js`),
+ * so the `./runtime/*` wildcard `exports` map + the deep consumer subpaths
+ * (`.../subsystems/jobs/index`, `.../bridge/index`, `./subsystems`) still
+ * resolve 1:1. Safe because the build is ESM-only (esbuild splitting is an
+ * ESM-only feature; there is no CJS output to regress).
  */
 export default defineConfig({
   entry: [
@@ -28,7 +46,7 @@ export default defineConfig({
     },
   },
   tsconfig: "tsconfig.build.json",
-  splitting: false,
+  splitting: true,
   sourcemap: true,
   outExtension: () => ({ js: ".js" }),
 });


### PR DESCRIPTION
## Summary

First time a **package-mode** consumer (`runtime: package`, ADR-037) drives a real **event → bridge → job *delivery*** end to end (webhook → `domain_events` outbox → `bridge_delivery` → wrapper `@framework/bridge_delivery` run → user `@JobHandler`). Three latent framework defects only this path exercises — codegen's own tests + dealbrain are **vendored** (a single `tsc` compilation = a single in-memory Map; a mocked `tx` that never touches a real FK), so none ever surfaced. All three fixes are framework-only; **vendored mode is byte-stable**.

### 1. Duplicated `JOB_HANDLER_REGISTRY` singleton across dist chunks (the headline)
`tsup.config.ts` ran with `splitting: false`, so esbuild **inlined** every shared module into each entry chunk that imported it. `runtime/subsystems/jobs/job-handler.base`'s `JOB_HANDLER_REGISTRY` Map — mutated at import time by the `@JobHandler` decorator — got a **second copy** inlined into the `bridge/*` chunk. The framework's own `@JobHandler('@framework/bridge_delivery')` (`BridgeDeliveryHandler`, bridge chunk) registered into the BRIDGE copy while the jobs `JobWorker` read the JOBS copy → the worker never upserted the wrapper's `job` row → the bridge outbox-drain couldn't spawn the wrapper `job_run` (its `job_type` FKs `job(type)`) → the `bridge_delivery` insert violated its `wrapper_run_id → job_run` FK and looped forever.

**Fix:** `splitting: true` hoists each shared module into a **single shared chunk** every entry imports. The named per-entry output files are preserved (each entry stays a physical `dist/runtime/.../x.js`), so the `./runtime/*` wildcard `exports` map + deep consumer subpaths (`…/subsystems/jobs/index`, `…/bridge/index`, `./subsystems`) still resolve 1:1. ESM-only build ⇒ no CJS output to regress.

**Proof (rebuilt dist):** exactly **one** `JOB_HANDLER_REGISTRY = new Map()` and one `HandlerRegistry` impl, in `chunk-CO6LUM72.js`, imported by **both** `bridge/bridge-delivery-handler.js` and `jobs/job-worker.js`.

### 2. `BridgeOutboxDrainHook` insert order vs the non-deferrable FK
`bridge_delivery.wrapper_run_id → job_run(id)` is a plain (non-deferrable) FK, so the wrapper run must exist **before** the delivery that references it. The drain inserted the delivery first (unit tests mock `tx`, so the ordering was never validated against a real FK). Now it inserts the wrapper `job_run` first, then the delivery (`ON CONFLICT (event_id, trigger_id) DO NOTHING RETURNING` preserved), and **DELETEs the speculative wrapper in-tx** when the delivery conflicts (outbox replay / facade-eager Case B) so no orphan `job_run` is left.

### 3. `JobWorker.nextStepSeq` array-destructured the raw `db.execute()` result
`db.execute(sql\`…\`)` is driver-shape-dependent and not uniformly array-iterable: `drizzle-orm/node-postgres` returns the pg `Result` **object** (`{ rows, rowCount, … }`), so `const [row] = await this.db.execute(...)` threw `TypeError: {} is not iterable`. Every wrapper run calls `ctx.step` → `nextStepSeq`, so the delivery failed on every attempt. Now normalised to a row array before reading; tolerates both the `{ rows }` and plain-array shapes.

## Tests / validation
- New regression guards: `dist-singleton-dedup.spec.ts` (greps the built dist for a single registry Map + impl, shared between the jobs + bridge entries) and `job-worker.next-step-seq.spec.ts` (`nextStepSeq` shape tolerance).
- Unit suite **2498 pass / 0 fail**; `test-baseline` + `test-smoke-subsystems` green; typecheck clean (3 pre-existing `junction.ts`/`barrel-generator.ts` errors unrelated).
- **Real proof — consumer e2e GOLDEN PATH PASS** via a faithful package-mode install (packed tarball, not `bun link`): swe-brain `inbound-spine-e2e` lands all four hops — `inbound_webhook_events` (processed) → `domain_events` → `bridge_delivery` (delivered) → `job_run` `inbound-sync` (completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)