### PR TITLE
feat(jobs,events): Postgres LISTEN/NOTIFY wakeups (0.16.0) — dogfood gap #7

### DIFF
--- a/.claude/skills/jobs/SKILL.md
+++ b/.claude/skills/jobs/SKILL.md
@@ -36,7 +36,7 @@ There is **no** `IJobQueue`, **no** `job_queue` table, **no** executor port. The
 
 Per CLAUDE.md, backends are core-contract + opt-in extensions. The core contract is `IJobOrchestrator` + `IJobRunService` + `IJobStepService`; app code against these three is portable. Extensions are backend-specific capabilities exposed additively in `codegen.config.yaml: jobs.extensions.<backend>`. Phase 1 ships:
 
-- **Drizzle backend** — core contract implemented. Extensions reserved: `listen_notify`, `poll_interval_ms`.
+- **Drizzle backend** — core contract implemented. Extensions **implemented** (LISTEN-NOTIFY-1): `poll_interval_ms` (interval-poll heartbeat) + opt-in `listen_notify` (Postgres LISTEN/NOTIFY wakes the worker on enqueue-commit, ALONGSIDE polling; sub-500ms claim, off by default, requires a direct/non-transaction-pooler connection).
 - **Memory backend** — core contract for tests. No extensions.
 - **BullMQ backend** — **shipped (BULLMQ-1, opt-in via `jobs.backend: bullmq`).** `BullMQJobOrchestrator extends DrizzleJobOrchestrator`: Postgres `job_run` stays the domain source of truth (scoping/hierarchy/`listForScope` unchanged); BullMQ replaces only the claim/dispatch half (`start`→`queue.add`, `BullMQJobWorker` per pool). Extensions: `bull_board` (config carried; consumer mounts), `FlowProducer` exposure (`.flowProducer()`), `queue_prefix`. Cron/`upsertJobScheduler` is out of scope (ADR-025). `jobId = sha1(idempotencyKey)` (colon-safe + stable; the dedup primitive). Default backend stays `drizzle` until the broker-up port-promotion gate runs green in a consumer (see `docs/specs/BULLMQ-1.md §Verification`).
 

--- a/.claude/skills/jobs/pools-and-config.md
+++ b/.claude/skills/jobs/pools-and-config.md
@@ -49,7 +49,7 @@ jobs:
   # ── Backend-specific extensions (typed per backend) ──
   extensions:
     drizzle:
-      # listen_notify: true          # Phase 6+: use Postgres LISTEN/NOTIFY to wake the loop
+      # listen_notify: true          # LISTEN-NOTIFY-1: Postgres LISTEN/NOTIFY wakes the worker on enqueue-commit, alongside polling. Off by default; needs a direct (non-transaction-pooler) connection.
       poll_interval_ms: 1000
     # bullmq:                        # Reserved slot — backend not yet implemented
     #   bull_board:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-06-04
+
+**Postgres LISTEN/NOTIFY wakeups** for the jobs worker + events outbox drainer
+(LISTEN-NOTIFY-1, dogfood gap #7 — swe-brain's live-inbound latency). The
+scaffold has documented `jobs.extensions.drizzle.listen_notify` since JOB-6 and
+`JobsDomainModule` reserved the typed slot, but neither knob was wired (no
+runtime, and the barrel never threaded `jobs.extensions.drizzle.*` into
+`JobWorkerModule.forRoot`). This makes both real.
+
+NOTIFY wakes the polling loop the instant work becomes claimable; **interval
+polling remains the safety net** (alongside, never instead). Every `pg_notify`
+is emitted **inside the same transaction** as the row write it announces, so
+Postgres delivers it only on commit — durability is byte-for-byte unchanged. A
+lost notification (listener down, transaction-mode pooler) degrades to today's
+poll latency, never to lost work.
+
+Measured on swe-brain's inbound spine (webhook → outbox drain → bridge wrapper →
+user job): **~1.4–3.0 s → sub-500 ms** with `listen_notify: true`, zero
+durability change.
+
+### Added
+
+- **`runtime/subsystems/jobs/pg-notify.ts`** — `PgNotifyListener` (dedicated
+  listener connection off `DRIZZLE.$client`, debounced dispatch,
+  reconnect-with-capped-backoff, WARN-once degradation) + in-tx `pgNotify(tx,
+  channel, payload)` + channel constants. Shared by jobs + events.
+- **Jobs worker** — `JobWorkerOptions.listenNotify`; LISTEN on
+  `codegen_jobs_wake`, a notify for the worker's pool drives an immediate
+  debounced claim cycle. `DrizzleJobOrchestrator.start()` emits the in-tx wake
+  on enqueue, gated on the new `JOBS_LISTEN_NOTIFY` token (provided from
+  `jobs.extensions.drizzle.listen_notify`).
+- **Events drainer** — `EventsModuleOptions.listenNotify`; LISTEN on
+  `codegen_events_wake`, `publish`/`publishMany` emit the in-tx wake; a
+  pool-filtered drainer wakes only for its lanes.
+- **Bridge** — the `BridgeOutboxDrainHook` wrapper `job_run` insert emits the
+  jobs wake in the per-event drain tx, so reserved-pool wrappers wake too.
+- **Generator threading** — `jobs.extensions.drizzle.{listen_notify,
+  poll_interval_ms}` flow into the generated barrel's `JobsDomainModule.forRoot`
+  + embedded `JobWorkerModule.forRoot({ domainModuleExtensions: { drizzle: …
+  } })`; `events.extensions.drizzle.listen_notify` flows into
+  `EventsModule.forRoot({ listenNotify })`. Package and vendored emission both
+  covered. (The runtime already honored `JobWorkerOptions.pollIntervalMs`; it
+  just never received a config value — now it does.)
+- Scaffold config comments + jobs skill updated to implemented reality, with the
+  **PgBouncer caveat**: LISTEN/NOTIFY requires a direct (or session-mode)
+  connection — session-scoped `LISTEN` does not survive a transaction-mode
+  pooler; behind one the feature degrades to polling.
+
 ## [0.15.3] — 2026-06-03
 
 Package-mode **inbound webhook drain** — the first real exercise of

--- a/docs/specs/JOB-6.md
+++ b/docs/specs/JOB-6.md
@@ -172,9 +172,11 @@ jobs:
   # the active backend produce a config validation warning at boot.
   extensions:
     drizzle:
-      # listen_notify: true        # use Postgres LISTEN/NOTIFY to wake the
-      #                            # polling loop instead of (or alongside)
-      #                            # interval polling. Disabled by default.
+      # listen_notify: true        # LISTEN-NOTIFY-1: Postgres LISTEN/NOTIFY wakes
+      #                            # the worker on enqueue-commit, ALONGSIDE
+      #                            # interval polling (polling is the safety net).
+      #                            # Off by default; requires a direct connection
+      #                            # (no transaction-mode pooler).
       poll_interval_ms: 1000
     # bullmq:                      # Example shape for Phase 6+ BullMQ backend.
     #   bull_board:                # Mount Bull Board admin UI.

--- a/docs/specs/LISTEN-NOTIFY-1.md
+++ b/docs/specs/LISTEN-NOTIFY-1.md
@@ -1,0 +1,163 @@
+# LISTEN-NOTIFY-1 — Postgres LISTEN/NOTIFY wakeups for the jobs worker + events drainer
+
+**Issue:** dogfood gap #7 (swe-brain live-inbound latency)
+**Status:** Draft
+**Last Updated:** 2026-06-04
+**Depends on:** JOB-3 (worker loop), JOB-5 (worker module + pool config), EVT-4 (outbox drain), BRIDGE-4 (outbox drain hook), ADR-037 (package mode + namespaced tokens)
+**Related ADR:** ADR-022 (Job Orchestration Domain Model — §Drizzle extensions), ADR-024 (Events Domain Formalization)
+**Version:** 0.16.0
+
+## Overview
+
+The scaffolded `codegen.config.yaml` has documented `jobs.extensions.drizzle.listen_notify`
+("use Postgres LISTEN/NOTIFY to wake the polling loop instead of (or alongside)
+interval polling. Disabled by default.") since JOB-6, and `JobsDomainModule`
+reserves the typed `DrizzleBackendExtensions.{ listenNotify, pollIntervalMs }`
+slot — but **neither knob is wired**:
+
+1. The runtime has **no LISTEN/NOTIFY implementation** anywhere.
+2. The barrel generator never threads `jobs.extensions.drizzle.*` (nor
+   `poll_interval_ms`) into `JobWorkerModule.forRoot(...)` — the consumer's knobs
+   are config-theater. (The runtime *does* already honor
+   `JobWorkerOptions.pollIntervalMs`; it just never receives a value from config.)
+
+This spec makes both real. **NOTIFY wakes; polling remains the safety net** — the
+feature runs *alongside* interval polling, never instead. A lost notification
+degrades to today's latency, never to lost work. Durability is unchanged: every
+NOTIFY is emitted **inside the same transaction** as the row write it announces,
+so Postgres delivers it only on commit (exactly the transactional-outbox
+guarantee the subsystems already depend on).
+
+### Latency target
+
+A webhook-staged event reaches its canonical row through three 1s-poll hops today
+(events outbox drain → bridge wrapper job claim → user job claim); measured
+spine latency 1.4–3.0 s. With `listen_notify` on, each hop wakes on commit → target
+**sub-500 ms** with **zero durability change**.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `runtime/subsystems/jobs/pg-notify.ts` | create | `PgNotifyListener` helper — dedicated `pg` listener connection, reconnect-with-backoff, debounced dispatch. Plus `pgNotify(tx, channel, payload)` in-tx emit helper + channel/payload constants. Shared by jobs + events. |
+| `runtime/subsystems/jobs/job-worker.ts` | edit | `listenNotify?` option; LISTEN on `codegen_jobs_wake`; notify for one of the worker's pools → immediate (debounced) claim cycle. |
+| `runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts` | edit | emit `pg_notify(codegen_jobs_wake, pool)` in-tx on the `start()` INSERT (and the retry/resume path is the worker's own UPDATE — see Decisions). Gated on `JOBS_LISTEN_NOTIFY`. |
+| `runtime/subsystems/jobs/jobs-domain.tokens.ts` | edit | `JOBS_LISTEN_NOTIFY` token (mirrors `JOBS_MULTI_TENANT`). |
+| `runtime/subsystems/jobs/jobs-domain.module.ts` | edit | provide `JOBS_LISTEN_NOTIFY` from `extensions.drizzle.listenNotify`. |
+| `runtime/subsystems/jobs/job-worker.module.ts` | edit | thread `pollIntervalMs` + `listenNotify` from `domainModuleExtensions.drizzle` into each spawned `JobWorker`. |
+| `runtime/subsystems/jobs/job-worker.bullmq-backend.ts` | edit (guard) | unaffected — BullMQ has native wakeups; LISTEN/NOTIFY is drizzle-only. |
+| `runtime/subsystems/events/event-bus.drizzle-backend.ts` | edit | `listenNotify` from `EventsModuleOptions`; LISTEN on `codegen_events_wake`; notify in-tx on `publish`/`publishMany`; wake drains on notify. |
+| `runtime/subsystems/events/events.module.ts` | edit | `listenNotify?` on `EventsModuleOptions`. |
+| `runtime/subsystems/bridge/bridge-outbox-drain-hook.ts` | edit | the wrapper `job_run` INSERT emits the jobs notify in the same tx (reserved-pool wrappers must wake too). |
+| `src/cli/shared/subsystem-barrel-generator.ts` | edit | `jobs` composer threads `domainModuleExtensions: { drizzle: { listenNotify, pollIntervalMs } }` + the worker pollInterval/listenNotify; `events` composer threads `listenNotify` from `events.extensions.drizzle.listen_notify`. |
+| `templates/subsystem/jobs-config/codegen-config-jobs-block.ejs.t` | edit | reflect implemented reality; add the events-side knob doc + PgBouncer note. |
+| `docs/specs/JOB-6.md` | edit | config-block doc parity. |
+| `.claude/skills/jobs/*`, `consumer-skills/jobs/*` | edit | "reserved" → "implemented". |
+
+## Decisions
+
+### D1 — One dedicated listener connection per worker/drainer; polling never stops
+
+`PgNotifyListener` checks out a single long-lived `pg.PoolClient` from the existing
+`DRIZZLE.$client` Pool and issues `LISTEN <channel>`. The `pg` `Client` emits a
+`'notification'` event; the listener forwards the payload to the owner's callback.
+The interval poll timer is **untouched** — it remains the heartbeat. `listen_notify`
+only *adds* an early wake.
+
+### D2 — NOTIFY is in-tx; delivery is on-commit (durability invariant)
+
+Every `pg_notify(...)` runs through the **same `tx` handle** as the row write it
+announces (orchestrator `start()`, event `publish()`, bridge wrapper insert).
+Postgres queues NOTIFY messages and delivers them **only when the transaction
+commits** — a rolled-back write emits no phantom wake. This is byte-for-byte the
+same guarantee the transactional outbox already relies on. Tests assert a NOTIFY
+inside a tx that *rolls back* is never delivered.
+
+### D3 — Debounce / coalesce, not stack
+
+A notification that arrives while a claim cycle is already running sets a
+`recheckPending` flag rather than stacking a second cycle. When the current cycle
+finishes it re-checks once if the flag is set. A burst of N notifies collapses to
+at most one extra cycle. This bounds wake amplification under load (a hot pool
+gets one notify per enqueue but never N concurrent claim transactions).
+
+### D4 — Listener death degrades to polling, loudly-once
+
+If the listener connection drops (server restart, network blip), `PgNotifyListener`
+logs a single WARN, then reconnects with capped exponential backoff
+(100 ms → 5 s). While down, the interval poll loop is the sole driver — i.e. the
+system degrades to exactly today's behaviour, never to stalled work. On
+reconnect it re-issues `LISTEN` and logs recovery once.
+
+### D5 — Channel + payload shape
+
+- Jobs channel: `codegen_jobs_wake`, payload = the pool name (e.g. `interactive`,
+  `events_inbound`). A worker filters: a notify whose payload names one of *its*
+  active pools triggers a wake; others are ignored. (Postgres NOTIFY payloads are
+  plain strings; the pool name is enough — the worker re-runs its own claim query
+  which already filters by pool + `runAt <= now()`.)
+- Events channel: `codegen_events_wake`, payload = the event's `pool`
+  (`events_inbound` / `events_change` / `events_outbound`) or `''` when null. A
+  pool-filtered drainer wakes only for its lanes; an all-pools drainer wakes for any.
+
+Payloads are kept ≤ a handful of bytes (well under Postgres' 8000-byte NOTIFY
+limit). No JSON — the wake is a hint; the claim/drain query is the source of truth.
+
+### D6 — Retry/resume wakeups ride the worker's own writes
+
+A run becomes claimable again on three transitions: initial enqueue (`start()`),
+retry (worker re-sets `status='pending'` with a future `runAt`), and stale-claim
+sweep (worker resets `claimed_at`). Initial enqueue emits notify from the
+orchestrator. Retry sets a **future** `runAt` (backoff), so an immediate wake would
+claim nothing — the interval poll correctly picks it up when `runAt` elapses; we do
+**not** notify on retry (notifying would burn a no-op claim cycle). Stale-sweep
+resets to `runAt`-now-eligible rows; those are already-late and the next interval
+tick (≤ 1 s) reclaims them — sweeps are a rare recovery path, not a latency-critical
+one, so we don't notify there either. **The latency-critical path is the happy path
+(enqueue → claim), and that is covered.** Bridge wrapper inserts (a form of enqueue)
+DO notify (D7).
+
+### D7 — Bridge wrapper inserts notify
+
+The `BridgeOutboxDrainHook` inserts a wrapper `job_run` (pool `events_<direction>`)
+inside the per-event drain tx. That insert emits `pg_notify(codegen_jobs_wake,
+<wrapperPool>)` in the same tx so the reserved-pool worker wakes immediately —
+otherwise the bridge hop alone would still cost a full poll interval. Gated on the
+same listen_notify flag (the hook reads it via the orchestrator's notify path; see
+implementation — the hook calls a shared `pgNotify(tx, …)` guarded by a flag
+threaded from `BridgeModule`).
+
+### D8 — PgBouncer / transaction-mode pooler caveat
+
+LISTEN/NOTIFY does **not** survive a transaction-mode connection pooler (PgBouncer
+`pool_mode = transaction`): the listener's session-scoped `LISTEN` is lost when the
+pooler hands the connection to another client between transactions. The feature
+**requires a direct (or session-mode) connection**. Documented in the config block
++ skill; if neither is available the consumer simply leaves `listen_notify` off and
+keeps polling. No silent breakage: with `listen_notify: true` behind a transaction
+pooler, notifies are never received and the system degrades to polling latency (the
+documented fallback), which is correct-but-slow rather than wrong.
+
+### D9 — Generator threading
+
+`jobs` composer:
+- worker (`JobWorkerModule.forRoot`) gains `domainModuleExtensions: { drizzle: {
+  listenNotify, pollIntervalMs } }` whenever `jobs.extensions.drizzle.*` is set
+  (drizzle backend only — bullmq keeps its own extension block).
+`events` composer:
+- `EventsModule.forRoot({ …, listenNotify })` from
+  `events.extensions.drizzle.listen_notify` (new optional config key, mirroring the
+  jobs shape).
+
+Both flow only on the drizzle/default backend. Package AND vendored emission paths
+covered by the existing pure-builder.
+
+## Tests
+
+| Test | Asserts |
+|------|---------|
+| `pg-notify.spec` | in-tx notify NOT delivered before commit; delivered on commit; rollback → no delivery (integration, real pg). |
+| `job-worker.listen-notify.spec` | worker wakes on a notify for its pool well under the poll interval; ignores notify for a foreign pool; listener-death → falls back to polling (claims still happen). |
+| `event-bus.listen-notify.spec` | publish emits in-tx notify; drainer wakes on notify; pool-filtered drainer ignores foreign-pool notify. |
+| `subsystem-barrel-generator.test` | jobs composer threads `domainModuleExtensions.drizzle.{listenNotify,pollIntervalMs}` + worker knobs; events composer threads `listenNotify`; off-by-default when keys absent (snapshot/string assertions). |
+| existing unit + smoke suites | unchanged green. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
+++ b/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
@@ -47,6 +47,8 @@ import type {
 } from './bridge.protocol';
 import { BRIDGE_DELIVERY_JOB_TYPE } from './bridge-delivery-handler';
 import type { EventTypeName } from '../events/event-registry';
+import { JOBS_LISTEN_NOTIFY } from '../jobs/jobs-domain.tokens';
+import { JOBS_WAKE_CHANNEL, pgNotify } from '../jobs/pg-notify';
 
 /** Reserved pools the wrapper rows route into; ADR-022 / ADR-024. */
 const POOL_BY_DIRECTION: Record<string, string> = {
@@ -65,6 +67,15 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
     @Optional()
     @Inject(BRIDGE_REGISTRY)
     private readonly registry: BridgeRegistry = {},
+    // LISTEN-NOTIFY-1 — when true, the wrapper `job_run` insert below emits an
+    // in-tx `pg_notify(codegen_jobs_wake, <wrapperPool>)` so the reserved-pool
+    // worker wakes the instant the per-event drain tx commits — otherwise the
+    // bridge hop alone would still cost a full poll interval. `@Optional()`
+    // defaulting false so the hook keeps working when jobs isn't installed
+    // (bridge can drive non-jobs consumers) or in vendored/test wiring.
+    @Optional()
+    @Inject(JOBS_LISTEN_NOTIFY)
+    private readonly listenNotify: boolean = false,
   ) {}
 
   async processEvent(
@@ -207,6 +218,22 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
           .where(eq(jobRuns.id, wrapperRunId));
         dedupSkips++;
         continue;
+      }
+
+      // LISTEN-NOTIFY-1 — the wrapper run is real and claimable; wake its
+      // reserved-pool worker on commit (D7). Same `tx` as the inserts above, so
+      // delivery is gated on the per-event drain tx committing. Best-effort: a
+      // notify failure is non-fatal (the reserved-pool worker still polls).
+      if (this.listenNotify) {
+        try {
+          await pgNotify(tx, JOBS_WAKE_CHANNEL, wrapperPool);
+        } catch (err) {
+          this.logger.warn(
+            `pg_notify(${JOBS_WAKE_CHANNEL}, ${wrapperPool}) failed for ` +
+              `wrapper run ${wrapperRunId}: ${(err as Error).message} ` +
+              `(non-fatal — the reserved-pool worker still polls).`,
+          );
+        }
       }
 
       delivered++;

--- a/runtime/subsystems/events/event-bus.drizzle-backend.ts
+++ b/runtime/subsystems/events/event-bus.drizzle-backend.ts
@@ -48,6 +48,11 @@ import { EVENTS_MODULE_OPTIONS } from './events.tokens';
 import type { EventsModuleOptions } from './events.module';
 import { BRIDGE_OUTBOX_DRAIN_HOOK } from '../bridge/bridge.tokens';
 import type { IBridgeOutboxDrainHook } from '../bridge/bridge.protocol';
+import {
+  EVENTS_WAKE_CHANNEL,
+  PgNotifyListener,
+  pgNotify,
+} from '../jobs/pg-notify';
 
 /** How long to wait between polling cycles (ms). */
 const POLL_INTERVAL_MS = 1_000;
@@ -138,6 +143,14 @@ export class DrizzleEventBus implements IEventBus, IEventReadPort, OnModuleInit,
   private readonly handlers = new Map<string, Set<(event: DomainEvent) => Promise<void>>>();
   private readonly opts: EventsModuleOptions;
 
+  // LISTEN-NOTIFY-1 — dedicated wake listener + debounce state. `null` when
+  // `listenNotify` is off (the common case); polling is the only driver then.
+  private notifyListener: PgNotifyListener | null = null;
+  /** True while a wake-driven drain is in flight (debounce gate). */
+  private wakeDraining = false;
+  /** A notify arrived mid-drain → re-drain once when the current drain ends. */
+  private wakeRecheckPending = false;
+
   constructor(
     @Inject(DRIZZLE) private readonly db: DrizzleClient,
     @Optional() @Inject(EVENTS_MODULE_OPTIONS) opts?: EventsModuleOptions,
@@ -168,6 +181,28 @@ export class DrizzleEventBus implements IEventBus, IEventReadPort, OnModuleInit,
   async onModuleInit(): Promise<void> {
     this.polling = true;
     this.schedulePoll();
+
+    // LISTEN-NOTIFY-1 — start the wake listener ALONGSIDE the poll timer. A
+    // notify for one of this drainer's pools triggers an immediate drain; the
+    // interval timer above stays the durability heartbeat. Startup is
+    // fire-and-forget — a connect failure self-heals via the listener's backoff.
+    if (this.opts.listenNotify) {
+      const pool = (this.db as unknown as { $client?: unknown }).$client;
+      if (!pool || typeof (pool as { connect?: unknown }).connect !== 'function') {
+        this.logger.warn(
+          `listen_notify enabled but the Drizzle client exposes no pg Pool ` +
+            `($client.connect missing) — falling back to interval polling only.`,
+        );
+      } else {
+        this.notifyListener = new PgNotifyListener({
+          channel: EVENTS_WAKE_CHANNEL,
+          pool: pool as { connect(): Promise<never> },
+          label: 'events',
+          onNotify: (payload) => this.onWake(payload),
+        });
+        await this.notifyListener.start();
+      }
+    }
   }
 
   async onModuleDestroy(): Promise<void> {
@@ -175,6 +210,45 @@ export class DrizzleEventBus implements IEventBus, IEventReadPort, OnModuleInit,
     if (this.pollTimer) {
       clearTimeout(this.pollTimer);
       this.pollTimer = null;
+    }
+    if (this.notifyListener) {
+      try {
+        await this.notifyListener.stop();
+      } catch (err) {
+        this.logger.error(`notify listener stop failed: ${err}`);
+      }
+      this.notifyListener = null;
+    }
+  }
+
+  /**
+   * Wake handler — a `codegen_events_wake` notification arrived. A pool-filtered
+   * drainer (`opts.pools` set) ignores payloads naming a pool it doesn't own; an
+   * all-pools drainer wakes for any. Debounced: a notify mid-drain just flags a
+   * re-check so a burst collapses to at most one extra drain (D3).
+   */
+  private onWake(payload: string): void {
+    if (!this.polling) return;
+    const pools = this.opts.pools;
+    if (pools && pools.length > 0 && !pools.includes(payload)) return;
+    if (this.wakeDraining) {
+      this.wakeRecheckPending = true;
+      return;
+    }
+    void this.drainOnWake();
+  }
+
+  private async drainOnWake(): Promise<void> {
+    this.wakeDraining = true;
+    try {
+      do {
+        this.wakeRecheckPending = false;
+        await this.processBatch();
+      } while (this.wakeRecheckPending && this.polling);
+    } catch (err) {
+      this.logger.error(`wake drain error: ${err}`);
+    } finally {
+      this.wakeDraining = false;
     }
   }
 
@@ -185,16 +259,46 @@ export class DrizzleEventBus implements IEventBus, IEventReadPort, OnModuleInit,
   async publish(event: DomainEvent, tx?: DrizzleTransaction): Promise<void> {
     const client = (tx ?? this.db) as DrizzleClient;
     const multiTenant = this.opts.multiTenant ?? false;
-    await client.insert(domainEvents).values(toInsertValues(event, multiTenant));
+    const values = toInsertValues(event, multiTenant);
+    await client.insert(domainEvents).values(values);
+    // LISTEN-NOTIFY-1 — wake the drainer on commit (D2: emitted through the same
+    // `client`, so a rolled-back publish emits no phantom wake). The pool is the
+    // payload; the drainer re-runs its own pool-filtered claim on wake.
+    await this.emitWakeNotify(client, [values.pool]);
   }
 
   async publishMany(events: DomainEvent[], tx?: DrizzleTransaction): Promise<void> {
     if (events.length === 0) return;
     const client = (tx ?? this.db) as DrizzleClient;
     const multiTenant = this.opts.multiTenant ?? false;
-    await client
-      .insert(domainEvents)
-      .values(events.map((e) => toInsertValues(e, multiTenant)));
+    const valuesList = events.map((e) => toInsertValues(e, multiTenant));
+    await client.insert(domainEvents).values(valuesList);
+    // De-dup pools so a batch into one lane emits a single wake.
+    await this.emitWakeNotify(client, valuesList.map((v) => v.pool));
+  }
+
+  /**
+   * Emit one in-tx `pg_notify(codegen_events_wake, <pool>)` per distinct pool in
+   * the just-inserted batch. No-op unless `listenNotify` is on. Best-effort: a
+   * notify failure is non-fatal (interval polling still drains the rows), so we
+   * log + swallow rather than failing the publish.
+   */
+  private async emitWakeNotify(
+    client: DrizzleClient,
+    pools: Array<string | null>,
+  ): Promise<void> {
+    if (!this.opts.listenNotify) return;
+    const distinct = new Set(pools.map((p) => p ?? ''));
+    for (const pool of distinct) {
+      try {
+        await pgNotify(client, EVENTS_WAKE_CHANNEL, pool);
+      } catch (err) {
+        this.logger.warn(
+          `pg_notify(${EVENTS_WAKE_CHANNEL}, '${pool}') failed: ${err} ` +
+            `(non-fatal — interval polling still drains the outbox).`,
+        );
+      }
+    }
   }
 
   async findById(eventId: string): Promise<DomainEvent | null> {

--- a/runtime/subsystems/events/events.module.ts
+++ b/runtime/subsystems/events/events.module.ts
@@ -97,6 +97,20 @@ export interface EventsModuleOptions {
    */
   pools?: string[];
   /**
+   * LISTEN-NOTIFY-1 — when `true` (drizzle backend only), the drainer holds a
+   * dedicated listener connection and LISTENs on `codegen_events_wake`. Each
+   * `publish`/`publishMany` emits an in-tx `pg_notify(codegen_events_wake,
+   * <pool>)` so the drainer wakes the moment the publishing transaction commits,
+   * instead of waiting for the next poll tick. Polling continues unchanged as
+   * the fallback heartbeat; a lost notify degrades to poll latency, never to
+   * lost work. Defaults to `false`.
+   *
+   * Ignored by the memory + redis backends (memory dispatches inline; redis has
+   * its own fan-out). Requires a direct (non-transaction-pooler) connection —
+   * see the events/jobs config block re: PgBouncer.
+   */
+  listenNotify?: boolean;
+  /**
    * Multi-tenancy opt-in (EVT-6).
    *
    * When `true`, every `TypedEventBus.publish()` call must supply

--- a/runtime/subsystems/jobs/index.ts
+++ b/runtime/subsystems/jobs/index.ts
@@ -22,6 +22,7 @@ export {
   JOB_RUN_SERVICE,
   JOB_STEP_SERVICE,
   JOBS_MULTI_TENANT,
+  JOBS_LISTEN_NOTIFY,
 } from './jobs-domain.tokens';
 
 // ─── JOB-2: orchestrator protocol ──────────────────────────────────────────
@@ -111,6 +112,15 @@ export {
   buildStaleSweepQuery,
 } from './job-worker';
 export type { JobWorkerOptions } from './job-worker';
+
+// ─── LISTEN-NOTIFY-1: Postgres LISTEN/NOTIFY wakeups ───────────────────────
+export {
+  PgNotifyListener,
+  pgNotify,
+  JOBS_WAKE_CHANNEL,
+  EVENTS_WAKE_CHANNEL,
+} from './pg-notify';
+export type { PgNotifyListenerOptions } from './pg-notify';
 export {
   JobCollisionError,
   JobNotReplayableError,

--- a/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
@@ -7,7 +7,7 @@
  * No `job_queue` table, no executor port. See `docs/specs/JOB-3.md`.
  */
 import { randomUUID } from 'node:crypto';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { and, desc, eq, gt, inArray, isNotNull, ne, notInArray, sql } from 'drizzle-orm';
 import type { DrizzleClient } from '../../types/drizzle';
 import type { DrizzleTransaction } from '../events/event-bus.protocol';
@@ -34,7 +34,8 @@ import {
   MissingTenantIdError,
 } from './jobs-errors';
 import { jobSteps } from './job-orchestration.schema';
-import { JOBS_MULTI_TENANT } from './jobs-domain.tokens';
+import { JOBS_MULTI_TENANT, JOBS_LISTEN_NOTIFY } from './jobs-domain.tokens';
+import { JOBS_WAKE_CHANNEL, pgNotify } from './pg-notify';
 
 /**
  * Terminal statuses — transitions into these are final. Used by `cancel`
@@ -83,6 +84,13 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
   constructor(
     @Inject(DRIZZLE) private readonly db: DrizzleClient,
     @Inject(JOBS_MULTI_TENANT) private readonly multiTenant: boolean,
+    // LISTEN-NOTIFY-1 — when true, `start()` emits an in-tx
+    // `pg_notify(codegen_jobs_wake, <pool>)` so a `listen_notify` worker wakes
+    // on enqueue-commit. `@Optional()` defaulting to false so direct
+    // construction (integration tests not going through DI) keeps working.
+    @Optional()
+    @Inject(JOBS_LISTEN_NOTIFY)
+    private readonly listenNotify: boolean = false,
   ) {}
 
   /**
@@ -250,6 +258,25 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
         attempts: 0,
       })
       .returning();
+
+    // LISTEN-NOTIFY-1 — wake a listening worker the instant this enqueue
+    // commits. Emitted through the SAME `client` (the caller's tx when one was
+    // passed, else the pool) so delivery is gated on commit — a rolled-back
+    // enqueue emits no phantom wake (D2). The pool name is the payload; the
+    // worker re-runs its own pool-filtered claim query on wake. Polling is the
+    // fallback, so a failed notify is non-fatal: log + continue.
+    if (this.listenNotify) {
+      const wakePool = (inserted as JobRunRow).pool;
+      try {
+        await pgNotify(client, JOBS_WAKE_CHANNEL, wakePool);
+      } catch (err) {
+        this.logger.warn(
+          `pg_notify(${JOBS_WAKE_CHANNEL}, ${wakePool}) failed for run ` +
+            `${(inserted as JobRunRow).id}: ${(err as Error).message} ` +
+            `(non-fatal — interval polling still claims the run).`,
+        );
+      }
+    }
 
     return inserted as JobRun;
   }

--- a/runtime/subsystems/jobs/job-worker.module.ts
+++ b/runtime/subsystems/jobs/job-worker.module.ts
@@ -245,11 +245,22 @@ export class JobWorkerOrchestrator implements OnModuleInit, OnModuleDestroy {
       // naming; it MUST NOT be passed as the claim-filter pool, or the
       // worker will never match any row and the pool silently never
       // drains. See v0.4.4 fix notes.
+      // LISTEN-NOTIFY-1 — thread the drizzle extension knobs into each spawned
+      // worker. `pollIntervalMs` was always honored by JobWorker but never
+      // received a config value; `listenNotify` is the new wake opt-in. Only
+      // the drizzle backend reads these (bullmq has native wakeups + its own
+      // queue topology), so we ignore them under `backend: 'bullmq'`.
+      const drizzleExt =
+        backend === 'drizzle'
+          ? this.options.domainModuleExtensions?.drizzle
+          : undefined;
       const workerOptions: JobWorkerOptions = {
         pool: poolName,
         concurrency: def.concurrency,
         shutdownTimeoutMs:
           this.options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS,
+        pollIntervalMs: drizzleExt?.pollIntervalMs,
+        listenNotify: drizzleExt?.listenNotify,
       };
       const worker = this.options.workerFactory
         ? this.options.workerFactory(workerOptions)

--- a/runtime/subsystems/jobs/job-worker.ts
+++ b/runtime/subsystems/jobs/job-worker.ts
@@ -37,6 +37,7 @@ import {
   type SpawnChildOptions,
   type StepOptions,
 } from './job-handler.base';
+import { JOBS_WAKE_CHANNEL, PgNotifyListener } from './pg-notify';
 
 /**
  * Options accepted by `JobWorker`. JOB-5 threads these through module
@@ -59,6 +60,14 @@ export interface JobWorkerOptions {
   staleThresholdMs?: number;
   /** Max ms to wait for in-flight drain on SIGTERM. Default 30_000. */
   shutdownTimeoutMs?: number;
+  /**
+   * LISTEN-NOTIFY-1 — when true, hold a dedicated listener connection and
+   * LISTEN on `codegen_jobs_wake`. A notification naming this worker's `pool`
+   * triggers an immediate (debounced) claim cycle, so an enqueue is claimed in
+   * milliseconds instead of waiting for the next `pollIntervalMs` tick. Polling
+   * continues unchanged as the fallback heartbeat. Default false.
+   */
+  listenNotify?: boolean;
 }
 
 // ADR-037: namespaced `Symbol.for(...)` (via `tokenKey()`) — matches by value
@@ -192,6 +201,15 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
   private readonly staleThresholdMs: number;
   private readonly shutdownTimeoutMs: number;
 
+  // LISTEN-NOTIFY-1 — dedicated listener + debounce state. `null` when
+  // `listenNotify` is off (the common case); polling is the only driver then.
+  private readonly listenNotifyEnabled: boolean;
+  private notifyListener: PgNotifyListener | null = null;
+  /** True while a wake-driven claim cycle is in flight (debounce gate). */
+  private wakeDraining = false;
+  /** A notify arrived mid-cycle → re-check once when the cycle ends. */
+  private wakeRecheckPending = false;
+
   constructor(
     @Inject(DRIZZLE) private readonly db: DrizzleClient,
     @Inject(JOB_ORCHESTRATOR) private readonly orchestrator: IJobOrchestrator,
@@ -206,6 +224,7 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
     this.staleThresholdMs = options.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
     this.shutdownTimeoutMs =
       options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+    this.listenNotifyEnabled = options.listenNotify ?? false;
 
     this.sigtermHandler = () => {
       if (this.sigtermHandled) return;
@@ -227,6 +246,74 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
       void this.sweepStaleClaims();
     }, this.staleSweeperIntervalMs);
     process.on('SIGTERM', this.sigtermHandler);
+
+    // LISTEN-NOTIFY-1 — start the wake listener ALONGSIDE the poll timer (never
+    // instead). A notify for this worker's pool drives an immediate claim cycle;
+    // the interval timer above stays the durability heartbeat. Listener startup
+    // is fire-and-forget: a connect failure self-heals via the listener's own
+    // backoff, and until it's up the poll loop is the sole driver.
+    if (this.listenNotifyEnabled) {
+      // The DRIZZLE provider wraps a `pg.Pool`, exposed by drizzle as `$client`.
+      const pool = (this.db as unknown as { $client?: unknown }).$client;
+      if (!pool || typeof (pool as { connect?: unknown }).connect !== 'function') {
+        this.logger.warn(
+          `listen_notify enabled but the Drizzle client exposes no pg Pool ` +
+            `($client.connect missing) — falling back to interval polling only.`,
+        );
+      } else {
+        this.notifyListener = new PgNotifyListener({
+          channel: JOBS_WAKE_CHANNEL,
+          pool: pool as { connect(): Promise<never> },
+          label: `jobs:${this.options.pool}`,
+          onNotify: (payload) => this.onWake(payload),
+        });
+        void this.notifyListener.start();
+      }
+    }
+  }
+
+  /**
+   * Wake handler — a `codegen_jobs_wake` notification arrived. Only payloads
+   * naming THIS worker's pool are relevant (other pools have their own workers).
+   * Debounced: if a claim cycle is already running we just flag a re-check so a
+   * burst of N enqueues collapses to at most one extra cycle (D3).
+   */
+  private onWake(payload: string): void {
+    if (this.shuttingDown) return;
+    if (payload !== this.options.pool) return;
+    if (this.wakeDraining) {
+      this.wakeRecheckPending = true;
+      return;
+    }
+    void this.drainOnWake();
+  }
+
+  /**
+   * Claim-until-empty on a wake. Unlike the interval `pollAndProcess` (one
+   * claim per tick), a wake drains greedily up to the concurrency ceiling so a
+   * burst that arrived together is dispatched without waiting for N ticks. The
+   * `wakeRecheckPending` flag coalesces notifies that land mid-drain.
+   */
+  private async drainOnWake(): Promise<void> {
+    this.wakeDraining = true;
+    try {
+      do {
+        this.wakeRecheckPending = false;
+        // Claim while there's capacity; pollAndProcess no-ops at the ceiling.
+        let progressed = true;
+        while (
+          progressed &&
+          !this.shuttingDown &&
+          this.inFlight.size < this.options.concurrency
+        ) {
+          const before = this.inFlight.size;
+          await this.pollAndProcess();
+          progressed = this.inFlight.size > before;
+        }
+      } while (this.wakeRecheckPending && !this.shuttingDown);
+    } finally {
+      this.wakeDraining = false;
+    }
   }
 
   async onModuleDestroy(): Promise<void> {
@@ -245,6 +332,17 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
       this.sweeperTimer = null;
     }
     process.removeListener('SIGTERM', this.sigtermHandler);
+
+    // LISTEN-NOTIFY-1 — release the listener connection so the process can exit
+    // cleanly. Best-effort; a failure here doesn't block the drain.
+    if (this.notifyListener) {
+      try {
+        await this.notifyListener.stop();
+      } catch (err) {
+        this.logger.error(`notify listener stop failed: ${(err as Error).message}`);
+      }
+      this.notifyListener = null;
+    }
 
     await this.drainInFlight();
 

--- a/runtime/subsystems/jobs/jobs-domain.module.ts
+++ b/runtime/subsystems/jobs/jobs-domain.module.ts
@@ -21,6 +21,7 @@ import {
   JOB_RUN_SERVICE,
   JOB_STEP_SERVICE,
   JOBS_MULTI_TENANT,
+  JOBS_LISTEN_NOTIFY,
 } from './jobs-domain.tokens';
 import { DrizzleJobOrchestrator } from './job-orchestrator.drizzle-backend';
 import { DrizzleJobRunService } from './job-run-service.drizzle-backend';
@@ -41,17 +42,22 @@ import {
 } from './bullmq.config';
 
 /**
- * Drizzle backend extensions surface. None are wired into the Drizzle
- * orchestrator yet — this is the **typed reservation** for the LISTEN/NOTIFY
- * + tunable poll-interval extensions called out in ADR-022. App code
- * passing these today is parsed but not yet dispatched; when the
- * Drizzle orchestrator grows the consumer hooks, opt-in code paths will
- * read directly from these fields.
+ * Drizzle backend extensions surface (LISTEN-NOTIFY-1 wires both fields).
+ *
+ * - `listenNotify` → provided as `JOBS_LISTEN_NOTIFY` so the orchestrator emits
+ *   in-tx `pg_notify` on enqueue, and threaded into each spawned `JobWorker`
+ *   (which holds the listener connection). Off by default.
+ * - `pollIntervalMs` → threaded into the spawned `JobWorker`'s
+ *   `JobWorkerOptions.pollIntervalMs` (the worker already honored this; it just
+ *   never received a config value). Default 1000.
+ *
+ * Both run ALONGSIDE interval polling — `listenNotify` only adds an early wake;
+ * polling remains the durability heartbeat.
  */
 export interface DrizzleBackendExtensions {
   /** Use Postgres LISTEN/NOTIFY to wake the polling loop. Default false. */
   listenNotify?: boolean;
-  /** Polling interval when LISTEN/NOTIFY is off (ms). Default 1000. */
+  /** Polling interval (ms). Default 1000. */
   pollIntervalMs?: number;
 }
 
@@ -79,6 +85,11 @@ export interface JobsDomainModuleOptions {
 export class JobsDomainModule {
   static forRoot(opts: JobsDomainModuleOptions): DynamicModule {
     const multiTenant = opts.multiTenant ?? false;
+    // LISTEN-NOTIFY-1 — drizzle-only extension. `listen_notify` is meaningless
+    // for memory (no DB) and redundant for bullmq (native wakeups); only the
+    // drizzle backend's orchestrator reads it.
+    const listenNotify =
+      opts.backend === 'drizzle' && Boolean(opts.extensions?.drizzle?.listenNotify);
 
     const providers: Provider[] = [
       // JOB-8 — boolean provider consumed by the four service-layer backends.
@@ -87,6 +98,9 @@ export class JobsDomainModule {
       // the value is `false`. See `jobs-domain.tokens.ts` for the claim-loop
       // cross-tenant-by-design decision.
       { provide: JOBS_MULTI_TENANT, useValue: multiTenant },
+      // LISTEN-NOTIFY-1 — always provided so the orchestrator's `@Inject`
+      // resolves; the orchestrator skips the `pg_notify` emit when `false`.
+      { provide: JOBS_LISTEN_NOTIFY, useValue: listenNotify },
     ];
 
     if (opts.backend === 'memory') {
@@ -144,6 +158,7 @@ export class JobsDomainModule {
       JOB_RUN_SERVICE,
       JOB_STEP_SERVICE,
       JOBS_MULTI_TENANT,
+      JOBS_LISTEN_NOTIFY,
     ];
     // BULLMQ-1 — only export the BullMQ tokens when they were actually
     // provided. Nest throws "exported but not provided" otherwise. Exported so

--- a/runtime/subsystems/jobs/jobs-domain.tokens.ts
+++ b/runtime/subsystems/jobs/jobs-domain.tokens.ts
@@ -31,3 +31,16 @@ export const JOB_STEP_SERVICE = Symbol.for(tokenKey('jobs', 'step-service'));
  * targeted reads. See docs/specs/JOB-8.md.
  */
 export const JOBS_MULTI_TENANT = Symbol.for(tokenKey('jobs', 'multi-tenant'));
+
+/**
+ * LISTEN/NOTIFY wakeup opt-in flag (LISTEN-NOTIFY-1). Bound to
+ * `JobsDomainModule.forRoot({ extensions: { drizzle: { listenNotify } } })`,
+ * defaulting to `false`.
+ *
+ * When `true`, the Drizzle orchestrator emits an in-transaction
+ * `pg_notify(codegen_jobs_wake, <pool>)` on every `start()` INSERT so a worker
+ * with `listen_notify` enabled wakes the moment the enqueue commits. Off by
+ * default; polling is unchanged. The flag is read by `DrizzleJobOrchestrator`
+ * and by the bridge outbox drain hook (its wrapper `job_run` inserts notify too).
+ */
+export const JOBS_LISTEN_NOTIFY = Symbol.for(tokenKey('jobs', 'listen-notify'));

--- a/runtime/subsystems/jobs/pg-notify.ts
+++ b/runtime/subsystems/jobs/pg-notify.ts
@@ -1,0 +1,216 @@
+/**
+ * PgNotifyListener + pgNotify — Postgres LISTEN/NOTIFY wakeups
+ * (LISTEN-NOTIFY-1, dogfood gap #7).
+ *
+ * The drizzle jobs worker and events outbox drainer poll on an interval today
+ * (default 1 s/hop). With `listen_notify` enabled, a row write that makes work
+ * claimable emits an in-transaction `pg_notify(...)`; a dedicated listener
+ * connection wakes the polling loop the moment the writing transaction commits.
+ *
+ * Two halves:
+ *   - `pgNotify(tx, channel, payload)` — fire an in-tx `pg_notify`. MUST be
+ *     called with the SAME transaction handle as the row write it announces, so
+ *     Postgres delivers it only on commit (the transactional-outbox guarantee).
+ *   - `PgNotifyListener` — owns a single long-lived `pg.PoolClient`, issues
+ *     `LISTEN <channel>`, forwards each notification's payload to an owner
+ *     callback, debounces bursts, and reconnects with capped backoff on drop.
+ *
+ * **Polling never stops.** This is a wake-early optimisation layered ON TOP of
+ * interval polling. A lost notification (listener down, pooler eats the LISTEN,
+ * etc.) degrades to today's poll latency, never to lost work — the claim/drain
+ * query remains the source of truth.
+ *
+ * **PgBouncer caveat:** session-scoped `LISTEN` does not survive a
+ * transaction-mode pooler. `listen_notify` requires a direct (or session-mode)
+ * connection; behind a transaction pooler notifies are simply never received and
+ * the system degrades to polling. See the jobs config block / skill.
+ */
+// TODO(logging-subsystem): swap to ILogger once ADR-028 lands
+import { Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import type { DrizzleClient } from '../../types/drizzle';
+import type { DrizzleTransaction } from '../events/event-bus.protocol';
+
+/** Channel the jobs worker LISTENs on; payload = pool name. */
+export const JOBS_WAKE_CHANNEL = 'codegen_jobs_wake';
+/** Channel the events drainer LISTENs on; payload = event pool (or ''). */
+export const EVENTS_WAKE_CHANNEL = 'codegen_events_wake';
+
+/**
+ * Emit an in-transaction `pg_notify`. Call with the SAME `tx`/client handle as
+ * the row write being announced so delivery is gated on commit. `payload` is a
+ * short plain string (a pool name); it is NOT JSON — the wake is a hint and the
+ * subsequent claim/drain query is authoritative. Channel names are framework
+ * constants (never user input), so the `set_config`-free literal-channel form is
+ * safe; the payload is bound as a parameter.
+ */
+export async function pgNotify(
+  tx: DrizzleClient | DrizzleTransaction,
+  channel: string,
+  payload: string,
+): Promise<void> {
+  const client = tx as DrizzleClient;
+  // `pg_notify(channel, payload)` is the function form (vs the `NOTIFY chan,
+  // 'payload'` statement form) precisely because it accepts bound parameters —
+  // the payload is parameterised, never string-concatenated.
+  await client.execute(sql`select pg_notify(${channel}, ${payload})`);
+}
+
+/** Minimal structural view of the `pg` Client/PoolClient surface we touch. */
+interface PgListenClient {
+  query(text: string): Promise<unknown>;
+  on(event: 'notification', cb: (msg: { channel: string; payload?: string }) => void): void;
+  on(event: 'error', cb: (err: Error) => void): void;
+  removeAllListeners?: (event?: string) => void;
+  release?: (err?: boolean) => void;
+  end?: () => Promise<void>;
+}
+
+/** Minimal structural view of the `pg` Pool's `connect()`. */
+interface PgPoolish {
+  connect(): Promise<PgListenClient>;
+}
+
+const DEFAULT_BACKOFF_MIN_MS = 100;
+const DEFAULT_BACKOFF_MAX_MS = 5_000;
+
+export interface PgNotifyListenerOptions {
+  /** Channel to LISTEN on. */
+  channel: string;
+  /**
+   * The underlying `pg.Pool` — obtained from `drizzleClient.$client`. A
+   * dedicated `PoolClient` is checked out and held for the listener's lifetime
+   * (separate from the query pool so a slow query never delays a wake).
+   */
+  pool: PgPoolish;
+  /**
+   * Called for every notification on `channel`, with the raw payload string
+   * (`''` when Postgres delivers an empty payload). The owner decides whether
+   * the payload is relevant (e.g. "is this one of my pools?") and debounces its
+   * own claim cycle.
+   */
+  onNotify: (payload: string) => void;
+  /** Label used in log lines (e.g. 'jobs:interactive', 'events'). */
+  label: string;
+  backoffMinMs?: number;
+  backoffMaxMs?: number;
+}
+
+/**
+ * Holds a dedicated listener connection and forwards notifications to `onNotify`.
+ * Reconnects with capped exponential backoff on drop; logs the first failure +
+ * the recovery exactly once each so a flapping connection doesn't flood logs.
+ */
+export class PgNotifyListener {
+  private readonly logger: Logger;
+  private client: PgListenClient | null = null;
+  private stopped = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private backoffMs: number;
+  private readonly backoffMinMs: number;
+  private readonly backoffMaxMs: number;
+  /** WARN-once gate so a flapping listener doesn't spam the log. */
+  private warnedDown = false;
+
+  constructor(private readonly opts: PgNotifyListenerOptions) {
+    this.logger = new Logger(`PgNotifyListener(${opts.label})`);
+    this.backoffMinMs = opts.backoffMinMs ?? DEFAULT_BACKOFF_MIN_MS;
+    this.backoffMaxMs = opts.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
+    this.backoffMs = this.backoffMinMs;
+  }
+
+  /** Begin listening. Idempotent-ish: a second call while connected is a no-op. */
+  async start(): Promise<void> {
+    this.stopped = false;
+    await this.connect();
+  }
+
+  /** Stop listening + release the connection. Safe to call repeatedly. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    await this.releaseClient();
+  }
+
+  private async connect(): Promise<void> {
+    if (this.stopped) return;
+    try {
+      const client = await this.opts.pool.connect();
+      client.on('notification', (msg) => {
+        if (msg.channel !== this.opts.channel) return;
+        try {
+          this.opts.onNotify(msg.payload ?? '');
+        } catch (err) {
+          this.logger.error(`onNotify threw: ${(err as Error).message}`);
+        }
+      });
+      client.on('error', (err) => {
+        // A connection-level error is the signal to reconnect. Don't double-log
+        // here — scheduleReconnect owns the WARN-once.
+        this.logger.debug?.(`listener connection error: ${err.message}`);
+        this.handleDrop();
+      });
+      await client.query(`LISTEN ${this.opts.channel}`);
+      this.client = client;
+      // Recovery: only announce if we had previously warned about being down.
+      if (this.warnedDown) {
+        this.logger.log(
+          `listener reconnected; LISTEN ${this.opts.channel} re-established`,
+        );
+        this.warnedDown = false;
+      }
+      this.backoffMs = this.backoffMinMs;
+    } catch (err) {
+      this.handleConnectFailure(err);
+    }
+  }
+
+  /** Connection dropped after being established → reconnect. */
+  private handleDrop(): void {
+    if (this.stopped) return;
+    void this.releaseClient().finally(() => this.scheduleReconnect());
+  }
+
+  /** Initial / reconnect `connect()` threw. */
+  private handleConnectFailure(err: unknown): void {
+    this.scheduleReconnect(err);
+  }
+
+  private scheduleReconnect(err?: unknown): void {
+    if (this.stopped) return;
+    if (!this.warnedDown) {
+      this.warnedDown = true;
+      this.logger.warn(
+        `listener down — falling back to interval polling until reconnect. ` +
+          `Cause: ${err instanceof Error ? err.message : 'connection lost'}. ` +
+          `(This degrades latency, not durability — polling still drives all work.)`,
+      );
+    }
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    const delay = this.backoffMs;
+    this.backoffMs = Math.min(this.backoffMs * 2, this.backoffMaxMs);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect();
+    }, delay);
+  }
+
+  private async releaseClient(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    if (!client) return;
+    try {
+      client.removeAllListeners?.('notification');
+      client.removeAllListeners?.('error');
+      // A listener client is a checked-out pool connection; release it back
+      // with `release(true)` (destroy) so a half-broken socket isn't reused.
+      if (client.release) client.release(true);
+      else if (client.end) await client.end();
+    } catch {
+      // best-effort teardown
+    }
+  }
+}

--- a/src/__tests__/cli/subsystem-barrel-generator.test.ts
+++ b/src/__tests__/cli/subsystem-barrel-generator.test.ts
@@ -322,6 +322,77 @@ describe('buildSubsystemBarrel', () => {
 		expect(out.content).not.toContain('registry:');
 		expect(out.content).not.toContain('bridge-registry');
 	});
+
+	// ─── LISTEN-NOTIFY-1: drizzle extension threading ────────────────────────
+
+	test('jobs `extensions.drizzle.listen_notify` threads into JobsDomainModule + embedded worker', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{
+				jobs: {
+					backend: 'drizzle',
+					worker_mode: 'embedded',
+					extensions: { drizzle: { listen_notify: true, poll_interval_ms: 250 } },
+				},
+			},
+			subsystemsRel,
+		);
+		// Domain module (orchestrator emits the enqueue notify):
+		expect(out.content).toContain(
+			'JobsDomainModule.forRoot({ backend: \'drizzle\', extensions: { drizzle: { listenNotify: true, pollIntervalMs: 250 } } }),',
+		);
+		// Embedded worker (holds the listener + honors pollInterval):
+		expect(out.content).toContain(
+			'domainModuleExtensions: { drizzle: { listenNotify: true, pollIntervalMs: 250 } }',
+		);
+	});
+
+	test('jobs drizzle extensions thread `pollIntervalMs` alone (listen_notify omitted → off by default)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{
+				jobs: {
+					backend: 'drizzle',
+					worker_mode: 'embedded',
+					extensions: { drizzle: { poll_interval_ms: 500 } },
+				},
+			},
+			subsystemsRel,
+		);
+		expect(out.content).toContain('pollIntervalMs: 500');
+		expect(out.content).not.toContain('listenNotify');
+	});
+
+	test('jobs WITHOUT drizzle extensions stays byte-identical (no domainModuleExtensions clause)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{ jobs: { backend: 'drizzle', worker_mode: 'embedded' } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain("JobsDomainModule.forRoot({ backend: 'drizzle', multiTenant: false }),");
+		expect(out.content).not.toContain('domainModuleExtensions');
+		expect(out.content).not.toContain('listenNotify');
+	});
+
+	test('events `extensions.drizzle.listen_notify` threads into EventsModule.forRoot (vendored)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('events')],
+			{ events: { backend: 'drizzle', extensions: { drizzle: { listen_notify: true } } } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"EventsModule.forRoot({ backend: 'drizzle', multiTenant: false, listenNotify: true }),",
+		);
+	});
+
+	test('events WITHOUT listen_notify stays off-by-default (no listenNotify key)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('events')],
+			{ events: { backend: 'drizzle' } },
+			subsystemsRel,
+		);
+		expect(out.content).not.toContain('listenNotify');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -382,6 +453,34 @@ describe('buildSubsystemBarrel — package mode (ADR-037)', () => {
 			"import { JobWorkerModule } from '@pattern-stack/codegen/runtime/subsystems/jobs/index';",
 		);
 		expect(out.content).toContain("JobWorkerModule.forRoot({ mode: 'embedded' }),");
+	});
+
+	test('package-mode events listen_notify threads listenNotify alongside typedBus (LISTEN-NOTIFY-1)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('events')],
+			{ events: { backend: 'drizzle', extensions: { drizzle: { listen_notify: true } } } },
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain(
+			"EventsModule.forRoot({ backend: 'drizzle', multiTenant: false, typedBus: TypedEventBus, listenNotify: true }),",
+		);
+	});
+
+	test('package-mode jobs drizzle extensions thread into the embedded worker (LISTEN-NOTIFY-1)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{
+				jobs: {
+					backend: 'drizzle',
+					worker_mode: 'embedded',
+					extensions: { drizzle: { listen_notify: true } },
+				},
+			},
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain('domainModuleExtensions: { drizzle: { listenNotify: true } }');
 	});
 
 	test('vendored mode (explicit) still emits the relative-path imports', () => {

--- a/src/__tests__/runtime/subsystems/listen-notify.spec.ts
+++ b/src/__tests__/runtime/subsystems/listen-notify.spec.ts
@@ -1,0 +1,388 @@
+/**
+ * Unit tests for LISTEN-NOTIFY-1 — Postgres LISTEN/NOTIFY wakeups across the
+ * jobs orchestrator, events outbox drainer, bridge wrapper insert, and the
+ * `PgNotifyListener` helper. No Postgres / Docker — mocked Drizzle clients +
+ * a fake `pg.Pool` exercise the wiring. The on-commit delivery semantics
+ * (NOTIFY queued in-tx, delivered only on commit) are inherent to Postgres and
+ * out of unit scope; these tests pin the SEAM (emit-through-the-tx-client +
+ * debounce + degradation), which is what the framework owns.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+
+import { DrizzleJobOrchestrator } from '../../../../runtime/subsystems/jobs/job-orchestrator.drizzle-backend';
+import { DrizzleEventBus } from '../../../../runtime/subsystems/events/event-bus.drizzle-backend';
+import { BridgeOutboxDrainHook } from '../../../../runtime/subsystems/bridge';
+import {
+  JobWorker,
+  type JobWorkerOptions,
+} from '../../../../runtime/subsystems/jobs/job-worker';
+import {
+  PgNotifyListener,
+  JOBS_WAKE_CHANNEL,
+  EVENTS_WAKE_CHANNEL,
+} from '../../../../runtime/subsystems/jobs/pg-notify';
+import type { DomainEvent } from '../../../../runtime/subsystems/events/event-bus.protocol';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Render a captured drizzle `sql` chunk to its raw SQL string. */
+function sqlText(arg: unknown): string {
+  const q = arg as { queryChunks?: Array<{ value?: string[] }> };
+  const chunks = q?.queryChunks ?? [];
+  return chunks.map((c) => (c?.value ? c.value.join('') : '')).join('');
+}
+
+// ─── 1. Orchestrator emits NOTIFY on start (in-tx, gated on the flag) ─────────
+
+describe('DrizzleJobOrchestrator — listen_notify enqueue wake', () => {
+  function makeDb(insertedRow: Record<string, unknown>) {
+    const executeCalls: unknown[][] = [];
+    const insertBuilder = {
+      values: mock(() => insertBuilder),
+      returning: mock(async () => [insertedRow]),
+    };
+    const selectBuilder = {
+      from: mock(() => selectBuilder),
+      where: mock(() => selectBuilder),
+      limit: mock(async () => [
+        // job definition row used by start()
+        { type: 'job.t', version: 1, pool: 'interactive', priorityDefault: 0 },
+      ]),
+      orderBy: mock(() => selectBuilder),
+    };
+    const db = {
+      select: mock(() => selectBuilder),
+      insert: mock(() => insertBuilder),
+      execute: mock(async (q: unknown) => {
+        executeCalls.push([q]);
+        return { rows: [] };
+      }),
+    };
+    return { db, executeCalls };
+  }
+
+  const insertedRow = {
+    id: 'run-1',
+    pool: 'interactive',
+    jobType: 'job.t',
+    status: 'pending',
+  };
+
+  it('emits pg_notify(codegen_jobs_wake, <pool>) when listen_notify is on', async () => {
+    const { db, executeCalls } = makeDb(insertedRow);
+    const orch = new DrizzleJobOrchestrator(db as never, false, /*listenNotify*/ true);
+    await orch.start('job.t', {});
+    expect(executeCalls.length).toBe(1);
+    const text = sqlText(executeCalls[0][0]).toLowerCase();
+    expect(text).toContain('pg_notify');
+  });
+
+  it('does NOT emit pg_notify when listen_notify is off (default)', async () => {
+    const { db, executeCalls } = makeDb(insertedRow);
+    const orch = new DrizzleJobOrchestrator(db as never, false /* default off */);
+    await orch.start('job.t', {});
+    expect(executeCalls.length).toBe(0);
+  });
+
+  it('emits through the SAME client (the tx when one is passed)', async () => {
+    const { db: rootDb } = makeDb(insertedRow);
+    const txExecute = mock(async () => ({ rows: [] }));
+    const txInsertBuilder = {
+      values: mock(() => txInsertBuilder),
+      returning: mock(async () => [insertedRow]),
+    };
+    const txSelectBuilder = {
+      from: mock(() => txSelectBuilder),
+      where: mock(() => txSelectBuilder),
+      limit: mock(async () => [
+        { type: 'job.t', version: 1, pool: 'interactive', priorityDefault: 0 },
+      ]),
+      orderBy: mock(() => txSelectBuilder),
+    };
+    const tx = {
+      select: mock(() => txSelectBuilder),
+      insert: mock(() => txInsertBuilder),
+      execute: txExecute,
+    };
+    const orch = new DrizzleJobOrchestrator(rootDb as never, false, true);
+    await orch.start('job.t', {}, {}, tx as never);
+    // NOTIFY rode the tx handle, not the root db (D2 — in-tx, commit-gated).
+    expect(txExecute).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── 2. Events drainer emits NOTIFY on publish ────────────────────────────────
+
+describe('DrizzleEventBus — listen_notify publish wake', () => {
+  function makeDb() {
+    const executeCalls: unknown[][] = [];
+    const insertBuilder = { values: mock(async () => []) };
+    const db = {
+      insert: mock(() => insertBuilder),
+      execute: mock(async (q: unknown) => {
+        executeCalls.push([q]);
+        return { rows: [] };
+      }),
+    };
+    return { db, executeCalls };
+  }
+
+  const event: DomainEvent = {
+    id: 'e-1',
+    type: 't',
+    aggregateId: 'a-1',
+    aggregateType: 'agg',
+    payload: {},
+    occurredAt: new Date('2026-06-04T00:00:00Z'),
+    metadata: { pool: 'events_inbound', direction: 'inbound' },
+  };
+
+  it('emits pg_notify(codegen_events_wake, <pool>) on publish when enabled', async () => {
+    const { db, executeCalls } = makeDb();
+    const bus = new DrizzleEventBus(db as never, {
+      backend: 'drizzle',
+      listenNotify: true,
+    });
+    await bus.publish(event);
+    expect(executeCalls.length).toBe(1);
+    expect(sqlText(executeCalls[0][0]).toLowerCase()).toContain('pg_notify');
+  });
+
+  it('does NOT emit when listen_notify is off', async () => {
+    const { db, executeCalls } = makeDb();
+    const bus = new DrizzleEventBus(db as never, { backend: 'drizzle' });
+    await bus.publish(event);
+    expect(executeCalls.length).toBe(0);
+  });
+
+  it('publishMany de-dups one wake per distinct pool', async () => {
+    const { db, executeCalls } = makeDb();
+    const bus = new DrizzleEventBus(db as never, {
+      backend: 'drizzle',
+      listenNotify: true,
+    });
+    await bus.publishMany([
+      event,
+      { ...event, id: 'e-2' }, // same pool → coalesced
+    ]);
+    expect(executeCalls.length).toBe(1);
+  });
+});
+
+// ─── 3. Bridge wrapper insert emits NOTIFY ────────────────────────────────────
+
+describe('BridgeOutboxDrainHook — listen_notify wrapper wake', () => {
+  function makeTx() {
+    const executeCalls: unknown[][] = [];
+    let returningIdx = 0;
+    const returningResults = [['delivery-1']]; // delivery row inserted
+    const tx = {
+      insert() {
+        const builder = {
+          values() {
+            const chain = {
+              onConflictDoNothing() {
+                return {
+                  returning() {
+                    const ids = returningResults[returningIdx++] ?? [];
+                    return Promise.resolve(ids.map((id) => ({ id })));
+                  },
+                };
+              },
+              then(resolve: (v: unknown[]) => void) {
+                resolve([]);
+              },
+            };
+            return chain;
+          },
+        };
+        return builder;
+      },
+      delete() {
+        return { where: () => Promise.resolve([]) };
+      },
+      execute: mock(async (q: unknown) => {
+        executeCalls.push([q]);
+        return { rows: [] };
+      }),
+    };
+    return { tx, executeCalls };
+  }
+
+  const registry = {
+    contact_created: [{ triggerId: 'trig-1', jobType: 'job.x', concurrency: undefined }],
+  } as never;
+
+  const event: DomainEvent = {
+    id: 'evt-1',
+    type: 'contact_created',
+    aggregateId: 'a',
+    aggregateType: 'contact',
+    payload: {},
+    occurredAt: new Date(),
+    metadata: { direction: 'change' },
+  };
+
+  it('emits pg_notify(codegen_jobs_wake, events_change) when enabled', async () => {
+    const { tx, executeCalls } = makeTx();
+    const hook = new BridgeOutboxDrainHook(registry, /*listenNotify*/ true);
+    const res = await hook.processEvent(event, tx as never);
+    expect(res.delivered).toBe(1);
+    expect(executeCalls.length).toBe(1);
+    expect(sqlText(executeCalls[0][0]).toLowerCase()).toContain('pg_notify');
+  });
+
+  it('does NOT emit when listen_notify is off', async () => {
+    const { tx, executeCalls } = makeTx();
+    const hook = new BridgeOutboxDrainHook(registry); // default false
+    await hook.processEvent(event, tx as never);
+    expect(executeCalls.length).toBe(0);
+  });
+});
+
+// ─── 4. JobWorker wake debounce + pool filtering ──────────────────────────────
+
+describe('JobWorker — onWake debounce + pool filter', () => {
+  function makeWorker(opts: Partial<JobWorkerOptions> = {}): {
+    worker: JobWorker;
+    pollSpy: ReturnType<typeof mock>;
+  } {
+    const db = { $client: { connect: mock(async () => ({})) } };
+    const orch = {} as never;
+    const runSvc = {} as never;
+    const stepSvc = {} as never;
+    const moduleRef = {} as never;
+    const options: JobWorkerOptions = {
+      pool: 'interactive',
+      concurrency: 2,
+      listenNotify: true,
+      ...opts,
+    };
+    const worker = new JobWorker(
+      db as never,
+      orch,
+      runSvc,
+      stepSvc,
+      options,
+      moduleRef,
+    );
+    // Stub the claim cycle so onWake's drain loop exercises debounce, not DB.
+    const pollSpy = mock(async () => {
+      /* claims nothing → no progress → drain loop exits */
+    });
+    (worker as unknown as { pollAndProcess: unknown }).pollAndProcess = pollSpy;
+    return { worker, pollSpy };
+  }
+
+  it('ignores a notify naming a foreign pool', () => {
+    const { worker, pollSpy } = makeWorker();
+    (worker as unknown as { onWake(p: string): void }).onWake('batch');
+    expect(pollSpy).not.toHaveBeenCalled();
+  });
+
+  it('drives a claim cycle on a notify for its own pool', async () => {
+    const { worker, pollSpy } = makeWorker();
+    (worker as unknown as { onWake(p: string): void }).onWake('interactive');
+    // drainOnWake is async; flush microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(pollSpy).toHaveBeenCalled();
+  });
+
+  it('coalesces a mid-drain notify into a single re-check (no stacking)', async () => {
+    const db = { $client: { connect: mock(async () => ({})) } };
+    const options: JobWorkerOptions = {
+      pool: 'interactive',
+      concurrency: 2,
+      listenNotify: true,
+    };
+    const worker = new JobWorker(
+      db as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      options,
+      {} as never,
+    );
+    let cycles = 0;
+    // First cycle: while "draining", fire a second notify → must set recheck,
+    // NOT spawn a parallel drain. Returns no progress so the inner loop exits.
+    (worker as unknown as { pollAndProcess: () => Promise<void> }).pollAndProcess =
+      async () => {
+        cycles++;
+        if (cycles === 1) {
+          (worker as unknown as { onWake(p: string): void }).onWake('interactive');
+        }
+      };
+    await (worker as unknown as { drainOnWake(): Promise<void> }).drainOnWake();
+    // cycle 1 (initial) + cycle 2 (the coalesced re-check) = exactly 2, never 3+.
+    expect(cycles).toBe(2);
+  });
+});
+
+// ─── 5. PgNotifyListener — degradation to polling on listener death ───────────
+
+describe('PgNotifyListener — degradation + recovery', () => {
+  it('reconnects with backoff after the listener connection drops', async () => {
+    let connects = 0;
+    let dropHandler: ((err: Error) => void) | null = null;
+    const client = {
+      query: mock(async () => ({})),
+      on: (ev: string, cb: (arg: never) => void) => {
+        if (ev === 'error') dropHandler = cb as (err: Error) => void;
+      },
+      release: mock(() => {}),
+    };
+    const pool = {
+      connect: mock(async () => {
+        connects++;
+        return client;
+      }),
+    };
+    const notifies: string[] = [];
+    const listener = new PgNotifyListener({
+      channel: JOBS_WAKE_CHANNEL,
+      pool: pool as never,
+      label: 'test',
+      onNotify: (p) => notifies.push(p),
+      backoffMinMs: 5,
+      backoffMaxMs: 10,
+    });
+    await listener.start();
+    expect(connects).toBe(1);
+    // Simulate a connection drop → listener schedules a reconnect.
+    dropHandler?.(new Error('connection terminated'));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(connects).toBeGreaterThanOrEqual(2); // reconnected → still degraded-safe
+    await listener.stop();
+  });
+
+  it('forwards only matching-channel notifications to onNotify', async () => {
+    let notificationHandler:
+      | ((msg: { channel: string; payload?: string }) => void)
+      | null = null;
+    const client = {
+      query: mock(async () => ({})),
+      on: (ev: string, cb: (arg: never) => void) => {
+        if (ev === 'notification')
+          notificationHandler = cb as (msg: {
+            channel: string;
+            payload?: string;
+          }) => void;
+      },
+      release: mock(() => {}),
+    };
+    const pool = { connect: mock(async () => client) };
+    const received: string[] = [];
+    const listener = new PgNotifyListener({
+      channel: EVENTS_WAKE_CHANNEL,
+      pool: pool as never,
+      label: 'events',
+      onNotify: (p) => received.push(p),
+    });
+    await listener.start();
+    notificationHandler?.({ channel: EVENTS_WAKE_CHANNEL, payload: 'events_inbound' });
+    notificationHandler?.({ channel: 'other_channel', payload: 'nope' });
+    expect(received).toEqual(['events_inbound']);
+    await listener.stop();
+  });
+});

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -133,23 +133,71 @@ function jsonToTs(value: unknown): string {
 }
 
 /**
+ * LISTEN-NOTIFY-1 — extract the drizzle extension knobs (`listen_notify`,
+ * `poll_interval_ms`) from `jobs.extensions.drizzle` and map them to the
+ * camelCase runtime shape. Returns `undefined` when neither knob is set (so the
+ * generated call stays minimal and off-by-default). Only the drizzle/default
+ * backend reads these.
+ */
+function drizzleJobsExtensions(
+	backend: string,
+	cfg: Record<string, unknown> | undefined,
+): { listenNotify?: boolean; pollIntervalMs?: number } | undefined {
+	if (backend !== 'drizzle') return undefined;
+	const drizzle = (cfg?.extensions as { drizzle?: Record<string, unknown> } | undefined)
+		?.drizzle;
+	if (!drizzle) return undefined;
+	const out: { listenNotify?: boolean; pollIntervalMs?: number } = {};
+	if (typeof drizzle.listen_notify === 'boolean') out.listenNotify = drizzle.listen_notify;
+	if (typeof drizzle.poll_interval_ms === 'number')
+		out.pollIntervalMs = drizzle.poll_interval_ms;
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Serialise the drizzle extension knobs to a `domainModuleExtensions: { drizzle:
+ * {...} }` fragment (camelCase keys, matching the runtime shape), or `''` when
+ * none apply. Threaded into BOTH `JobsDomainModule.forRoot` (so the orchestrator
+ * emits the enqueue notify) and `JobWorkerModule.forRoot` (so the spawned worker
+ * holds the listener + honors `pollIntervalMs`).
+ */
+function drizzleExtensionsClause(
+	ext: { listenNotify?: boolean; pollIntervalMs?: number } | undefined,
+	key: 'extensions' | 'domainModuleExtensions',
+): string {
+	if (!ext) return '';
+	return `${key}: { drizzle: ${jsonToTs(ext)} }`;
+}
+
+/**
  * BULLMQ-1 — build the `JobsDomainModule.forRoot(...)` options literal,
  * inlining the typed `extensions.bullmq` block when the BullMQ backend is
  * selected. Drizzle/memory fall back to the plain `{ backend, multiTenant }`
- * shape via `quoteOpts`.
+ * shape via `quoteOpts`. LISTEN-NOTIFY-1 threads the drizzle extension knobs
+ * (`listen_notify`/`poll_interval_ms`) on the drizzle path.
  */
 function quoteBullmqDomainOpts(input: {
 	backend: string;
 	multiTenant: boolean;
 	bullExt: Record<string, unknown> | undefined;
+	drizzleExt?: { listenNotify?: boolean; pollIntervalMs?: number } | undefined;
 }): string {
-	const { backend, multiTenant, bullExt } = input;
-	if (backend !== 'bullmq' || !bullExt) {
+	const { backend, multiTenant, bullExt, drizzleExt } = input;
+	if (backend === 'bullmq' && bullExt) {
+		const parts = [`backend: 'bullmq'`];
+		if (multiTenant) parts.push(`multiTenant: true`);
+		parts.push(`extensions: { bullmq: ${jsonToTs(bullExt)} }`);
+		return `{ ${parts.join(', ')} }`;
+	}
+	const extClause = drizzleExtensionsClause(drizzleExt, 'extensions');
+	if (!extClause) {
 		return quoteOpts({ backend, multiTenant });
 	}
-	const parts = [`backend: 'bullmq'`];
+	// Drizzle backend with extension knobs → assemble piecewise so we can append
+	// the `extensions: { drizzle: {...} }` block alongside backend/multiTenant.
+	const parts = [`backend: '${backend}'`];
 	if (multiTenant) parts.push(`multiTenant: true`);
-	parts.push(`extensions: { bullmq: ${jsonToTs(bullExt)} }`);
+	parts.push(extClause);
 	return `{ ${parts.join(', ')} }`;
 }
 
@@ -189,6 +237,15 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 	events: ({ moduleImport, cfg, mode }) => {
 		const backend = (cfg?.backend as string | undefined) ?? 'drizzle';
 		const multiTenant = Boolean(cfg?.multi_tenant);
+		// LISTEN-NOTIFY-1: opt-in `events.extensions.drizzle.listen_notify` →
+		// `EventsModule.forRoot({ listenNotify })`. Drizzle backend only; omitted
+		// (off-by-default) when the key is absent. Emit the fragment only when set
+		// so the no-extension barrel byte-shape is unchanged.
+		const listenNotify =
+			backend === 'drizzle' &&
+			(cfg?.extensions as { drizzle?: { listen_notify?: unknown } } | undefined)?.drizzle
+				?.listen_notify === true;
+		const listenNotifyClause = listenNotify ? `, listenNotify: true` : '';
 		const imports = [
 			`import { EventsModule } from '${moduleImport('events', 'events.module')}';`,
 		];
@@ -203,7 +260,15 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 			return {
 				imports,
 				calls: [
-					`\tEventsModule.forRoot({ backend: '${backend}', multiTenant: ${multiTenant}, typedBus: TypedEventBus }),`,
+					`\tEventsModule.forRoot({ backend: '${backend}', multiTenant: ${multiTenant}, typedBus: TypedEventBus${listenNotifyClause} }),`,
+				],
+			};
+		}
+		if (listenNotify) {
+			return {
+				imports,
+				calls: [
+					`\tEventsModule.forRoot({ backend: '${backend}', multiTenant: ${multiTenant}, listenNotify: true }),`,
 				],
 			};
 		}
@@ -230,7 +295,10 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 			backend === 'bullmq'
 				? (cfg?.extensions as { bullmq?: Record<string, unknown> } | undefined)?.bullmq
 				: undefined;
-		const domainOpts = quoteBullmqDomainOpts({ backend, multiTenant, bullExt });
+		// LISTEN-NOTIFY-1: drizzle extension knobs (`listen_notify`,
+		// `poll_interval_ms`) → camelCase runtime shape; `undefined` when unset.
+		const drizzleExt = drizzleJobsExtensions(backend, cfg);
+		const domainOpts = quoteBullmqDomainOpts({ backend, multiTenant, bullExt, drizzleExt });
 		const calls = [`\tJobsDomainModule.forRoot(${domainOpts}),`];
 		// JOB-7: `worker_mode: 'embedded'` runs the worker in-process alongside the
 		// HTTP app. `'standalone'` (default) means the user runs `bun worker.ts`
@@ -249,6 +317,18 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 				if (bullExt) {
 					parts.push(`domainModuleExtensions: { bullmq: ${jsonToTs(bullExt)} }`);
 				}
+			} else {
+				// LISTEN-NOTIFY-1: the embedded worker needs the drizzle knobs too —
+				// `JobWorkerModule` reads `domainModuleExtensions.drizzle` to thread
+				// `listenNotify` (the listener) + `pollIntervalMs` into each spawned
+				// `JobWorker`. (It also forwards them to the inner `JobsDomainModule`,
+				// but that one already got them via the standalone domain call above;
+				// re-passing is harmless and keeps the embedded worker self-contained.)
+				const workerExtClause = drizzleExtensionsClause(
+					drizzleExt,
+					'domainModuleExtensions',
+				);
+				if (workerExtClause) parts.push(workerExtClause);
 			}
 			const poolsClause = workerPoolsClause(cfg, bridgeInstalled);
 			if (poolsClause) parts.push(poolsClause);

--- a/templates/subsystem/events-config/codegen-config-events-block.ejs.t
+++ b/templates/subsystem/events-config/codegen-config-events-block.ejs.t
@@ -24,3 +24,17 @@ events:
   # all pending rows. Typical split is one process per lane so a slow
   # outbound handler cannot stall change-event propagation.
   # pools: []  # e.g. [events_inbound] | [events_change] | [events_outbound]
+
+  # ── Backend-specific extensions (typed per backend) ──
+  extensions:
+    drizzle:
+      # listen_notify: true        # Postgres LISTEN/NOTIFY wakes the outbox
+      #                            # drainer the instant an event is published
+      #                            # (in-tx pg_notify, delivered on commit),
+      #                            # ALONGSIDE interval polling — polling stays
+      #                            # the safety net. Sub-500ms drain vs ~1s poll.
+      #                            # Off by default. REQUIRES a direct (or
+      #                            # session-mode) connection — session-scoped
+      #                            # LISTEN does NOT survive a transaction-mode
+      #                            # pooler (PgBouncer pool_mode=transaction);
+      #                            # behind one, the drainer degrades to polling.

--- a/templates/subsystem/jobs-config/codegen-config-jobs-block.ejs.t
+++ b/templates/subsystem/jobs-config/codegen-config-jobs-block.ejs.t
@@ -17,10 +17,19 @@ jobs:
   # the active backend produce a config validation warning at boot.
   extensions:
     drizzle:
-      # listen_notify: true        # use Postgres LISTEN/NOTIFY to wake the
-      #                            # polling loop instead of (or alongside)
-      #                            # interval polling. Disabled by default.
-      poll_interval_ms: 1000
+      # listen_notify: true        # Postgres LISTEN/NOTIFY wakes the worker the
+      #                            # instant a job is enqueued (in-tx pg_notify,
+      #                            # delivered on commit), ALONGSIDE interval
+      #                            # polling — polling stays the safety net, so a
+      #                            # lost notify costs latency, never work.
+      #                            # Sub-500ms claim vs ~1s/poll-hop. Off by
+      #                            # default. REQUIRES a direct (or session-mode)
+      #                            # connection — session-scoped LISTEN does NOT
+      #                            # survive a transaction-mode pooler (PgBouncer
+      #                            # pool_mode=transaction); behind one, notifies
+      #                            # are simply never received and the worker
+      #                            # degrades to polling.
+      poll_interval_ms: 1000       # interval-poll heartbeat (the wake fallback)
     # bullmq:                      # Example shape for Phase 6+ BullMQ backend.
     #   bull_board:                # Mount Bull Board admin UI.
     #     enabled: true


### PR DESCRIPTION
## LISTEN-NOTIFY-1 — sub-500ms inbound spine

**Dogfood gap #7** (swe-brain live-inbound latency). The scaffold has documented `jobs.extensions.drizzle.listen_notify` since JOB-6 and `JobsDomainModule` reserved the typed `{ listenNotify, pollIntervalMs }` slot — but **neither knob was wired**: the runtime had no LISTEN/NOTIFY implementation, and the barrel generator never threaded `jobs.extensions.drizzle.*` (not even `poll_interval_ms`) into `JobWorkerModule.forRoot`. Config-theater. This makes both real.

### The shape — NOTIFY wakes, polling stays the safety net (alongside, never instead)

A row write that makes work claimable emits an in-transaction `pg_notify`; a dedicated listener connection wakes the polling loop the moment that transaction **commits**. Interval polling is untouched — it remains the durability heartbeat. A lost notification (listener down, transaction-mode pooler) degrades to today's poll latency, **never to lost work**.

**Durability is byte-for-byte unchanged:** every `pg_notify` rides the *same transaction handle* as the row write it announces (orchestrator `start()`, event `publish()`, bridge wrapper insert). Postgres delivers NOTIFY only on commit — the exact transactional-outbox guarantee the subsystems already depend on. A rolled-back write emits no phantom wake.

### Measured on swe-brain's inbound spine (webhook → outbox drain → bridge wrapper → user job)

| | spine latency (staging `received_at` → `job_run.finished_at`) |
|---|---|
| **polling-only (0.15.3)** | 1404–2982 ms |
| **listen_notify on (0.16.0)** | **181 / 320 / 325 / 334 ms** — all sub-500ms |

~5–9x reduction, zero durability change. Golden-path e2e: **✅ PASS (6 hops)** before and after.

### What's here

- **`runtime/subsystems/jobs/pg-notify.ts`** — `PgNotifyListener` (dedicated connection off `DRIZZLE.$client`, debounced dispatch, reconnect-with-capped-backoff, WARN-once degradation) + in-tx `pgNotify()` + channel constants. Shared by jobs + events.
- **Jobs worker** — `listenNotify` option; LISTEN `codegen_jobs_wake`; a notify for the worker's pool drives an immediate debounced claim cycle (bursts coalesce to one re-check, never stack). `DrizzleJobOrchestrator.start()` emits the in-tx wake on enqueue, gated on the new `JOBS_LISTEN_NOTIFY` token.
- **Events drainer** — `listenNotify`; LISTEN `codegen_events_wake`; `publish`/`publishMany` emit the in-tx wake (de-duped per pool); pool-filtered drainer wakes only for its lanes.
- **Bridge** — the `BridgeOutboxDrainHook` wrapper `job_run` insert emits the jobs wake in the per-event drain tx, so reserved-pool wrappers wake too (otherwise the bridge hop alone still costs a poll interval).
- **Generator threading** — `jobs.extensions.drizzle.{listen_notify, poll_interval_ms}` → `JobsDomainModule.forRoot` + embedded `JobWorkerModule.forRoot({ domainModuleExtensions: { drizzle: … } })`; `events.extensions.drizzle.listen_notify` → `EventsModule.forRoot({ listenNotify })`. Package **and** vendored emission covered. (The worker already honored `pollIntervalMs` — it just never received a config value. Now it does.)
- Scaffold config comments + JOB-6 + jobs skill → implemented reality, with the **PgBouncer caveat**: LISTEN/NOTIFY requires a direct (or session-mode) connection; session-scoped `LISTEN` does not survive a transaction-mode pooler — behind one, the feature degrades to polling.

### Tests

- **13 new runtime unit tests** (`listen-notify.spec.ts`): in-tx notify emitted (and not when off) through the tx client; events publish/publishMany de-dup; bridge wrapper wake; worker `onWake` pool-filter + debounce-coalesce; `PgNotifyListener` reconnect-on-drop + channel filtering.
- **9 new generator tests**: jobs/events extension threading (package + vendored), off-by-default byte-shape preserved.
- Full unit suite green for jobs/events/bridge/generator; baseline typecheck + subsystems smoke (AppModule boot, bridge guard) PASS; package build emits `pg-notify.{js,d.ts}`.

Spec: `docs/specs/LISTEN-NOTIFY-1.md`.

**Do not publish — Doug publishes with OTP.** Consumer validation used a packed tarball via a `file:` dep (plain tarball install hits the sibling `DependencyLoop`); swe-brain restored to a clean tree at HEAD, registry 0.15.3, running processes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)