### PR TITLE
feat(integration): WebhookFetchCallback yields {record, eventId?, cursor?} — prefer yielded eventId for dedupKey

### DIFF
--- a/.claude/skills/integration/SKILL.md
+++ b/.claude/skills/integration/SKILL.md
@@ -285,10 +285,14 @@ Files that ship to the consumer app (not templates):
   `WebhookChangeSource<T>` webhook-mode primitive: parameterized by a
   parsed `DetectionConfig` (`mode: 'webhook'`) + a consumer-supplied
   `WebhookFetchCallback<T>` that iterates the consumer-owned inbound
-  staging queue. Stamps `Change<T>.source = 'webhook'`, populates
-  `dedupKey` from `webhook.eventIdField`, derives `externalId` from
-  the mapping table's `external_id` target, composes middleware via
-  the locked `ChangeMiddleware<T>` shape. Passive iterator — does NOT
+  staging queue, yielding `{ record, eventId?, cursor? }`. Stamps
+  `Change<T>.source = 'webhook'`, derives `dedupKey` with the precedence
+  **yielded `eventId` > `webhook.eventIdField` record extraction >
+  undefined** (`eventIdField` is optional — the yield is the right channel
+  for vendor delivery metadata and keeps a record + its same-`external_id`
+  edit distinct in one drain batch), derives `externalId` from the mapping
+  table's `external_id` target (via its `source` field), composes middleware
+  via the locked `ChangeMiddleware<T>` shape. Passive iterator — does NOT
   drive the orchestrator. Inbound staging-table schema is
   consumer-owned and deferred per ADR-0002 §Phase 4. (#226-4)
 - `runtime/subsystems/integration/integration-run-recorder.protocol.ts` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.1] — 2026-06-04
+
+**`WebhookFetchCallback<T>` yields `{ record, eventId?, cursor? }`** —
+`WebhookChangeSource` now prefers a queue-yielded `eventId` for
+`Change<T>.dedupKey` (gap #6 follow-through, swe-brain ADR-0009 Amendment B
+§B5). swe-brain's Slack inbound drain documented an `eventIdField: 'externalId'`
+substitution — delivery dedup happens at the receiver, so record identity stood
+in for event identity. That substitution becomes genuinely unsafe once a message
+and its edit (same `externalId`, different vendor event) can share one drain
+batch — they'd collapse to a single `dedupKey`. Vendor delivery metadata (the
+event id) should never need a field on the vendor-neutral canonical record; the
+queue-yield is the right channel for it. Backward-compatible: callbacks that
+yield `{ record, cursor? }` and configs that set `webhook.eventIdField` are
+unchanged; opting into `eventId` is the only migration, and it's optional.
+
+### Changed
+
+- **`WebhookFetchCallback<T>` yield shape** is now `{ record: T; eventId?:
+  string; cursor?: WebhookCursor }` (was `{ record: T; cursor?: WebhookCursor }`)
+  — the new `eventId` is opt-in and additive; existing callbacks compile and run
+  unchanged.
+- **`WebhookChangeSource.dedupKey` precedence** is now **yielded `eventId` >
+  `webhook.eventIdField` record extraction > undefined**. A non-empty yielded
+  `eventId` always wins; otherwise the configured `eventIdField` is read off the
+  emitted record (and still throws if the field is configured but absent on the
+  record); with neither, `dedupKey` is `undefined` (the orchestrator simply has
+  no delivery-level dedup signal for that change).
+- **`detection-config.schema.ts`: `webhook.eventIdField` is now optional**
+  (`z.string().min(1).optional()`). A callback that always yields `eventId` need
+  not declare a record field for it. The `webhook` block itself stays
+  structurally required in webhook mode (an empty `{}` is valid; a missing block
+  is not), so the existing "webhook-mode missing webhook block" validation is
+  unaffected.
+
+### Docs
+
+- ADR-033 §1 amended (the `webhook: { eventIdField? }` shape + the yield channel
+  + dedupKey precedence), integration `SKILL.md` + consumer
+  `change-sources-and-sinks.md` updated to the yield-preferred precedence.
+
 ## [0.16.0] — 2026-06-04
 
 **Postgres LISTEN/NOTIFY wakeups** for the jobs worker + events outbox drainer

--- a/consumer-skills/integration/change-sources-and-sinks.md
+++ b/consumer-skills/integration/change-sources-and-sinks.md
@@ -75,7 +75,7 @@ interface Change<T> {
   record: T;                           // canonical shape — provider mapping happens in the adapter
   cursor: unknown;                     // typed internally; opaque at the seam
   source: 'poll' | 'cdc' | 'webhook';  // provenance for the run-log audit
-  dedupKey?: string;                   // CDC replay_id / webhook event_id when available
+  dedupKey?: string;                   // CDC replay_id / webhook event id when available (webhook: prefers the eventId yielded by WebhookFetchCallback, else webhook.eventIdField)
   providerChangedFields?: string[];    // CDC-only hint; lets the differ skip untouched fields
 }
 ```

--- a/docs/adrs/ADR-033-config-driven-change-sources.md
+++ b/docs/adrs/ADR-033-config-driven-change-sources.md
@@ -35,9 +35,23 @@ Per-entity sync detection is a `DetectionConfig` value, not a hand-authored clas
 type DetectionConfig =
   | { mode: 'poll';    poll: { cursor: CursorStrategy; provenance?: 'poll' | 'cdc' };
                        mapping: FieldMapping[]; filters: ResolvedFilter[] }
-  | { mode: 'webhook'; webhook: { eventIdField: string };
+  | { mode: 'webhook'; webhook: { eventIdField?: string };
                        mapping: FieldMapping[]; filters: ResolvedFilter[] };
 ```
+
+> **Amendment (0.16.1, swe-brain ADR-0009 Amendment B §B5):** `webhook.eventIdField`
+> is now **optional**, and the `WebhookFetchCallback` may yield an `eventId`
+> alongside each record: `{ record: T; eventId?: string; cursor?: WebhookCursor }`.
+> `WebhookChangeSource` derives `Change<T>.dedupKey` with the precedence
+> **yielded `eventId` > `eventIdField` record extraction > undefined**. The yield
+> is the right channel for vendor delivery metadata — an event id should never
+> need a field on the vendor-neutral canonical record. It is also the safe channel
+> when one canonical record identity (the `external_id`) can recur across distinct
+> vendor events in a single drain batch: a message create and its later edit share
+> one `external_id`, so an `eventIdField`-on-the-record substitution collapses them
+> to one `dedupKey`; the yielded `eventId` keeps them distinct. Backward-compatible:
+> callbacks that yield `{ record, cursor? }` and configs that set `eventIdField`
+> are unchanged.
 
 `CursorStrategy` is itself a tagged union over `systemModstamp | replayId | timestamp | eventId` — each variant names the field on the upstream record (or staging row) the strategy reads to advance the cursor.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/integration/detection-config.schema.ts
+++ b/runtime/subsystems/integration/detection-config.schema.ts
@@ -22,10 +22,12 @@
  *     primitive while emitting `Change<T>.source = 'cdc'`. Long-lived
  *     streaming CDC (SFDC Pub-Sub, Debezium) is a separate primitive
  *     deferred to #226-8.
- *   - `webhook` mode requires `eventIdField` so `WebhookChangeSource<T>`
- *     can populate `Change<T>.dedupKey` from the inbound staging row.
+ *   - `webhook` mode's `eventIdField` is optional: `WebhookChangeSource<T>`
+ *     prefers an `eventId` yielded by the queue iterator and falls back to the
+ *     `eventIdField` record extraction (precedence: yielded eventId >
+ *     eventIdField extraction > undefined dedupKey).
  */
-import { z } from 'zod';
+import { z } from "zod";
 
 // ============================================================================
 // Field mapping — provider field → canonical target
@@ -37,9 +39,9 @@ import { z } from 'zod';
  * etc.); the schema does not enumerate transforms — adapters interpret them.
  */
 export const FieldMappingSchema = z.object({
-  source: z.string().min(1),
-  target: z.string().min(1),
-  transform: z.string().min(1).optional(),
+	source: z.string().min(1),
+	target: z.string().min(1),
+	transform: z.string().min(1).optional(),
 });
 
 export type FieldMapping = z.infer<typeof FieldMappingSchema>;
@@ -54,9 +56,9 @@ export type FieldMapping = z.infer<typeof FieldMappingSchema>;
  * adapters interpret per provider.
  */
 export const ResolvedFilterSchema = z.object({
-  field: z.string().min(1),
-  op: z.enum(['eq', 'neq', 'in', 'nin', 'gt', 'gte', 'lt', 'lte']),
-  value: z.unknown(),
+	field: z.string().min(1),
+	op: z.enum(["eq", "neq", "in", "nin", "gt", "gte", "lt", "lte"]),
+	value: z.unknown(),
 });
 
 export type ResolvedFilter = z.infer<typeof ResolvedFilterSchema>;
@@ -66,23 +68,23 @@ export type ResolvedFilter = z.infer<typeof ResolvedFilterSchema>;
 // ============================================================================
 
 const SystemModstampCursorSchema = z.object({
-  kind: z.literal('systemModstamp'),
-  field: z.string().min(1),
+	kind: z.literal("systemModstamp"),
+	field: z.string().min(1),
 });
 
 const ReplayIdCursorSchema = z.object({
-  kind: z.literal('replayId'),
-  field: z.string().min(1),
+	kind: z.literal("replayId"),
+	field: z.string().min(1),
 });
 
 const TimestampCursorSchema = z.object({
-  kind: z.literal('timestamp'),
-  field: z.string().min(1),
+	kind: z.literal("timestamp"),
+	field: z.string().min(1),
 });
 
 const EventIdCursorSchema = z.object({
-  kind: z.literal('eventId'),
-  field: z.string().min(1),
+	kind: z.literal("eventId"),
+	field: z.string().min(1),
 });
 
 /**
@@ -91,8 +93,8 @@ const EventIdCursorSchema = z.object({
  * `field` is metadata for codegen/adapters (the response key the token lives on).
  */
 const HistoryIdCursorSchema = z.object({
-  kind: z.literal('historyId'),
-  field: z.string().min(1),
+	kind: z.literal("historyId"),
+	field: z.string().min(1),
 });
 
 /**
@@ -100,17 +102,17 @@ const HistoryIdCursorSchema = z.object({
  * same divisibility profile as `historyId`.
  */
 const SyncTokenCursorSchema = z.object({
-  kind: z.literal('syncToken'),
-  field: z.string().min(1),
+	kind: z.literal("syncToken"),
+	field: z.string().min(1),
 });
 
-export const CursorStrategySchema = z.discriminatedUnion('kind', [
-  SystemModstampCursorSchema,
-  ReplayIdCursorSchema,
-  TimestampCursorSchema,
-  EventIdCursorSchema,
-  HistoryIdCursorSchema,
-  SyncTokenCursorSchema,
+export const CursorStrategySchema = z.discriminatedUnion("kind", [
+	SystemModstampCursorSchema,
+	ReplayIdCursorSchema,
+	TimestampCursorSchema,
+	EventIdCursorSchema,
+	HistoryIdCursorSchema,
+	SyncTokenCursorSchema,
 ]);
 
 export type CursorStrategy = z.infer<typeof CursorStrategySchema>;
@@ -135,18 +137,20 @@ export type CursorStrategy = z.infer<typeof CursorStrategySchema>;
  * `eventId` is classified atomic conservatively: a generic opaque id is treated
  * all-or-nothing unless a concrete strategy proves it monotonically resumable.
  */
-export const CURSOR_DIVISIBILITY: Readonly<Record<CursorStrategy['kind'], boolean>> = {
-  systemModstamp: true,
-  timestamp: true,
-  replayId: true,
-  eventId: false,
-  historyId: false,
-  syncToken: false,
+export const CURSOR_DIVISIBILITY: Readonly<
+	Record<CursorStrategy["kind"], boolean>
+> = {
+	systemModstamp: true,
+	timestamp: true,
+	replayId: true,
+	eventId: false,
+	historyId: false,
+	syncToken: false,
 };
 
 /** Predicate form of {@link CURSOR_DIVISIBILITY}. */
-export function isDivisibleCursor(kind: CursorStrategy['kind']): boolean {
-  return CURSOR_DIVISIBILITY[kind];
+export function isDivisibleCursor(kind: CursorStrategy["kind"]): boolean {
+	return CURSOR_DIVISIBILITY[kind];
 }
 
 // ============================================================================
@@ -159,19 +163,25 @@ export function isDivisibleCursor(kind: CursorStrategy['kind']): boolean {
  * `field` — used for Stripe-style event endpoints. Defaults to `'poll'`.
  */
 export const PollDetectionSchema = z.object({
-  cursor: CursorStrategySchema,
-  provenance: z.enum(['poll', 'cdc']).optional(),
+	cursor: CursorStrategySchema,
+	provenance: z.enum(["poll", "cdc"]).optional(),
 });
 
 export type PollDetection = z.infer<typeof PollDetectionSchema>;
 
 /**
- * Webhook-mode block. `eventIdField` names the column in the consumer-owned
- * inbound staging row that `WebhookChangeSource<T>` reads to set
- * `Change<T>.dedupKey`.
+ * Webhook-mode block. `eventIdField`, when present, names the field on the
+ * emitted canonical record that `WebhookChangeSource<T>` reads to set
+ * `Change<T>.dedupKey` — used only as the fallback when the queue iterator
+ * does NOT yield an `eventId` alongside the record.
+ *
+ * `eventIdField` is **optional**: a queue iterator that always yields an
+ * `eventId` (vendor delivery metadata, the preferred channel) need not declare
+ * a record field for it. dedupKey precedence is: yielded `eventId` >
+ * `eventIdField` record extraction > undefined.
  */
 export const WebhookDetectionSchema = z.object({
-  eventIdField: z.string().min(1),
+	eventIdField: z.string().min(1).optional(),
 });
 
 export type WebhookDetection = z.infer<typeof WebhookDetectionSchema>;
@@ -181,17 +191,17 @@ export type WebhookDetection = z.infer<typeof WebhookDetectionSchema>;
 // ============================================================================
 
 const PollModeSchema = z.object({
-  mode: z.literal('poll'),
-  poll: PollDetectionSchema,
-  mapping: z.array(FieldMappingSchema).min(1),
-  filters: z.array(ResolvedFilterSchema).default([]),
+	mode: z.literal("poll"),
+	poll: PollDetectionSchema,
+	mapping: z.array(FieldMappingSchema).min(1),
+	filters: z.array(ResolvedFilterSchema).default([]),
 });
 
 const WebhookModeSchema = z.object({
-  mode: z.literal('webhook'),
-  webhook: WebhookDetectionSchema,
-  mapping: z.array(FieldMappingSchema).min(1),
-  filters: z.array(ResolvedFilterSchema).default([]),
+	mode: z.literal("webhook"),
+	webhook: WebhookDetectionSchema,
+	mapping: z.array(FieldMappingSchema).min(1),
+	filters: z.array(ResolvedFilterSchema).default([]),
 });
 
 /**
@@ -201,9 +211,9 @@ const WebhookModeSchema = z.object({
  * (Stripe-style event endpoints) is expressed via `mode: 'poll'` with
  * `poll.provenance: 'cdc'`.
  */
-export const DetectionConfigSchema = z.discriminatedUnion('mode', [
-  PollModeSchema,
-  WebhookModeSchema,
+export const DetectionConfigSchema = z.discriminatedUnion("mode", [
+	PollModeSchema,
+	WebhookModeSchema,
 ]);
 
 export type DetectionConfig = z.infer<typeof DetectionConfigSchema>;

--- a/runtime/subsystems/integration/webhook-change-source.ts
+++ b/runtime/subsystems/integration/webhook-change-source.ts
@@ -7,8 +7,11 @@
  * queue. The primitive owns:
  *
  *   - canonical `Change<T>.source = 'webhook'` stamping;
- *   - `dedupKey` derivation from the configured `webhook.eventIdField` on
- *     the emitted record;
+ *   - `dedupKey` derivation, preferring the `eventId` yielded alongside the
+ *     record by the queue iterator, and falling back to the configured
+ *     `webhook.eventIdField` on the emitted record when no `eventId` is yielded
+ *     (precedence: yielded `eventId` > `eventIdField` record extraction >
+ *     undefined `dedupKey`);
  *   - `externalId` derivation: the mapping entry whose `target === 'external_id'`
  *     names — via its `source` — the field on the emitted record that carries
  *     the canonical external id (mirrors `PollChangeSource`);
@@ -37,16 +40,16 @@
  * into either this primitive or the poll primitive.
  */
 
-import type { DetectionConfig } from './detection-config.schema';
+import type { DetectionConfig } from "./detection-config.schema";
 import type {
-  Change,
-  IChangeSource,
-  IntegrationSubscriptionView,
-} from './integration-change-source.protocol';
+	Change,
+	IChangeSource,
+	IntegrationSubscriptionView,
+} from "./integration-change-source.protocol";
 import type {
-  ChangeIterator,
-  ChangeMiddleware,
-} from './integration-middleware.protocol';
+	ChangeIterator,
+	ChangeMiddleware,
+} from "./integration-middleware.protocol";
 
 // ============================================================================
 // Cursor + queue callback shapes
@@ -66,16 +69,28 @@ export type WebhookCursor = unknown;
  * `userId` / `tenantId`.
  */
 export interface WebhookFetchContext {
-  readonly subscription: IntegrationSubscriptionView;
-  readonly cursor: WebhookCursor | null;
+	readonly subscription: IntegrationSubscriptionView;
+	readonly cursor: WebhookCursor | null;
 }
 
 /**
  * Consumer-supplied queue iterator. Returns an async iterable of
- * `{ record }` pairs — the consumer drains the inbound staging queue and
- * emits already-mapped canonical records `T`. The primitive stamps
- * `source: 'webhook'` and `dedupKey` from the record's configured
- * `webhook.eventIdField`; the consumer is the one who decided when a
+ * `{ record, eventId?, cursor? }` tuples — the consumer drains the inbound
+ * staging queue and emits already-mapped canonical records `T`. The primitive
+ * stamps `source: 'webhook'` and derives `dedupKey` with this precedence:
+ *
+ *   1. the yielded `eventId` (vendor delivery metadata — the queue is the
+ *      right channel for it: a vendor's event id should never need a field
+ *      on the vendor-neutral canonical record);
+ *   2. else the record field named by `webhook.eventIdField`, when configured;
+ *   3. else `undefined`.
+ *
+ * Yielding `eventId` is the safe channel when one canonical record identity
+ * (the `external_id`) can recur across distinct vendor events in a single
+ * drain batch — e.g. a message create and its later edit share an
+ * `external_id` but are different events. Reading dedup identity off the
+ * record (`eventIdField`) collapses those into one `dedupKey`; the yielded
+ * `eventId` keeps them distinct. The consumer is the one who decided when a
  * staging row is "ready" to drain.
  *
  * Webhook mode has no per-record cursor advance — the staging-row drain
@@ -84,33 +99,33 @@ export interface WebhookFetchContext {
  * is whatever the consumer chooses to surface, if anything.
  */
 export type WebhookFetchCallback<T> = (
-  ctx: WebhookFetchContext,
-) => AsyncIterable<{ record: T; cursor?: WebhookCursor }>;
+	ctx: WebhookFetchContext,
+) => AsyncIterable<{ record: T; eventId?: string; cursor?: WebhookCursor }>;
 
 // ============================================================================
 // Constructor options
 // ============================================================================
 
 export interface WebhookChangeSourceOptions<T> {
-  /** Consumer-supplied inbound queue iterator. */
-  readonly queue: WebhookFetchCallback<T>;
-  /**
-   * Parsed detection config. MUST be `mode: 'webhook'`; the constructor
-   * throws if a poll config is supplied. Codegen-emitted factories call
-   * `DetectionConfigSchema.parse(...)` upstream so this is a safety net,
-   * not the primary validation point.
-   */
-  readonly config: DetectionConfig;
-  /**
-   * Optional middleware chain. Same shape and composition rules as
-   * `PollChangeSource` — first element is the outermost layer.
-   */
-  readonly middlewares?: ReadonlyArray<ChangeMiddleware<T>>;
-  /**
-   * Optional human label for run logs (e.g. `'stripe-webhook-charge'`).
-   * Defaults to a derived label based on the mapping at construction.
-   */
-  readonly label?: string;
+	/** Consumer-supplied inbound queue iterator. */
+	readonly queue: WebhookFetchCallback<T>;
+	/**
+	 * Parsed detection config. MUST be `mode: 'webhook'`; the constructor
+	 * throws if a poll config is supplied. Codegen-emitted factories call
+	 * `DetectionConfigSchema.parse(...)` upstream so this is a safety net,
+	 * not the primary validation point.
+	 */
+	readonly config: DetectionConfig;
+	/**
+	 * Optional middleware chain. Same shape and composition rules as
+	 * `PollChangeSource` — first element is the outermost layer.
+	 */
+	readonly middlewares?: ReadonlyArray<ChangeMiddleware<T>>;
+	/**
+	 * Optional human label for run logs (e.g. `'stripe-webhook-charge'`).
+	 * Defaults to a derived label based on the mapping at construction.
+	 */
+	readonly label?: string;
 }
 
 // ============================================================================
@@ -118,100 +133,139 @@ export interface WebhookChangeSourceOptions<T> {
 // ============================================================================
 
 export class WebhookChangeSource<T> implements IChangeSource<T> {
-  public readonly label: string;
+	public readonly label: string;
 
-  private readonly queue: WebhookFetchCallback<T>;
-  private readonly externalIdSourceField: string;
-  private readonly eventIdSourceField: string;
-  private readonly composed: ChangeIterator<T>;
+	private readonly queue: WebhookFetchCallback<T>;
+	private readonly externalIdSourceField: string;
+	/**
+	 * Record field carrying the event id, when `webhook.eventIdField` is
+	 * configured. Used only as the fallback when the queue iterator does NOT
+	 * yield an `eventId` — see {@link WebhookFetchCallback} for the precedence.
+	 */
+	private readonly eventIdSourceField: string | undefined;
+	private readonly composed: ChangeIterator<T>;
 
-  constructor(opts: WebhookChangeSourceOptions<T>) {
-    if (opts.config.mode !== 'webhook') {
-      throw new Error(
-        `WebhookChangeSource requires DetectionConfig.mode === 'webhook'; got '${(opts.config as { mode: string }).mode}'`,
-      );
-    }
-    const config = opts.config;
+	constructor(opts: WebhookChangeSourceOptions<T>) {
+		if (opts.config.mode !== "webhook") {
+			throw new Error(
+				`WebhookChangeSource requires DetectionConfig.mode === 'webhook'; got '${(opts.config as { mode: string }).mode}'`,
+			);
+		}
+		const config = opts.config;
 
-    // Field mapping: locate the entry whose canonical `target` is `external_id`
-    // — mirrors the poll primitive's contract. Adapters emit records
-    // already-mapped; the primitive needs to know which key on T carries the
-    // external id so it can stamp `Change.externalId`. That key is the
-    // mapping's `source` (the field on the emitted record), NOT its `target`
-    // (the canonical column) — they differ whenever the canonical record is
-    // vendor-neutral camelCase (e.g. `source: 'externalId'` → `target: 'external_id'`).
-    const externalIdMapping = config.mapping.find(
-      (m) => m.target === 'external_id',
-    );
-    if (!externalIdMapping) {
-      throw new Error(
-        "WebhookChangeSource: DetectionConfig.mapping must include an entry with target 'external_id' so emitted Change<T>.externalId can be populated",
-      );
-    }
-    this.externalIdSourceField = externalIdMapping.source;
-    this.eventIdSourceField = config.webhook.eventIdField;
+		// Field mapping: locate the entry whose canonical `target` is `external_id`
+		// — mirrors the poll primitive's contract. Adapters emit records
+		// already-mapped; the primitive needs to know which key on T carries the
+		// external id so it can stamp `Change.externalId`. That key is the
+		// mapping's `source` (the field on the emitted record), NOT its `target`
+		// (the canonical column) — they differ whenever the canonical record is
+		// vendor-neutral camelCase (e.g. `source: 'externalId'` → `target: 'external_id'`).
+		const externalIdMapping = config.mapping.find(
+			(m) => m.target === "external_id",
+		);
+		if (!externalIdMapping) {
+			throw new Error(
+				"WebhookChangeSource: DetectionConfig.mapping must include an entry with target 'external_id' so emitted Change<T>.externalId can be populated",
+			);
+		}
+		this.externalIdSourceField = externalIdMapping.source;
+		this.eventIdSourceField = config.webhook.eventIdField;
+		// `eventIdField` is optional (a callback that always yields `eventId` need
+		// not declare one); `undefined` here just disables the fallback extraction.
 
-    this.queue = opts.queue;
+		this.queue = opts.queue;
 
-    this.label =
-      opts.label ?? `webhook-change-source:${externalIdMapping.source}`;
+		this.label =
+			opts.label ?? `webhook-change-source:${externalIdMapping.source}`;
 
-    // Compose middleware chain — same shape as PollChangeSource.
-    const inner: ChangeIterator<T> = (sub, cur) => this.fetch(sub, cur);
-    const middlewares = opts.middlewares ?? [];
-    this.composed = middlewares.reduceRight<ChangeIterator<T>>(
-      (next, mw) => mw(next),
-      inner,
-    );
-  }
+		// Compose middleware chain — same shape as PollChangeSource.
+		const inner: ChangeIterator<T> = (sub, cur) => this.fetch(sub, cur);
+		const middlewares = opts.middlewares ?? [];
+		this.composed = middlewares.reduceRight<ChangeIterator<T>>(
+			(next, mw) => mw(next),
+			inner,
+		);
+	}
 
-  listChanges(
-    subscription: IntegrationSubscriptionView,
-    cursor: unknown | null,
-  ): AsyncIterable<Change<T>> {
-    return this.composed(subscription, cursor);
-  }
+	listChanges(
+		subscription: IntegrationSubscriptionView,
+		cursor: unknown | null,
+	): AsyncIterable<Change<T>> {
+		return this.composed(subscription, cursor);
+	}
 
-  private async *fetch(
-    subscription: IntegrationSubscriptionView,
-    cursor: unknown | null,
-  ): AsyncIterable<Change<T>> {
-    const ctx: WebhookFetchContext = {
-      subscription,
-      cursor: cursor as WebhookCursor | null,
-    };
+	private async *fetch(
+		subscription: IntegrationSubscriptionView,
+		cursor: unknown | null,
+	): AsyncIterable<Change<T>> {
+		const ctx: WebhookFetchContext = {
+			subscription,
+			cursor: cursor as WebhookCursor | null,
+		};
 
-    for await (const { record, cursor: nextCursor } of this.queue(ctx)) {
-      const externalIdRaw = (record as Record<string, unknown>)[
-        this.externalIdSourceField
-      ];
-      if (typeof externalIdRaw !== 'string' || externalIdRaw.length === 0) {
-        throw new Error(
-          `WebhookChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping source`,
-        );
-      }
-      const eventIdRaw = (record as Record<string, unknown>)[
-        this.eventIdSourceField
-      ];
-      if (typeof eventIdRaw !== 'string' || eventIdRaw.length === 0) {
-        throw new Error(
-          `WebhookChangeSource: record missing string '${this.eventIdSourceField}' — webhook records MUST carry the event id (DetectionConfig.webhook.eventIdField) so Change<T>.dedupKey can be populated`,
-        );
-      }
+		for await (const {
+			record,
+			eventId: yieldedEventId,
+			cursor: nextCursor,
+		} of this.queue(ctx)) {
+			const externalIdRaw = (record as Record<string, unknown>)[
+				this.externalIdSourceField
+			];
+			if (typeof externalIdRaw !== "string" || externalIdRaw.length === 0) {
+				throw new Error(
+					`WebhookChangeSource: record missing string '${this.externalIdSourceField}' — emitted records MUST carry the canonical external id keyed by the mapping source`,
+				);
+			}
 
-      const change: Change<T> = {
-        externalId: externalIdRaw,
-        // Webhook mode cannot distinguish create vs. update vs. delete on
-        // its own — the orchestrator's diff stage handles classification.
-        // Tombstone / soft-delete detection is consumer-driven (same as
-        // poll mode — see ADR-033).
-        operation: 'updated',
-        record,
-        cursor: nextCursor ?? null,
-        source: 'webhook',
-        dedupKey: eventIdRaw,
-      };
-      yield change;
-    }
-  }
+			// dedupKey precedence: yielded `eventId` > `eventIdField` record
+			// extraction > undefined. The yielded id is vendor delivery metadata
+			// (the right channel for it), and keeps distinct vendor events for the
+			// same `external_id` (e.g. a message and its edit) from collapsing to
+			// one dedupKey — which a record-field extraction would do.
+			const dedupKey = this.deriveDedupKey(yieldedEventId, record);
+
+			const change: Change<T> = {
+				externalId: externalIdRaw,
+				// Webhook mode cannot distinguish create vs. update vs. delete on
+				// its own — the orchestrator's diff stage handles classification.
+				// Tombstone / soft-delete detection is consumer-driven (same as
+				// poll mode — see ADR-033).
+				operation: "updated",
+				record,
+				cursor: nextCursor ?? null,
+				source: "webhook",
+				dedupKey,
+			};
+			yield change;
+		}
+	}
+
+	/**
+	 * Resolve `Change<T>.dedupKey` with the precedence: yielded `eventId` >
+	 * `webhook.eventIdField` record extraction > `undefined`. A non-empty
+	 * yielded `eventId` always wins; otherwise the configured field is read off
+	 * the record (and must be a non-empty string when the field is configured);
+	 * with neither, `dedupKey` is `undefined` (the orchestrator then has no
+	 * delivery-level dedup signal for this change).
+	 */
+	private deriveDedupKey(
+		yieldedEventId: string | undefined,
+		record: T,
+	): string | undefined {
+		if (yieldedEventId !== undefined && yieldedEventId.length > 0) {
+			return yieldedEventId;
+		}
+		if (this.eventIdSourceField === undefined) {
+			return undefined;
+		}
+		const eventIdRaw = (record as Record<string, unknown>)[
+			this.eventIdSourceField
+		];
+		if (typeof eventIdRaw !== "string" || eventIdRaw.length === 0) {
+			throw new Error(
+				`WebhookChangeSource: record missing string '${this.eventIdSourceField}' — a webhook record MUST carry the event id (DetectionConfig.webhook.eventIdField) so Change<T>.dedupKey can be populated, unless the queue iterator yields an 'eventId' alongside the record`,
+			);
+		}
+		return eventIdRaw;
+	}
 }

--- a/src/__tests__/runtime/subsystems/detection-config.schema.spec.ts
+++ b/src/__tests__/runtime/subsystems/detection-config.schema.spec.ts
@@ -9,245 +9,287 @@
  *
  * See ADR-033 + decision memo Q4.
  */
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from "bun:test";
 import {
-  CURSOR_DIVISIBILITY,
-  DetectionConfigSchema,
-  FieldMappingSchema,
-  isDivisibleCursor,
-  ResolvedFilterSchema,
-  CursorStrategySchema,
-} from '../../../../runtime/subsystems/integration/detection-config.schema';
+	CURSOR_DIVISIBILITY,
+	CursorStrategySchema,
+	DetectionConfigSchema,
+	FieldMappingSchema,
+	isDivisibleCursor,
+	ResolvedFilterSchema,
+} from "../../../../runtime/subsystems/integration/detection-config.schema";
 
-describe('FieldMappingSchema', () => {
-  it('accepts a minimal { source, target } pair', () => {
-    expect(
-      FieldMappingSchema.parse({ source: 'Id', target: 'external_id' }),
-    ).toEqual({ source: 'Id', target: 'external_id' });
-  });
+describe("FieldMappingSchema", () => {
+	it("accepts a minimal { source, target } pair", () => {
+		expect(
+			FieldMappingSchema.parse({ source: "Id", target: "external_id" }),
+		).toEqual({ source: "Id", target: "external_id" });
+	});
 
-  it('accepts an optional transform tag', () => {
-    expect(
-      FieldMappingSchema.parse({
-        source: 'CreatedDate',
-        target: 'created_at',
-        transform: 'date-iso',
-      }),
-    ).toEqual({
-      source: 'CreatedDate',
-      target: 'created_at',
-      transform: 'date-iso',
-    });
-  });
+	it("accepts an optional transform tag", () => {
+		expect(
+			FieldMappingSchema.parse({
+				source: "CreatedDate",
+				target: "created_at",
+				transform: "date-iso",
+			}),
+		).toEqual({
+			source: "CreatedDate",
+			target: "created_at",
+			transform: "date-iso",
+		});
+	});
 
-  it('rejects empty source or target', () => {
-    expect(
-      FieldMappingSchema.safeParse({ source: '', target: 'x' }).success,
-    ).toBe(false);
-    expect(
-      FieldMappingSchema.safeParse({ source: 'x', target: '' }).success,
-    ).toBe(false);
-  });
+	it("rejects empty source or target", () => {
+		expect(
+			FieldMappingSchema.safeParse({ source: "", target: "x" }).success,
+		).toBe(false);
+		expect(
+			FieldMappingSchema.safeParse({ source: "x", target: "" }).success,
+		).toBe(false);
+	});
 });
 
-describe('ResolvedFilterSchema', () => {
-  it('accepts a flat-AND filter triple', () => {
-    expect(
-      ResolvedFilterSchema.parse({
-        field: 'StageName',
-        op: 'eq',
-        value: 'Closed Won',
-      }),
-    ).toEqual({ field: 'StageName', op: 'eq', value: 'Closed Won' });
-  });
+describe("ResolvedFilterSchema", () => {
+	it("accepts a flat-AND filter triple", () => {
+		expect(
+			ResolvedFilterSchema.parse({
+				field: "StageName",
+				op: "eq",
+				value: "Closed Won",
+			}),
+		).toEqual({ field: "StageName", op: "eq", value: "Closed Won" });
+	});
 
-  it('accepts every locked operator', () => {
-    for (const op of ['eq', 'neq', 'in', 'nin', 'gt', 'gte', 'lt', 'lte'] as const) {
-      expect(
-        ResolvedFilterSchema.safeParse({ field: 'f', op, value: 1 }).success,
-      ).toBe(true);
-    }
-  });
+	it("accepts every locked operator", () => {
+		for (const op of [
+			"eq",
+			"neq",
+			"in",
+			"nin",
+			"gt",
+			"gte",
+			"lt",
+			"lte",
+		] as const) {
+			expect(
+				ResolvedFilterSchema.safeParse({ field: "f", op, value: 1 }).success,
+			).toBe(true);
+		}
+	});
 
-  it('accepts array values for in / nin', () => {
-    expect(
-      ResolvedFilterSchema.parse({
-        field: 'StageName',
-        op: 'in',
-        value: ['Closed Won', 'Closed Lost'],
-      }),
-    ).toBeDefined();
-  });
+	it("accepts array values for in / nin", () => {
+		expect(
+			ResolvedFilterSchema.parse({
+				field: "StageName",
+				op: "in",
+				value: ["Closed Won", "Closed Lost"],
+			}),
+		).toBeDefined();
+	});
 
-  it('rejects unknown operators', () => {
-    expect(
-      ResolvedFilterSchema.safeParse({ field: 'f', op: 'matches', value: 'x' })
-        .success,
-    ).toBe(false);
-  });
+	it("rejects unknown operators", () => {
+		expect(
+			ResolvedFilterSchema.safeParse({ field: "f", op: "matches", value: "x" })
+				.success,
+		).toBe(false);
+	});
 });
 
-describe('CursorStrategySchema', () => {
-  it('accepts the system-modstamp variant', () => {
-    expect(
-      CursorStrategySchema.parse({
-        kind: 'systemModstamp',
-        field: 'SystemModstamp',
-      }),
-    ).toEqual({ kind: 'systemModstamp', field: 'SystemModstamp' });
-  });
+describe("CursorStrategySchema", () => {
+	it("accepts the system-modstamp variant", () => {
+		expect(
+			CursorStrategySchema.parse({
+				kind: "systemModstamp",
+				field: "SystemModstamp",
+			}),
+		).toEqual({ kind: "systemModstamp", field: "SystemModstamp" });
+	});
 
-  it('accepts the replay-id variant', () => {
-    expect(
-      CursorStrategySchema.parse({ kind: 'replayId', field: 'ReplayId' }),
-    ).toEqual({ kind: 'replayId', field: 'ReplayId' });
-  });
+	it("accepts the replay-id variant", () => {
+		expect(
+			CursorStrategySchema.parse({ kind: "replayId", field: "ReplayId" }),
+		).toEqual({ kind: "replayId", field: "ReplayId" });
+	});
 
-  it('accepts the timestamp variant', () => {
-    expect(
-      CursorStrategySchema.parse({ kind: 'timestamp', field: 'occurredAt' }),
-    ).toEqual({ kind: 'timestamp', field: 'occurredAt' });
-  });
+	it("accepts the timestamp variant", () => {
+		expect(
+			CursorStrategySchema.parse({ kind: "timestamp", field: "occurredAt" }),
+		).toEqual({ kind: "timestamp", field: "occurredAt" });
+	});
 
-  it('accepts the eventId variant (webhook dedup)', () => {
-    expect(
-      CursorStrategySchema.parse({ kind: 'eventId', field: 'event_id' }),
-    ).toEqual({ kind: 'eventId', field: 'event_id' });
-  });
+	it("accepts the eventId variant (webhook dedup)", () => {
+		expect(
+			CursorStrategySchema.parse({ kind: "eventId", field: "event_id" }),
+		).toEqual({ kind: "eventId", field: "event_id" });
+	});
 
-  it('accepts the historyId variant (Gmail — atomic, RFC-0003 §3)', () => {
-    expect(
-      CursorStrategySchema.parse({ kind: 'historyId', field: 'historyId' }),
-    ).toEqual({ kind: 'historyId', field: 'historyId' });
-  });
+	it("accepts the historyId variant (Gmail — atomic, RFC-0003 §3)", () => {
+		expect(
+			CursorStrategySchema.parse({ kind: "historyId", field: "historyId" }),
+		).toEqual({ kind: "historyId", field: "historyId" });
+	});
 
-  it('accepts the syncToken variant (Calendar — atomic, RFC-0003 §3)', () => {
-    expect(
-      CursorStrategySchema.parse({ kind: 'syncToken', field: 'nextSyncToken' }),
-    ).toEqual({ kind: 'syncToken', field: 'nextSyncToken' });
-  });
+	it("accepts the syncToken variant (Calendar — atomic, RFC-0003 §3)", () => {
+		expect(
+			CursorStrategySchema.parse({ kind: "syncToken", field: "nextSyncToken" }),
+		).toEqual({ kind: "syncToken", field: "nextSyncToken" });
+	});
 
-  it('rejects an unknown kind', () => {
-    expect(
-      CursorStrategySchema.safeParse({ kind: 'offset', field: 'n' }).success,
-    ).toBe(false);
-  });
+	it("rejects an unknown kind", () => {
+		expect(
+			CursorStrategySchema.safeParse({ kind: "offset", field: "n" }).success,
+		).toBe(false);
+	});
 });
 
-describe('cursor divisibility (RFC-0003 §3)', () => {
-  it('classifies sortable/monotonic watermarks as divisible', () => {
-    expect(isDivisibleCursor('systemModstamp')).toBe(true);
-    expect(isDivisibleCursor('timestamp')).toBe(true);
-    expect(isDivisibleCursor('replayId')).toBe(true);
-  });
+describe("cursor divisibility (RFC-0003 §3)", () => {
+	it("classifies sortable/monotonic watermarks as divisible", () => {
+		expect(isDivisibleCursor("systemModstamp")).toBe(true);
+		expect(isDivisibleCursor("timestamp")).toBe(true);
+		expect(isDivisibleCursor("replayId")).toBe(true);
+	});
 
-  it('classifies opaque vendor tokens as atomic', () => {
-    expect(isDivisibleCursor('historyId')).toBe(false);
-    expect(isDivisibleCursor('syncToken')).toBe(false);
-    expect(isDivisibleCursor('eventId')).toBe(false);
-  });
+	it("classifies opaque vendor tokens as atomic", () => {
+		expect(isDivisibleCursor("historyId")).toBe(false);
+		expect(isDivisibleCursor("syncToken")).toBe(false);
+		expect(isDivisibleCursor("eventId")).toBe(false);
+	});
 
-  it('CURSOR_DIVISIBILITY covers every cursor kind exactly', () => {
-    const kinds = ['systemModstamp', 'replayId', 'timestamp', 'eventId', 'historyId', 'syncToken'];
-    expect(Object.keys(CURSOR_DIVISIBILITY).sort()).toEqual([...kinds].sort());
-    // predicate agrees with the map for every kind
-    for (const k of kinds) {
-      expect(isDivisibleCursor(k as keyof typeof CURSOR_DIVISIBILITY)).toBe(
-        CURSOR_DIVISIBILITY[k as keyof typeof CURSOR_DIVISIBILITY],
-      );
-    }
-  });
+	it("CURSOR_DIVISIBILITY covers every cursor kind exactly", () => {
+		const kinds = [
+			"systemModstamp",
+			"replayId",
+			"timestamp",
+			"eventId",
+			"historyId",
+			"syncToken",
+		];
+		expect(Object.keys(CURSOR_DIVISIBILITY).sort()).toEqual([...kinds].sort());
+		// predicate agrees with the map for every kind
+		for (const k of kinds) {
+			expect(isDivisibleCursor(k as keyof typeof CURSOR_DIVISIBILITY)).toBe(
+				CURSOR_DIVISIBILITY[k as keyof typeof CURSOR_DIVISIBILITY],
+			);
+		}
+	});
 });
 
-describe('DetectionConfigSchema — modes', () => {
-  it('parses a poll-mode config', () => {
-    const parsed = DetectionConfigSchema.parse({
-      mode: 'poll',
-      poll: {
-        cursor: { kind: 'systemModstamp', field: 'SystemModstamp' },
-      },
-      mapping: [{ source: 'Id', target: 'external_id' }],
-      filters: [{ field: 'IsDeleted', op: 'eq', value: false }],
-    });
-    expect(parsed.mode).toBe('poll');
-    if (parsed.mode === 'poll') {
-      expect(parsed.poll.cursor.kind).toBe('systemModstamp');
-      expect(parsed.poll.provenance ?? 'poll').toBe('poll');
-    }
-  });
+describe("DetectionConfigSchema — modes", () => {
+	it("parses a poll-mode config", () => {
+		const parsed = DetectionConfigSchema.parse({
+			mode: "poll",
+			poll: {
+				cursor: { kind: "systemModstamp", field: "SystemModstamp" },
+			},
+			mapping: [{ source: "Id", target: "external_id" }],
+			filters: [{ field: "IsDeleted", op: "eq", value: false }],
+		});
+		expect(parsed.mode).toBe("poll");
+		if (parsed.mode === "poll") {
+			expect(parsed.poll.cursor.kind).toBe("systemModstamp");
+			expect(parsed.poll.provenance ?? "poll").toBe("poll");
+		}
+	});
 
-  it('parses a poll-mode config with cdc-as-provenance opt-in', () => {
-    const parsed = DetectionConfigSchema.parse({
-      mode: 'poll',
-      poll: {
-        cursor: { kind: 'eventId', field: 'id' },
-        provenance: 'cdc',
-      },
-      mapping: [{ source: 'id', target: 'external_id' }],
-    });
-    expect(parsed.mode).toBe('poll');
-    if (parsed.mode === 'poll') {
-      expect(parsed.poll.provenance).toBe('cdc');
-    }
-  });
+	it("parses a poll-mode config with cdc-as-provenance opt-in", () => {
+		const parsed = DetectionConfigSchema.parse({
+			mode: "poll",
+			poll: {
+				cursor: { kind: "eventId", field: "id" },
+				provenance: "cdc",
+			},
+			mapping: [{ source: "id", target: "external_id" }],
+		});
+		expect(parsed.mode).toBe("poll");
+		if (parsed.mode === "poll") {
+			expect(parsed.poll.provenance).toBe("cdc");
+		}
+	});
 
-  it('parses a webhook-mode config', () => {
-    const parsed = DetectionConfigSchema.parse({
-      mode: 'webhook',
-      webhook: {
-        eventIdField: 'event_id',
-      },
-      mapping: [{ source: 'id', target: 'external_id' }],
-    });
-    expect(parsed.mode).toBe('webhook');
-    if (parsed.mode === 'webhook') {
-      expect(parsed.webhook.eventIdField).toBe('event_id');
-    }
-  });
+	it("parses a webhook-mode config", () => {
+		const parsed = DetectionConfigSchema.parse({
+			mode: "webhook",
+			webhook: {
+				eventIdField: "event_id",
+			},
+			mapping: [{ source: "id", target: "external_id" }],
+		});
+		expect(parsed.mode).toBe("webhook");
+		if (parsed.mode === "webhook") {
+			expect(parsed.webhook.eventIdField).toBe("event_id");
+		}
+	});
 
-  it('defaults filters to an empty array when omitted', () => {
-    const parsed = DetectionConfigSchema.parse({
-      mode: 'poll',
-      poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } },
-      mapping: [{ source: 'Id', target: 'external_id' }],
-    });
-    expect(parsed.filters).toEqual([]);
-  });
+	it("parses a webhook-mode config WITHOUT eventIdField (optional — callback yields eventId)", () => {
+		// A queue iterator that always yields `eventId` (vendor delivery metadata)
+		// need not declare a record field for it — `eventIdField` is optional.
+		const parsed = DetectionConfigSchema.parse({
+			mode: "webhook",
+			webhook: {},
+			mapping: [{ source: "id", target: "external_id" }],
+		});
+		expect(parsed.mode).toBe("webhook");
+		if (parsed.mode === "webhook") {
+			expect(parsed.webhook.eventIdField).toBeUndefined();
+		}
+	});
 
-  it('rejects mode mismatched with branch (poll-mode missing poll block)', () => {
-    expect(
-      DetectionConfigSchema.safeParse({
-        mode: 'poll',
-        mapping: [{ source: 'Id', target: 'external_id' }],
-      }).success,
-    ).toBe(false);
-  });
+	it("still requires the webhook block itself in webhook mode (block required, field optional)", () => {
+		// The `webhook` block stays structurally required even though its only
+		// field is now optional — an empty {} is valid, a missing block is not.
+		expect(
+			DetectionConfigSchema.safeParse({
+				mode: "webhook",
+				webhook: {},
+				mapping: [{ source: "id", target: "external_id" }],
+			}).success,
+		).toBe(true);
+	});
 
-  it('rejects mode mismatched with branch (webhook-mode missing webhook block)', () => {
-    expect(
-      DetectionConfigSchema.safeParse({
-        mode: 'webhook',
-        mapping: [{ source: 'Id', target: 'external_id' }],
-      }).success,
-    ).toBe(false);
-  });
+	it("defaults filters to an empty array when omitted", () => {
+		const parsed = DetectionConfigSchema.parse({
+			mode: "poll",
+			poll: { cursor: { kind: "systemModstamp", field: "SystemModstamp" } },
+			mapping: [{ source: "Id", target: "external_id" }],
+		});
+		expect(parsed.filters).toEqual([]);
+	});
 
-  it('rejects empty mapping (entity must map at least external_id)', () => {
-    expect(
-      DetectionConfigSchema.safeParse({
-        mode: 'poll',
-        poll: { cursor: { kind: 'systemModstamp', field: 'SystemModstamp' } },
-        mapping: [],
-      }).success,
-    ).toBe(false);
-  });
+	it("rejects mode mismatched with branch (poll-mode missing poll block)", () => {
+		expect(
+			DetectionConfigSchema.safeParse({
+				mode: "poll",
+				mapping: [{ source: "Id", target: "external_id" }],
+			}).success,
+		).toBe(false);
+	});
 
-  it('rejects unknown mode', () => {
-    expect(
-      DetectionConfigSchema.safeParse({
-        mode: 'stream',
-        mapping: [{ source: 'Id', target: 'external_id' }],
-      }).success,
-    ).toBe(false);
-  });
+	it("rejects mode mismatched with branch (webhook-mode missing webhook block)", () => {
+		expect(
+			DetectionConfigSchema.safeParse({
+				mode: "webhook",
+				mapping: [{ source: "Id", target: "external_id" }],
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects empty mapping (entity must map at least external_id)", () => {
+		expect(
+			DetectionConfigSchema.safeParse({
+				mode: "poll",
+				poll: { cursor: { kind: "systemModstamp", field: "SystemModstamp" } },
+				mapping: [],
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects unknown mode", () => {
+		expect(
+			DetectionConfigSchema.safeParse({
+				mode: "stream",
+				mapping: [{ source: "Id", target: "external_id" }],
+			}).success,
+		).toBe(false);
+	});
 });

--- a/src/__tests__/runtime/subsystems/webhook-change-source.spec.ts
+++ b/src/__tests__/runtime/subsystems/webhook-change-source.spec.ts
@@ -4,12 +4,19 @@
  * Validates the webhook-mode primitive: a `DetectionConfig`-parameterized
  * `IChangeSource<T>` that iterates a consumer-owned inbound staging queue
  * and emits canonical `Change<T>` records with `source: 'webhook'` and a
- * `dedupKey` populated from the configured `webhook.eventIdField`.
+ * `dedupKey` derived with the precedence: yielded `eventId` >
+ * `webhook.eventIdField` record extraction > undefined.
  *
  * Key invariants under test:
  *   - constructor accepts `{ queue, config, middlewares? }`
  *   - `listChanges(subscription, cursor)` yields `Change<T>` with
- *     `source: 'webhook'`, `dedupKey` from the configured event-id field
+ *     `source: 'webhook'`, `dedupKey` per the precedence above
+ *   - a yielded `eventId` wins over the `eventIdField` record extraction
+ *   - with no yielded `eventId`, falls back to the `eventIdField` record field
+ *   - with neither a yielded `eventId` nor a configured `eventIdField`,
+ *     `dedupKey` is `undefined`
+ *   - a mixed batch where a create and a same-`external_id` mutation carry
+ *     distinct yielded `eventId`s gets distinct `dedupKey`s
  *   - empty-queue iteration yields nothing
  *   - errors thrown by the queue iterator surface to the consumer
  *   - the primitive does NOT synchronously drive the orchestrator —
@@ -17,137 +24,311 @@
  *   - middleware composition works the same shape as PollChangeSource
  *   - constructor rejects a non-webhook config
  */
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from "bun:test";
+import type { DetectionConfig } from "../../../../runtime/subsystems/integration/detection-config.schema";
+import type { IntegrationSubscriptionView } from "../../../../runtime/subsystems/integration/integration-change-source.protocol";
+import type { ChangeMiddleware } from "../../../../runtime/subsystems/integration/integration-middleware.protocol";
 import {
-  WebhookChangeSource,
-  type WebhookFetchCallback,
-  type WebhookFetchContext,
-} from '../../../../runtime/subsystems/integration/webhook-change-source';
-import type { IntegrationSubscriptionView } from '../../../../runtime/subsystems/integration/integration-change-source.protocol';
-import type { ChangeMiddleware } from '../../../../runtime/subsystems/integration/integration-middleware.protocol';
-import type { DetectionConfig } from '../../../../runtime/subsystems/integration/detection-config.schema';
+	WebhookChangeSource,
+	type WebhookFetchCallback,
+	type WebhookFetchContext,
+} from "../../../../runtime/subsystems/integration/webhook-change-source";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
 interface WebhookRecord {
-  external_id: string;
-  name: string;
-  event_id: string;
+	external_id: string;
+	name: string;
+	event_id: string;
 }
 
 const subscription: IntegrationSubscriptionView = {
-  id: 'sub-webhook-1',
-  domain: 'opportunity',
-  externalRef: 'sf-org-A',
+	id: "sub-webhook-1",
+	domain: "opportunity",
+	externalRef: "sf-org-A",
 };
 
 function makeWebhookConfig(extra?: Partial<DetectionConfig>): DetectionConfig {
-  return {
-    mode: 'webhook',
-    webhook: {
-      eventIdField: 'event_id',
-    },
-    // The queue yields ALREADY-MAPPED canonical records keyed by the mapping
-    // `source` (the field on the emitted record). These fixtures emit records
-    // keyed `external_id`/`name`, so `source` must match those keys — the
-    // primitive reads `record[source]`, NOT `record[target]`. (The original
-    // fixtures declared `source: 'id'`/`'Name'` while emitting `external_id`;
-    // that only passed because the pre-fix primitive read `.target` — the gap
-    // #6 transposition. Aligned here so the fixture exercises the real path.)
-    mapping: [
-      { source: 'external_id', target: 'external_id' },
-      { source: 'name', target: 'name' },
-    ],
-    filters: [],
-    ...(extra as object),
-  } as DetectionConfig;
+	return {
+		mode: "webhook",
+		webhook: {
+			eventIdField: "event_id",
+		},
+		// The queue yields ALREADY-MAPPED canonical records keyed by the mapping
+		// `source` (the field on the emitted record). These fixtures emit records
+		// keyed `external_id`/`name`, so `source` must match those keys — the
+		// primitive reads `record[source]`, NOT `record[target]`. (The original
+		// fixtures declared `source: 'id'`/`'Name'` while emitting `external_id`;
+		// that only passed because the pre-fix primitive read `.target` — the gap
+		// #6 transposition. Aligned here so the fixture exercises the real path.)
+		mapping: [
+			{ source: "external_id", target: "external_id" },
+			{ source: "name", target: "name" },
+		],
+		filters: [],
+		...(extra as object),
+	} as DetectionConfig;
 }
 
 async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
-  const out: T[] = [];
-  for await (const x of it) out.push(x);
-  return out;
+	const out: T[] = [];
+	for await (const x of it) out.push(x);
+	return out;
 }
 
 // ---------------------------------------------------------------------------
 // Empty queue
 // ---------------------------------------------------------------------------
 
-describe('WebhookChangeSource — empty queue', () => {
-  it('yields no changes when the queue is empty', async () => {
-    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
-      // empty
-    };
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue,
-      config: makeWebhookConfig(),
-    });
-    const out = await collect(src.listChanges(subscription, null));
-    expect(out).toEqual([]);
-  });
+describe("WebhookChangeSource — empty queue", () => {
+	it("yields no changes when the queue is empty", async () => {
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			// empty
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toEqual([]);
+	});
 });
 
 // ---------------------------------------------------------------------------
 // Event-id dedup
 // ---------------------------------------------------------------------------
 
-describe('WebhookChangeSource — event-id dedup', () => {
-  it('populates Change.dedupKey from the configured eventIdField on the record', async () => {
-    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
-      yield {
-        record: { external_id: 'A1', name: 'Alpha', event_id: 'evt_001' },
-      };
-      yield {
-        record: { external_id: 'A2', name: 'Beta', event_id: 'evt_002' },
-      };
-    };
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue,
-      config: makeWebhookConfig(),
-    });
-    const out = await collect(src.listChanges(subscription, null));
-    expect(out).toHaveLength(2);
-    expect(out[0].source).toBe('webhook');
-    expect(out[0].dedupKey).toBe('evt_001');
-    expect(out[0].externalId).toBe('A1');
-    expect(out[1].dedupKey).toBe('evt_002');
-  });
+describe("WebhookChangeSource — event-id dedup (eventIdField fallback)", () => {
+	it("falls back to the configured eventIdField on the record when no eventId is yielded", async () => {
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A1", name: "Alpha", event_id: "evt_001" },
+			};
+			yield {
+				record: { external_id: "A2", name: "Beta", event_id: "evt_002" },
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(2);
+		expect(out[0].source).toBe("webhook");
+		expect(out[0].dedupKey).toBe("evt_001");
+		expect(out[0].externalId).toBe("A1");
+		expect(out[1].dedupKey).toBe("evt_002");
+	});
 
-  it('throws if a record is missing the configured eventIdField', async () => {
-    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
-      yield {
-        record: { external_id: 'A1', name: 'Alpha' } as WebhookRecord,
-      };
-    };
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue,
-      config: makeWebhookConfig(),
-    });
-    await expect(
-      (async () => {
-        for await (const _c of src.listChanges(subscription, null)) {
-          // drain
-        }
-      })(),
-    ).rejects.toThrow(/event_id/);
-  });
+	it("throws if a record is missing the configured eventIdField AND no eventId is yielded", async () => {
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A1", name: "Alpha" } as WebhookRecord,
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		await expect(
+			(async () => {
+				for await (const _c of src.listChanges(subscription, null)) {
+					// drain
+				}
+			})(),
+		).rejects.toThrow(/event_id/);
+	});
 
-  it('forwards subscription + cursor to the queue iterator context', async () => {
-    let seen: WebhookFetchContext | undefined;
-    const queue: WebhookFetchCallback<WebhookRecord> = async function* (ctx) {
-      seen = ctx;
-    };
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue,
-      config: makeWebhookConfig(),
-    });
-    await collect(src.listChanges(subscription, { lastTs: 'x' }));
-    expect(seen).toBeDefined();
-    expect(seen!.subscription.id).toBe('sub-webhook-1');
-    expect(seen!.cursor).toEqual({ lastTs: 'x' });
-  });
+	it("forwards subscription + cursor to the queue iterator context", async () => {
+		let seen: WebhookFetchContext | undefined;
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* (ctx) {
+			seen = ctx;
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		await collect(src.listChanges(subscription, { lastTs: "x" }));
+		expect(seen).toBeDefined();
+		expect(seen!.subscription.id).toBe("sub-webhook-1");
+		expect(seen!.cursor).toEqual({ lastTs: "x" });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Yielded eventId — the preferred dedupKey channel (gap #6 follow-through,
+// swe-brain ADR-0009 Amendment B §B5). Vendor delivery metadata (the event id)
+// should never need a field on the vendor-neutral canonical record; the
+// queue-yield is the right channel for it. The dedupKey precedence the
+// primitive implements is: yielded `eventId` > `eventIdField` record
+// extraction > undefined.
+// ---------------------------------------------------------------------------
+
+describe("WebhookChangeSource — yielded eventId precedence", () => {
+	it("prefers the yielded eventId over the eventIdField record extraction", async () => {
+		// The record ALSO carries event_id: 'evt_record', but the yielded eventId
+		// must win — proving the queue-yield is consulted first.
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A1", name: "Alpha", event_id: "evt_record" },
+				eventId: "evt_yielded",
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(1);
+		expect(out[0].source).toBe("webhook");
+		expect(out[0].externalId).toBe("A1");
+		expect(out[0].dedupKey).toBe("evt_yielded");
+	});
+
+	it("uses the yielded eventId even when no eventIdField is configured", async () => {
+		// No `webhook.eventIdField` at all — the callback always yields eventId, so
+		// the record need not declare a field for it.
+		const noFieldConfig = {
+			mode: "webhook",
+			webhook: {},
+			mapping: [{ source: "external_id", target: "external_id" }],
+			filters: [],
+		} as DetectionConfig;
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A1", name: "Alpha" } as WebhookRecord,
+				eventId: "evt_only_yielded",
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: noFieldConfig,
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(1);
+		expect(out[0].dedupKey).toBe("evt_only_yielded");
+	});
+
+	it("falls back to eventIdField when the yielded eventId is undefined", async () => {
+		// Mixed yield: one record yields no eventId (falls back to the field), one
+		// yields an eventId (wins). Proves precedence resolves per-record.
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A1", name: "Alpha", event_id: "evt_field" },
+				// no eventId yielded → fall back to event_id field
+			};
+			yield {
+				record: { external_id: "A2", name: "Beta", event_id: "evt_field2" },
+				eventId: "evt_yielded2",
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(2);
+		expect(out[0].dedupKey).toBe("evt_field");
+		expect(out[1].dedupKey).toBe("evt_yielded2");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// No dedup signal — neither yielded eventId nor configured eventIdField →
+// dedupKey is undefined (the orchestrator simply has no delivery-level dedup
+// signal for that change; it does not throw).
+// ---------------------------------------------------------------------------
+
+describe("WebhookChangeSource — no dedup signal", () => {
+	it("leaves dedupKey undefined when neither eventId is yielded nor eventIdField configured", async () => {
+		const noFieldConfig = {
+			mode: "webhook",
+			webhook: {},
+			mapping: [{ source: "external_id", target: "external_id" }],
+			filters: [],
+		} as DetectionConfig;
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield { record: { external_id: "A1", name: "Alpha" } as WebhookRecord };
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: noFieldConfig,
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(1);
+		expect(out[0].source).toBe("webhook");
+		expect(out[0].externalId).toBe("A1");
+		expect(out[0].dedupKey).toBeUndefined();
+	});
+
+	it('treats an empty-string yielded eventId as "not yielded" and falls back', async () => {
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A1", name: "Alpha", event_id: "evt_field" },
+				eventId: "",
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(1);
+		expect(out[0].dedupKey).toBe("evt_field");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Mixed batch — a create and a same-external_id mutation in one drain batch.
+// This is the motivating case: a message create and its later edit share one
+// `external_id` but are distinct vendor events. Reading dedup identity off the
+// record (the old `eventIdField === 'externalId'` substitution swe-brain's
+// Slack drain documented) would collapse them to ONE dedupKey; the yielded
+// eventId keeps them distinct.
+// ---------------------------------------------------------------------------
+
+describe("WebhookChangeSource — mixed batch (create + same-id mutation)", () => {
+	it("gives a create and a same-external_id edit distinct dedupKeys via yielded eventIds", async () => {
+		// Both records carry the SAME external_id (the canonical record identity);
+		// the eventIdField substitution would set dedupKey = external_id for both,
+		// collapsing them. Yielded eventIds keep them apart.
+		const camelConfig = {
+			mode: "webhook",
+			// eventIdField === the externalId field — the exact swe-brain substitution
+			// that becomes unsafe once a record + its edit share one drain batch.
+			webhook: { eventIdField: "externalId" },
+			mapping: [{ source: "externalId", target: "external_id" }],
+			filters: [],
+		} as DetectionConfig;
+		const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
+			// message create
+			yield {
+				record: { externalId: "slack:msg_1", name: "hello" },
+				eventId: "slack:evt_create",
+			};
+			// its later edit — SAME externalId, DIFFERENT vendor event
+			yield {
+				record: { externalId: "slack:msg_1", name: "hello (edited)" },
+				eventId: "slack:evt_edit",
+			};
+		};
+		const src = new WebhookChangeSource<CamelCaseRecord>({
+			queue,
+			config: camelConfig,
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(2);
+		// Same canonical record identity...
+		expect(out[0].externalId).toBe("slack:msg_1");
+		expect(out[1].externalId).toBe("slack:msg_1");
+		// ...but distinct delivery-level dedupKeys (would have collapsed under the
+		// eventIdField substitution: both would be 'slack:msg_1').
+		expect(out[0].dedupKey).toBe("slack:evt_create");
+		expect(out[1].dedupKey).toBe("slack:evt_edit");
+		expect(out[0].dedupKey).not.toBe(out[1].dedupKey);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -168,169 +349,169 @@ describe('WebhookChangeSource — event-id dedup', () => {
 // ---------------------------------------------------------------------------
 
 interface CamelCaseRecord {
-  externalId: string;
-  name: string;
+	externalId: string;
+	name: string;
 }
 
-describe('WebhookChangeSource — camelCase canonical record (mapping.source)', () => {
-  function makeCamelConfig(): DetectionConfig {
-    return {
-      mode: 'webhook',
-      // The eventIdField IS the externalId field here — the swe-brain shape,
-      // where the canonical event id and external id are the same camelCase key.
-      webhook: { eventIdField: 'externalId' },
-      mapping: [{ source: 'externalId', target: 'external_id' }],
-      filters: [],
-    } as DetectionConfig;
-  }
+describe("WebhookChangeSource — camelCase canonical record (mapping.source)", () => {
+	function makeCamelConfig(): DetectionConfig {
+		return {
+			mode: "webhook",
+			// The eventIdField IS the externalId field here — the swe-brain shape,
+			// where the canonical event id and external id are the same camelCase key.
+			webhook: { eventIdField: "externalId" },
+			mapping: [{ source: "externalId", target: "external_id" }],
+			filters: [],
+		} as DetectionConfig;
+	}
 
-  it('reads externalId off the record via mapping.source (record has NO external_id key)', async () => {
-    const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
-      // Note: keyed `externalId` only — there is deliberately NO `external_id`
-      // key on the record. The buggy `.target` lookup would throw here.
-      yield { record: { externalId: 'gh:123', name: 'Alpha' } };
-    };
-    const src = new WebhookChangeSource<CamelCaseRecord>({
-      queue,
-      config: makeCamelConfig(),
-    });
-    const out = await collect(src.listChanges(subscription, null));
-    expect(out).toHaveLength(1);
-    expect(out[0].source).toBe('webhook');
-    expect(out[0].externalId).toBe('gh:123');
-    expect(out[0].dedupKey).toBe('gh:123');
-    // Sanity: the emitted record carries no `external_id` key whatsoever, so a
-    // passing assertion proves the primitive resolved via `.source`.
-    expect(
-      (out[0].record as Record<string, unknown>).external_id,
-    ).toBeUndefined();
-  });
+	it("reads externalId off the record via mapping.source (record has NO external_id key)", async () => {
+		const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
+			// Note: keyed `externalId` only — there is deliberately NO `external_id`
+			// key on the record. The buggy `.target` lookup would throw here.
+			yield { record: { externalId: "gh:123", name: "Alpha" } };
+		};
+		const src = new WebhookChangeSource<CamelCaseRecord>({
+			queue,
+			config: makeCamelConfig(),
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(1);
+		expect(out[0].source).toBe("webhook");
+		expect(out[0].externalId).toBe("gh:123");
+		expect(out[0].dedupKey).toBe("gh:123");
+		// Sanity: the emitted record carries no `external_id` key whatsoever, so a
+		// passing assertion proves the primitive resolved via `.source`.
+		expect(
+			(out[0].record as Record<string, unknown>).external_id,
+		).toBeUndefined();
+	});
 
-  it('throws naming the mapping source field when the record is missing it', async () => {
-    const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
-      yield { record: { name: 'Alpha' } as unknown as CamelCaseRecord };
-    };
-    const src = new WebhookChangeSource<CamelCaseRecord>({
-      queue,
-      config: makeCamelConfig(),
-    });
-    await expect(
-      (async () => {
-        for await (const _c of src.listChanges(subscription, null)) {
-          // drain
-        }
-      })(),
-    ).rejects.toThrow(/externalId/);
-  });
+	it("throws naming the mapping source field when the record is missing it", async () => {
+		const queue: WebhookFetchCallback<CamelCaseRecord> = async function* () {
+			yield { record: { name: "Alpha" } as unknown as CamelCaseRecord };
+		};
+		const src = new WebhookChangeSource<CamelCaseRecord>({
+			queue,
+			config: makeCamelConfig(),
+		});
+		await expect(
+			(async () => {
+				for await (const _c of src.listChanges(subscription, null)) {
+					// drain
+				}
+			})(),
+		).rejects.toThrow(/externalId/);
+	});
 });
 
 // ---------------------------------------------------------------------------
 // Queue errors
 // ---------------------------------------------------------------------------
 
-describe('WebhookChangeSource — queue errors', () => {
-  it('propagates errors thrown by the queue iterator', async () => {
-    const boom: WebhookFetchCallback<WebhookRecord> = async function* () {
-      throw new Error('queue offline');
-    };
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue: boom,
-      config: makeWebhookConfig(),
-    });
-    await expect(
-      (async () => {
-        for await (const _c of src.listChanges(subscription, null)) {
-          // drain
-        }
-      })(),
-    ).rejects.toThrow(/queue offline/);
-  });
+describe("WebhookChangeSource — queue errors", () => {
+	it("propagates errors thrown by the queue iterator", async () => {
+		const boom: WebhookFetchCallback<WebhookRecord> = async function* () {
+			throw new Error("queue offline");
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue: boom,
+			config: makeWebhookConfig(),
+		});
+		await expect(
+			(async () => {
+				for await (const _c of src.listChanges(subscription, null)) {
+					// drain
+				}
+			})(),
+		).rejects.toThrow(/queue offline/);
+	});
 });
 
 // ---------------------------------------------------------------------------
 // Middleware composition
 // ---------------------------------------------------------------------------
 
-describe('WebhookChangeSource — middleware composition', () => {
-  it('composes middlewares the same shape as PollChangeSource (first = outermost)', async () => {
-    const order: string[] = [];
-    const tag =
-      (label: string): ChangeMiddleware<WebhookRecord> =>
-      (next) =>
-      async function* (sub, cur) {
-        order.push(`${label}:enter`);
-        for await (const c of next(sub, cur)) {
-          order.push(`${label}:yield`);
-          yield c;
-        }
-        order.push(`${label}:exit`);
-      };
-    const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
-      yield {
-        record: { external_id: 'A', name: 'a', event_id: 'evt_1' },
-      };
-    };
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue,
-      config: makeWebhookConfig(),
-      middlewares: [tag('outer'), tag('inner')],
-    });
-    const out = await collect(src.listChanges(subscription, null));
-    expect(out).toHaveLength(1);
-    expect(order).toEqual([
-      'outer:enter',
-      'inner:enter',
-      'inner:yield',
-      'outer:yield',
-      'inner:exit',
-      'outer:exit',
-    ]);
-  });
+describe("WebhookChangeSource — middleware composition", () => {
+	it("composes middlewares the same shape as PollChangeSource (first = outermost)", async () => {
+		const order: string[] = [];
+		const tag =
+			(label: string): ChangeMiddleware<WebhookRecord> =>
+			(next) =>
+				async function* (sub, cur) {
+					order.push(`${label}:enter`);
+					for await (const c of next(sub, cur)) {
+						order.push(`${label}:yield`);
+						yield c;
+					}
+					order.push(`${label}:exit`);
+				};
+		const queue: WebhookFetchCallback<WebhookRecord> = async function* () {
+			yield {
+				record: { external_id: "A", name: "a", event_id: "evt_1" },
+			};
+		};
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue,
+			config: makeWebhookConfig(),
+			middlewares: [tag("outer"), tag("inner")],
+		});
+		const out = await collect(src.listChanges(subscription, null));
+		expect(out).toHaveLength(1);
+		expect(order).toEqual([
+			"outer:enter",
+			"inner:enter",
+			"inner:yield",
+			"outer:yield",
+			"inner:exit",
+			"outer:exit",
+		]);
+	});
 });
 
 // ---------------------------------------------------------------------------
 // Construction guard
 // ---------------------------------------------------------------------------
 
-describe('WebhookChangeSource — construction', () => {
-  it('rejects a non-webhook config', () => {
-    const pollConfig: DetectionConfig = {
-      mode: 'poll',
-      poll: { cursor: { kind: 'systemModstamp', field: 'm' } },
-      mapping: [{ source: 'Id', target: 'external_id' }],
-      filters: [],
-    };
-    expect(
-      () =>
-        new WebhookChangeSource<WebhookRecord>({
-          queue: async function* () {},
-          config: pollConfig,
-        }),
-    ).toThrow(/webhook/);
-  });
+describe("WebhookChangeSource — construction", () => {
+	it("rejects a non-webhook config", () => {
+		const pollConfig: DetectionConfig = {
+			mode: "poll",
+			poll: { cursor: { kind: "systemModstamp", field: "m" } },
+			mapping: [{ source: "Id", target: "external_id" }],
+			filters: [],
+		};
+		expect(
+			() =>
+				new WebhookChangeSource<WebhookRecord>({
+					queue: async function* () {},
+					config: pollConfig,
+				}),
+		).toThrow(/webhook/);
+	});
 
-  it('exposes a label for run logs', () => {
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue: async function* () {},
-      config: makeWebhookConfig(),
-      label: 'stripe-webhook-charge',
-    });
-    expect(src.label).toBe('stripe-webhook-charge');
-  });
+	it("exposes a label for run logs", () => {
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue: async function* () {},
+			config: makeWebhookConfig(),
+			label: "stripe-webhook-charge",
+		});
+		expect(src.label).toBe("stripe-webhook-charge");
+	});
 
-  it('falls back to a default label when not provided', () => {
-    const src = new WebhookChangeSource<WebhookRecord>({
-      queue: async function* () {},
-      config: makeWebhookConfig(),
-    });
-    expect(typeof src.label).toBe('string');
-    expect(src.label.length).toBeGreaterThan(0);
-  });
+	it("falls back to a default label when not provided", () => {
+		const src = new WebhookChangeSource<WebhookRecord>({
+			queue: async function* () {},
+			config: makeWebhookConfig(),
+		});
+		expect(typeof src.label).toBe("string");
+		expect(src.label.length).toBeGreaterThan(0);
+	});
 });
 
 // Compile-time guard: WebhookFetchContext must NOT include userId/tenantId.
 const _shapeGuard: WebhookFetchContext = {
-  subscription,
-  cursor: null,
+	subscription,
+	cursor: null,
 };
 void _shapeGuard;


### PR DESCRIPTION
## What

`WebhookFetchCallback<T>` now yields `{ record: T; eventId?: string; cursor?: WebhookCursor }` (was `{ record: T; cursor?: WebhookCursor }`), and `WebhookChangeSource` **prefers the yielded `eventId`** for `Change<T>.dedupKey`. `webhook.eventIdField` in `detection-config.schema.ts` is now **optional**.

**dedupKey precedence:** yielded `eventId` > `webhook.eventIdField` record extraction > `undefined`.

## Why

swe-brain's Slack inbound drain documented an `eventIdField: 'externalId'` substitution — delivery dedup happens at the receiver, so record identity stood in for event identity. That substitution becomes genuinely **unsafe** once a message and its edit (same `externalId`, different vendor event) can share one drain batch — they'd collapse to a single `dedupKey`. Vendor delivery metadata (the event id) should never need a field on the vendor-neutral canonical record; the **queue-yield is the right channel** for it.

`eventIdField` is made optional because a callback that always yields `eventId` shouldn't be forced to declare a record field for it. The `webhook` block itself stays structurally required in webhook mode (empty `{}` valid, missing block not), so the existing "webhook-mode missing webhook block" validation is unaffected.

## Behavior

- A non-empty yielded `eventId` always wins.
- Otherwise the configured `eventIdField` is read off the emitted record (and still throws if the field is configured but absent on the record).
- With neither a yielded `eventId` nor a configured `eventIdField`, `dedupKey` is `undefined` (the orchestrator simply has no delivery-level dedup signal for that change).
- An empty-string yielded `eventId` is treated as "not yielded" and falls back.

## Backward compatibility

**Nothing mandatory for consumers.** Callbacks that yield `{ record, cursor? }` and configs that set `webhook.eventIdField` compile and run unchanged. Opting into `eventId` (and dropping `eventIdField`) is the only migration, and it is opt-in.

## Tests

- `webhook-change-source.spec.ts` — added: yielded eventId wins over eventIdField; yielded eventId with no eventIdField configured; per-record fallback to eventIdField when eventId not yielded; neither → `dedupKey` undefined; empty-string yielded eventId falls back; **mixed batch** (a create and a same-`external_id` edit get distinct dedupKeys via distinct yielded eventIds — the motivating case).
- `detection-config.schema.spec.ts` — added: webhook config parses without `eventIdField`; `webhook` block still required (empty `{}` valid, missing block not).
- Change-source + schema specs: **118 pass / 0 fail** (was 110 on main; +8 new).
- Full `bun run test`: green. Typecheck: only the 3 pre-existing errors on main (`junction.ts` ×2, `barrel-generator.ts` ×1) — no new errors introduced.

## Docs

- `ADR-033` §1 amended (the `webhook: { eventIdField? }` shape + the yield channel + dedupKey precedence; amendment note, not a rewrite).
- `.claude/skills/integration/SKILL.md` + consumer `change-sources-and-sinks.md` updated to the yield-preferred precedence.
- `CHANGELOG.md` 0.16.1 entry; `package.json` 0.16.0 → 0.16.1.

Ref: swe-brain ADR-0009 Amendment B §B5, gap-#6 follow-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)