### PR TITLE
feat(patterns): config-driven subject scoping for Activity (0.17.0) — ACTIVITY-SUBJECT-1

### DIFF
--- a/.claude/skills/codegen/SKILL.md
+++ b/.claude/skills/codegen/SKILL.md
@@ -260,7 +260,7 @@ All families inherit the standard CRUD set: `findById`, `findByIds`, `list`, `co
 | Family | Additional Methods |
 |--------|--------------------|
 | `integrated` | `findByExternalId`, `findAllByUserId`, `findVisibleByUserId`, `integrationUpsert` |
-| `activity` | `findByDateRange`, `findByUserId`, `findByOpportunityId`, `findRecentByOpportunityId` |
+| `activity` | `findByDateRange`, `findByUserId`, `findBySubjectId`, `findRecentBySubjectId` (subject FK + recency column from `config: { Activity: { subject: <entity> } }`) |
 | `metadata` | `findByEntityIdAndType`, `listByEntityId`, `listHistoryByEntityId` |
 | `knowledge` | `semanticSearch`, `findPendingByOpportunityId`, `updateStatus`, `updateStatusBatch` (pgvector at runtime) |
 | `base` | Standard CRUD only |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-06-04
+
+**`ActivityPattern` subject scoping is config-driven** (ACTIVITY-SUBJECT-1) —
+the library's Activity base classes no longer bake the CRM term "opportunity"
+into their finders. An activity/interaction entity declares which subject it is
+scoped to via the pattern's new `config:` block, and the generated repo/service
+expose generic, config-resolved subject lookups. Surfaced by the swe-brain
+dogfood, whose interactions (meeting, email, transcript, message) reference
+`person`/`repo`/`team` subjects (ADR-0006), not CRM opportunities.
+
+Consumer census confirmed **no project used the Activity pattern** (dealbrain's
+sole `findByOpportunityId` is a `JunctionSyncRepository` method, not the pattern;
+swe-brain's interactions are all `pattern: Integrated`), so this is a clean cut
+with no aliases per the "no backwards compatibility until users" rule. The
+`patterns: [Integrated, Activity]` composition — the swe-brain target — is
+validated and tested.
+
+### Added
+
+- **`ActivityPattern.configSchema`** — `{ subject?, subjectColumn?, occurredAt? }`
+  (all optional, `.strict()`). `subject` derives the FK column `<subject>_id`;
+  `subjectColumn` overrides it explicitly; `occurredAt` names the recency column
+  (default `occurred_at`). Validated at parse time via the standard ADR-031
+  composition path; emitted onto the concrete repo as `patternConfig` (the same
+  hand-off `IntegratedEntityRepository` uses for `integrationConfig`).
+- **`ActivityPatternConfig`** interface exported from
+  `runtime/base-classes/activity-entity-repository.ts`.
+
+### Changed
+
+- **`ActivityEntityRepository` finders are config-driven.**
+  `findByOpportunityId` / `findRecentByOpportunityId` are replaced by
+  `findBySubjectId` / `findRecentBySubjectId`, which resolve the subject FK column
+  (and recency-ordering column) from `this.patternConfig` at runtime. Calling a
+  subject finder with no subject configured throws a clear error naming the
+  config key to set. `findByDateRange` and `findByUserId` are unchanged (actor
+  scoping is generally applicable, not CRM-shaped).
+- **`ActivityEntityService`** mirrors the rename: `findBySubject` /
+  `findRecent` (was `findByOpportunity` / `findRecent`); `IActivityEntityRepository`
+  drops the opportunity methods for the subject ones. `findByDateRange` /
+  `findByUser` unchanged.
+- **`ActivityPattern` inherited-method comment strings** now advertise the
+  subject finders; the header's byte-identical-to-FAMILY_MAP claim is removed (it
+  was a one-time PATTERN-5 migration guarantee, not a standing contract).
+
+### Migration
+
+No consumer action required — no project used the Activity pattern. A project
+adopting it now declares `pattern: Activity` (or `patterns: [Integrated,
+Activity]`) plus `config: { Activity: { subject: <entity> } }`. Named per-subject
+finders (`findByPersonId`) remain available the same way they always were — via
+the entity's declarative `queries:` block.
+
 ## [0.16.1] — 2026-06-04
 
 **`WebhookFetchCallback<T>` yields `{ record, eventId?, cursor? }`** —

--- a/consumer-skills/entities/families-and-queries.md
+++ b/consumer-skills/entities/families-and-queries.md
@@ -16,7 +16,7 @@ an optional `tx?: DrizzleTx` for transactional composition.
 |---|---|---|
 | `Base` | plain tables with no special access pattern | nothing — standard CRUD only |
 | `Synced` | records mirrored from an external system (have an external id + per-user visibility) | `findByExternalId`, `findAllByUserId`, `findVisibleByUserId`, `syncUpsert` |
-| `Activity` | time-ordered activity/event rows tied to a parent | `findByDateRange`, `findByUserId`, `findByOpportunityId`, `findRecentByOpportunityId` |
+| `Activity` | time-ordered activity/interaction rows scoped to a subject | `findByDateRange`, `findByUserId`, `findBySubjectId`, `findRecentBySubjectId` (subject FK + recency column resolved from `config: { Activity: { subject: <entity> } }`) |
 | `Metadata` | key/value or definition/value rows describing other entities | `findByEntityIdAndType`, `listByEntityId`, `listHistoryByEntityId` |
 | `Knowledge` | semantically-searchable knowledge rows (pgvector at runtime) | `semanticSearch`, `findPendingByOpportunityId`, `updateStatus`, `updateStatusBatch` |
 
@@ -77,6 +77,8 @@ and a `GET /<plural>/search` route. `paginate: true` makes the route accept
 - **`order:` is the default sort**, not a parameter — add a `queries:` search
   entry if you need caller-controlled ordering.
 - **Family methods assume their columns exist.** `Synced` expects an external-id
-  + user-visibility shape; `Activity` expects a parent FK like
-  `opportunity_id`. If your table doesn't fit, pick `Base` and add explicit
+  + user-visibility shape; `Activity`'s subject finders expect the subject FK
+  named by its `config:` (`subject: person` → `person_id`, or an explicit
+  `subjectColumn`) plus a recency column (`occurred_at` by default, or
+  `config.occurredAt`). If your table doesn't fit, pick `Base` and add explicit
   `queries:`.

--- a/docs/specs/ACTIVITY-SUBJECT-1.md
+++ b/docs/specs/ACTIVITY-SUBJECT-1.md
@@ -1,0 +1,195 @@
+# ACTIVITY-SUBJECT-1 — config-driven subject scoping for the Activity pattern
+
+**Status:** Draft — ready to build (bounded; library pattern + runtime base + tests)
+**Date:** 2026-06-04
+**Version:** 0.17.0 (minor — new pattern config surface + runtime base signature change)
+**Origin:** swe-brain dogfood (second consumer of `@pattern-stack/codegen`). swe-brain's
+ADR-0006 models interactions (meeting, email, transcript, message) as referencing
+*subjects* (`person`, later `repo`/`team`) — the Salesforce Activities-vs-Records
+shape. The library's `ActivityPattern` bakes the CRM term "opportunity" into the
+shared base class, so the only subject-scoped finders it ships are
+`findByOpportunityId` / `findRecentByOpportunityId`.
+**Related:** ADR-031 (App-Defined Patterns — `configSchema` + `patternConfig` hand-off),
+ADR-005 (superseded family base classes), CREATE-DTO-1 / LISTEN-NOTIFY-1 (house spec format).
+
+---
+
+## Problem
+
+`src/patterns/library/activity.pattern.ts` and its runtime base classes hardcode CRM
+vocabulary:
+
+- `ActivityPattern.repositoryInheritedMethods` / `serviceInheritedMethods` advertise
+  `findByOpportunityId, findRecentByOpportunityId`.
+- `runtime/base-classes/activity-entity-repository.ts` implements those two against the
+  literal column `this.table['opportunityId']`, and orders recency by the literal
+  `this.table['occurredAt']`.
+- `runtime/base-classes/activity-entity-service.ts` mirrors them
+  (`findByOpportunity`, `findRecent`).
+
+"Opportunity" is a CRM-ism. An activity/interaction entity is scoped to *some subject*,
+and which subject is a per-entity fact, not a library constant. The pattern should let a
+consumer declare the subject and get subject-scoped finders accordingly — for swe-brain,
+`{ Activity: { subject: person } }` → finders scoped to `person_id`.
+
+## Consumer census (settled before designing compat)
+
+Searched both dogfood consumers' entity YAML and source:
+
+| Consumer | `pattern: Activity` / `family: activity` | `ActivityEntityRepository` extends | `findByOpportunityId` from the pattern |
+|---|---|---|---|
+| dealbrain-integrations (main tree) | **zero** entity YAML — patterns in use are `Synced`, `Base`, `Metadata` | none — the `src/shared/base-classes/activity-entity-*.ts` are dead vendored library copies | none. The one `findByOpportunityId` in `src/modules/opportunity_contacts/` is a **`JunctionSyncRepository`** hand/declarative method, not the Activity pattern |
+| swe-brain | **zero** — interaction entities are all `pattern: Integrated` / `pattern: Base` | none | none |
+
+**Result: no consumer uses the Activity pattern.** Per CLAUDE.md ("no backwards
+compatibility until we have users"), this is a **clean cut**: the CRM-named finders are
+**deleted**, not aliased. The header comment claiming the method strings must stay
+"byte-identical" to the legacy `FAMILY_MAP` was a one-time PATTERN-5 *migration*
+guarantee (the `family:`→`pattern:` swap had to produce identical output); it is **not**
+a standing contract once `family:` is gone and no fixture depends on the old strings.
+The byte-identical baseline test (`prompt-extension.test.ts` "base-class output is
+byte-identical to the pre-PATTERN-5 FAMILY_MAP") asserts only `Integrated` today and is
+unaffected; we update the Activity expectations in the PATTERN-5 suite.
+
+## Design decisions
+
+### D1 — Generic `findBySubjectId`, not named `findByPersonId` (the load-bearing call)
+
+The runtime base class is generic over `TEntity` and is defined once, at library build
+time — it **cannot** know the subject name. The subject FK column is therefore read from
+per-entity config at runtime, exactly as `IntegratedEntityRepository` reads
+`this.integrationConfig` (the established ADR-031 §4 `patternConfig` hand-off). That
+makes a **generic** finder the natural fit:
+
+```ts
+findBySubjectId(subjectId: string): Promise<TEntity[]>
+findRecentBySubjectId(subjectId: string, limit = 10): Promise<TEntity[]>
+```
+
+Tradeoff recorded:
+
+- **Generic (chosen).** One method, zero new codegen surface (config rides the existing
+  `patternConfig` emission). Forward-compatible with **multi-subject** interactions
+  (ADR-0006: a meeting references person + repo + team) — a later `findBySubjectId(type,
+  id)` overload extends this without a combinatorial explosion of named methods. Reads
+  slightly less naturally than `findByPersonId`.
+- **Named (`findByPersonId`, rejected as the base method).** Reads better, but the
+  runtime base can't generate per-config method *names*; achieving it would require the
+  template to emit method *bodies* into every concrete repo — a large codegen change for
+  marginal readability, and it does not generalize to multi-subject. Consumers who want
+  a named finder already have the declarative `queries:` block
+  (`queries: [{ by: [person_id] }]` → `findByPersonId`); that is the right surface for
+  named, entity-specific finders, and it composes with this pattern.
+
+### D2 — `findByUserId` stays as-is
+
+`user_id` is **actor/owner** scoping, not subject scoping — generally applicable across
+domains (every audited entity that has an owner uses `user_id`). It is not CRM-shaped.
+Keep `findByUserId` / `findByUser` unchanged on the Activity base.
+
+### D3 — Subject FK column derives from config, with an explicit override
+
+The base resolves the FK column in this order, then camelCases it for `this.table[...]`:
+
+1. `patternConfig.subjectColumn` — explicit snake_case column name, when the FK does not
+   follow the convention.
+2. `<patternConfig.subject>_id` — derived (e.g. `subject: person` → `person_id`).
+
+If neither is present, `findBySubjectId` / `findRecentBySubjectId` throw a clear runtime
+error naming the entity-config key to set. (Pattern entities that only want
+`findByDateRange` / `findByUserId` simply never call the subject finders; the throw is
+lazy, so a date/user-only Activity entity needs no subject config.) The recency ordering
+column is `patternConfig.occurredAt` (snake_case) → camelCase, defaulting to
+`occurred_at` → `occurredAt`.
+
+### D4 — Composition with `Integrated` is valid; subject finders follow base resolution
+
+`patterns: [Integrated, Activity]` is the swe-brain composition target (interactions are
+`Integrated`). Composition validation must pass (no column/method conflict — Activity
+contributes **no columns**; `subject_id` is an entity-declared FK, and `findBySubjectId`
+does not collide with any `Integrated` method). The existing single-base rule
+(`resolvePatternBaseClasses` uses `patterns[0]`) stands: with `Integrated` first, the
+base class is `IntegratedEntityRepository` and the Activity subject finders are **not**
+inherited — the consumer reaches subject scoping via the `queries:` block (D1). With
+`Activity` first (or `pattern: Activity`), the base is `ActivityEntityRepository` and the
+generic finders are inherited. This matches the documented Phase-1 limitation in
+`resolvePatternBaseClasses` ("subsequent patterns contribute columns + implied behaviors
+but do not change the base class") — multi-base mixin is out of scope here and unneeded:
+the entire point of the composition is that the entity is `Integrated` *and* carries the
+subject config for downstream tooling, not that it inherits two runtime bases. A
+composition test locks that it validates clean and that `Integrated` wins the base.
+
+### D5 — Config flows through the existing `patternConfig` property; no new template locals
+
+`ActivityPattern` gains a `configSchema`. The clean-lite-ps repository/service templates
+already emit `protected override readonly patternConfig = {...} as const` for any pattern
+that has a `configSchema` and an entity that supplies a `config:` block (ADR-031 §4). The
+Activity base reads `this.patternConfig` and computes the column keys itself. **No
+template edit is required** — the change is the pattern record, the runtime base classes,
+and tests. (The `as const` literal is structurally typed; the base declares
+`patternConfig` as the inferred config type so `this.patternConfig.subject` is typed.)
+
+## Config schema
+
+```ts
+const ActivityPatternConfigSchema = z
+  .object({
+    subject: z.string().optional(),        // subject entity name → FK column <subject>_id
+    subjectColumn: z.string().optional(),  // explicit snake_case FK column override
+    occurredAt: z.string().optional(),     // snake_case recency column; default occurred_at
+  })
+  .strict();
+```
+
+All optional: a date/user-only Activity entity supplies no `config:` block at all (and
+then the templates emit no `patternConfig` property — the base falls back to
+`occurred_at` for date range, and the subject finders throw if called). `.strict()`
+rejects misspelled keys loudly, matching `JunctionPattern`.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/patterns/library/activity.pattern.ts` | edit | Add `configSchema`; replace `findByOpportunityId, findRecentByOpportunityId` in the inherited-method comment lists with `findBySubjectId, findRecentBySubjectId`; rewrite header (no more byte-compat claim); generic `description`. |
+| `runtime/base-classes/activity-entity-repository.ts` | edit | Add `protected readonly patternConfig?` (typed via the schema's inferred shape); replace `findByOpportunityId`/`findRecentByOpportunityId` with config-driven `findBySubjectId`/`findRecentBySubjectId`; resolve the subject + occurredAt columns from `patternConfig` (camelCased); keep `findByDateRange` / `findByUserId`. |
+| `runtime/base-classes/activity-entity-service.ts` | edit | Mirror: `IActivityEntityRepository` interface gains `findBySubjectId` / `findRecentBySubjectId` (drops the opportunity pair); service exposes `findBySubject` / `findRecent` delegating to the repo; keep `findByDateRange` / `findByUser`. |
+| `test/scaffold/tests/activity-entity-repository.test.ts` | edit | Retarget the `findByOpportunityId` / `findRecentByOpportunityId` integration cases to `findBySubjectId` / `findRecentBySubjectId` with a `patternConfig = { subject: 'opportunity' }` on the test subclass (proves the same DB column via config). Add a case: a subclass with `subjectColumn` override; a case: calling a subject finder with no config throws. Keep gated behind `SCAFFOLD_INTEGRATION=1`. |
+| `src/__tests__/patterns/activity-pattern.test.ts` | create | Registry-surface unit tests (mirror `junction-pattern.test.ts`): registered under `Activity`; advertises `findBySubjectId` / `findRecentBySubjectId` and **not** the opportunity finders; exposes a `configSchema`; schema accepts `{ subject: 'person' }`, accepts `{}`, rejects an unknown key. |
+| `src/__tests__/clean-lite-ps/prompt-extension.test.ts` | edit | Update the PATTERN-5 expectations for `Activity` (inherited-method strings) so the byte-snapshot reflects the new finders. Add a `patterns: [Integrated, Activity]` case asserting composition resolves base to `IntegratedEntityRepository` and validates clean. |
+| `src/__tests__/patterns/validate-composition.test.ts` | edit | Add a case: `patterns: [Integrated, Activity]` with `config: { Activity: { subject: 'person' } }` → no issues (valid composition; the whole point). Add: `config: { Activity: { subject: 42 } }` → `pattern_config_invalid`. |
+| `CHANGELOG.md` | edit | 0.17.0 entry (Changed: Activity finders are config-driven; Breaking-for-nobody note re: census). |
+| `package.json` | edit | `0.16.1` → `0.17.0`. |
+
+## Test plan
+
+- `bun test src/__tests__/patterns/` — pattern registry + composition (fast, no DB).
+- `bun test src/__tests__/clean-lite-ps/prompt-extension.test.ts` — PATTERN-5 emission.
+- The scaffold integration suite is gated behind `SCAFFOLD_INTEGRATION=1` (real Postgres)
+  and is **not** in the default CI unit lane; the edits keep it compiling and correct for
+  when it runs. Net-new behavior is covered by the unit + composition + registry tests
+  above plus the base-class logic exercised through the retargeted integration cases.
+- Pre-existing baseline (NOT in scope, do not fix): 7 schema-v2 failures
+  (`contact-v2.yaml` integration + `cross-block validation`). Confirmed orthogonal.
+
+## Consumer notes (post-merge)
+
+- **swe-brain** (the originator): once published + bumped, an interaction entity can adopt
+  `patterns: [Integrated, Activity]` with `config: { Activity: { subject: person } }`.
+  Because `Integrated` wins the base (D4), the subject-scoped query is reached via the
+  entity's `queries:` block (`queries: [{ by: [person_id] }]` → `findByPersonId`); the
+  `Activity` config remains the declarative marker that the entity is a subject-scoped
+  interaction (legible to the agent-aware query surface). If/when swe-brain wants the
+  generic `findBySubjectId` inherited at runtime, it declares `pattern: Activity` (Activity
+  primary) instead.
+- **dealbrain-integrations**: unaffected — it never used the Activity pattern. No regen
+  consequence.
+
+## Out of scope
+
+- Multi-base mixin so `[Integrated, Activity]` inherits *both* runtime bases (D4). Deferred
+  until a consumer needs the generic finder inherited on an `Integrated`-primary entity.
+- Multi-subject `findBySubjectId(subjectType, id)` overload (D1). The generic signature is
+  chosen specifically so this lands additively when ADR-0006's multi-subject interactions
+  arrive.
+- Generating named per-subject finders (`findByPersonId`) into concrete repos from config
+  — the `queries:` block already covers named finders.

--- a/justfile
+++ b/justfile
@@ -28,9 +28,12 @@ gen-subsystem name:
 
 # ─── Test ─────────────────────────────────────────────────────────────────────
 
-# Run unit tests (base classes + subsystems + scanner + schema)
+# Run unit tests (base classes + subsystems + scanner + schema).
+# Paths are anchored via justfile_directory(): `bun test <path>` treats the
+# arg as a SUBSTRING filter, so a relative `src/__tests__/` also matches any
+# checkout under worktrees/<x>/src/__tests__/ and runs its stale tests.
 test-unit:
-    bun test src/__tests__/
+    bun test "{{justfile_directory()}}/src/__tests__/"
 
 # Run end-to-end smoke test: scaffold + generate + typecheck a fresh project.
 # Completes in ~60-120s. Set KEEP_SMOKE_DIR=1 to preserve the tmp project.
@@ -56,14 +59,14 @@ test-smoke-junction-cross-domain-clean:
 # Junction snapshot tests — locks emitted output of junction codegen against drift.
 # Regenerate after intentional template changes: bun test --update-snapshots test/junction/
 test-junction:
-    bun test test/junction/
+    bun test "{{justfile_directory()}}/test/junction/"
 
 # Integration-emit snapshot (RFC-0001 §7) — locks the emitted src/integrations/**
 # tree (provider modules + adapters + barrel + aggregator + types.generated.ts)
 # for the checked-in integration-patterns fixture. Regenerate after intentional
 # emission changes: bun test --update-snapshots test/integration-emit/
 test-integration-emit:
-    bun test test/integration-emit/
+    bun test "{{justfile_directory()}}/test/integration-emit/"
 
 # Refresh the integration-patterns snapshot fixture YAML from a local checkout.
 # Manual + reviewed — NEVER auto-synced (RFC-0001 §7). Point at your local
@@ -130,7 +133,7 @@ compare:
 
 # Run family repo integration tests (requires Docker + db-up + db-push)
 test-family:
-    bun test test/scaffold/tests/crm-entity-repository.test.ts test/scaffold/tests/activity-entity-repository.test.ts test/scaffold/tests/metadata-entity-repository.test.ts
+    bun test "{{justfile_directory()}}/test/scaffold/tests/crm-entity-repository.test.ts" "{{justfile_directory()}}/test/scaffold/tests/activity-entity-repository.test.ts" "{{justfile_directory()}}/test/scaffold/tests/metadata-entity-repository.test.ts"
 
 # Run scaffold integration tests (requires Docker)
 test-integration:
@@ -146,7 +149,7 @@ test-integration-quick:
 # unit run (it needs Docker). Closes the OBS-LIST-1 "Drizzle SQL not
 # exercised" gap (metadata->>'rootRunId' + keyset OR-expansion).
 test-obs-integration:
-    bun test test/integration/observability-list-reads.drizzle.integration.test.ts
+    bun test "{{justfile_directory()}}/test/integration/observability-list-reads.drizzle.integration.test.ts"
 
 # Run the full scaffold validation (Docker + codegen + NestJS + CRUD)
 validate:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/base-classes/activity-entity-repository.ts
+++ b/runtime/base-classes/activity-entity-repository.ts
@@ -1,26 +1,84 @@
 /**
  * ActivityEntityRepository<TEntity>
  *
- * Family-specific base for activity entities (emails, calls, meetings, notes).
- * Adds date-range queries, user/opportunity scoping, and recency ordering.
+ * Family-specific base for activity / interaction entities (emails, calls,
+ * meetings, messages, transcripts). Adds date-range queries, actor (`user_id`)
+ * scoping, recency ordering, and **config-driven subject scoping** — the
+ * subject FK column is resolved from the concrete repo's `patternConfig`
+ * (ADR-031 §4) rather than hardcoded, so the same base serves a CRM
+ * `opportunity`-scoped activity and a swe-brain `person`-scoped interaction.
  *
- * Concrete repos extend this and declare their table + behaviors.
+ * Concrete repos extend this and declare their table + behaviors, and (when
+ * they use the subject finders) a `patternConfig` carrying `subject` /
+ * `subjectColumn` / `occurredAt`. The template emits that property from the
+ * entity's `config: { Activity: {...} }` block. See ACTIVITY-SUBJECT-1.
  */
 import { eq, between, desc } from 'drizzle-orm';
 import { BaseRepository } from './base-repository';
 
+/**
+ * Per-entity Activity config (matches `ActivityPatternConfigSchema` in
+ * `src/patterns/library/activity.pattern.ts`). Carried on the concrete repo as
+ * `patternConfig` and read here to resolve column names at runtime.
+ */
+export interface ActivityPatternConfig {
+  /** Subject entity name → derives the FK column `<subject>_id`. */
+  subject?: string;
+  /** Explicit snake_case FK column, when it does not follow `<subject>_id`. */
+  subjectColumn?: string;
+  /** snake_case recency-ordering column; defaults to `occurred_at`. */
+  occurredAt?: string;
+}
+
+const toCamel = (snake: string): string =>
+  snake.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+
 export abstract class ActivityEntityRepository<TEntity> extends BaseRepository<TEntity> {
   /**
-   * Find activities within a date range (inclusive).
+   * Per-entity Activity config. The template emits this from `config:
+   * { Activity: {...} }`; entities that only use date-range / user scoping omit
+   * it (and must not call the subject finders).
+   */
+  protected readonly patternConfig?: ActivityPatternConfig;
+
+  /**
+   * camelCase key for the recency-ordering column. Defaults to `occurredAt`
+   * (column `occurred_at`); override via `patternConfig.occurredAt`.
+   */
+  protected get occurredAtColumn(): string {
+    const snake = this.patternConfig?.occurredAt ?? 'occurred_at';
+    return toCamel(snake);
+  }
+
+  /**
+   * camelCase key for the subject FK column, resolved from `patternConfig`:
+   * `subjectColumn` (explicit) → `<subject>_id` (derived). Throws when neither
+   * is configured — the subject finders are unusable without it, and a clear
+   * error beats a silent `undefined` column index.
+   */
+  protected get subjectColumn(): string {
+    const explicit = this.patternConfig?.subjectColumn;
+    if (explicit) return toCamel(explicit);
+    const subject = this.patternConfig?.subject;
+    if (subject) return toCamel(`${subject}_id`);
+    throw new Error(
+      'ActivityEntityRepository: subject finders require a subject column. ' +
+        "Set `config: { Activity: { subject: '<entity>' } }` (→ <entity>_id) " +
+        "or `config: { Activity: { subjectColumn: '<column>' } }` on the entity YAML.",
+    );
+  }
+
+  /**
+   * Find activities within a date range (inclusive), by the recency column.
    */
   async findByDateRange(start: Date, end: Date): Promise<TEntity[]> {
     const rows = await this.baseQuery()
-      .where(between(this.table['occurredAt'], start, end));
+      .where(between(this.table[this.occurredAtColumn], start, end));
     return rows as TEntity[];
   }
 
   /**
-   * Find all activities for a specific user.
+   * Find all activities for a specific user (actor / owner scoping).
    */
   async findByUserId(userId: string): Promise<TEntity[]> {
     const rows = await this.baseQuery()
@@ -29,21 +87,22 @@ export abstract class ActivityEntityRepository<TEntity> extends BaseRepository<T
   }
 
   /**
-   * Find all activities for a specific opportunity.
+   * Find all activities for a specific subject (config-driven FK column).
    */
-  async findByOpportunityId(opportunityId: string): Promise<TEntity[]> {
+  async findBySubjectId(subjectId: string): Promise<TEntity[]> {
     const rows = await this.baseQuery()
-      .where(eq(this.table['opportunityId'], opportunityId));
+      .where(eq(this.table[this.subjectColumn], subjectId));
     return rows as TEntity[];
   }
 
   /**
-   * Find the most recent activities for an opportunity, ordered by occurredAt desc.
+   * Find the most recent activities for a subject, ordered by the recency
+   * column descending.
    */
-  async findRecentByOpportunityId(opportunityId: string, limit = 10): Promise<TEntity[]> {
+  async findRecentBySubjectId(subjectId: string, limit = 10): Promise<TEntity[]> {
     const rows = await this.baseQuery()
-      .where(eq(this.table['opportunityId'], opportunityId))
-      .orderBy(desc(this.table['occurredAt']))
+      .where(eq(this.table[this.subjectColumn], subjectId))
+      .orderBy(desc(this.table[this.occurredAtColumn]))
       .limit(limit);
     return rows as TEntity[];
   }

--- a/runtime/base-classes/activity-entity-service.ts
+++ b/runtime/base-classes/activity-entity-service.ts
@@ -1,17 +1,19 @@
 /**
  * ActivityEntityService<TRepo, TEntity>
  *
- * Family-specific base service for activity entities.
- * Delegates to an activity repository that provides date-range,
- * user, and opportunity queries.
+ * Family-specific base service for activity / interaction entities. Delegates
+ * to an activity repository that provides date-range, actor (`user_id`), and
+ * config-driven subject queries. The subject FK column is resolved inside the
+ * repository from its `patternConfig` (ADR-031 §4) — the service is
+ * subject-name-agnostic. See ACTIVITY-SUBJECT-1.
  */
 import { BaseService, type IBaseRepository } from './base-service';
 
 export interface IActivityEntityRepository<TEntity> extends IBaseRepository<TEntity> {
   findByDateRange(start: Date, end: Date): Promise<TEntity[]>;
   findByUserId(userId: string): Promise<TEntity[]>;
-  findByOpportunityId(opportunityId: string): Promise<TEntity[]>;
-  findRecentByOpportunityId(opportunityId: string, limit?: number): Promise<TEntity[]>;
+  findBySubjectId(subjectId: string): Promise<TEntity[]>;
+  findRecentBySubjectId(subjectId: string, limit?: number): Promise<TEntity[]>;
 }
 
 export abstract class ActivityEntityService<
@@ -26,23 +28,23 @@ export abstract class ActivityEntityService<
   }
 
   /**
-   * Find all activities for a specific user.
+   * Find all activities for a specific user (actor / owner scoping).
    */
   findByUser(userId: string): Promise<TEntity[]> {
     return this.repository.findByUserId(userId);
   }
 
   /**
-   * Find all activities for a specific opportunity.
+   * Find all activities for a specific subject (config-driven FK column).
    */
-  findByOpportunity(opportunityId: string): Promise<TEntity[]> {
-    return this.repository.findByOpportunityId(opportunityId);
+  findBySubject(subjectId: string): Promise<TEntity[]> {
+    return this.repository.findBySubjectId(subjectId);
   }
 
   /**
-   * Find the most recent activities for an opportunity.
+   * Find the most recent activities for a subject.
    */
-  findRecent(opportunityId: string, limit?: number): Promise<TEntity[]> {
-    return this.repository.findRecentByOpportunityId(opportunityId, limit);
+  findRecent(subjectId: string, limit?: number): Promise<TEntity[]> {
+    return this.repository.findRecentBySubjectId(subjectId, limit);
   }
 }

--- a/src/__tests__/clean-lite-ps/prompt-extension.test.ts
+++ b/src/__tests__/clean-lite-ps/prompt-extension.test.ts
@@ -535,6 +535,46 @@ describe('buildCleanLitePsLocals — PATTERN-5 registry integration', () => {
       '@pattern-stack/codegen/runtime/base-classes/integrated-entity-service',
     );
   });
+
+  // ACTIVITY-SUBJECT-1 — Activity inherited-method strings are config-driven now.
+  it('Activity advertises the config-driven subject finders (not the CRM names)', () => {
+    const def = {
+      entity: { name: 'meeting', plural: 'meetings', table: 'meetings', pattern: 'Activity' },
+      fields: {},
+      relationships: {},
+      behaviors: [],
+    };
+    const locals = buildCleanLitePsLocals(def, EMPTY_BASE_LOCALS);
+    const repoLines = (locals.repositoryInheritedMethods ?? []).join(' | ');
+    const serviceLines = (locals.serviceInheritedMethods ?? []).join(' | ');
+    expect(repoLines).toContain('findBySubjectId');
+    expect(repoLines).toContain('findRecentBySubjectId');
+    expect(repoLines).not.toContain('Opportunity');
+    expect(serviceLines).not.toContain('Opportunity');
+  });
+
+  // ACTIVITY-SUBJECT-1 D4 — the swe-brain composition target. `Integrated`
+  // wins the base; `Activity` rides along as the subject marker + config.
+  it('patterns: [Integrated, Activity] resolves base to IntegratedEntityRepository', () => {
+    const def = {
+      entity: {
+        name: 'message',
+        plural: 'messages',
+        table: 'messages',
+        patterns: ['Integrated', 'Activity'],
+      },
+      fields: {},
+      relationships: {},
+      behaviors: ['timestamps'],
+      config: { Activity: { subject: 'person' } },
+    };
+    const locals = buildCleanLitePsLocals(def, EMPTY_BASE_LOCALS);
+    // First pattern wins the base class (documented single-base Phase-1 rule).
+    expect(locals.repositoryBaseClass).toBe('IntegratedEntityRepository');
+    expect(locals.patternName).toBe('Integrated');
+    // Integrated's implied behavior still folds in under composition.
+    expect(locals.hasExternalIdTracking).toBe(true);
+  });
 });
 
 describe('impliedBehaviors fold — pattern-implied behaviors merge into emit', () => {

--- a/src/__tests__/patterns/activity-pattern.test.ts
+++ b/src/__tests__/patterns/activity-pattern.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ActivityPattern registry-surface tests (ACTIVITY-SUBJECT-1).
+ *
+ * Confirms the pattern is reachable through the library barrel, advertises the
+ * config-driven subject finders (not the deleted CRM-named ones), and that its
+ * configSchema validates `{ subject }` / `{}` and rejects unknown keys.
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+// Importing the barrel pre-registers the library patterns as a side effect.
+import '../../patterns/index.ts';
+
+import { getPattern, getLibraryPatternNames } from '../../patterns/registry.ts';
+import { ActivityPattern } from '../../patterns/library/index.ts';
+
+describe('ActivityPattern', () => {
+	test('is registered under the name "Activity"', () => {
+		const def = getPattern('Activity');
+		expect(def).toBeDefined();
+		expect(def?.name).toBe('Activity');
+	});
+
+	test('appears in getLibraryPatternNames()', () => {
+		expect(getLibraryPatternNames()).toContain('Activity');
+	});
+
+	test('declares the ActivityEntity base classes', () => {
+		expect(ActivityPattern.repositoryClass).toBe('ActivityEntityRepository');
+		expect(ActivityPattern.serviceClass).toBe('ActivityEntityService');
+	});
+
+	test('advertises the config-driven subject finders', () => {
+		const repoMethods = (ActivityPattern.repositoryInheritedMethods ?? []).join(
+			', ',
+		);
+		expect(repoMethods).toContain('findBySubjectId');
+		expect(repoMethods).toContain('findRecentBySubjectId');
+		// Actor scoping stays; it is not CRM-shaped.
+		expect(repoMethods).toContain('findByUserId');
+		expect(repoMethods).toContain('findByDateRange');
+	});
+
+	test('no longer advertises the CRM-named opportunity finders (clean cut)', () => {
+		const repoMethods = (ActivityPattern.repositoryInheritedMethods ?? []).join(
+			', ',
+		);
+		const serviceMethods = (ActivityPattern.serviceInheritedMethods ?? []).join(
+			', ',
+		);
+		expect(repoMethods).not.toContain('Opportunity');
+		expect(serviceMethods).not.toContain('Opportunity');
+	});
+
+	test('exposes a configSchema', () => {
+		expect(ActivityPattern.configSchema).toBeDefined();
+	});
+});
+
+describe('ActivityPattern.configSchema', () => {
+	const schema = ActivityPattern.configSchema!;
+
+	test('accepts { subject }', () => {
+		expect(schema.safeParse({ subject: 'person' }).success).toBe(true);
+	});
+
+	test('accepts { subjectColumn, occurredAt }', () => {
+		expect(
+			schema.safeParse({ subjectColumn: 'person_id', occurredAt: 'sent_at' })
+				.success,
+		).toBe(true);
+	});
+
+	test('accepts an empty config (date/user-only activity)', () => {
+		expect(schema.safeParse({}).success).toBe(true);
+	});
+
+	test('rejects a non-string subject', () => {
+		expect(schema.safeParse({ subject: 42 }).success).toBe(false);
+	});
+
+	test('rejects an unknown key (.strict)', () => {
+		expect(schema.safeParse({ subjet: 'person' }).success).toBe(false);
+	});
+});

--- a/src/__tests__/patterns/validate-composition.test.ts
+++ b/src/__tests__/patterns/validate-composition.test.ts
@@ -373,6 +373,65 @@ describe('validatePatternComposition — configSchema validation', () => {
 });
 
 // ============================================================================
+// ACTIVITY-SUBJECT-1 — Activity ⨉ Integrated composition (the swe-brain target)
+// ============================================================================
+
+describe('validatePatternComposition — Activity + Integrated composition', () => {
+	// Use the real library patterns (barrel pre-registered at top of file). The
+	// afterAll() above re-seeds the canonical library set for later files.
+	beforeEach(() => {
+		_resetRegistryForTests({ includeLibrary: true });
+		registerLibraryPattern(BasePattern);
+		registerLibraryPattern(IntegratedPattern);
+		registerLibraryPattern(ActivityPattern);
+		registerLibraryPattern(KnowledgePattern);
+		registerLibraryPattern(MetadataPattern);
+		registerLibraryPattern(JunctionPattern);
+	});
+
+	test('patterns: [Integrated, Activity] with a valid Activity config → no issues', () => {
+		const entity = makeEntity({
+			name: 'message',
+			patterns: ['Integrated', 'Activity'],
+			fields: fieldMap(['person_id']),
+			patternConfig: { Activity: { subject: 'person' } },
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+
+	test('patterns: [Integrated, Activity] with no config → no issues (all-optional schema)', () => {
+		const entity = makeEntity({
+			name: 'message',
+			patterns: ['Integrated', 'Activity'],
+		});
+		expect(validatePatternComposition(entity)).toEqual([]);
+	});
+
+	test('invalid Activity config (non-string subject) → pattern_config_invalid', () => {
+		const entity = makeEntity({
+			name: 'message',
+			patterns: ['Integrated', 'Activity'],
+			patternConfig: { Activity: { subject: 42 as unknown as string } },
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_config_invalid');
+		expect(errs[0]!.message).toMatch(/Activity/);
+	});
+
+	test('unknown Activity config key → pattern_config_invalid (.strict schema)', () => {
+		const entity = makeEntity({
+			name: 'message',
+			pattern: 'Activity',
+			patternConfig: { Activity: { subjet: 'person' } },
+		});
+		const errs = errors(validatePatternComposition(entity));
+		expect(errs.length).toBe(1);
+		expect(errs[0]!.type).toBe('pattern_config_invalid');
+	});
+});
+
+// ============================================================================
 // Project-level — plan Risk 4
 // ============================================================================
 

--- a/src/__tests__/runtime/base-classes/activity-entity-service.spec.ts
+++ b/src/__tests__/runtime/base-classes/activity-entity-service.spec.ts
@@ -30,8 +30,8 @@ function makeMockRepo(
     delete: mock(async () => undefined),
     findByDateRange: mock(async () => []),
     findByUserId: mock(async () => []),
-    findByOpportunityId: mock(async () => []),
-    findRecentByOpportunityId: mock(async () => []),
+    findBySubjectId: mock(async () => []),
+    findRecentBySubjectId: mock(async () => []),
     ...overrides,
   };
 }
@@ -63,27 +63,27 @@ describe('ActivityEntityService', () => {
     });
   });
 
-  describe('findByOpportunity', () => {
-    it('delegates to repository.findByOpportunityId', async () => {
+  describe('findBySubject', () => {
+    it('delegates to repository.findBySubjectId', async () => {
       const entities: TestEntity[] = [{ id: '1', name: 'Note' }];
-      const repo = makeMockRepo({ findByOpportunityId: mock(async () => entities) });
+      const repo = makeMockRepo({ findBySubjectId: mock(async () => entities) });
       const service = new TestActivityService(repo);
 
-      const result = await service.findByOpportunity('opp-1');
+      const result = await service.findBySubject('subj-1');
       expect(result).toEqual(entities);
-      expect(repo.findByOpportunityId).toHaveBeenCalledWith('opp-1');
+      expect(repo.findBySubjectId).toHaveBeenCalledWith('subj-1');
     });
   });
 
   describe('findRecent', () => {
-    it('delegates to repository.findRecentByOpportunityId with limit', async () => {
+    it('delegates to repository.findRecentBySubjectId with limit', async () => {
       const entities: TestEntity[] = [{ id: '1', name: 'Email' }];
-      const repo = makeMockRepo({ findRecentByOpportunityId: mock(async () => entities) });
+      const repo = makeMockRepo({ findRecentBySubjectId: mock(async () => entities) });
       const service = new TestActivityService(repo);
 
-      const result = await service.findRecent('opp-1', 5);
+      const result = await service.findRecent('subj-1', 5);
       expect(result).toEqual(entities);
-      expect(repo.findRecentByOpportunityId).toHaveBeenCalledWith('opp-1', 5);
+      expect(repo.findRecentBySubjectId).toHaveBeenCalledWith('subj-1', 5);
     });
   });
 });

--- a/src/patterns/library/activity.pattern.ts
+++ b/src/patterns/library/activity.pattern.ts
@@ -1,16 +1,45 @@
 /**
- * ActivityPattern — replaces `family: activity`.
+ * ActivityPattern — config-driven subject-scoped interaction base.
  *
- * Activity entities represent time-bounded interactions (calls, meetings,
- * emails). The base repository/service expose date-range + opportunity +
- * user-scoped lookups on top of the standard CRUD methods.
+ * Activity entities represent interactions (calls, meetings, emails, messages,
+ * transcripts) that reference a *subject* — the thing the interaction is about.
+ * Which subject is a per-entity fact, not a library constant: a CRM activity is
+ * scoped to an `opportunity`, a swe-brain interaction to a `person` (later
+ * `repo`/`team`, ADR-0006's Salesforce Activities-vs-Records shape). The base
+ * repository/service therefore expose **generic** subject-scoped finders
+ * (`findBySubjectId` / `findRecentBySubjectId`) that read the subject FK column
+ * from the entity's `config:` block, on top of the standard CRUD methods plus
+ * date-range and actor (`user_id`) scoping.
  *
- * Class names, import paths, and inherited-method strings match the
- * legacy `FAMILY_MAP` entry verbatim so PATTERN-5's template swap produces
- * byte-identical output.
+ * The subject FK column resolves from `config: { Activity: { ... } }`:
+ *   - `subjectColumn` — explicit snake_case column, OR
+ *   - `<subject>_id` — derived from the `subject` entity name.
+ * The recency-ordering column is `occurredAt` (snake_case in config), default
+ * `occurred_at`. The base reads these via `this.patternConfig` — the same
+ * ADR-031 §4 hand-off `IntegratedEntityRepository` uses for `integrationConfig`.
+ *
+ * See `docs/specs/ACTIVITY-SUBJECT-1.md`.
  */
 
+import { z } from 'zod';
 import { definePattern } from '../pattern-definition.js';
+
+/**
+ * Per-entity `config: { Activity: {...} }` block, validated at parse time.
+ * All fields optional — a date/user-only Activity entity supplies no config
+ * (and the subject finders throw if called). `.strict()` rejects misspelled
+ * keys loudly, matching JunctionPattern.
+ */
+const ActivityPatternConfigSchema = z
+	.object({
+		/** Subject entity name → derives the FK column `<subject>_id`. */
+		subject: z.string().optional(),
+		/** Explicit snake_case FK column, when it does not follow `<subject>_id`. */
+		subjectColumn: z.string().optional(),
+		/** snake_case recency-ordering column; defaults to `occurred_at`. */
+		occurredAt: z.string().optional(),
+	})
+	.strict();
 
 export const ActivityPattern = definePattern({
 	name: 'Activity',
@@ -19,14 +48,15 @@ export const ActivityPattern = definePattern({
 	serviceClass: 'ActivityEntityService',
 	repositoryImport: '@shared/base-classes/activity-entity-repository',
 	serviceImport: '@shared/base-classes/activity-entity-service',
+	configSchema: ActivityPatternConfigSchema,
 	repositoryInheritedMethods: [
 		'findById, findByIds, list, count, exists, create, update, delete, upsertMany',
-		'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
+		'findByDateRange, findByUserId, findBySubjectId, findRecentBySubjectId',
 	],
 	serviceInheritedMethods: [
 		'findById, findByIds, list, count, exists, create, update, delete',
-		'findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId',
+		'findByDateRange, findByUser, findBySubject, findRecent',
 	],
 	description:
-		'Time-bounded interaction entities — date-range + opportunity scoped lookups',
+		'Subject-scoped interaction entities — date-range + actor + config-driven subject lookups',
 });

--- a/test/junction/__snapshots__/opportunity-activity.test.ts.snap
+++ b/test/junction/__snapshots__/opportunity-activity.test.ts.snap
@@ -531,7 +531,7 @@ export class ActivityService extends WithAnalytics(
 
   // Inherited from ActivityEntityService:
   //   findById, findByIds, list, count, exists, create, update, delete
-  //   findByDateRange, findByUserId, findByOpportunityId, findRecentByOpportunityId
+  //   findByDateRange, findByUser, findBySubject, findRecent
 
 
 

--- a/test/scaffold/tests/activity-entity-repository.test.ts
+++ b/test/scaffold/tests/activity-entity-repository.test.ts
@@ -1,8 +1,11 @@
 /**
  * ActivityEntityRepository integration tests against real Postgres.
  *
- * Tests family-specific methods: findByDateRange, findByUserId,
- * findByOpportunityId, findRecentByOpportunityId.
+ * Tests family-specific methods: findByDateRange, findByUserId, and the
+ * config-driven subject finders findBySubjectId / findRecentBySubjectId
+ * (ACTIVITY-SUBJECT-1). The test scaffold's activityEntities table keeps its
+ * `opportunity_id` column, so the test repo configures `subject: 'opportunity'`
+ * (→ opportunityId) — proving the SAME column reached via config, not a hardcode.
  *
  * Gated behind SCAFFOLD_INTEGRATION=1 — see ./_skip-guard.ts.
  */
@@ -30,6 +33,8 @@ beforeAll(async () => {
   class TestActivityRepository extends ActivityEntityRepository<ActivityEntity> {
     readonly table = activityEntities;
     protected readonly behaviors = { timestamps: true, softDelete: false, userTracking: false };
+    // Config-driven subject scoping: subject 'opportunity' → opportunityId column.
+    protected readonly patternConfig = { subject: 'opportunity' };
   }
 
   repo = new TestActivityRepository(getTestDb() as any);
@@ -95,18 +100,40 @@ d('findByUserId', () => {
   });
 });
 
-d('findByOpportunityId', () => {
-  test('returns activities for the given opportunity', async () => {
+d('findBySubjectId (config-driven → opportunityId)', () => {
+  test('returns activities for the given subject', async () => {
     await repo.create(activityEntityFactory({ opportunityId: 'opp-1', name: 'A' }));
     await repo.create(activityEntityFactory({ opportunityId: 'opp-1', name: 'B' }));
     await repo.create(activityEntityFactory({ opportunityId: 'opp-2', name: 'C' }));
 
-    const found = await repo.findByOpportunityId('opp-1');
+    const found = await repo.findBySubjectId('opp-1');
     expect(found).toHaveLength(2);
+  });
+
+  test('resolves the same column via an explicit subjectColumn override', async () => {
+    class OverrideRepo extends ActivityEntityRepository<ActivityEntity> {
+      readonly table = activityEntities;
+      protected readonly behaviors = { timestamps: true, softDelete: false, userTracking: false };
+      protected readonly patternConfig = { subjectColumn: 'opportunity_id' };
+    }
+    const overrideRepo = new OverrideRepo(getTestDb() as any);
+    await overrideRepo.create(activityEntityFactory({ opportunityId: 'opp-9', name: 'X' }));
+    const found = await overrideRepo.findBySubjectId('opp-9');
+    expect(found).toHaveLength(1);
+  });
+
+  test('throws when no subject is configured', async () => {
+    class NoSubjectRepo extends ActivityEntityRepository<ActivityEntity> {
+      readonly table = activityEntities;
+      protected readonly behaviors = { timestamps: true, softDelete: false, userTracking: false };
+      // no patternConfig — subject finders are unusable
+    }
+    const noSubjectRepo = new NoSubjectRepo(getTestDb() as any);
+    expect(noSubjectRepo.findBySubjectId('opp-1')).rejects.toThrow(/subject/i);
   });
 });
 
-d('findRecentByOpportunityId', () => {
+d('findRecentBySubjectId', () => {
   test('returns activities ordered by occurredAt desc with limit', async () => {
     const t1 = new Date('2025-01-01T10:00:00Z');
     const t2 = new Date('2025-01-02T10:00:00Z');
@@ -116,7 +143,7 @@ d('findRecentByOpportunityId', () => {
     await repo.create(activityEntityFactory({ opportunityId: 'opp-1', occurredAt: t3, name: 'Newest' }));
     await repo.create(activityEntityFactory({ opportunityId: 'opp-1', occurredAt: t2, name: 'Middle' }));
 
-    const found = await repo.findRecentByOpportunityId('opp-1', 2);
+    const found = await repo.findRecentBySubjectId('opp-1', 2);
     expect(found).toHaveLength(2);
     expect(found[0].name).toBe('Newest');
     expect(found[1].name).toBe('Middle');
@@ -127,7 +154,7 @@ d('findRecentByOpportunityId', () => {
       await repo.create(activityEntityFactory({ opportunityId: 'opp-x' }));
     }
 
-    const found = await repo.findRecentByOpportunityId('opp-x');
+    const found = await repo.findRecentBySubjectId('opp-x');
     expect(found).toHaveLength(10);
   });
 });


### PR DESCRIPTION
## Summary

Generalizes the library's `ActivityPattern` so its subject-scoped lookups are **config-driven instead of CRM-hardcoded**. Surfaced by the swe-brain dogfood (second `@pattern-stack/codegen` consumer), whose interactions (meeting, email, transcript, message) reference `person`/`repo`/`team` subjects (ADR-0006's Salesforce Activities-vs-Records shape), not CRM opportunities.

Before, the shared base baked "opportunity" in: `findByOpportunityId` / `findRecentByOpportunityId` against a literal `opportunityId` column, ordered by a literal `occurredAt`.

## Consumer census (drove the no-alias decision)

| Consumer | Activity pattern usage |
|---|---|
| dealbrain-integrations (main tree) | **zero** — patterns in use are `Synced`/`Base`/`Metadata`; its one `findByOpportunityId` is a `JunctionSyncRepository` method, not the pattern |
| swe-brain | **zero** — interactions are all `pattern: Integrated` / `pattern: Base` |

**No consumer uses the Activity pattern**, so per CLAUDE.md ("no backwards compatibility until users") this is a **clean cut** — the CRM-named finders are deleted, not aliased. The header's "byte-identical to FAMILY_MAP" claim was a one-time PATTERN-5 migration guarantee, not a standing contract.

## Design decisions (recorded in the spec)

- **Generic `findBySubjectId` over named `findByPersonId`** — the runtime base is generic over `TEntity` and built once; the subject FK comes from per-entity config (the `integrationConfig` hand-off, ADR-031 §4). Generic = zero new codegen surface + forward-compatible with **multi-subject** interactions. Named per-subject finders remain available via the declarative `queries:` block.
- **`findByUserId` stays** — actor/owner scoping is generally applicable, not CRM-shaped.
- **Subject FK derives from config** — `subject: person` → `person_id`, with an explicit `subjectColumn` override; recency column is `occurredAt` (default `occurred_at`).
- **`patterns: [Integrated, Activity]` is valid** (the swe-brain target) — composition validates clean; `Integrated` wins the base (documented single-base rule), Activity rides along as the subject marker + config. Tested.

## Changes

- `ActivityPattern` gains a `.strict()` `configSchema` `{ subject?, subjectColumn?, occurredAt? }` (all optional).
- `ActivityEntityRepository` / `ActivityEntityService`: `findBySubjectId` / `findRecentBySubjectId` resolve columns from `this.patternConfig` at runtime; throw a clear error if the subject is unconfigured. `findByDateRange` / `findByUserId` unchanged.
- Spec `docs/specs/ACTIVITY-SUBJECT-1.md`; CHANGELOG 0.17.0; version bump 0.16.1 → 0.17.0.
- Living-docs: updated the Activity rows in `consumer-skills/entities/families-and-queries.md` and `.claude/skills/codegen/SKILL.md`.

## Tests

- New `activity-pattern.test.ts` (registry surface + schema); `[Integrated, Activity]` composition cases in `validate-composition.test.ts`; PATTERN-5 emission cases in `prompt-extension.test.ts`; service spec + scaffold integration spec retargeted to the new finders (+ override/throw cases).
- `bun test src/__tests__/`: **4705 pass / 7 fail** — the 7 are the pre-existing schema-v2 baseline failures (`contact-v2.yaml` + `cross-block validation`), unrelated and unchanged. **+17 net-new passing.**
- `just test-smoke`: **PASS** (generated consumer code typechecks against the new runtime bases).
- `tsc --noEmit`: clean (only the pre-existing `baseUrl` deprecation warning).

## Remaining for Doug

Review → merge → **OTP publish** (`just release` / `npm publish` — not done here). Then consumers `bun install` the new version. swe-brain can adopt `patterns: [Integrated, Activity]` + `config: { Activity: { subject: person } }` (reach the subject query via its `queries:` block since Integrated wins the base); dealbrain is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)