### PR TITLE
feat(messaging): CanonicalReaction — append-only reaction delta vocabulary (0.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@pattern-stack/codegen-calendar": "workspace:*",
     "@pattern-stack/codegen-crm": "workspace:*",
     "@pattern-stack/codegen-mail": "workspace:*",
+    "@pattern-stack/codegen-messaging": "workspace:*",
     "@pattern-stack/codegen-transcript": "workspace:*",
     "@cubejs-client/core": "^1.0.0",
     "@nestjs/common": "10",

--- a/packages/codegen-messaging/package.json
+++ b/packages/codegen-messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen-messaging",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "L2 messaging surface package for @pattern-stack/codegen — the canonical Channel/Message vocabulary, the MessagingPort composing contract, the bot-user write seam, and DI tokens. See ADR-036 + swe-brain ADR-0008.",
   "type": "module",
   "license": "MIT",

--- a/packages/codegen-messaging/src/canonical.ts
+++ b/packages/codegen-messaging/src/canonical.ts
@@ -1,12 +1,14 @@
 /**
- * Canonical `messaging`-surface vocabulary (ADR-036 §7; swe-brain ADR-0008 §1).
+ * Canonical `messaging`-surface vocabulary (ADR-036 §7; swe-brain ADR-0008 §1;
+ * swe-brain ADR-0009 Amendment B §B2).
  *
- * `CanonicalChannel` and `CanonicalMessage` are the vendor-agnostic `T`s a
- * messaging provider adapter reads into — the records that flow through the L1
- * change-source pipeline (`IChangeSource<Canonical…>` → differ → sink). Every
- * vendor adapter maps its vendor DTO → External (Zod-validated) → these canonical
- * shapes; vendor DTO/External shapes never cross the port boundary (hard rule #4).
- * IDs are vendor-prefixed at the boundary (`slack:C…`, `slack:C…:ts`, `slack:U…`).
+ * `CanonicalChannel`, `CanonicalMessage`, and `CanonicalReaction` are the
+ * vendor-agnostic `T`s a messaging provider adapter reads into — the records that
+ * flow through the L1 change-source pipeline (`IChangeSource<Canonical…>` → differ
+ * → sink). Every vendor adapter maps its vendor DTO → External (Zod-validated) →
+ * these canonical shapes; vendor DTO/External shapes never cross the port boundary
+ * (hard rule #4). IDs are vendor-prefixed at the boundary (`slack:C…`,
+ * `slack:C…:ts`, `slack:U…`, `slack:Ev…`).
  *
  * Modeled from swe-brain ADR-0008 (MessagingDomain, Slack first), trimmed to the
  * cross-vendor load-bearing core so Teams/Discord (planned vendor #2) map cleanly.
@@ -115,4 +117,32 @@ export type CanonicalMessage = {
    * self-authored messages (ADR-0008 §9).
    */
   isAppAuthored: boolean;
+};
+
+/**
+ * An append-only reaction delta (swe-brain ADR-0009 Amendment B §B2; reactions
+ * ARE interactions per swe-brain ADR-0006). One row per vendor add/remove
+ * event; aggregate counts are DERIVED at read (SUM(delta) per (message, emoji))
+ * — never stored on the delta. The poll-side aggregate snapshot remains
+ * `CanonicalMessage.reactions` (`MessageReaction[]`).
+ */
+export type CanonicalReaction = {
+  /** Vendor-prefixed DELTA identity — the vendor *event* id (e.g. `slack:Ev…`), not an object id: each add/remove is its own immutable fact. */
+  externalId: string;
+  /** The message the delta concerns (cross-entity join key, not a DB FK), e.g. `slack:C…:ts`. */
+  messageExternalId: string;
+  /** Parent container, vendor-prefixed, e.g. `slack:C…`. */
+  channelExternalId: string;
+  /** Emoji shortname as the vendor reports it (e.g. `thumbsup`); vendor vocabulary preserved. */
+  emoji: string;
+  /** The reacting actor's vendor user id, e.g. `slack:U…`. */
+  actorExternalId: string;
+  /** Actor email when resolvable (ExactEmailMatch — hard rule #5); null for bots/guests/unresolved. */
+  actorEmail: string | null;
+  /** +1 (added) or −1 (removed). */
+  delta: number;
+  /** When the reaction happened (vendor event timestamp). */
+  occurredAt: Date;
+  /** Observed visibility (`public` | `private`) — the consent lattice's runtime currency. */
+  visibility: string;
 };

--- a/src/__tests__/packages/codegen-messaging-smoke.test.ts
+++ b/src/__tests__/packages/codegen-messaging-smoke.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Cross-workspace smoke test for @pattern-stack/codegen-messaging (interaction lift).
+ *
+ * Resolves the package BY ITS PUBLISHED NAME from the codegen root workspace —
+ * proving `bun install` linked the new workspace package and its public barrel
+ * exports the canonical types (CanonicalChannel, CanonicalMessage, and the
+ * append-only CanonicalReaction delta — swe-brain ADR-0009 Amendment B §B2), the
+ * MessagingPort contract's capability descriptor, and the DI tokens.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  MESSAGE_WRITE,
+  MESSAGING_CAPABILITIES,
+  MESSAGING_PORT,
+  NO_MESSAGING_CAPABILITIES,
+  type CanonicalChannel,
+  type CanonicalMessage,
+  type CanonicalReaction,
+  type MessagingCapabilities,
+} from '@pattern-stack/codegen-messaging';
+
+describe('@pattern-stack/codegen-messaging public barrel', () => {
+  it('exports DI tokens as registered symbols', () => {
+    expect(MESSAGING_CAPABILITIES).toBe(
+      Symbol.for('@pattern-stack/codegen-messaging.capabilities'),
+    );
+    expect(MESSAGING_PORT).toBe(
+      Symbol.for('@pattern-stack/codegen-messaging.port'),
+    );
+    expect(MESSAGE_WRITE).toBe(
+      Symbol.for('@pattern-stack/codegen-messaging.message-write'),
+    );
+  });
+
+  it('CanonicalChannel + CanonicalMessage are implementable surface-shaped types', () => {
+    const channel: CanonicalChannel = {
+      externalId: 'slack:C123',
+      kind: 'public',
+      name: 'eng',
+      topic: null,
+      purpose: null,
+      isArchived: false,
+      isExtShared: false,
+      createdAt: new Date('2026-05-31T15:00:00Z'),
+    };
+    const message: CanonicalMessage = {
+      externalId: 'slack:C123:1717000000.000100',
+      channelExternalId: 'slack:C123',
+      authorExternalId: 'slack:U456',
+      authorEmail: 'doug@findtempo.co',
+      occurredAt: new Date('2026-05-31T15:00:00Z'),
+      threadExternalId: null,
+      text: 'ship the ledger',
+      mentionExternalIds: null,
+      subtype: null,
+      reactions: [{ emoji: 'thumbsup', count: 2 }],
+      files: null,
+      editedAt: null,
+      deletedAt: null,
+      visibility: 'public',
+      isAppAuthored: false,
+    };
+    expect(channel.externalId).toBe('slack:C123');
+    expect(message.channelExternalId).toBe('slack:C123');
+    expect(message.reactions?.[0]?.emoji).toBe('thumbsup');
+  });
+
+  it('CanonicalReaction is an append-only delta: ±1 per (actor, emoji), counts derived at read', () => {
+    const added: CanonicalReaction = {
+      externalId: 'slack:Ev0PV52K25',
+      messageExternalId: 'slack:C123:1717000000.000100',
+      channelExternalId: 'slack:C123',
+      emoji: 'thumbsup',
+      actorExternalId: 'slack:U456',
+      actorEmail: 'doug@findtempo.co',
+      delta: 1,
+      occurredAt: new Date('2026-05-31T15:01:00Z'),
+      visibility: 'public',
+    };
+    const removed: CanonicalReaction = {
+      ...added,
+      externalId: 'slack:Ev0PV52K9Z',
+      actorEmail: null, // null for bots / guests / unresolved (ExactEmailMatch)
+      delta: -1,
+      occurredAt: new Date('2026-05-31T15:02:00Z'),
+    };
+    // Each add/remove is its own immutable fact keyed by the vendor EVENT id.
+    expect(added.externalId).not.toBe(removed.externalId);
+    // Aggregate count is DERIVED — SUM(delta) per (message, emoji) — never stored.
+    const derivedCount = added.delta + removed.delta;
+    expect(derivedCount).toBe(0);
+  });
+
+  it('NO_MESSAGING_CAPABILITIES + spread declares entity coverage', () => {
+    expect(NO_MESSAGING_CAPABILITIES).toEqual({ entities: [] });
+    const caps: MessagingCapabilities = {
+      ...NO_MESSAGING_CAPABILITIES,
+      entities: ['channel', 'message', 'reaction'],
+    };
+    expect(caps.entities).toEqual(['channel', 'message', 'reaction']);
+    expect(NO_MESSAGING_CAPABILITIES.entities).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds `CanonicalReaction` to the `@pattern-stack/codegen-messaging` canonical vocabulary, alongside the existing `CanonicalChannel` + `CanonicalMessage`. Driven by **swe-brain ADR-0009 Amendment B §B2**: reactions are modeled as a proper **interaction entity** (per **swe-brain ADR-0006**) — append-only deltas (±1 per actor per emoji), aggregate counts **derived at read** (`SUM(delta)` per `(message, emoji)`), never stored on the delta.

The DELTA identity is the vendor **event** id (`slack:Ev…`), not an object id — each add/remove is its own immutable fact. Vendor-prefixed IDs at the boundary (hard rule #4); `actorEmail` resolves via `ExactEmailMatch` (hard rule #5).

The existing `MessageReaction` (emoji + aggregate count) is **untouched** — it remains the poll-side snapshot shape carried by `CanonicalMessage.reactions`. This is a pure vocabulary addition; **no generator behavior changes.**

## The exported type (as landed)

```ts
/**
 * An append-only reaction delta (swe-brain ADR-0009 Amendment B §B2; reactions
 * ARE interactions per swe-brain ADR-0006). One row per vendor add/remove
 * event; aggregate counts are DERIVED at read (SUM(delta) per (message, emoji))
 * — never stored on the delta. The poll-side aggregate snapshot remains
 * `CanonicalMessage.reactions` (`MessageReaction[]`).
 */
export type CanonicalReaction = {
  /** Vendor-prefixed DELTA identity — the vendor *event* id (e.g. `slack:Ev…`), not an object id: each add/remove is its own immutable fact. */
  externalId: string;
  /** The message the delta concerns (cross-entity join key, not a DB FK), e.g. `slack:C…:ts`. */
  messageExternalId: string;
  /** Parent container, vendor-prefixed, e.g. `slack:C…`. */
  channelExternalId: string;
  /** Emoji shortname as the vendor reports it (e.g. `thumbsup`); vendor vocabulary preserved. */
  emoji: string;
  /** The reacting actor's vendor user id, e.g. `slack:U…`. */
  actorExternalId: string;
  /** Actor email when resolvable (ExactEmailMatch — hard rule #5); null for bots/guests/unresolved. */
  actorEmail: string | null;
  /** +1 (added) or −1 (removed). */
  delta: number;
  /** When the reaction happened (vendor event timestamp). */
  occurredAt: Date;
  /** Observed visibility (`public` | `private`) — the consent lattice's runtime currency. */
  visibility: string;
};
```

Declared as `type` (not `interface`) per the file header's `Record<string, unknown>` constraint. Exported automatically via the barrel's `export * from './canonical'`.

## Generator templating — does the sink scaffold pick up `CanonicalReaction` automatically?

**No — and that's expected; this PR does not touch generator behavior.**

Two relevant facts about the codegen sink scaffold (`src/cli/shared/sink-emission-generator.ts`):

1. **The scaffold's canonical type is named `${entityClass}Canonical`** (e.g. `ReactionCanonical`), **not** `Canonical${PascalEntity}`. The naming order is reversed from the surface-package vocabulary, so a name-collision pickup wouldn't occur even by accident.
2. **It defaults that type to the local generated projection** — it emits `export type ReactionCanonical = ReactionIntegrationProjection;` and leaves the canonical-shape mapping as an explicit author seam (a doc comment: *"widen to your adapter's canonical shape if it carries fields the projection does not"*). The generator imports the canonical shape from the **consumer's own repo**, never from the surface package.

`SURFACE_REGISTRY` (in `adapter-emission-generator.ts`) maps each surface → package name + `portType` + `capabilitiesType` + `noCapsConst`, but it carries **no canonical record-type mapping** — the surface package's `Canonical*` type names (`CanonicalChannel`/`CanonicalMessage`/`CanonicalReaction`) are referenced nowhere in the CLI. So for a `surface: messaging` entity named `reaction`, the scaffold will emit `ReactionCanonical = ReactionIntegrationProjection` and the author wires `CanonicalReaction` in by hand at the change-source/sink seam (the same seam they already use for channel/message). **Consuming `CanonicalReaction` is opt-in, exactly like the existing two canonical types.**

## Versioning / changelog

- `packages/codegen-messaging`: **0.1.1 → 0.1.2** (surface packages are versioned independently; precedent set by #444, which bumped surfaces without touching the repo-root `CHANGELOG.md`). No per-package `CHANGELOG.md` exists for any surface package — the bump + rationale live in the commit/PR, matching the established convention.
- Repo-root `CHANGELOG.md` tracks the main `@pattern-stack/codegen` package (0.16.1) and is intentionally **not** touched.
- `dist/` is gitignored (built on publish via `prepublishOnly`); the package builds clean (`tsup` ESM + DTS) — verified, not committed.

## Incidental fix

`@pattern-stack/codegen-messaging` was missing from the repo-root `package.json` `devDependencies` `workspace:*` list (it was added in #440 but never wired into the root workspace, and consequently had **no** package smoke test while transcript/mail/calendar all do). This PR:
- adds the `workspace:*` dep so the package links into the root `node_modules`, and
- adds `src/__tests__/packages/codegen-messaging-smoke.test.ts` mirroring the transcript/mail/calendar smoke tests — it resolves the package by published name and instantiates all three canonical types (incl. the new `CanonicalReaction` delta), the capability descriptor, and the DI tokens.

## Tests / typecheck (vs baseline)

- **Package typecheck** (`tsc --noEmit` in the package): **clean.**
- **Package build** (`tsup`): **clean** (ESM + DTS emit).
- **New smoke test**: **4 pass / 0 fail.**
- **All package smoke tests** (`src/__tests__/packages/`): **43 pass / 0 fail** (was 39; +4 from the new file).
- **CI typecheck** (`tsc --noEmit -p tsconfig.build.json`): **3 errors, all pre-existing** (`junction.ts` ×2, `barrel-generator.ts` ×1) — identical with and without this branch (verified by stashing). **Zero new errors introduced.**
- **`src/__tests__/` unit suite**: the only failures are 7 pre-existing baseline failures in `schema/schema-v2.test.ts` (contact-v2.yaml parsing + cross-block query validation) — identical with/without this branch, unrelated to this change.

Reference: swe-brain ADR-0009 Amendment B §B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)