### PR TITLE
fix(integration): WebhookChangeSource reads externalId via mapping.source, not target (0.15.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.3] — 2026-06-03
+
+Package-mode **inbound webhook drain** — the first real exercise of
+`WebhookChangeSource` by a `runtime: package` consumer (swe-brain's Slack
+inbound pipeline-parity drain, ADR-0009 §6). One latent transposition this path
+exercises; the fix is framework-only.
+
+### Fixed
+
+- **`WebhookChangeSource` (and the identically-shaped `PollChangeSource`) now
+  derive `Change<T>.externalId` from the mapping `source`, not `target`.** Both
+  primitives located the `DetectionConfig` mapping entry with `target ===
+  'external_id'` correctly, then read the emitted record off
+  `mapping.target` — a transposition. Mapping semantics are `{ source: <field on
+  the emitted record>, target: <canonical column> }`, and `fetch()` reads
+  `record[externalIdSourceField]` off the emitted record, so it must use
+  `.source`. The two diverge only when the canonical record is vendor-neutral
+  camelCase (`source: 'externalId'` → `target: 'external_id'`): such a consumer
+  hit `record missing string 'external_id'` and the primitive was unusable. The
+  original unit fixtures masked it by keying records `external_id` (== the
+  target). Regression tests now cover the camelCase consumer shape directly.
+
+### Added
+
+- **Webhook/poll/detection symbols re-exported from
+  `@pattern-stack/codegen/subsystems`.** `WebhookChangeSource`,
+  `WebhookChangeSourceOptions`, `WebhookFetchCallback`, `WebhookFetchContext`,
+  `WebhookCursor`, `buildChangeSource`, `DetectionConfigSchema`,
+  `DetectionConfig` (+ poll equivalents) were previously reachable only via the
+  deep `.../integration/index` path; they now ride the public barrel alongside
+  the curated `IncrementalReadBase` / `ExecuteIntegrationUseCase` forwards.
+
 ## [0.15.2] — 2026-06-03
 
 Package-mode **bridge *delivery*** — the first time a `runtime: package` consumer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/index.ts
+++ b/runtime/subsystems/index.ts
@@ -92,6 +92,33 @@ export type {
   SourcedRecord,
 } from './integration';
 
+// Integration — change-source primitives + DetectionConfig (#226-3/4, ADR-033).
+// Re-exported here so consumers authoring a webhook/poll drain across the
+// package boundary import them from `@pattern-stack/codegen/subsystems` instead
+// of reaching into the deep `.../integration/index` path. Surfaced by the
+// swe-brain dogfood (gap #6 — the first real consumer of `WebhookChangeSource`,
+// whose Slack inbound drain otherwise had to deep-import the primitive +
+// `DetectionConfigSchema`). Selective re-export (mirrors the curated
+// `IncrementalReadBase` / `ExecuteIntegrationUseCase` forwards above) — not
+// `export *`, to keep the `IntegrationRunSummary` name clash contained.
+export {
+  WebhookChangeSource,
+  PollChangeSource,
+  buildChangeSource,
+  DetectionConfigSchema,
+} from './integration';
+export type {
+  WebhookChangeSourceOptions,
+  WebhookFetchCallback,
+  WebhookFetchContext,
+  WebhookCursor,
+  PollChangeSourceOptions,
+  PollFetchCallback,
+  PollFetchContext,
+  PollCursor,
+  DetectionConfig,
+} from './integration';
+
 // Integration — assembly emission (RFC-0002). The generated per-entity sink
 // imports `IIntegrationSink`; the generated per-entity assembly module imports
 // `ExecuteIntegrationUseCase` + `INTEGRATION_CHANGE_SOURCE` + `INTEGRATION_SINK`

--- a/runtime/subsystems/integration/poll-change-source.ts
+++ b/runtime/subsystems/integration/poll-change-source.ts
@@ -133,11 +133,14 @@ export class PollChangeSource<T> implements IChangeSource<T> {
     }
     const config = opts.config;
 
-    // Field mapping: locate the canonical `external_id` target. Adapters
-    // emit T already-mapped, but the primitive needs to know which key on
-    // T carries the external id so it can stamp `Change.externalId`. Source
-    // of truth is the mapping table — codegen emits it from YAML, the
-    // primitive reads it here.
+    // Field mapping: locate the entry whose canonical `target` is `external_id`.
+    // Adapters emit T already-mapped, but the primitive needs to know which key
+    // on T carries the external id so it can stamp `Change.externalId`. That key
+    // is the mapping's `source` (the field on the emitted record), NOT its
+    // `target` (the canonical column) — they differ whenever the canonical
+    // record is vendor-neutral camelCase (e.g. `source: 'externalId'` →
+    // `target: 'external_id'`). Source of truth is the mapping table — codegen
+    // emits it from YAML, the primitive reads it here.
     const externalIdMapping = config.mapping.find(
       (m) => m.target === 'external_id',
     );
@@ -146,7 +149,7 @@ export class PollChangeSource<T> implements IChangeSource<T> {
         "PollChangeSource: DetectionConfig.mapping must include an entry with target 'external_id' so emitted Change<T>.externalId can be populated",
       );
     }
-    this.externalIdSourceField = externalIdMapping.target;
+    this.externalIdSourceField = externalIdMapping.source;
 
     this.adapter = opts.adapter;
     this.filters = config.filters;
@@ -196,7 +199,7 @@ export class PollChangeSource<T> implements IChangeSource<T> {
       ];
       if (typeof externalIdRaw !== 'string' || externalIdRaw.length === 0) {
         throw new Error(
-          `PollChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping target`,
+          `PollChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping source`,
         );
       }
       let dedupKey: string | undefined;

--- a/runtime/subsystems/integration/webhook-change-source.ts
+++ b/runtime/subsystems/integration/webhook-change-source.ts
@@ -9,8 +9,9 @@
  *   - canonical `Change<T>.source = 'webhook'` stamping;
  *   - `dedupKey` derivation from the configured `webhook.eventIdField` on
  *     the emitted record;
- *   - `externalId` derivation from the mapping table's `external_id` target
- *     (mirrors `PollChangeSource`);
+ *   - `externalId` derivation: the mapping entry whose `target === 'external_id'`
+ *     names — via its `source` — the field on the emitted record that carries
+ *     the canonical external id (mirrors `PollChangeSource`);
  *   - middleware-chain composition via the locked `ChangeMiddleware<T>` shape
  *     (#226-1) — same composition seam as the poll primitive.
  *
@@ -132,10 +133,13 @@ export class WebhookChangeSource<T> implements IChangeSource<T> {
     }
     const config = opts.config;
 
-    // Field mapping: locate the canonical `external_id` target — mirrors the
-    // poll primitive's contract. Adapters emit records already-mapped; the
-    // primitive needs to know which key on T carries the external id so it
-    // can stamp `Change.externalId`.
+    // Field mapping: locate the entry whose canonical `target` is `external_id`
+    // — mirrors the poll primitive's contract. Adapters emit records
+    // already-mapped; the primitive needs to know which key on T carries the
+    // external id so it can stamp `Change.externalId`. That key is the
+    // mapping's `source` (the field on the emitted record), NOT its `target`
+    // (the canonical column) — they differ whenever the canonical record is
+    // vendor-neutral camelCase (e.g. `source: 'externalId'` → `target: 'external_id'`).
     const externalIdMapping = config.mapping.find(
       (m) => m.target === 'external_id',
     );
@@ -144,7 +148,7 @@ export class WebhookChangeSource<T> implements IChangeSource<T> {
         "WebhookChangeSource: DetectionConfig.mapping must include an entry with target 'external_id' so emitted Change<T>.externalId can be populated",
       );
     }
-    this.externalIdSourceField = externalIdMapping.target;
+    this.externalIdSourceField = externalIdMapping.source;
     this.eventIdSourceField = config.webhook.eventIdField;
 
     this.queue = opts.queue;
@@ -183,7 +187,7 @@ export class WebhookChangeSource<T> implements IChangeSource<T> {
       ];
       if (typeof externalIdRaw !== 'string' || externalIdRaw.length === 0) {
         throw new Error(
-          `WebhookChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping target`,
+          `WebhookChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping source`,
         );
       }
       const eventIdRaw = (record as Record<string, unknown>)[

--- a/src/__tests__/runtime/subsystems/build-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/build-change-source.spec.ts
@@ -39,11 +39,17 @@ const subscription: IntegrationSubscriptionView = {
   externalRef: 'sf-org-A',
 };
 
+// The fetch callbacks below emit ALREADY-MAPPED canonical records keyed
+// `external_id`. The primitive reads `record[mapping.source]`, so `source` must
+// match the emitted key (`external_id`), NOT `'Id'`/`'id'`. The original
+// fixtures declared `source: 'Id'`/`'id'` while emitting `external_id` keys;
+// that only passed because the pre-fix primitive read `.target` — the gap #6
+// transposition this PR fixes.
 function pollConfig(): DetectionConfig {
   return {
     mode: 'poll',
     poll: { cursor: { kind: 'systemModstamp', field: 'modstamp' } },
-    mapping: [{ source: 'Id', target: 'external_id' }],
+    mapping: [{ source: 'external_id', target: 'external_id' }],
     filters: [],
   } as DetectionConfig;
 }
@@ -52,12 +58,12 @@ function webhookConfig(): DetectionConfig {
   return {
     mode: 'webhook',
     webhook: { eventIdField: 'event_id' },
-    mapping: [{ source: 'id', target: 'external_id' }],
+    mapping: [{ source: 'external_id', target: 'external_id' }],
     filters: [],
   } as DetectionConfig;
 }
 
-async function collect<T>(it: AintegrationIterable<T>): Promise<T[]> {
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = [];
   for await (const x of it) out.push(x);
   return out;

--- a/src/__tests__/runtime/subsystems/poll-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/poll-change-source.spec.ts
@@ -52,16 +52,21 @@ function makeConfig(extra?: Partial<DetectionConfig>): DetectionConfig {
     poll: {
       cursor: { kind: 'systemModstamp', field: 'modstamp' },
     },
+    // The adapter yields ALREADY-MAPPED canonical records keyed `external_id`/
+    // `name`; the primitive reads `record[mapping.source]`, so `source` must
+    // match those keys. (The original fixtures declared `source: 'Id'`/`'Name'`
+    // while emitting `external_id`/`name`; that only passed because the pre-fix
+    // primitive read `.target` — the gap #6 transposition this PR fixes.)
     mapping: [
-      { source: 'Id', target: 'external_id' },
-      { source: 'Name', target: 'name' },
+      { source: 'external_id', target: 'external_id' },
+      { source: 'name', target: 'name' },
     ],
     filters: [{ field: 'StageName', op: 'eq', value: 'Won' }],
     ...(extra as object),
   } as DetectionConfig;
 }
 
-async function collect<T>(it: AintegrationIterable<T>): Promise<T[]> {
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = [];
   for await (const x of it) out.push(x);
   return out;
@@ -162,7 +167,7 @@ describe('PollChangeSource — filter passthrough', () => {
     const config: DetectionConfig = {
       mode: 'poll',
       poll: { cursor: { kind: 'systemModstamp', field: 'modstamp' } },
-      mapping: [{ source: 'Id', target: 'external_id' }],
+      mapping: [{ source: 'external_id', target: 'external_id' }],
       filters: [],
     };
     const src = new PollChangeSource<OppRecord>({ adapter, config });
@@ -176,7 +181,7 @@ describe('PollChangeSource — filter passthrough', () => {
 // ---------------------------------------------------------------------------
 
 describe('PollChangeSource — field mapping', () => {
-  it('uses the mapping target "external_id" to populate Change.externalId', async () => {
+  it('uses the mapping source for external_id to populate Change.externalId', async () => {
     const adapter: PollFetchCallback<OppRecord> = async function* () {
       yield {
         record: { external_id: 'OPP-42', name: 'Mapped', modstamp: 't' },
@@ -189,6 +194,38 @@ describe('PollChangeSource — field mapping', () => {
     });
     const [change] = await collect(src.listChanges(subscription, null));
     expect(change.externalId).toBe('OPP-42');
+  });
+
+  // Regression for the gap #6 transposition (shared with WebhookChangeSource):
+  // when the canonical record is vendor-neutral camelCase the mapping `source`
+  // (`externalId`) diverges from its `target` (`external_id`). The primitive
+  // MUST read `record[source]`. The buggy `.target` lookup looked up
+  // `record['external_id']` → undefined → spurious "record missing string".
+  it('reads externalId via mapping.source when source diverges from target (camelCase canonical)', async () => {
+    interface CamelRecord {
+      externalId: string;
+      name: string;
+      modstamp: string;
+    }
+    const adapter: PollFetchCallback<CamelRecord> = async function* () {
+      // keyed `externalId` only — deliberately NO `external_id` key.
+      yield {
+        record: { externalId: 'gh:42', name: 'Camel', modstamp: 't' },
+        cursor: { systemModstamp: 't' },
+      };
+    };
+    const config: DetectionConfig = {
+      mode: 'poll',
+      poll: { cursor: { kind: 'systemModstamp', field: 'modstamp' } },
+      mapping: [{ source: 'externalId', target: 'external_id' }],
+      filters: [],
+    };
+    const src = new PollChangeSource<CamelRecord>({ adapter, config });
+    const [change] = await collect(src.listChanges(subscription, null));
+    expect(change.externalId).toBe('gh:42');
+    expect(
+      (change.record as Record<string, unknown>).external_id,
+    ).toBeUndefined();
   });
 
   it('throws if the mapping declares no external_id target', () => {
@@ -336,7 +373,7 @@ describe('PollChangeSource — cdc-as-provenance', () => {
         cursor: { kind: 'eventId', field: 'event_id' },
         provenance: 'cdc',
       },
-      mapping: [{ source: 'id', target: 'external_id' }],
+      mapping: [{ source: 'external_id', target: 'external_id' }],
       filters: [],
     };
   }

--- a/src/__tests__/runtime/subsystems/webhook-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/webhook-change-source.spec.ts
@@ -49,16 +49,23 @@ function makeWebhookConfig(extra?: Partial<DetectionConfig>): DetectionConfig {
     webhook: {
       eventIdField: 'event_id',
     },
+    // The queue yields ALREADY-MAPPED canonical records keyed by the mapping
+    // `source` (the field on the emitted record). These fixtures emit records
+    // keyed `external_id`/`name`, so `source` must match those keys — the
+    // primitive reads `record[source]`, NOT `record[target]`. (The original
+    // fixtures declared `source: 'id'`/`'Name'` while emitting `external_id`;
+    // that only passed because the pre-fix primitive read `.target` — the gap
+    // #6 transposition. Aligned here so the fixture exercises the real path.)
     mapping: [
-      { source: 'id', target: 'external_id' },
-      { source: 'Name', target: 'name' },
+      { source: 'external_id', target: 'external_id' },
+      { source: 'name', target: 'name' },
     ],
     filters: [],
     ...(extra as object),
   } as DetectionConfig;
 }
 
-async function collect<T>(it: AintegrationIterable<T>): Promise<T[]> {
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = [];
   for await (const x of it) out.push(x);
   return out;
@@ -140,6 +147,80 @@ describe('WebhookChangeSource — event-id dedup', () => {
     expect(seen).toBeDefined();
     expect(seen!.subscription.id).toBe('sub-webhook-1');
     expect(seen!.cursor).toEqual({ lastTs: 'x' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// camelCase canonical record — externalId read via mapping.source, not target
+//
+// Regression for the externalId mapping transposition (gap #6, swe-brain
+// dogfood — the first real exercise of WebhookChangeSource). The constructor
+// must read the emitted record off the mapping's `source` (the field on the
+// emitted record), NOT its `target` (the canonical column). The two diverge
+// whenever the canonical record is vendor-neutral camelCase: a consumer that
+// emits records keyed `externalId` with `mapping: [{ source: 'externalId',
+// target: 'external_id' }]` and NO `external_id` key on the record. The bug
+// (`.target`) made the primitive look up `record['external_id']` → undefined →
+// "record missing string 'external_id'", rendering the primitive unusable for
+// any camelCase-canonical consumer. The original fixtures masked it because
+// they keyed records `external_id` (== the target), so source vs. target never
+// diverged.
+// ---------------------------------------------------------------------------
+
+interface CamelCaseRecord {
+  externalId: string;
+  name: string;
+}
+
+describe('WebhookChangeSource — camelCase canonical record (mapping.source)', () => {
+  function makeCamelConfig(): DetectionConfig {
+    return {
+      mode: 'webhook',
+      // The eventIdField IS the externalId field here — the swe-brain shape,
+      // where the canonical event id and external id are the same camelCase key.
+      webhook: { eventIdField: 'externalId' },
+      mapping: [{ source: 'externalId', target: 'external_id' }],
+      filters: [],
+    } as DetectionConfig;
+  }
+
+  it('reads externalId off the record via mapping.source (record has NO external_id key)', async () => {
+    const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
+      // Note: keyed `externalId` only — there is deliberately NO `external_id`
+      // key on the record. The buggy `.target` lookup would throw here.
+      yield { record: { externalId: 'gh:123', name: 'Alpha' } };
+    };
+    const src = new WebhookChangeSource<CamelCaseRecord>({
+      queue,
+      config: makeCamelConfig(),
+    });
+    const out = await collect(src.listChanges(subscription, null));
+    expect(out).toHaveLength(1);
+    expect(out[0].source).toBe('webhook');
+    expect(out[0].externalId).toBe('gh:123');
+    expect(out[0].dedupKey).toBe('gh:123');
+    // Sanity: the emitted record carries no `external_id` key whatsoever, so a
+    // passing assertion proves the primitive resolved via `.source`.
+    expect(
+      (out[0].record as Record<string, unknown>).external_id,
+    ).toBeUndefined();
+  });
+
+  it('throws naming the mapping source field when the record is missing it', async () => {
+    const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
+      yield { record: { name: 'Alpha' } as unknown as CamelCaseRecord };
+    };
+    const src = new WebhookChangeSource<CamelCaseRecord>({
+      queue,
+      config: makeCamelConfig(),
+    });
+    await expect(
+      (async () => {
+        for await (const _c of src.listChanges(subscription, null)) {
+          // drain
+        }
+      })(),
+    ).rejects.toThrow(/externalId/);
   });
 });
 


### PR DESCRIPTION
## Summary

Package-mode gap **#6** from the swe-brain dogfood — the **first real exercise of `WebhookChangeSource`** by a `runtime: package` consumer (swe-brain's Slack inbound *pipeline-parity drain*, ADR-0009 §6).

`WebhookChangeSource` located the `DetectionConfig` mapping entry with `target === 'external_id'` correctly, then assigned `this.externalIdSourceField = externalIdMapping.target` — a transposition. Mapping semantics are `{ source: <field on the emitted record>, target: <canonical column> }`, and `fetch()` reads `record[this.externalIdSourceField]` off the **emitted record**, so it must use `.source`. The field is literally named `externalIdSourceField`, and the derived label on the next line already used `externalIdMapping.source` — evidence of a one-token transposition.

**Net effect today:** any consumer with a vendor-neutral camelCase canonical record (e.g. keyed `externalId`, `mapping: [{ source: 'externalId', target: 'external_id' }]`) hit `WebhookChangeSource: record missing string 'external_id'` and the primitive was unusable. The original unit fixtures masked it by keying records `external_id` (== the `target`), so `source` and `target` never diverged.

The identically-shaped `PollChangeSource` carried the **same** transposition (same field name, same `.target` assignment); it is not exercised by the swe-brain webhook drain (the Google/Slack poll adapters use `IncrementalReadBase`), but the bug is latent and the fix is one token — fixed in the same PR for consistency.

## Changes

- **fix** (`webhook-change-source.ts`, `poll-change-source.ts`): `.target` → `.source` in the constructor assignment; doc + error-message text corrected to say "keyed by the mapping source".
- **regression tests**: a camelCase canonical record keyed `externalId` with **no** `external_id` key — the exact consumer shape that failed — asserting `Change.externalId` / `Change.dedupKey` are populated and `source === 'webhook'` (plus a sibling for the poll primitive). Existing poll/webhook/build fixtures realigned so the emitted record key matches the mapping `source` (they previously encoded the buggy semantics; also fixed a stray `AintegrationIterable` → `AsyncIterable` typo).
- **rider** (`runtime/subsystems/index.ts`): re-export the webhook/poll/detection symbols from the public `@pattern-stack/codegen/subsystems` barrel — `WebhookChangeSource`, `WebhookChangeSourceOptions`, `WebhookFetchCallback`, `WebhookFetchContext`, `WebhookCursor`, `buildChangeSource`, `DetectionConfigSchema`, `DetectionConfig` (+ poll equivalents). The primitive was previously reachable only via the deep `.../integration/index` path (swe-brain's drain had to deep-import it). Mirrors the curated `IncrementalReadBase` / `ExecuteIntegrationUseCase` forwards.
- **release**: `0.15.3` (package.json + CHANGELOG).

## Validation

- Full runtime-subsystem unit suite green (1649 pass / 0 fail); change-source specs 110 pass / 0 fail. Typecheck unchanged (only 3 pre-existing `junction.ts` / `barrel-generator.ts` errors on `main`, unrelated to this diff).
- `npm pack` → installed the tarball into swe-brain → `bun run scripts/inbound-spine-e2e.ts` → **`✅ GOLDEN PATH PASS`** with all SIX hops, incl. the 6th `integration_run action=webhook status=success processed=1`. swe-brain tree restored to `0.15.2` + local patch afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)