### PR TITLE
fix(jobs,integration): honor concurrency/dedupe key forms + differ unignore knob (0.17.1)

### DIFF
--- a/.claude/skills/integration/protocols-and-ports.md
+++ b/.claude/skills/integration/protocols-and-ports.md
@@ -274,7 +274,28 @@ persist; the audit stays faithful to the input.
 { provide: INTEGRATION_FIELD_DIFFER, useValue: new DeepEqualDiffer({ ignore: ['integration_version'] }) }
 ```
 
-Values are merged with the default set; you can't remove defaults.
+`ignore` values are merged with the default set.
+
+**Un-ignoring a default (`unignore`)** — the inverse knob. A normally-metadata
+column can be domain data for a given entity: e.g. an entity with
+`softDelete: false` whose `deletedAt` carries a vendor-observed retraction
+tombstone on the canonical record. Without un-ignoring it the tombstone diffs to
+`'noop'` and never lands. `unignore` removes the field from the ignore set
+(subtracted after `ignore`, so it wins):
+
+```ts
+{ provide: INTEGRATION_FIELD_DIFFER, useValue: new DeepEqualDiffer({ unignore: ['deletedAt'] }) }
+```
+
+Or set it app-wide via config — `integration.differ.{ignore,unignore}` in
+`codegen.config.yaml` threads into the default differ that
+`IntegrationModule.forRoot` provides:
+
+```yaml
+integration:
+  differ:
+    unignore: [deletedAt]
+```
 
 **Writing a custom `IFieldDiffer<T>`** (e.g. a type-aware differ that
 normalizes enums, or a CDC differ that only inspects hinted fields):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,74 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-06-04
+
+**Two dogfood fixes that bit the same swe-brain mutation drain** (ADR-0009
+Amendment B): the jobs orchestrator silently dropped function-form
+concurrency/dedupe keys, and the integration differ unconditionally ignored
+`deletedAt`. Both are honored now; both are backward-compatible.
+
+### Fixed
+
+- **`@JobHandler` function-form `concurrency.key` / `dedupe.key` are honored
+  end-to-end** (JOB-FN-KEY; swe-brain ADR-0009 Amendment B §B3). The typed API
+  (`ConcurrencyPolicy.key`/`DedupePolicy.key`) had ALWAYS required a function,
+  but registration (`upsertJobRows`) stored only `typeof key === 'string' ? key
+  : null` — a function key persisted as a NULL `concurrency_key_template`, so
+  `start()` wrote a NULL `job_run.concurrency_key` and the worker's queue-release
+  gate (which keys off `claimed.concurrencyKey`) never engaged. Observed in
+  swe-brain: three `inbound-sync` runs the handler believed shared one
+  `collisionMode: 'queue'` lane ran fully concurrently, three `integration_runs`
+  racing one message row. Now both backends persist a function key as the
+  `FN_KEY_SENTINEL` marker (non-null, so the collision/dedupe path engages, and
+  hash-stable so the definition-hash gate doesn't churn) and re-resolve the live
+  function from `JOB_HANDLER_REGISTRY` at `start()`. A `FN_KEY_SENTINEL` with no
+  live function throws `JobKeyFunctionUnavailableError` (fail loud, never
+  silently degrade to no-key). Drizzle + memory + BullMQ (which delegates to the
+  Drizzle `start`) all agree.
+
+### Changed
+
+- **`ConcurrencyPolicy.key` / `DedupePolicy.key` widen to
+  `JobKeySelector<TInput> = string | ((input) => string)`.** The string form is
+  documented as a `{{field}}` template (evaluated by `evaluateKeyTemplate`); the
+  function form is the one that previously type-checked but was dropped. Existing
+  function keys now WORK (were silently no-key before); existing string-template
+  keys behave identically. New exports from `@pattern-stack/codegen/runtime/*`
+  jobs: `JobKeySelector`, `FN_KEY_SENTINEL`, `keySelectorToTemplate`,
+  `resolveJobKey`, `JobKeyFunctionUnavailableError`.
+
+### Added
+
+- **`DeepEqualDifferOptions.unignore`** — the inverse of `ignore`, subtracted
+  from the default ignore set after the merge (DIFFER-UNIGNORE; swe-brain
+  ADR-0009 Amendment B §B4). Lets a consumer declare that a normally-metadata
+  column is DOMAIN DATA for their entity. The canonical case: an entity with
+  `softDelete: false` whose `deletedAt` carries a vendor-observed retraction
+  tombstone ON the canonical record (a Slack `message_deleted` → `deletedAt`,
+  ADR-0008 §1). `deletedAt` is in `DEFAULT_IGNORE_FIELDS`, so the tombstone
+  overlay diffed to `'noop'` → the upsert was skipped → `deleted_at` never
+  landed (observed: `integration_run_items` `{operation: noop, changed_fields:
+  {}}` for every delete). `new DeepEqualDiffer({ unignore: ['deletedAt'] })` now
+  makes the field register as a change. `unignore` wins over a field also in
+  `ignore`; un-ignoring a field not in the set is a harmless no-op; per-instance
+  (never mutates `DEFAULT_IGNORE_FIELDS`).
+- **`IntegrationModuleOptions.differ` + `integration.differ.{ignore,unignore}`
+  config threading.** `IntegrationModule.forRoot({ differ: { unignore:
+  [...] } })` threads into the default `DeepEqualDiffer` bound to
+  `INTEGRATION_FIELD_DIFFER`, and the subsystem barrel generator emits that
+  `forRoot` option from `integration.differ.*` in `codegen.config.yaml` (same
+  off-by-default config-threading shape as 0.16.0's `listen_notify`; vendored +
+  package mode both covered). A feature module that binds its own
+  `IFieldDiffer<T>` still overrides entirely.
+
+### Docs
+
+- Differ header comment + `integration` consumer skill (`audit-and-detection.md`,
+  `protocols-and-ports.md`) document the `unignore` knob and the
+  `integration.differ.*` config path; the `integration-config` codegen.config
+  template gains a commented `differ:` block.
+
 ## [0.17.0] — 2026-06-04
 
 **`ActivityPattern` subject scoping is config-driven** (ACTIVITY-SUBJECT-1) —

--- a/consumer-skills/integration/audit-and-detection.md
+++ b/consumer-skills/integration/audit-and-detection.md
@@ -285,15 +285,40 @@ as changes), but the diff output preserves the *raw* values:
   Drizzle while adapters deliver numbers; a numeric and a finite-parseable
   string compare equal (with an empty-string guard against silent 0-equality).
 
-**Augment the ignore list per entity** (values merge with the defaults; you
-cannot remove defaults):
+**Augment the ignore list** (`ignore` values merge with the defaults):
 
 ```ts
 { provide: INTEGRATION_FIELD_DIFFER, useValue: new DeepEqualDiffer({ ignore: ['integration_version'] }) }
 ```
 
-Bind it as `useValue: new DeepEqualDiffer(...)`, not `useClass` — the
-constructor's optional options object confuses Nest's metadata reflection.
+**Un-ignore a default** (`unignore` — the inverse knob). A normally-metadata
+column can be *domain data* for a given entity. The canonical case: an entity
+with `softDelete: false` whose `deletedAt` carries a vendor-observed retraction
+tombstone *on the canonical record* (e.g. a Slack `message_deleted` maps to
+`deletedAt`). Because `deletedAt` is in the default ignore list, the tombstone
+overlay diffs to `'noop'`, the upsert is skipped, and `deleted_at` never lands.
+`unignore` removes it from the ignore set so it registers as a field change:
+
+```ts
+{ provide: INTEGRATION_FIELD_DIFFER, useValue: new DeepEqualDiffer({ unignore: ['deletedAt'] }) }
+```
+
+`unignore` is subtracted after `ignore` is merged, so it wins on a field listed
+in both. Un-ignoring a field that isn't in the (merged) set is a harmless no-op.
+
+**Set it once for the whole app via config** instead of binding per feature
+module — `integration.differ.{ignore,unignore}` in `codegen.config.yaml` threads
+into the default differ that `IntegrationModule.forRoot` provides:
+
+```yaml
+integration:
+  backend: drizzle
+  differ:
+    unignore: [deletedAt]   # this entity's deletedAt is domain data
+```
+
+Bind a per-module differ as `useValue: new DeepEqualDiffer(...)`, not `useClass`
+— the constructor's optional options object confuses Nest's metadata reflection.
 
 **`providerChangedFields` is advisory.** When a CDC provider tells you which
 columns changed, set it on the `Change<T>` and the differ skips deep-equal over

--- a/justfile
+++ b/justfile
@@ -151,6 +151,15 @@ test-integration-quick:
 test-obs-integration:
     bun test "{{justfile_directory()}}/test/integration/observability-list-reads.drizzle.integration.test.ts"
 
+# JOB-FN-KEY (0.17.1) — function-form concurrency keys serialize at the DB
+# level against a real Postgres (testcontainers). Spins its own ephemeral
+# postgres:16; skips gracefully when Docker is unavailable. NOT in test-unit/CI
+# unit run. Proves two orchestrator instances over one DB persist matching,
+# non-null concurrency_keys + the queue-release gate holds the second behind
+# the first (the swe-brain ADR-0009 Amendment B §B3 regression).
+test-jobs-fnkey-integration:
+    bun test "{{justfile_directory()}}/test/integration/jobs-fn-concurrency-key.drizzle.integration.test.ts"
+
 # Run the full scaffold validation (Docker + codegen + NestJS + CRUD)
 validate:
     bash test/scaffold/validate.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/integration/deep-equal.differ.ts
+++ b/runtime/subsystems/integration/deep-equal.differ.ts
@@ -12,7 +12,11 @@
  *      `id`, `createdAt`, `updatedAt`, `deletedAt`, `type`,
  *      `lastModifiedAt`, `fields`, `providerMetadata`
  *    (`fields` is the EAV bag — it's diffed by the sink's EAV dual-write
- *    path, not at the canonical-record layer.)
+ *    path, not at the canonical-record layer.) Consumers augment the list via
+ *    `options.ignore` and — when a default is domain data for their entity —
+ *    REMOVE a default via `options.unignore` (e.g. an entity whose
+ *    `deletedAt` is a vendor-observed retraction tombstone, not row metadata;
+ *    see `DeepEqualDifferOptions.unignore`).
  *
  * 2. **`providerChangedFields` hint (CDC)** — when present, restricts the
  *    comparison to the hinted field set. The hint is advisory; fields in
@@ -75,6 +79,26 @@ export interface DeepEqualDifferOptions {
    * merged (not replaced) with `DEFAULT_IGNORE_FIELDS`.
    */
   readonly ignore?: readonly string[];
+
+  /**
+   * Field names to REMOVE from the default ignore list — the inverse of
+   * `ignore`. Use this to declare that a normally-metadata column is in fact
+   * DOMAIN DATA for this entity and must register as a field change.
+   *
+   * The canonical case (swe-brain ADR-0008 §1, the gap this knob closes):
+   * `deletedAt` is in `DEFAULT_IGNORE_FIELDS` because most sinks stamp it as
+   * row metadata sinks own unconditionally. But an entity with
+   * `softDelete: false` and a domain-owned `deleted_at` carries the
+   * vendor-observed retraction tombstone ON the canonical record (a Slack
+   * `message_deleted` → `deletedAt`). Without un-ignoring it, the tombstone
+   * overlay diffs to `'noop'`, the upsert is skipped, and `deleted_at` never
+   * lands. `unignore: ['deletedAt']` makes the differ treat it as domain data.
+   *
+   * Applied AFTER `ignore` is merged, so `unignore` wins on a field listed in
+   * both. Subtracting a field not in the (merged) ignore set is a harmless
+   * no-op. Does not touch `DEFAULT_IGNORE_FIELDS` for any other instance.
+   */
+  readonly unignore?: readonly string[];
 }
 
 @Injectable()
@@ -84,11 +108,16 @@ export class DeepEqualDiffer<T extends Record<string, unknown>>
   private readonly ignore: ReadonlySet<string>;
 
   constructor(opts: DeepEqualDifferOptions = {}) {
-    if (opts.ignore && opts.ignore.length > 0) {
-      this.ignore = new Set([...DEFAULT_IGNORE_FIELDS, ...opts.ignore]);
-    } else {
-      this.ignore = DEFAULT_IGNORE_FIELDS;
+    const merged = new Set<string>(DEFAULT_IGNORE_FIELDS);
+    if (opts.ignore) {
+      for (const field of opts.ignore) merged.add(field);
     }
+    // `unignore` is subtracted last so it wins over a field that also appears
+    // in `ignore` or the defaults — "this column is domain data here."
+    if (opts.unignore) {
+      for (const field of opts.unignore) merged.delete(field);
+    }
+    this.ignore = merged;
   }
 
   diff(

--- a/runtime/subsystems/integration/integration.module.ts
+++ b/runtime/subsystems/integration/integration.module.ts
@@ -73,7 +73,7 @@ import { MemoryCursorStore } from './integration-cursor-store.memory-backend';
 import { MemoryRunRecorder } from './integration-run-recorder.memory-backend';
 import { PostgresCursorStore } from './integration-cursor-store.drizzle-backend';
 import { DrizzleIntegrationRunRecorder } from './integration-run-recorder.drizzle-backend';
-import { DeepEqualDiffer } from './deep-equal.differ';
+import { DeepEqualDiffer, type DeepEqualDifferOptions } from './deep-equal.differ';
 
 export interface IntegrationModuleOptions {
   /**
@@ -100,6 +100,24 @@ export interface IntegrationModuleOptions {
    * Defaults to `false`.
    */
   multiTenant?: boolean;
+
+  /**
+   * Default-differ configuration (DIFFER-UNIGNORE, 0.17.1). Threaded into the
+   * `DeepEqualDiffer` bound to `INTEGRATION_FIELD_DIFFER`. Omit for the
+   * historical behaviour (the default ignore list, unchanged).
+   *
+   * Mirrors `DeepEqualDifferOptions`:
+   *   - `ignore`   — extra field names to ignore (merged with the defaults).
+   *   - `unignore` — default-ignored field names to RE-include as domain data
+   *     (e.g. `['deletedAt']` for an entity whose `deletedAt` is a
+   *     vendor-observed retraction tombstone, not row metadata — swe-brain
+   *     ADR-0008 §1). Subtracted after the merge, so it wins.
+   *
+   * A feature module that binds its own `IFieldDiffer<T>` to
+   * `INTEGRATION_FIELD_DIFFER` overrides this entirely (per-entity escape hatch
+   * unchanged).
+   */
+  differ?: DeepEqualDifferOptions;
 }
 
 @Module({})
@@ -112,7 +130,13 @@ export class IntegrationModule {
       { provide: INTEGRATION_MULTI_TENANT, useValue: multiTenant },
       // Default differ — consumers can override by binding a different
       // `IFieldDiffer<T>` to `INTEGRATION_FIELD_DIFFER` in their feature module.
-      { provide: INTEGRATION_FIELD_DIFFER, useValue: new DeepEqualDiffer() },
+      // DIFFER-UNIGNORE: `options.differ` (ignore/unignore) is threaded here so
+      // a consumer can declare a default-ignored column (e.g. `deletedAt`) as
+      // domain data for their entities without binding a bespoke differ.
+      {
+        provide: INTEGRATION_FIELD_DIFFER,
+        useValue: new DeepEqualDiffer(options.differ ?? {}),
+      },
     ];
 
     const backendProviders: Provider[] =

--- a/runtime/subsystems/jobs/job-handler.base.ts
+++ b/runtime/subsystems/jobs/job-handler.base.ts
@@ -42,13 +42,33 @@ export interface RetryPolicy {
   nonRetryableErrors?: string[];
 }
 
+/**
+ * Concurrency lane key (JOB-FN-KEY, 0.16.2).
+ *
+ * Two authoring forms, both honored end-to-end (the typed function form was
+ * previously dropped to `null` at registration — see `upsertJobRows` — so
+ * `collisionMode` silently never engaged):
+ *
+ *   - **`string`** — a `{{field}}` template evaluated against the start
+ *     payload by `evaluateKeyTemplate` (single-key substitution, no dotted
+ *     paths). Persisted verbatim to `job.concurrency_key_template`.
+ *   - **`(input) => string`** — an arbitrary function of the input. Persisted
+ *     as the `FN_KEY_SENTINEL` marker so the definition-hash gate stays stable
+ *     and the collision path engages; `start()` re-resolves the live function
+ *     from `JOB_HANDLER_REGISTRY` and evaluates it against the payload.
+ *
+ * Both forms produce a per-lane key; same key + in-flight incumbent ⇒
+ * `collisionMode` ('queue' | 'reject' | 'replace') decides.
+ */
+export type JobKeySelector<TInput> = string | ((input: TInput) => string);
+
 export interface ConcurrencyPolicy<TInput> {
-  key: (input: TInput) => string;
+  key: JobKeySelector<TInput>;
   collisionMode: 'queue' | 'reject' | 'replace';
 }
 
 export interface DedupePolicy<TInput> {
-  key: (input: TInput) => string;
+  key: JobKeySelector<TInput>;
   windowMs: number;
 }
 
@@ -243,5 +263,98 @@ export namespace HandlerRegistry {
   /** Lookup by job type, or `undefined` if no `@JobHandler` is registered. */
   export function get(type: string): HandlerRegistryEntry | undefined {
     return JOB_HANDLER_REGISTRY.get(type);
+  }
+}
+
+// ─── Key resolution (JOB-FN-KEY, 0.16.2) ────────────────────────────────────
+
+/**
+ * Sentinel persisted to `job.concurrency_key_template` / `dedupe_key_template`
+ * when the authored `key` is a function rather than a `{{field}}` template.
+ *
+ * Why a sentinel (not `null`): the collision/dedupe paths in both backends gate
+ * on `definition.concurrencyKeyTemplate != null`. A function key persisted as
+ * `null` (the pre-0.16.2 bug) left those columns empty, so `collisionMode` /
+ * the dedupe window never engaged — the job ran with NO key. A stable sentinel
+ * keeps the column non-null (path engages) AND keeps the definition-hash gate
+ * (`upsertJobRows`' `IS DISTINCT FROM` clause) stable across boots, since the
+ * function identity itself can't be hashed. `start()` detects the sentinel and
+ * re-resolves the live function from `JOB_HANDLER_REGISTRY`.
+ *
+ * Chosen as an angle-bracketed token so it can never collide with a real
+ * `{{field}}` template (which never contains a literal `<`).
+ */
+export const FN_KEY_SENTINEL = '<fn>';
+
+/**
+ * Registration-time projection: collapse an authored `JobKeySelector` to the
+ * string stored in the `job` definition row. A string template is stored
+ * verbatim; a function is stored as `FN_KEY_SENTINEL`; absence stays `null`.
+ */
+export function keySelectorToTemplate(
+  key: JobKeySelector<unknown> | undefined,
+): string | null {
+  if (typeof key === 'string') return key;
+  if (typeof key === 'function') return FN_KEY_SENTINEL;
+  return null;
+}
+
+/** Which meta policy a key belongs to — selects the live fn at `start()`. */
+export type KeyKind = 'concurrency' | 'dedupe';
+
+/**
+ * `start()`-time resolution shared by every backend. Turns the persisted
+ * template column into the concrete per-run key for the given payload.
+ *
+ *   - `template == null` → `null` (no key; caller skips the collision/dedupe path).
+ *   - `template === FN_KEY_SENTINEL` → look the live `@JobHandler` meta up in
+ *     `JOB_HANDLER_REGISTRY`, pull `meta[kind].key`, and invoke it against the
+ *     payload. The registry is the runtime source of truth (the worker already
+ *     resolves handler classes the same way), so the function survives the DB
+ *     round-trip even though it can't be persisted.
+ *   - otherwise → a `{{field}}` template, evaluated via the injected
+ *     `evaluateTemplate` (each backend passes its own copy to avoid a runtime
+ *     import cycle).
+ *
+ * Throws `JobKeyFunctionUnavailableError` if the sentinel is present but no
+ * live function can be found (e.g. the registry was reset, or a function key
+ * was persisted by a newer build and read by an older one). Failing loud beats
+ * silently degrading to no-key — the exact regression this fix exists to kill.
+ */
+export function resolveJobKey(
+  kind: KeyKind,
+  type: string,
+  template: string | null,
+  payload: Record<string, unknown>,
+  evaluateTemplate: (template: string, payload: Record<string, unknown>) => string,
+): string | null {
+  if (template == null) return null;
+  if (template !== FN_KEY_SENTINEL) return evaluateTemplate(template, payload);
+
+  const meta = JOB_HANDLER_REGISTRY.get(type)?.meta;
+  const key = (meta?.[kind] as { key?: unknown } | undefined)?.key;
+  if (typeof key !== 'function') {
+    throw new JobKeyFunctionUnavailableError(type, kind);
+  }
+  return (key as (input: unknown) => string)(payload);
+}
+
+/**
+ * Raised when a `${FN_KEY_SENTINEL}` template is read but the live function
+ * key is missing from `JOB_HANDLER_REGISTRY`. Kept here (not in `jobs-errors`)
+ * so `job-handler.base` stays import-cycle-free.
+ */
+export class JobKeyFunctionUnavailableError extends Error {
+  constructor(
+    readonly jobType: string,
+    readonly kind: KeyKind,
+  ) {
+    super(
+      `[jobs] ${kind} key for job '${jobType}' was persisted as a function ` +
+        `sentinel ('${FN_KEY_SENTINEL}') but no live function is registered ` +
+        `for it. The @JobHandler must be imported before start() so its meta ` +
+        `is in JOB_HANDLER_REGISTRY.`,
+    );
+    this.name = 'JobKeyFunctionUnavailableError';
   }
 }

--- a/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.drizzle-backend.ts
@@ -36,6 +36,11 @@ import {
 import { jobSteps } from './job-orchestration.schema';
 import { JOBS_MULTI_TENANT, JOBS_LISTEN_NOTIFY } from './jobs-domain.tokens';
 import { JOBS_WAKE_CHANNEL, pgNotify } from './pg-notify';
+import {
+  keySelectorToTemplate,
+  resolveJobKey,
+  type JobKeySelector,
+} from './job-handler.base';
 
 /**
  * Terminal statuses — transitions into these are final. Used by `cancel`
@@ -140,9 +145,17 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
     if (!def) throw new JobTypeNotFoundError(type);
     const definition = def as JobDefinitionRow;
 
-    // 1b. Dedupe check.
+    // 1b. Dedupe check. JOB-FN-KEY: `resolveJobKey` honors both the `{{field}}`
+    // template AND a function key persisted as `FN_KEY_SENTINEL` (re-resolved
+    // live from JOB_HANDLER_REGISTRY).
     if (definition.dedupeKeyTemplate && definition.dedupeWindowMs) {
-      const dedupeKey = evaluateKeyTemplate(definition.dedupeKeyTemplate, payload);
+      const dedupeKey = resolveJobKey(
+        'dedupe',
+        type,
+        definition.dedupeKeyTemplate,
+        payload,
+        evaluateKeyTemplate,
+      ) as string;
       const windowStart = new Date(Date.now() - definition.dedupeWindowMs);
       const existing = await client
         .select()
@@ -166,10 +179,15 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
     // 1c. Concurrency collision check.
     let concurrencyKey: string | null = null;
     if (definition.concurrencyKeyTemplate) {
-      concurrencyKey = evaluateKeyTemplate(
+      // Non-null cast: the branch guard proves the template is present, so the
+      // resolver never returns null here (it only nulls on a null template).
+      concurrencyKey = resolveJobKey(
+        'concurrency',
+        type,
         definition.concurrencyKeyTemplate,
         payload,
-      );
+        evaluateKeyTemplate,
+      ) as string;
       const inFlight = await client
         .select()
         .from(jobRuns)
@@ -223,10 +241,13 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
       rootRunId = parent.rootRunId;
     }
 
-    const dedupeKey =
-      definition.dedupeKeyTemplate
-        ? evaluateKeyTemplate(definition.dedupeKeyTemplate, payload)
-        : null;
+    const dedupeKey = resolveJobKey(
+      'dedupe',
+      type,
+      definition.dedupeKeyTemplate,
+      payload,
+      evaluateKeyTemplate,
+    );
 
     const [inserted] = await client
       .insert(jobRuns)
@@ -460,17 +481,23 @@ export class DrizzleJobOrchestrator implements IJobOrchestrator {
         backoff: 'fixed' as const,
         baseMs: 0,
       };
-      const concurrencyKeyTemplate =
-        (meta.concurrency as { key?: unknown } | undefined)?.key;
-      const concurrencyKeyTemplateStr =
-        typeof concurrencyKeyTemplate === 'string' ? concurrencyKeyTemplate : null;
+      // JOB-FN-KEY (0.16.2): both authored key forms are honored. A `{{field}}`
+      // string is persisted verbatim; a function is persisted as
+      // `FN_KEY_SENTINEL` (non-null so the collision/dedupe path engages, and
+      // hash-stable so the definition-hash gate doesn't churn on every boot —
+      // the function identity can't be hashed). `start()` re-resolves the live
+      // function from `JOB_HANDLER_REGISTRY`. The pre-0.16.2 `typeof === string
+      // ? … : null` dropped function keys to null, so `collisionMode` silently
+      // never engaged.
+      const concurrencyKeyTemplateStr = keySelectorToTemplate(
+        meta.concurrency?.key as JobKeySelector<unknown> | undefined,
+      );
       const collisionMode =
         (meta.concurrency?.collisionMode as JobDefinitionRow['collisionMode']) ??
         'queue';
-      const dedupeKeyTemplate =
-        (meta.dedupe as { key?: unknown } | undefined)?.key;
-      const dedupeKeyTemplateStr =
-        typeof dedupeKeyTemplate === 'string' ? dedupeKeyTemplate : null;
+      const dedupeKeyTemplateStr = keySelectorToTemplate(
+        meta.dedupe?.key as JobKeySelector<unknown> | undefined,
+      );
       const dedupeWindowMs = meta.dedupe?.windowMs ?? null;
       const timeoutMs = meta.timeoutMs ?? null;
       const replayFrom = meta.replayFrom ?? 'last_checkpoint';

--- a/runtime/subsystems/jobs/job-orchestrator.memory-backend.ts
+++ b/runtime/subsystems/jobs/job-orchestrator.memory-backend.ts
@@ -32,11 +32,17 @@ import type {
   JobContext,
   JobHandlerBase,
   JobHandlerMeta,
+  JobKeySelector,
   RetryPolicy,
   SpawnChildOptions,
   StepOptions,
 } from './job-handler.base';
-import { ParentClosePolicy } from './job-handler.base';
+import {
+  ParentClosePolicy,
+  keySelectorToTemplate,
+  FN_KEY_SENTINEL,
+  JobKeyFunctionUnavailableError,
+} from './job-handler.base';
 import {
   JobCollisionError,
   JobNotReplayableError,
@@ -176,10 +182,9 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
     meta: JobHandlerMeta<TInput>,
     handlerClass: new (...args: unknown[]) => JobHandlerBase<TInput>,
   ): void {
-    const concurrencyKeyTemplate =
-      (meta.concurrency as { key?: string } | undefined)?.key ?? null;
-    const dedupeKeyTemplate =
-      (meta.dedupe as { key?: string } | undefined)?.key ?? null;
+    // JOB-FN-KEY (0.16.2): mirror the Drizzle backend — collapse a function
+    // key to `FN_KEY_SENTINEL` so the def row stays non-null (collision/dedupe
+    // path engages); `start()` re-resolves the live fn from `handlerRegistry`.
     const dedupeWindowMs = meta.dedupe?.windowMs ?? null;
     const now = new Date();
 
@@ -194,13 +199,15 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
         baseMs: 0,
       },
       timeoutMs: meta.timeoutMs ?? null,
-      concurrencyKeyTemplate:
-        typeof concurrencyKeyTemplate === 'string' ? concurrencyKeyTemplate : null,
+      concurrencyKeyTemplate: keySelectorToTemplate(
+        meta.concurrency?.key as JobKeySelector<unknown> | undefined,
+      ),
       collisionMode:
         (meta.concurrency?.collisionMode as JobDefinitionRow['collisionMode']) ??
         'queue',
-      dedupeKeyTemplate:
-        typeof dedupeKeyTemplate === 'string' ? dedupeKeyTemplate : null,
+      dedupeKeyTemplate: keySelectorToTemplate(
+        meta.dedupe?.key as JobKeySelector<unknown> | undefined,
+      ),
       dedupeWindowMs,
       priorityDefault: 0,
       replayFrom: meta.replayFrom ?? 'last_checkpoint',
@@ -221,6 +228,34 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
   /** Test helper — look up a registered handler without exposing the map. */
   getHandlerRegistration(type: string): HandlerRegistration | undefined {
     return this.handlerRegistry.get(type);
+  }
+
+  /**
+   * JOB-FN-KEY (0.16.2): resolve a persisted key template against the payload.
+   * Delegates to the shared `resolveJobKey`, but binds the FUNCTION-sentinel
+   * lookup to THIS backend's local `handlerRegistry` (the memory backend keeps
+   * its own meta map seeded by `registerHandler`, distinct from the global
+   * `JOB_HANDLER_REGISTRY` that the Drizzle/worker path uses — memory tests
+   * register handlers directly, never via the `@JobHandler` decorator). The
+   * `evaluateTemplate` callback handles the ordinary `{{field}}` path.
+   */
+  private resolveKey(
+    kind: 'concurrency' | 'dedupe',
+    type: string,
+    template: string | null,
+    payload: Record<string, unknown>,
+  ): string | null {
+    if (template == null) return null;
+    if (template !== FN_KEY_SENTINEL) {
+      return evaluateKeyTemplate(template, payload);
+    }
+    const key = (this.handlerRegistry.get(type)?.meta?.[kind] as
+      | { key?: unknown }
+      | undefined)?.key;
+    if (typeof key !== 'function') {
+      throw new JobKeyFunctionUnavailableError(type, kind);
+    }
+    return (key as (input: unknown) => string)(payload);
   }
 
   /**
@@ -270,11 +305,10 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
       if (!definition) throw new JobTypeNotFoundError(type);
 
       // 1. Dedupe — return existing non-excluded run within the window.
+      // JOB-FN-KEY: `resolveKey` honors the `{{field}}` template AND a function
+      // key persisted as `FN_KEY_SENTINEL` (re-resolved from `handlerRegistry`).
       if (definition.dedupeKeyTemplate && definition.dedupeWindowMs) {
-        const dedupeKey = evaluateKeyTemplate(
-          definition.dedupeKeyTemplate,
-          payload,
-        );
+        const dedupeKey = this.resolveKey('dedupe', type, definition.dedupeKeyTemplate, payload) as string;
         const windowStart = Date.now() - definition.dedupeWindowMs;
         const existing = this.findDedupeCandidate(type, dedupeKey, windowStart);
         if (existing) return existing;
@@ -284,10 +318,13 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
       let concurrencyKey: string | null = null;
       let queueBlockedBy: string | null = null;
       if (definition.concurrencyKeyTemplate) {
-        concurrencyKey = evaluateKeyTemplate(
+        // Non-null cast: the branch guard proves the template is present.
+        concurrencyKey = this.resolveKey(
+          'concurrency',
+          type,
           definition.concurrencyKeyTemplate,
           payload,
-        );
+        ) as string;
         const incumbent = this.findInFlightByConcurrencyKey(concurrencyKey);
         if (incumbent) {
           switch (definition.collisionMode) {
@@ -331,9 +368,12 @@ export class MemoryJobOrchestrator implements IJobOrchestrator {
       // 4. Compute dedupe key for the persisted row (separate from dedupe
       //    short-circuit above — we store it even when no prior run matched
       //    so future dedupe checks see it).
-      const dedupeKey = definition.dedupeKeyTemplate
-        ? evaluateKeyTemplate(definition.dedupeKeyTemplate, payload)
-        : null;
+      const dedupeKey = this.resolveKey(
+        'dedupe',
+        type,
+        definition.dedupeKeyTemplate,
+        payload,
+      );
 
       const now = new Date();
       const runAt = queueBlockedBy

--- a/src/__tests__/cli/subsystem-barrel-generator.test.ts
+++ b/src/__tests__/cli/subsystem-barrel-generator.test.ts
@@ -180,6 +180,52 @@ describe('buildSubsystemBarrel', () => {
 		);
 	});
 
+	test('integration `differ.unignore` threads into IntegrationModule.forRoot (DIFFER-UNIGNORE)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('integration')],
+			{ integration: { backend: 'drizzle', differ: { unignore: ['deletedAt'] } } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"IntegrationModule.forRoot({ backend: 'drizzle', multiTenant: false, differ: { unignore: ['deletedAt'] } }),",
+		);
+	});
+
+	test('integration `differ.ignore` + `differ.unignore` both thread', () => {
+		const out = buildSubsystemBarrel(
+			[inst('integration')],
+			{
+				integration: {
+					backend: 'drizzle',
+					differ: { ignore: ['internalSeq'], unignore: ['deletedAt'] },
+				},
+			},
+			subsystemsRel,
+		);
+		expect(out.content).toContain(
+			"differ: { ignore: ['internalSeq'], unignore: ['deletedAt'] }",
+		);
+	});
+
+	test('integration WITHOUT a differ block stays byte-identical (no differ clause)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('integration')],
+			{ integration: { backend: 'drizzle' } },
+			subsystemsRel,
+		);
+		expect(out.content).toContain("IntegrationModule.forRoot({ backend: 'drizzle', multiTenant: false }),");
+		expect(out.content).not.toContain('differ:');
+	});
+
+	test('integration empty `differ` block (no lists) emits no differ clause', () => {
+		const out = buildSubsystemBarrel(
+			[inst('integration')],
+			{ integration: { backend: 'drizzle', differ: {} } },
+			subsystemsRel,
+		);
+		expect(out.content).not.toContain('differ:');
+	});
+
 	test('installed subsystem without a composer is listed in `skipped`', () => {
 		// `observability` / `auth` aren't in COMPOSABLE_ORDER yet — they should
 		// register as skipped, not silently dropped.
@@ -481,6 +527,19 @@ describe('buildSubsystemBarrel — package mode (ADR-037)', () => {
 			'package',
 		);
 		expect(out.content).toContain('domainModuleExtensions: { drizzle: { listenNotify: true } }');
+	});
+
+	test('package-mode integration differ.unignore threads into forRoot (DIFFER-UNIGNORE)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('integration')],
+			{ integration: { backend: 'drizzle', differ: { unignore: ['deletedAt'] } } },
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain(
+			"import { IntegrationModule } from '@pattern-stack/codegen/runtime/subsystems/integration/index';",
+		);
+		expect(out.content).toContain("differ: { unignore: ['deletedAt'] }");
 	});
 
 	test('vendored mode (explicit) still emits the relative-path imports', () => {

--- a/src/__tests__/runtime/subsystems/deep-equal.differ.spec.ts
+++ b/src/__tests__/runtime/subsystems/deep-equal.differ.spec.ts
@@ -92,6 +92,80 @@ describe('DeepEqualDiffer', () => {
     });
   });
 
+  // DIFFER-UNIGNORE (0.17.1) — the inverse knob: REMOVE a default-ignored field
+  // so it registers as a domain change. Regression coverage for the swe-brain
+  // ADR-0009 Amendment B §B4 drain: a `message` entity with `softDelete: false`
+  // carries the retraction tombstone on `deletedAt`; without un-ignoring it the
+  // delete diffs to 'noop', the upsert is skipped, and `deleted_at` never lands.
+  describe('unignore knob', () => {
+    it('by DEFAULT, a deletedAt-only change diffs to noop (the bug)', () => {
+      const d = new DeepEqualDiffer<Rec>();
+      const result = d.diff(
+        { id: 'a', amount: 100, deletedAt: null },
+        { id: 'a', amount: 100, deletedAt: '2026-06-04T00:00:00.000Z' },
+      );
+      expect(result).toBe('noop');
+    });
+
+    it('un-ignored deletedAt produces a field diff (the tombstone lands)', () => {
+      const d = new DeepEqualDiffer<Rec>({ unignore: ['deletedAt'] });
+      const result = d.diff(
+        { id: 'a', amount: 100, deletedAt: null },
+        { id: 'a', amount: 100, deletedAt: '2026-06-04T00:00:00.000Z' },
+      );
+      expect(result).toEqual({
+        deletedAt: { from: null, to: '2026-06-04T00:00:00.000Z' },
+      });
+    });
+
+    it('un-ignored deletedAt is created-shape on null existing', () => {
+      // The orchestrator turns a non-noop diff into 'created'/'updated' — here
+      // the un-ignored tombstone field is part of the created shape.
+      const d = new DeepEqualDiffer<Rec>({ unignore: ['deletedAt'] });
+      const result = d.diff(null, {
+        id: 'a',
+        amount: 100,
+        deletedAt: '2026-06-04T00:00:00.000Z',
+      });
+      expect(result).toEqual({
+        amount: { from: null, to: 100 },
+        deletedAt: { from: null, to: '2026-06-04T00:00:00.000Z' },
+      });
+    });
+
+    it('un-ignoring a field NOT in the ignore set is a harmless no-op', () => {
+      const d = new DeepEqualDiffer<Rec>({ unignore: ['amount'] });
+      const result = d.diff({ amount: 100 }, { amount: 120 });
+      expect(result).toEqual({ amount: { from: 100, to: 120 } });
+    });
+
+    it('unignore wins over a field also listed in ignore', () => {
+      const d = new DeepEqualDiffer<Rec>({
+        ignore: ['deletedAt'],
+        unignore: ['deletedAt'],
+      });
+      const result = d.diff(
+        { deletedAt: null },
+        { deletedAt: '2026-06-04T00:00:00.000Z' },
+      );
+      expect(result).toEqual({
+        deletedAt: { from: null, to: '2026-06-04T00:00:00.000Z' },
+      });
+    });
+
+    it('un-ignoring deletedAt does NOT leak to a separate default differ', () => {
+      // Per-instance isolation — DEFAULT_IGNORE_FIELDS is never mutated.
+      const unignored = new DeepEqualDiffer<Rec>({ unignore: ['deletedAt'] });
+      const plain = new DeepEqualDiffer<Rec>();
+      const args: [Rec, Rec] = [
+        { deletedAt: null },
+        { deletedAt: '2026-06-04T00:00:00.000Z' },
+      ];
+      expect(unignored.diff(...args)).not.toBe('noop');
+      expect(plain.diff(...args)).toBe('noop');
+    });
+  });
+
   describe('providerChangedFields hint (CDC)', () => {
     it('restricts comparison to the hinted field set', () => {
       const d = new DeepEqualDiffer<Rec>();

--- a/src/__tests__/runtime/subsystems/integration.module.spec.ts
+++ b/src/__tests__/runtime/subsystems/integration.module.spec.ts
@@ -144,6 +144,46 @@ describe('IntegrationModule.forRoot({ backend: "memory" })', () => {
     await moduleRef.close();
   });
 
+  // DIFFER-UNIGNORE (0.17.1): `options.differ` threads into the bound differ.
+  it('threads options.differ.unignore into the bound DeepEqualDiffer', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        IntegrationModule.forRoot({
+          backend: 'memory',
+          differ: { unignore: ['deletedAt'] },
+        }),
+      ],
+    }).compile();
+
+    const differ = moduleRef.get(INTEGRATION_FIELD_DIFFER) as DeepEqualDiffer<
+      Record<string, unknown>
+    >;
+    // Behavioural proof: the default differ would 'noop' a deletedAt-only
+    // change; the threaded unignore makes it register as a field diff.
+    const result = differ.diff(
+      { deletedAt: null },
+      { deletedAt: '2026-06-04T00:00:00.000Z' },
+    );
+    expect(result).toEqual({
+      deletedAt: { from: null, to: '2026-06-04T00:00:00.000Z' },
+    });
+    await moduleRef.close();
+  });
+
+  it('default differ (no options.differ) keeps deletedAt ignored', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [IntegrationModule.forRoot({ backend: 'memory' })],
+    }).compile();
+
+    const differ = moduleRef.get(INTEGRATION_FIELD_DIFFER) as DeepEqualDiffer<
+      Record<string, unknown>
+    >;
+    expect(
+      differ.diff({ deletedAt: null }, { deletedAt: '2026-06-04T00:00:00.000Z' }),
+    ).toBe('noop');
+    await moduleRef.close();
+  });
+
   it('binds INTEGRATION_MODULE_OPTIONS to the passed options', async () => {
     const options = { backend: 'memory' as const, multiTenant: true };
     const moduleRef = await Test.createTestingModule({

--- a/src/__tests__/runtime/subsystems/job-handler.base.types.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-handler.base.types.spec.ts
@@ -12,6 +12,8 @@ import { describe, it, expect } from 'bun:test';
 import {
   JobHandler,
   JobHandlerBase,
+  FN_KEY_SENTINEL,
+  keySelectorToTemplate,
   type JobContext,
   type JobTrigger,
 } from '../../../../runtime/subsystems/jobs/job-handler.base';
@@ -100,5 +102,40 @@ void _badEvent;
 describe('JobHandlerMeta.triggers — authoring type (BRIDGE-6 follow-up)', () => {
   it('@JobHandler({ triggers }) compiles and narrows map/when per event', () => {
     expect(ContactWritebackHandler).toBeDefined();
+  });
+});
+
+// ── JOB-FN-KEY (0.16.2): both key forms compile + project correctly ─────────
+// The typed `key` accepts BOTH a `{{field}}` template string AND a function of
+// the input. The string form is unchanged; the function form is the one that
+// previously typed-checked (the type REQUIRED a function) but was dropped at
+// registration. Both must compile under one `@JobHandler`.
+
+interface SlackInboundInput {
+  channel: string;
+  ts: string;
+  eventId: string;
+}
+
+@JobHandler<SlackInboundInput>('slack.inbound.types-test', {
+  pool: 'batch',
+  // Function form — arbitrary projection of the input into a lane key.
+  concurrency: { key: (input) => `chan:${input.channel}`, collisionMode: 'queue' },
+  // String-template form on the dedupe policy in the same handler.
+  dedupe: { key: '{{eventId}}', windowMs: 30_000 },
+})
+class SlackInboundHandler extends JobHandlerBase<SlackInboundInput, void> {
+  async run(_ctx: JobContext<SlackInboundInput>): Promise<void> {}
+}
+
+describe('JobKeySelector — both key forms (JOB-FN-KEY)', () => {
+  it('@JobHandler accepts a function concurrency key + a template dedupe key', () => {
+    expect(SlackInboundHandler).toBeDefined();
+  });
+
+  it('keySelectorToTemplate projects each form for the definition row', () => {
+    expect(keySelectorToTemplate('{{eventId}}')).toBe('{{eventId}}');
+    expect(keySelectorToTemplate((i: { x: string }) => i.x)).toBe(FN_KEY_SENTINEL);
+    expect(keySelectorToTemplate(undefined)).toBeNull();
   });
 });

--- a/src/__tests__/runtime/subsystems/job-orchestrator.unit.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-orchestrator.unit.spec.ts
@@ -17,6 +17,8 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import {
   JobHandlerBase,
   ParentClosePolicy,
+  FN_KEY_SENTINEL,
+  JobKeyFunctionUnavailableError,
   type JobContext,
   type JobHandlerMeta,
 } from '../../../../runtime/subsystems/jobs/job-handler.base';
@@ -221,6 +223,146 @@ describe('MemoryJobOrchestrator — collision modes (Group 2)', () => {
 
     const claimed = await orchestrator.claimNext('batch');
     expect(claimed?.id).toBe(second.id);
+  });
+});
+
+// ─── Group 2b — function-form keys (JOB-FN-KEY, 0.16.2) ──────────────────────
+//
+// Regression guard for the swe-brain ADR-0009 Amendment B drain: a `@JobHandler`
+// authored with `concurrency.key: (input) => …` (the typed function form) was
+// silently dropped to `null` at registration, so `collisionMode` never engaged
+// and three "shared-lane" runs ran fully concurrently. These assert the function
+// key is honored end-to-end on the memory backend.
+
+describe('MemoryJobOrchestrator — function-form keys (Group 2b)', () => {
+  it('registration persists a function key as the FN_KEY_SENTINEL (non-null)', () => {
+    const { orchestrator, store } = buildOrchestrator();
+    const meta: JobHandlerMeta<{ channel: string; ts: string }> = {
+      pool: 'batch',
+      concurrency: {
+        key: (input) => `lane:${input.channel}`,
+        collisionMode: 'queue',
+      },
+    };
+    orchestrator.registerHandler('t.fnkey.reg', meta, NoopHandler);
+
+    // The def row stores the sentinel, NOT null — the pre-0.16.2 bug stored
+    // null here, which is exactly why the collision path never fired.
+    const def = store.jobs.get('t.fnkey.reg');
+    expect(def?.concurrencyKeyTemplate).toBe(FN_KEY_SENTINEL);
+  });
+
+  it('queue: a function concurrency key serializes two same-lane starts', async () => {
+    const { orchestrator } = buildOrchestrator();
+    const meta: JobHandlerMeta<{ channel: string; ts: string }> = {
+      pool: 'batch',
+      // Function of input — the lane is the channel, NOT the per-message ts.
+      // Two different messages on the same channel share a lane.
+      concurrency: {
+        key: (input) => `chan:${input.channel}`,
+        collisionMode: 'queue',
+      },
+    };
+    orchestrator.registerHandler('t.fnkey.queue', meta, NoopHandler);
+
+    const first = await orchestrator.start('t.fnkey.queue', {
+      channel: 'C1',
+      ts: '100',
+    });
+    const claimed = await orchestrator.claimNext('batch');
+    expect(claimed?.id).toBe(first.id);
+    expect(claimed?.status).toBe('running');
+
+    // Second message, same channel, DIFFERENT ts — without the fn key being
+    // honored this would run concurrently (the bug). With it, same lane ⇒ queued.
+    const second = await orchestrator.start('t.fnkey.queue', {
+      channel: 'C1',
+      ts: '200',
+    });
+    expect(second.status).toBe('pending');
+    expect(second.concurrencyKey).toBe('chan:C1');
+    expect(first.concurrencyKey).toBe('chan:C1');
+    // Blocked: not claimable while the incumbent is in-flight.
+    expect(await orchestrator.claimNext('batch')).toBeNull();
+  });
+
+  it('reject: a function concurrency key throws JobCollisionError on the same lane', async () => {
+    const { orchestrator } = buildOrchestrator();
+    const meta: JobHandlerMeta<{ channel: string }> = {
+      pool: 'batch',
+      concurrency: {
+        key: (input) => `chan:${input.channel}`,
+        collisionMode: 'reject',
+      },
+    };
+    orchestrator.registerHandler('t.fnkey.reject', meta, NoopHandler);
+
+    await orchestrator.start('t.fnkey.reject', { channel: 'C1' });
+    await expect(
+      orchestrator.start('t.fnkey.reject', { channel: 'C1' }),
+    ).rejects.toBeInstanceOf(JobCollisionError);
+  });
+
+  it('different lanes from the same fn key do NOT collide', async () => {
+    const { orchestrator } = buildOrchestrator();
+    const meta: JobHandlerMeta<{ channel: string }> = {
+      pool: 'batch',
+      concurrency: {
+        key: (input) => `chan:${input.channel}`,
+        collisionMode: 'reject',
+      },
+    };
+    orchestrator.registerHandler('t.fnkey.lanes', meta, NoopHandler);
+
+    const a = await orchestrator.start('t.fnkey.lanes', { channel: 'C1' });
+    const b = await orchestrator.start('t.fnkey.lanes', { channel: 'C2' });
+    expect(a.concurrencyKey).toBe('chan:C1');
+    expect(b.concurrencyKey).toBe('chan:C2');
+    expect(b.status).toBe('pending');
+  });
+
+  it('dedupe: a function dedupe key collapses two same-key starts in-window', async () => {
+    const { orchestrator } = buildOrchestrator();
+    const meta: JobHandlerMeta<{ eventId: string }> = {
+      pool: 'batch',
+      dedupe: {
+        key: (input) => `evt:${input.eventId}`,
+        windowMs: 60_000,
+      },
+    };
+    orchestrator.registerHandler('t.fnkey.dedupe', meta, NoopHandler);
+
+    const first = await orchestrator.start('t.fnkey.dedupe', { eventId: 'E1' });
+    const second = await orchestrator.start('t.fnkey.dedupe', { eventId: 'E1' });
+    // Same dedupe key within the window ⇒ the second returns the first run.
+    expect(second.id).toBe(first.id);
+    expect(first.dedupeKey).toBe('evt:E1');
+
+    // A different event id is NOT deduped.
+    const third = await orchestrator.start('t.fnkey.dedupe', { eventId: 'E2' });
+    expect(third.id).not.toBe(first.id);
+  });
+
+  it('throws JobKeyFunctionUnavailableError if the live fn is missing for a sentinel', async () => {
+    const { orchestrator, store } = buildOrchestrator();
+    orchestrator.registerHandler(
+      't.fnkey.orphan',
+      {
+        pool: 'batch',
+        concurrency: { key: (i: { x: string }) => i.x, collisionMode: 'queue' },
+      } as JobHandlerMeta<{ x: string }>,
+      NoopHandler,
+    );
+    // Simulate the registry losing the live meta while the def row keeps the
+    // sentinel (e.g. an older build reading a newer-persisted definition).
+    const reg = orchestrator.getHandlerRegistration('t.fnkey.orphan')!;
+    reg.meta = { pool: 'batch' };
+    expect(store.jobs.get('t.fnkey.orphan')?.concurrencyKeyTemplate).toBe(
+      FN_KEY_SENTINEL,
+    );
+    await expect(
+      orchestrator.start('t.fnkey.orphan', { x: 'a' }),
+    ).rejects.toBeInstanceOf(JobKeyFunctionUnavailableError);
   });
 });
 

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -369,16 +369,56 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 	integration: ({ moduleImport, cfg }) => {
 		const backend = (cfg?.backend as string | undefined) ?? 'drizzle';
 		const multiTenant = Boolean(cfg?.multi_tenant);
+		// DIFFER-UNIGNORE (0.17.1): opt-in `integration.differ.{ignore,unignore}`
+		// → `IntegrationModule.forRoot({ differ: { … } })`. Emitted only when the
+		// block carries a non-empty list, so the no-differ barrel byte-shape is
+		// unchanged (off-by-default, mirrors the listen_notify threading).
+		const differClause = integrationDifferClause(cfg);
+		if (!differClause) {
+			return {
+				imports: [
+					`import { IntegrationModule } from '${moduleImport('integration', 'integration.module')}';`,
+				],
+				calls: [
+					`\tIntegrationModule.forRoot(${quoteOpts({ backend, multiTenant })}),`,
+				],
+			};
+		}
+		// Assemble piecewise so the `differ: {...}` block sits alongside
+		// backend/multiTenant (quoteOpts can't serialise a nested object).
+		const parts = [`backend: '${backend}'`, `multiTenant: ${multiTenant}`, differClause];
 		return {
 			imports: [
 				`import { IntegrationModule } from '${moduleImport('integration', 'integration.module')}';`,
 			],
-			calls: [
-				`\tIntegrationModule.forRoot(${quoteOpts({ backend, multiTenant })}),`,
-			],
+			calls: [`\tIntegrationModule.forRoot({ ${parts.join(', ')} }),`],
 		};
 	},
 };
+
+/**
+ * DIFFER-UNIGNORE (0.17.1): extract `integration.differ.{ignore,unignore}` and
+ * serialise to a `differ: { ignore: [...], unignore: [...] }` fragment, or `''`
+ * when neither list is present/non-empty. Each is a string array (field names);
+ * only string entries survive, so a malformed config can't emit garbage. Mirrors
+ * `DeepEqualDifferOptions` — `unignore` removes a default-ignored field (e.g.
+ * `deletedAt`) so it registers as a domain field change.
+ */
+function integrationDifferClause(cfg: Record<string, unknown> | undefined): string {
+	const differ = cfg?.differ as
+		| { ignore?: unknown; unignore?: unknown }
+		| undefined;
+	if (!differ) return '';
+	const toStrings = (v: unknown): string[] =>
+		Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+	const ignore = toStrings(differ.ignore);
+	const unignore = toStrings(differ.unignore);
+	const inner: Record<string, string[]> = {};
+	if (ignore.length > 0) inner.ignore = ignore;
+	if (unignore.length > 0) inner.unignore = unignore;
+	if (Object.keys(inner).length === 0) return '';
+	return `differ: ${jsonToTs(inner)}`;
+}
 
 const PACKAGE = '@pattern-stack/codegen';
 

--- a/templates/subsystem/integration-config/codegen-config-integration-block.ejs.t
+++ b/templates/subsystem/integration-config/codegen-config-integration-block.ejs.t
@@ -27,3 +27,20 @@ integration:
   # Enabling post-install requires a reinstall (`subsystem install integration
   # --force --force-config`) plus an Atlas migration.
   multi_tenant: false
+
+  # ── Default-differ tuning (DIFFER-UNIGNORE) ──
+  # Threaded into the `DeepEqualDiffer` bound to INTEGRATION_FIELD_DIFFER.
+  # Off-by-default — omit the whole `differ:` block for the historical
+  # behaviour (the built-in ignore list, unchanged). A feature module that
+  # binds its own `IFieldDiffer<T>` overrides this entirely.
+  #
+  # differ:
+  #   # Extra field names to ALSO ignore (merged with the defaults).
+  #   ignore: [internalSeq]
+  #   # Default-ignored field names to RE-INCLUDE as domain data. The canonical
+  #   # case: an entity with `softDelete: false` whose `deletedAt` carries a
+  #   # vendor-observed retraction tombstone ON the canonical record. Without
+  #   # this the tombstone overlay diffs to 'noop', the upsert is skipped, and
+  #   # `deleted_at` never lands. `unignore` is subtracted after `ignore`, so it
+  #   # wins on a field listed in both.
+  #   unignore: [deletedAt]

--- a/test/integration/jobs-fn-concurrency-key.drizzle.integration.test.ts
+++ b/test/integration/jobs-fn-concurrency-key.drizzle.integration.test.ts
@@ -1,0 +1,361 @@
+/**
+ * JOB-FN-KEY (0.16.2) — function-form concurrency keys serialize at the DB
+ * level against a REAL Postgres (testcontainers).
+ *
+ * Regression coverage for the swe-brain ADR-0009 Amendment B §B3 drain: a
+ * `@JobHandler` authored with `concurrency.key: (input) => …` (the typed
+ * function form) was silently dropped to `null` at registration
+ * (`upsertJobRows`' `typeof === 'string' ? … : null`). The persisted
+ * `job.concurrency_key_template` was NULL, so `start()` wrote a NULL
+ * `job_run.concurrency_key`, and the worker's queue-release gate (which keys
+ * off `claimed.concurrencyKey`) never engaged — three "shared-lane"
+ * inbound-sync runs raced the same message row fully concurrently.
+ *
+ * Pure-memory unit coverage (`job-orchestrator.unit.spec.ts` Group 2b) proves
+ * the function form serializes in the memory backend. This suite proves the
+ * SAME for the Drizzle backend against a real database, where the contract is
+ * subtler: `start()` reads the `job` definition row out of Postgres (the
+ * function can't be persisted), so it MUST re-resolve the live function from
+ * the in-process `JOB_HANDLER_REGISTRY`. Two orchestrator instances over ONE
+ * pool must still produce matching, non-null `concurrency_key`s and the
+ * DB-level queue gate must hold the second behind the first.
+ *
+ * Self-contained / CI-friendly: spins its own ephemeral `postgres:16` via
+ * testcontainers and skips gracefully (not fails) when Docker is unavailable —
+ * mirrors `observability-list-reads.drizzle.integration.test.ts`. NOT part of
+ * `just test-unit`; run via `just test-jobs-fnkey-integration`.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { and, eq, sql } from 'drizzle-orm';
+import { Wait } from 'testcontainers';
+
+import type { DrizzleClient } from '../../runtime/types/drizzle';
+import {
+  jobRuns,
+  jobs,
+} from '../../runtime/subsystems/jobs/job-orchestration.schema';
+import { DrizzleJobOrchestrator } from '../../runtime/subsystems/jobs/job-orchestrator.drizzle-backend';
+import { buildClaimQuery } from '../../runtime/subsystems/jobs/job-worker';
+import {
+  FN_KEY_SENTINEL,
+  JOB_HANDLER_REGISTRY,
+  JobHandlerBase,
+  type JobContext,
+  type JobHandlerMeta,
+  type JobUpsertEntry,
+} from '../../runtime/subsystems/jobs/job-handler.base';
+import type { JobPoolDef } from '../../runtime/subsystems/jobs/job-orchestrator.protocol';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Docker availability probe → skip gracefully when absent.
+// ────────────────────────────────────────────────────────────────────────────
+
+async function dockerIsAvailable(): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(['docker', 'info'], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+    return (await proc.exited) === 0;
+  } catch {
+    return false;
+  }
+}
+
+const DOCKER_OK = await dockerIsAvailable();
+if (!DOCKER_OK) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[jobs-fnkey integration] Docker not available — skipping testcontainers Postgres suite.',
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// DDL — just the two jobs tables (no domain_events). Mirrors the schema file.
+// ────────────────────────────────────────────────────────────────────────────
+
+const JOBS_DDL = /* sql */ `
+DO $$ BEGIN
+  CREATE TYPE job_run_status AS ENUM
+    ('pending','running','waiting','completed','failed','timed_out','canceled');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_collision_mode AS ENUM ('queue','reject','replace');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_replay_from AS ENUM ('scratch','last_step','last_checkpoint');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_parent_close_policy AS ENUM ('terminate','cancel','abandon');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_wait_kind AS ENUM ('signal');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_trigger_source AS ENUM ('manual','schedule','event','parent');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+CREATE TABLE IF NOT EXISTS job (
+  type                     text PRIMARY KEY,
+  version                  integer NOT NULL DEFAULT 1,
+  pool                     text NOT NULL,
+  scope_entity_type        text,
+  retry_policy             jsonb NOT NULL,
+  timeout_ms               integer,
+  concurrency_key_template text,
+  collision_mode           job_collision_mode NOT NULL DEFAULT 'queue',
+  dedupe_key_template      text,
+  dedupe_window_ms         integer,
+  priority_default         integer NOT NULL DEFAULT 0,
+  replay_from              job_replay_from NOT NULL DEFAULT 'last_checkpoint',
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS job_run (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_type            text NOT NULL REFERENCES job(type),
+  job_version         integer NOT NULL,
+  parent_run_id       uuid REFERENCES job_run(id),
+  root_run_id         uuid NOT NULL,
+  parent_close_policy job_parent_close_policy NOT NULL DEFAULT 'terminate',
+  scope_entity_type   text,
+  scope_entity_id     text,
+  tenant_id           text,
+  tags                jsonb NOT NULL DEFAULT '{}',
+  pool                text NOT NULL,
+  priority            integer NOT NULL DEFAULT 0,
+  concurrency_key     text,
+  dedupe_key          text,
+  status              job_run_status NOT NULL DEFAULT 'pending',
+  input               jsonb NOT NULL,
+  output              jsonb,
+  error               jsonb,
+  trigger_source      job_trigger_source NOT NULL,
+  trigger_ref         text,
+  run_at              timestamptz NOT NULL DEFAULT now(),
+  started_at          timestamptz,
+  finished_at         timestamptz,
+  claimed_at          timestamptz,
+  attempts            integer NOT NULL DEFAULT 0,
+  wait_kind           job_wait_kind,
+  resume_token        text,
+  wait_deadline       timestamptz,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+`;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Handler with a FUNCTION concurrency key. The lane is the channel — two
+// different messages (different ts) on the same channel share a lane. This is
+// the swe-brain inbound-sync shape: per-channel ordering, NOT per-message.
+// ────────────────────────────────────────────────────────────────────────────
+
+const JOB_TYPE = 'inbound_sync_fnkey_it';
+const POOL = 'batch';
+
+interface InboundInput extends Record<string, unknown> {
+  channel: string;
+  ts: string;
+}
+
+class InboundHandler extends JobHandlerBase<InboundInput, void> {
+  async run(_ctx: JobContext<InboundInput>): Promise<void> {}
+}
+
+const META: JobHandlerMeta<InboundInput> = {
+  pool: POOL,
+  concurrency: {
+    key: (input) => `chan:${input.channel}`,
+    collisionMode: 'queue',
+  },
+};
+
+const POOL_CONFIG: ReadonlyMap<string, JobPoolDef> = new Map([
+  [POOL, { queue: POOL, concurrency: 4, reserved: false }],
+]);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Container + clients.
+// ────────────────────────────────────────────────────────────────────────────
+
+let container: import('@testcontainers/postgresql').StartedPostgreSqlContainer;
+let pool: Pool;
+let db: DrizzleClient;
+let orchestratorA: DrizzleJobOrchestrator;
+let orchestratorB: DrizzleJobOrchestrator;
+
+beforeAll(async () => {
+  if (!DOCKER_OK) return;
+
+  const { PostgreSqlContainer } = await import('@testcontainers/postgresql');
+  container = await new PostgreSqlContainer('postgres:16')
+    .withWaitStrategy(Wait.forHealthCheck())
+    .withStartupTimeout(60_000)
+    .start();
+
+  pool = new Pool({ connectionString: container.getConnectionUri() });
+  db = drizzle(pool) as unknown as DrizzleClient;
+  await pool.query(JOBS_DDL);
+
+  // The live function key lives in the in-process registry — the Drizzle
+  // backend re-resolves it there at start() (the DB only stores the sentinel).
+  // Register directly (no @JobHandler decorator) for an isolated, deterministic
+  // registry entry under this test's job type.
+  JOB_HANDLER_REGISTRY.set(JOB_TYPE, {
+    type: JOB_TYPE,
+    meta: META as JobHandlerMeta<unknown>,
+    handlerClass: InboundHandler as unknown as new (
+      ...args: unknown[]
+    ) => JobHandlerBase<unknown>,
+  });
+
+  // Two orchestrator instances over the SAME pool — single-tenant, no
+  // listen/notify. They model two app processes contending on one DB.
+  orchestratorA = new DrizzleJobOrchestrator(db, false);
+  orchestratorB = new DrizzleJobOrchestrator(db, false);
+
+  // Boot-time definition upsert — this is the path that previously dropped the
+  // function key to null.
+  const entries: JobUpsertEntry[] = [
+    {
+      type: JOB_TYPE,
+      meta: META as JobHandlerMeta<unknown>,
+      handlerClass: InboundHandler as unknown as new (...args: unknown[]) => unknown,
+    },
+  ];
+  await orchestratorA.upsertJobRows(entries, POOL_CONFIG);
+}, 90_000);
+
+afterAll(async () => {
+  JOB_HANDLER_REGISTRY.delete(JOB_TYPE);
+  await pool?.end();
+  await container?.stop();
+});
+
+beforeEach(async () => {
+  if (!DOCKER_OK) return;
+  await db.delete(jobRuns);
+});
+
+const maybe = DOCKER_OK ? describe : describe.skip;
+
+maybe('DrizzleJobOrchestrator — function concurrency key (DB-level)', () => {
+  it('persists the function key as FN_KEY_SENTINEL in the job definition row', async () => {
+    const [def] = await db
+      .select({ template: jobs.concurrencyKeyTemplate, mode: jobs.collisionMode })
+      .from(jobs)
+      .where(eq(jobs.type, JOB_TYPE));
+    // The bug stored NULL here; the fix stores the sentinel (non-null), which
+    // is exactly what makes start()'s collision path engage.
+    expect(def.template).toBe(FN_KEY_SENTINEL);
+    expect(def.mode).toBe('queue');
+  });
+
+  it('two concurrent same-lane starts both persist the SAME non-null concurrency_key', async () => {
+    // Two DIFFERENT messages (different ts) on the SAME channel → one lane.
+    // Pre-0.16.2 both rows got concurrency_key = NULL (fn dropped). Now the
+    // live fn is re-resolved at start() against each payload.
+    const [a, b] = await Promise.all([
+      orchestratorA.start(JOB_TYPE, { channel: 'C1', ts: '100' }),
+      orchestratorB.start(JOB_TYPE, { channel: 'C1', ts: '200' }),
+    ]);
+
+    expect(a.concurrencyKey).toBe('chan:C1');
+    expect(b.concurrencyKey).toBe('chan:C1');
+    expect(a.concurrencyKey).not.toBeNull();
+
+    // Both landed in Postgres with the resolved key.
+    const rows = await db
+      .select({ id: jobRuns.id, key: jobRuns.concurrencyKey })
+      .from(jobRuns)
+      .where(eq(jobRuns.concurrencyKey, 'chan:C1'));
+    expect(rows).toHaveLength(2);
+  });
+
+  it('different lanes (different channels) get different concurrency_keys', async () => {
+    const [a, b] = await Promise.all([
+      orchestratorA.start(JOB_TYPE, { channel: 'C1', ts: '1' }),
+      orchestratorB.start(JOB_TYPE, { channel: 'C2', ts: '1' }),
+    ]);
+    expect(a.concurrencyKey).toBe('chan:C1');
+    expect(b.concurrencyKey).toBe('chan:C2');
+  });
+
+  it('the DB-level queue-release gate holds the second same-lane run behind the first', async () => {
+    // Enqueue two same-lane runs.
+    const first = await orchestratorA.start(JOB_TYPE, { channel: 'C1', ts: '100' });
+    const second = await orchestratorB.start(JOB_TYPE, { channel: 'C1', ts: '200' });
+    expect(first.concurrencyKey).toBe('chan:C1');
+    expect(second.concurrencyKey).toBe('chan:C1');
+
+    // ── Claim #1 via the REAL claim query (FOR UPDATE SKIP LOCKED), then mark
+    //    running — this is what the worker does on the first run. ────────────
+    const claimRow = async () => {
+      return db.transaction(async (tx) => {
+        const [cand] = await buildClaimQuery(tx as unknown as DrizzleClient, POOL);
+        if (!cand) return null;
+        const [claimed] = await tx
+          .update(jobRuns)
+          .set({ status: 'running', claimedAt: new Date(), startedAt: new Date() })
+          .where(eq(jobRuns.id, cand.id))
+          .returning();
+        return claimed ?? null;
+      });
+    };
+
+    const claimedFirst = await claimRow();
+    expect(claimedFirst?.status).toBe('running');
+
+    // ── Claim #2: the second pending row is claimable by the query, but the
+    //    worker's queue-release GATE defers it back to pending because another
+    //    run on the same concurrency_key is already 'running'. Replicate the
+    //    exact gate SQL from JobWorker.processRun (lines 497-519). ───────────
+    const claimedSecond = await claimRow();
+    expect(claimedSecond).not.toBeNull();
+
+    const gateDefer = async (claimed: { id: string; concurrencyKey: string | null }) => {
+      if (!claimed.concurrencyKey) return false;
+      const inflight = await db
+        .select({ id: jobRuns.id })
+        .from(jobRuns)
+        .where(
+          and(
+            eq(jobRuns.concurrencyKey, claimed.concurrencyKey),
+            eq(jobRuns.status, 'running'),
+          ),
+        );
+      const other = inflight.find((r) => r.id !== claimed.id);
+      if (other) {
+        await db
+          .update(jobRuns)
+          .set({ status: 'pending', claimedAt: null, startedAt: null, updatedAt: new Date() })
+          .where(eq(jobRuns.id, claimed.id));
+        return true;
+      }
+      return false;
+    };
+
+    const deferred = await gateDefer(claimedSecond!);
+    // The gate fired — the second run was pushed back to pending. THIS is the
+    // serialization the bug defeated (with concurrency_key NULL the gate's
+    // `if (claimed.concurrencyKey)` guard was falsy and both ran at once).
+    expect(deferred).toBe(true);
+
+    // Exactly one run is `running`; the other is back to `pending`.
+    const running = await db
+      .select({ c: sql<number>`count(*)::int` })
+      .from(jobRuns)
+      .where(and(eq(jobRuns.concurrencyKey, 'chan:C1'), eq(jobRuns.status, 'running')));
+    expect(running[0].c).toBe(1);
+
+    const pending = await db
+      .select({ c: sql<number>`count(*)::int` })
+      .from(jobRuns)
+      .where(and(eq(jobRuns.concurrencyKey, 'chan:C1'), eq(jobRuns.status, 'pending')));
+    expect(pending[0].c).toBe(1);
+  });
+});


### PR DESCRIPTION
Two upstream fixes surfaced by the swe-brain dogfood's **ADR-0009 Amendment B**
mutation drains — they bit the **same** drain in one e2e run. One PR, version
bump **0.17.0 → 0.17.1** (originally scoped as 0.16.2; re-upped onto fresh main
after #456 landed 0.17.0). Both fixes are backward-compatible.

---

## Gap A — `concurrency.key` / `dedupe.key` function forms silently dropped (jobs)

**Evidence (swe-brain ADR-0009 Amendment B §B3):** the typed API
(`ConcurrencyPolicy.key` / `DedupePolicy.key`) had *always required a function*,
but registration in `job-orchestrator.drizzle-backend.ts` `upsertJobRows` did
`typeof key === 'string' ? key : null` — a function key persisted as a **NULL**
`concurrency_key_template`. So `start()` wrote a NULL `job_run.concurrency_key`,
and the worker's queue-release gate (`if (claimed.concurrencyKey)` in
`JobWorker.processRun`) never engaged. Observed: three `inbound-sync` runs the
handler believed shared one `collisionMode: 'queue'` lane ran fully
**concurrently** — three `integration_runs` racing one message row.

**Fix:**
- Widen to `JobKeySelector<TInput> = string | ((input: TInput) => string)`. The
  string form is documented as a `{{field}}` template; the function form is the
  one that previously type-checked but was dropped.
- Persist a function key as a stable `FN_KEY_SENTINEL` (`'<fn>'`): **non-null**
  so the collision/dedupe path engages, **hash-stable** so the definition-hash
  gate (`upsertJobRows`' `IS DISTINCT FROM` clause) doesn't churn (a function
  identity can't be hashed).
- At `start()`, both backends detect the sentinel and **re-resolve the live
  function** from the registry (drizzle/bullmq from the global
  `JOB_HANDLER_REGISTRY`, exactly how the worker already resolves handler
  classes; memory from its own `handlerRegistry`), then evaluate it against the
  payload. BullMQ delegates to `super.start()`, so it's covered too.
- A sentinel with no live function throws `JobKeyFunctionUnavailableError` —
  **fail loud, never silently degrade to no-key** (the exact regression this
  kills).
- String templates and the memory/drizzle/bullmq agreement are unchanged.

**Final types:**
```ts
export type JobKeySelector<TInput> = string | ((input: TInput) => string);
export interface ConcurrencyPolicy<TInput> {
  key: JobKeySelector<TInput>;
  collisionMode: 'queue' | 'reject' | 'replace';
}
export interface DedupePolicy<TInput> {
  key: JobKeySelector<TInput>;
  windowMs: number;
}
```

**Function keys are SUPPORTED** (not rejected). `start()` resolves them via the
new shared `resolveJobKey(kind, type, template, payload, evaluateTemplate)`:
`null → null`; `FN_KEY_SENTINEL →` look up the live fn in the registry and
invoke it; otherwise the ordinary `{{field}}` template path.

**DB-level proof:** `test/integration/jobs-fn-concurrency-key.drizzle.integration.test.ts`
(real `postgres:16` via testcontainers, skips gracefully without Docker) — two
`DrizzleJobOrchestrator` instances over **one** DB `start()` two different
messages on the same channel; both `job_run` rows persist the **same non-null**
`concurrency_key` (`chan:C1`), and the worker's queue-release gate (replicated
verbatim) holds the second behind the first (exactly 1 `running`, 1 `pending`).
Run via `just test-jobs-fnkey-integration`.

## Gap B — differ unconditionally ignores `deletedAt` (integration)

**Evidence (swe-brain ADR-0009 Amendment B §B4):** `DEFAULT_IGNORE_FIELDS`
contains `'deletedAt'` on the assumption it's row metadata sinks stamp. But an
entity with `softDelete: false` and a domain-owned `deleted_at` carries the
vendor-observed retraction tombstone **on the canonical record** (a Slack
`message_deleted` → `deletedAt`; ADR-0008 §1 "a retracted message is alignment
signal"). The tombstone overlay diffed to `'noop'` → the upsert was skipped →
`deleted_at` never landed. Observed: `integration_run_items`
`{operation: noop, changed_fields: {}}` for every delete.

**Fix (smallest API that lets a consumer say "deletedAt is domain data here"):**
- Add `DeepEqualDifferOptions.unignore?: readonly string[]` — subtracted from
  the defaults **after** `ignore` is merged (so `unignore` wins on a field in
  both; un-ignoring a field not in the set is a harmless no-op; per-instance,
  never mutates `DEFAULT_IGNORE_FIELDS`).
- Thread from consumer config: `IntegrationModule.forRoot({ differ })` →
  `new DeepEqualDiffer(options.differ ?? {})`, and the subsystem barrel
  generator emits that `forRoot` option from `integration.differ.*`. Same
  off-by-default config-threading shape as 0.16.0's `listen_notify` (#453);
  vendored **and** package mode both covered.

**Config YAML shape:**
```yaml
integration:
  backend: drizzle
  differ:
    unignore: [deletedAt]   # this entity's deletedAt is domain data
    # ignore: [internalSeq]  # (also supported — merged with defaults)
```

**Generated `forRoot` diff** (barrel generator), off → on:
```diff
-  IntegrationModule.forRoot({ backend: 'drizzle', multiTenant: false }),
+  IntegrationModule.forRoot({ backend: 'drizzle', multiTenant: false, differ: { unignore: ['deletedAt'] } }),
```
(no `differ:` block → byte-identical to before.)

---

## Tests vs baseline (fresh origin/main @ #456, 0.17.0)

- **Full unit suite: 2547 → 2568 pass, 0 fail** (+21 new). 3 skips unchanged.
- Typecheck: **3 errors, unchanged** (pre-existing junction.ts ×2 +
  barrel-generator.ts ×1 — not introduced here).
- New: +6 memory fn-key unit, +2 base-types compile/projection, +6 differ
  unignore, +2 module-threading, +9 barrel-generator threading (vendored +
  package), +4 real-Postgres DB-level integration.

## Consumer migration notes (swe-brain)

1. **Gap A:** no config change needed — function keys now Just Work. After a
   `bun install` of 0.17.1 + `bunx @pattern-stack/codegen entity new --all
   --force` regen, the existing fn-keyed `@JobHandler`s serialize. (Verify the
   inbound-sync lane now shows one `integration_run` per channel, not three.)
2. **Gap B:** add to `codegen.config.yaml`, then regen:
   ```yaml
   integration:
     differ:
       unignore: [deletedAt]
   ```
   Regen rewrites `src/generated/subsystems.ts` so
   `IntegrationModule.forRoot({ … differ: { unignore: ['deletedAt'] } })`. No
   Atlas migration (runtime-only wiring). Run `bunx @biomejs/biome check --write
   .` after regen per house process.

Do NOT publish — Doug publishes manually (OTP). Stops at the opened PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)