### PR TITLE
feat(schema,parser): per-entity sync mode + cross-entity registry — ADR-038 FE-1

### DIFF
--- a/ai-docs/specs/fe-1-schema-naming-groundwork.md
+++ b/ai-docs/specs/fe-1-schema-naming-groundwork.md
@@ -1,0 +1,79 @@
+# FE-1: Schema + Naming Groundwork Spec
+
+**Parent:** docs/specs/2026-06-04-frontend-pipeline-rebuild.md (FE-1) · ADR-038
+**Branch:** `fe-1/schema-naming-groundwork` off `feat/frontend-pipeline-rebuild`
+**Status:** approved (parent spec gated 2026-06-04; e2e run authorized)
+
+## Overview
+
+Pure src-side groundwork, no emission change: (1) per-entity sync mode in the entity YAML schema, (2) a cross-entity naming registry in the parser for FK target resolution, (3) delete the dead `pipelines:` config surface.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/schema/entity-definition.schema.ts` | modify | add `sync` to `EntityConfigSchema` |
+| `src/parser/entity-registry.ts` | create | `loadEntityRegistry()` |
+| `src/parser/index.ts` | modify | export it |
+| `src/schema/pipelines-config.schema.ts` | modify | delete `ArchitectureTargetSchema`, `BackendPipelineSchema`, `FrontendPipelineSchema`, `SharedPipelineSchema`, `PipelinesConfigSchema`, both `validate*` helpers. KEEP `GenerateConfigSchema`, `PathsConfigSchema`, `PatternsConfigSchema`, `RuntimeModeSchema` |
+| `src/config/config-loader.ts` | modify | drop pipelines import/validation block + `ProjectConfig.pipelines` field + stale doc comments |
+| `src/config/paths.mjs` | modify | delete `getPipelinesConfig` (def ~line 622 + export ~684 + doc example ~619) |
+| `templates/entity/new/prompt.js` | modify | drop the `getPipelinesConfig` import (line 23) — its only reference |
+| `src/__tests__/schema/schema-v2.test.ts` | modify | delete the `pipelines config` describe block (~line 264); add `entity.sync` cases |
+| `src/__tests__/parser/entity-registry.test.ts` | create | registry tests |
+| `test/fixtures/codegen.config.yaml` | modify | remove the `pipelines:` block (lines `pipelines:` … `enabled: true` before `generate:`) |
+| `docs/specs/2026-06-04-frontend-pipeline-rebuild.md` | modify | record refinement: `sync:` lives inside the `entity:` block (strict schema, sibling to `surface:`/`context:`), not top-level |
+
+## Interface
+
+```ts
+// src/schema/entity-definition.schema.ts — inside EntityConfigSchema, sibling to `surface:`
+// ADR-038: per-entity frontend sync mode. Overrides global frontend.sync.mode.
+//   'api'      → queryCollectionOptions (REST via TanStack Query)
+//   'electric' → electricCollectionOptions (real-time shape sync)
+// 'offline' (Electric + Dexie) is deferred — see docs/specs/2026-06-04-frontend-pipeline-rebuild.md OQ-6.
+sync: z.enum(['api', 'electric']).optional(),
+```
+
+```ts
+// src/parser/entity-registry.ts
+export interface EntityRegistryEntry {
+  name: string;          // 'deal_state'
+  plural: string;        // authoritative, from YAML entity.plural
+  table: string;
+  className: string;     // 'DealState'  (pascal of name)
+  classNamePlural: string;
+  camelName: string;     // 'dealState'
+  pluralCamelName: string;
+  sync: 'api' | 'electric' | null;   // null → inherit global frontend.sync.mode
+}
+
+export interface LoadEntityRegistryResult {
+  registry: Map<string, EntityRegistryEntry>;  // keyed by entity name
+  issues: AnalysisIssue[];                     // invalid YAMLs reported, not thrown
+}
+
+export function loadEntityRegistry(entitiesDir: string): LoadEntityRegistryResult;
+```
+
+## Implementation Steps
+
+1. Branch `fe-1/schema-naming-groundwork` from `feat/frontend-pipeline-rebuild` (current HEAD).
+2. Add `sync` to `EntityConfigSchema` with the comment above (match the house style of `surface:`/`context:` entries).
+3. `entity-registry.ts`: glob `*.yaml`/`*.yml` under `entitiesDir`, load via the existing schema-validated loader (`loadEntityFromYaml` from `src/utils/yaml-loader`, re-exported by `src/parser/index.ts`), tolerant of invalid files (mirror `loadEntities`' issue-collection pattern — see `loadErrorToIssue`). Derive casings with existing naming helpers if exported; else local `pascalCase`/`camelCase` consistent with `prompt.js`. **Never derive plural — read it from the YAML.**
+4. Delete the pipelines schema surface per the Files table. Check for any straggler imports (`grep -rn "PipelinesConfig\|getPipelinesConfig\|FrontendPipelineSchema"`).
+5. Update tests + fixture; add registry tests covering: two entities with cross-references; an irregular/explicit plural (e.g. `person` with `plural: people`) asserting the registry returns the YAML plural; `sync` round-trip; invalid-YAML tolerance.
+6. Update the parent spec's FE-1 + "New" sections with the `entity.sync` placement refinement (one sentence).
+7. Run `just test-unit` — must pass. Run `bunx tsc --noEmit` if the project typechecks (check package.json scripts; use the project's own check script if present).
+8. Conventional commit(s) on the branch. End commit body with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## Constraints
+
+- Do NOT touch `templates/entity/new/frontend/**` (FE-2/FE-3 delete them wholesale).
+- Do NOT start the emitter.
+- No deprecation shims, no "deprecated" comments — delete cleanly (CLAUDE.md operating principle).
+- `schema-v2.test.ts` line 268 references `FrontendPipelineSchema` types — that whole describe dies with the schema.
+
+## Open Questions
+
+None — all resolved in parent spec / ADR-038.

--- a/docs/specs/2026-06-04-frontend-pipeline-rebuild.md
+++ b/docs/specs/2026-06-04-frontend-pipeline-rebuild.md
@@ -64,7 +64,7 @@ Every file is a **complete-file write** with the `@generated` banner. No inject 
 
 ## New
 
-1. **Per-entity sync mode** — entity YAML gains top-level `sync: api | electric` (absent → global `frontend.sync.mode`, default `electric`). `offline` (Electric + Dexie) is **deferred** — schema rejects it with a pointer to this spec.
+1. **Per-entity sync mode** — entity YAML gains `sync: api | electric` *inside the `entity:` block* (sibling to `surface:`/`context:`, under the strict `EntityConfigSchema`), read as `entity.sync` — not a top-level key (refined during FE-1 implementation). Absent → global `frontend.sync.mode`, default `electric`. `offline` (Electric + Dexie) is **deferred** — schema rejects it with a pointer to this spec.
 2. **Cross-entity registry naming** — the emitter loads ALL `entities/*.yaml` (existing parser) and resolves FK target names (file name, plural, class, collection var) from the **target's own YAML**. Mirrors pts `_resolve_relationship_targets`. No plural is ever derived from a string at emit time.
 3. **REST api client** — `api/<entity>.ts` emits `list/get/create/update/delete` (+ declarative-queries finders, follow-on) against the generated NestJS controller routes, returning `{ txid }` passthrough where the backend provides it. `api/client.ts` carries baseURL resolution (`apiBaseUrlImport` | `apiUrl`) and the auth-header function.
 4. **Whole-set step** — `entity new` post-step and `gen-all` both end with `emitFrontendSet(allEntities)`; output is deterministic for a given entity set (safe under the baseline runner's wipe-and-regenerate).
@@ -86,7 +86,7 @@ Pinned as a constant in `src/emitters/frontend/deps.ts`; emitted into a comment 
 ## Implementation steps (stacked, PR-sized)
 
 **FE-1 — schema + naming groundwork** (src-only, no emission change)
-- `entity-definition.schema.ts`: add `sync: z.enum(['api','electric'])` optional.
+- `entity-definition.schema.ts`: add `sync: z.enum(['api','electric'])` optional *inside `EntityConfigSchema`* (the `entity:` block, sibling to `surface:`/`context:`), read as `entity.sync` — NOT a top-level key.
 - Expose a cross-entity registry from the parser: `{ name → { plural, className, fileBase } }` for all sibling YAMLs (extend the existing `targetExists` machinery in prompt.js/parser).
 - `GenerateConfigSchema`: enumerate surviving frontend knobs; drop `.passthrough()` for the frontend keys; delete `pipelines-config.schema.ts` pipelines block + `config-loader` validation + `getPipelinesConfig`.
 - Update `test/fixtures/codegen.config.yaml` (remove dead `pipelines:` block).

--- a/src/__tests__/parser/entity-registry.test.ts
+++ b/src/__tests__/parser/entity-registry.test.ts
@@ -1,0 +1,185 @@
+/**
+ * loadEntityRegistry unit tests (ADR-038, FE-1).
+ *
+ * The registry is the authoritative cross-entity naming source for FK target
+ * resolution: plural comes straight from `entity.plural` (never derived), and
+ * casings are computed from the snake_case name/plural. Tests use
+ * `mkdtempSync(tmpdir())` so fixtures (incl. intentionally-broken YAML) stay
+ * out of the checked-in tree.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadEntityRegistry } from '../../parser/entity-registry';
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), 'entity-registry-'));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function writeEntity(file: string, body: string): void {
+	writeFileSync(join(dir, file), body, 'utf-8');
+}
+
+// ----------------------------------------------------------------------------
+// Cross-entity load + casings
+// ----------------------------------------------------------------------------
+
+describe('loadEntityRegistry — two cross-referencing entities', () => {
+	beforeEach(() => {
+		// `deal` belongs_to `deal_state`; the registry is what an emitter would
+		// consult to resolve the `deal_state` target's authoritative names.
+		writeEntity(
+			'deal.yaml',
+			`entity:
+  name: deal
+  plural: deals
+  table: deals
+fields:
+  name: { type: string, required: true }
+relationships:
+  state:
+    type: belongs_to
+    target: deal_state
+    foreign_key: deal_state_id
+`,
+		);
+		writeEntity(
+			'deal_state.yaml',
+			`entity:
+  name: deal_state
+  plural: deal_states
+  table: deal_states
+fields:
+  label: { type: string, required: true }
+`,
+		);
+	});
+
+	it('keys the registry by entity name with zero issues', () => {
+		const { registry, issues } = loadEntityRegistry(dir);
+		expect(issues).toEqual([]);
+		expect([...registry.keys()].sort()).toEqual(['deal', 'deal_state']);
+	});
+
+	it('derives pascal/camel casings for a multi-word name', () => {
+		const { registry } = loadEntityRegistry(dir);
+		const dealState = registry.get('deal_state');
+		expect(dealState).toMatchObject({
+			name: 'deal_state',
+			plural: 'deal_states',
+			table: 'deal_states',
+			className: 'DealState',
+			classNamePlural: 'DealStates',
+			camelName: 'dealState',
+			pluralCamelName: 'dealStates',
+		});
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Authoritative plural — never derived
+// ----------------------------------------------------------------------------
+
+describe('loadEntityRegistry — irregular plural is read from YAML, never derived', () => {
+	it('returns plural: people for person (not pluralized "persons")', () => {
+		writeEntity(
+			'person.yaml',
+			`entity:
+  name: person
+  plural: people
+  table: people
+fields:
+  name: { type: string, required: true }
+`,
+		);
+
+		const { registry } = loadEntityRegistry(dir);
+		const person = registry.get('person');
+		expect(person?.plural).toBe('people');
+		expect(person?.pluralCamelName).toBe('people');
+		expect(person?.classNamePlural).toBe('People');
+	});
+});
+
+// ----------------------------------------------------------------------------
+// sync round-trip
+// ----------------------------------------------------------------------------
+
+describe('loadEntityRegistry — sync mode round-trip', () => {
+	it('carries entity.sync through; absent → null (inherit global)', () => {
+		writeEntity(
+			'order.yaml',
+			`entity:
+  name: order
+  plural: orders
+  table: orders
+  sync: api
+fields:
+  total: { type: decimal, required: true }
+`,
+		);
+		writeEntity(
+			'invoice.yaml',
+			`entity:
+  name: invoice
+  plural: invoices
+  table: invoices
+fields:
+  total: { type: decimal, required: true }
+`,
+		);
+
+		const { registry } = loadEntityRegistry(dir);
+		expect(registry.get('order')?.sync).toBe('api');
+		expect(registry.get('invoice')?.sync).toBeNull();
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Invalid-YAML tolerance
+// ----------------------------------------------------------------------------
+
+describe('loadEntityRegistry — tolerant of invalid files', () => {
+	it('loads valid entities and reports the broken one as an issue', () => {
+		writeEntity(
+			'good.yaml',
+			`entity:
+  name: good
+  plural: goods
+  table: goods
+fields:
+  name: { type: string, required: true }
+`,
+		);
+		// Missing required `table` → schema validation failure.
+		writeEntity(
+			'broken.yaml',
+			`entity:
+  name: broken
+  plural: brokens
+fields:
+  name: { type: string, required: true }
+`,
+		);
+
+		const { registry, issues } = loadEntityRegistry(dir);
+		expect(registry.has('good')).toBe(true);
+		expect(registry.has('broken')).toBe(false);
+		expect(issues.some((i) => i.severity === 'error')).toBe(true);
+		expect(issues.some((i) => i.path?.endsWith('broken.yaml'))).toBe(true);
+	});
+
+	it('reports a missing directory as an error, returns an empty registry', () => {
+		const { registry, issues } = loadEntityRegistry(join(dir, 'does-not-exist'));
+		expect(registry.size).toBe(0);
+		expect(issues.some((i) => i.severity === 'error')).toBe(true);
+	});
+});

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -1,16 +1,13 @@
 /**
  * Schema v2 validation tests
  *
- * Tests for ADR-031 pattern, queries, integration, events blocks
- * and pipelines config schema.
+ * Tests for ADR-031 pattern, queries, integration, events blocks,
+ * per-entity sync mode (ADR-038), and the generate config schema.
  */
 
 import { describe, it, expect } from 'bun:test';
 import { EntityDefinitionSchema } from '../../schema/entity-definition.schema';
-import {
-	GenerateConfigSchema,
-	PipelinesConfigSchema,
-} from '../../schema/pipelines-config.schema';
+import { GenerateConfigSchema } from '../../schema/pipelines-config.schema';
 import { loadEntityFromYaml } from '../../utils/yaml-loader';
 import { loadEntities } from '../../parser/load-entities';
 import { buildDomainGraph } from '../../analyzer/graph-builder';
@@ -258,38 +255,45 @@ describe('external_id_tracking behavior', () => {
 });
 
 // ============================================================================
-// Pipelines Config
+// Per-entity sync mode (ADR-038, FE-1)
 // ============================================================================
 
-describe('pipelines config', () => {
-	it('accepts full config', () => {
-		const result = PipelinesConfigSchema.safeParse({
-			backend: { enabled: true, architecture: 'clean-lite-ps' },
-			frontend: { enabled: true, preset: 'dealbrain' },
-			shared: { enabled: false },
+describe('entity.sync — per-entity frontend sync mode', () => {
+	const base = {
+		entity: { name: 'deal', plural: 'deals', table: 'deals' },
+		fields: { id: { type: 'uuid', required: true } },
+	};
+
+	it('accepts sync: api', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, sync: 'api' },
 		});
 		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.entity.sync).toBe('api');
 	});
 
-	it('accepts empty config (all defaults)', () => {
-		const result = PipelinesConfigSchema.safeParse({});
+	it('accepts sync: electric', () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, sync: 'electric' },
+		});
 		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.entity.sync).toBe('electric');
 	});
 
-	it('rejects invalid architecture', () => {
-		const result = PipelinesConfigSchema.safeParse({
-			backend: { architecture: 'nonexistent' },
+	it('treats sync as optional (absent → undefined, inherits global default)', () => {
+		const result = EntityDefinitionSchema.safeParse(base);
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.entity.sync).toBeUndefined();
+	});
+
+	it("rejects deferred 'offline' mode", () => {
+		const result = EntityDefinitionSchema.safeParse({
+			...base,
+			entity: { ...base.entity, sync: 'offline' },
 		});
 		expect(result.success).toBe(false);
-	});
-
-	it('accepts all architecture targets', () => {
-		for (const arch of ['clean', 'clean-lite', 'clean-lite-ps', 'vertical-slice']) {
-			const result = PipelinesConfigSchema.safeParse({
-				backend: { architecture: arch },
-			});
-			expect(result.success).toBe(true);
-		}
 	});
 });
 

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -2,8 +2,8 @@
  * Shared configuration loader for codegen
  *
  * Loads and caches codegen.config.yaml once, shared by all config modules.
- * Validates the `pipelines` block with Zod if present; passes all other
- * config through as-is for backward compatibility.
+ * Validates the `generate`, `patterns`, and `runtime` blocks with Zod; passes
+ * all other config through as-is.
  */
 
 import fs from 'node:fs';
@@ -12,11 +12,9 @@ import yaml from 'yaml';
 import {
   GenerateConfigSchema,
   PatternsConfigSchema,
-  PipelinesConfigSchema,
   RuntimeModeSchema,
   type GenerateConfig,
   type PatternsConfig,
-  type PipelinesConfig,
   type RuntimeMode,
 } from '../schema/pipelines-config.schema.js';
 
@@ -25,11 +23,10 @@ import {
 // ============================================================================
 
 /**
- * Typed representation of the `pipelines` block.
- * Only this block is Zod-validated; the rest of the config is untyped.
+ * Typed representation of the Zod-validated config blocks (`generate`,
+ * `patterns`, `runtime`). The rest of the config is untyped passthrough.
  */
 export interface ProjectConfig {
-  pipelines?: PipelinesConfig;
   generate?: GenerateConfig;
   /**
    * Array of globs (relative to project root) that `loadAppPatterns()`
@@ -54,9 +51,9 @@ export interface ProjectConfig {
  * Load project-specific codegen configuration from codegen.config.yaml.
  * Returns null if the config file doesn't exist (falls back to defaults).
  *
- * If a `pipelines` block is present it is parsed and validated through
- * PipelinesConfigSchema. A warning is printed on validation failure and
- * the raw value is preserved so nothing else breaks.
+ * The `generate`, `patterns`, and `runtime` blocks are validated through their
+ * Zod schemas (defaults applied even when absent); a warning is printed on
+ * validation failure and the raw value is preserved so nothing else breaks.
  */
 function loadProjectConfig(cwd = process.cwd()): ProjectConfig | null {
   const configPath = path.resolve(cwd, 'codegen.config.yaml');
@@ -68,22 +65,6 @@ function loadProjectConfig(cwd = process.cwd()): ProjectConfig | null {
   try {
     const content = fs.readFileSync(configPath, 'utf-8');
     const raw = yaml.parse(content) as Record<string, unknown>;
-
-    // Validate the pipelines block if present
-    if (raw && typeof raw === 'object' && 'pipelines' in raw && raw.pipelines != null) {
-      const result = PipelinesConfigSchema.safeParse(raw.pipelines);
-      if (result.success) {
-        raw.pipelines = result.data;
-      } else {
-        console.warn(
-          `Warning: codegen.config.yaml has an invalid "pipelines" block:\n` +
-            result.error.issues
-              .map((i) => `  - ${i.path.join('.')}: ${i.message}`)
-              .join('\n')
-        );
-        // Leave raw.pipelines as-is so callers still get something
-      }
-    }
 
     // Validate the generate block (always — we want defaults applied even when absent)
     const rawGenerate = raw && typeof raw === 'object' && 'generate' in raw ? raw.generate : undefined;

--- a/src/config/paths.mjs
+++ b/src/config/paths.mjs
@@ -612,18 +612,6 @@ export function getProjectConfig() {
 }
 
 /**
- * Get pipelines configuration from project config.
- * Returns the pipelines block (or an empty object if not configured).
- *
- * Usage:
- *   const pipelines = getPipelinesConfig();
- *   const arch = pipelines?.backend?.architecture ?? 'clean';
- */
-export function getPipelinesConfig() {
-  return projectConfig?.pipelines ?? {};
-}
-
-/**
  * Resolve the directory codegen writes barrel files to (modules.ts, schema.ts).
  *
  * Honors `paths.generated` from codegen.config.yaml; defaults to 'src/generated'.
@@ -681,7 +669,6 @@ export default {
   getLayoutConfig,
   getDatabaseDialect,
   getProjectConfig,
-  getPipelinesConfig,
   getGenerateConfig,
   getGeneratedDir,
   // NEW: Config-driven naming functions

--- a/src/parser/entity-registry.ts
+++ b/src/parser/entity-registry.ts
@@ -1,0 +1,121 @@
+/**
+ * Cross-Entity Naming Registry (ADR-038, FE-1)
+ *
+ * Loads every entity YAML under a directory and exposes an authoritative
+ * name → naming-record map so FK target names (file, plural, class, collection
+ * var) are resolved against the TARGET entity's own YAML rather than re-derived
+ * by pluralizing strings at emit time. Mirrors the pts generator's
+ * `_resolve_relationship_targets`: no plural is ever inferred — `plural` is read
+ * straight from `entity.plural`.
+ *
+ * Tolerant of invalid files: malformed YAMLs are reported as `AnalysisIssue`s
+ * (same shape as `loadEntities`) rather than thrown, so one bad file does not
+ * sink the whole set.
+ */
+
+import { resolve } from 'node:path';
+import { findYamlFiles } from '../utils/find-yaml-files';
+import { loadEntityFromYaml, type LoadError } from '../utils/yaml-loader';
+import type { AnalysisIssue } from '../analyzer/types';
+
+export interface EntityRegistryEntry {
+	name: string; // 'deal_state'
+	plural: string; // authoritative, from YAML entity.plural
+	table: string;
+	className: string; // 'DealState'  (pascal of name)
+	classNamePlural: string;
+	camelName: string; // 'dealState'
+	pluralCamelName: string;
+	sync: 'api' | 'electric' | null; // null → inherit global frontend.sync.mode
+}
+
+export interface LoadEntityRegistryResult {
+	registry: Map<string, EntityRegistryEntry>; // keyed by entity name
+	issues: AnalysisIssue[]; // invalid YAMLs reported, not thrown
+}
+
+// snake_case → camelCase / PascalCase, consistent with prompt.js helpers.
+const camelCase = (s: string): string =>
+	s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+const pascalCase = (s: string): string => {
+	const camel = camelCase(s);
+	return camel.charAt(0).toUpperCase() + camel.slice(1);
+};
+
+/**
+ * Convert a load error to analysis issues (mirrors `loadEntities`'
+ * `loadErrorToIssue`).
+ */
+function loadErrorToIssue(error: LoadError): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [
+		{
+			severity: 'error',
+			type: 'parse_error',
+			message: error.error,
+			path: error.filePath,
+		},
+	];
+
+	if (error.details) {
+		for (const detail of error.details) {
+			issues.push({
+				severity: 'error',
+				type: 'schema_error',
+				message: detail,
+				path: error.filePath,
+			});
+		}
+	}
+
+	return issues;
+}
+
+/**
+ * Load the cross-entity naming registry from a directory of entity YAMLs.
+ *
+ * @param entitiesDir Directory to walk recursively for `*.yaml`/`*.yml`.
+ * @returns A name-keyed registry plus any issues encountered (missing dir,
+ *   malformed files). Never throws.
+ */
+export function loadEntityRegistry(entitiesDir: string): LoadEntityRegistryResult {
+	const registry = new Map<string, EntityRegistryEntry>();
+	const issues: AnalysisIssue[] = [];
+
+	const resolvedDir = resolve(entitiesDir);
+
+	let files: string[];
+	try {
+		files = findYamlFiles(resolvedDir);
+	} catch {
+		issues.push({
+			severity: 'error',
+			type: 'parse_error',
+			message: `Failed to read directory: ${resolvedDir}`,
+			path: resolvedDir,
+		});
+		return { registry, issues };
+	}
+
+	for (const filePath of files) {
+		const result = loadEntityFromYaml(filePath);
+
+		if (!result.success) {
+			issues.push(...loadErrorToIssue(result));
+			continue;
+		}
+
+		const { entity } = result.definition;
+		registry.set(entity.name, {
+			name: entity.name,
+			plural: entity.plural, // authoritative — never derived
+			table: entity.table,
+			className: pascalCase(entity.name),
+			classNamePlural: pascalCase(entity.plural),
+			camelName: camelCase(entity.name),
+			pluralCamelName: camelCase(entity.plural),
+			sync: entity.sync ?? null,
+		});
+	}
+
+	return { registry, issues };
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -17,6 +17,12 @@ export {
 } from './load-entities';
 
 export {
+	loadEntityRegistry,
+	type EntityRegistryEntry,
+	type LoadEntityRegistryResult,
+} from './entity-registry';
+
+export {
 	validateProviders,
 	collectEntitySurfaces,
 	resolveImportRef,

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -532,6 +532,14 @@ const EntityConfigSchema = z
         "context must be lowercase snake_case (e.g. 'integration')",
       )
       .optional(),
+
+    // ADR-038: per-entity frontend sync mode. Overrides global frontend.sync.mode.
+    //   'api'      → queryCollectionOptions (REST via TanStack Query)
+    //   'electric' → electricCollectionOptions (real-time shape sync)
+    // 'offline' (Electric + Dexie) is deferred — see
+    // docs/specs/2026-06-04-frontend-pipeline-rebuild.md OQ-6.
+    // Sibling to `surface:`/`context:`; lives inside the `entity:` block.
+    sync: z.enum(['api', 'electric']).optional(),
   })
   .strict()
   .refine((d) => !(d.pattern && d.patterns), {

--- a/src/schema/pipelines-config.schema.ts
+++ b/src/schema/pipelines-config.schema.ts
@@ -1,91 +1,13 @@
 import { z } from "zod";
 
 /**
- * Pipelines Configuration Schema
+ * Codegen Configuration Schemas
  *
- * Defines which generation pipelines are enabled and how they are configured.
- * Each pipeline controls a distinct layer of generated output:
- * - backend: NestJS/Clean Architecture scaffolding
- * - frontend: Electric SQL collections, hooks, type metadata
- * - shared: Zod entity schemas in shared packages (e.g., packages/db)
+ * Zod schemas for the survivable `codegen.config.yaml` blocks:
+ * `generate`, `paths`, `patterns`, and the ADR-037 runtime mode. The dead
+ * `pipelines:` block (validated but never consumed) was deleted in ADR-038
+ * FE-1 — `generate.frontend` is the single frontend gate.
  */
-
-// ============================================================================
-// Architecture Target
-// ============================================================================
-
-/**
- * Backend architecture pattern to generate code for
- *
- * - clean: Full Clean Architecture (domain + application + infrastructure + presentation)
- * - clean-lite: Clean Architecture without repository interfaces
- * - clean-lite-ps: Clean Architecture lite with PostgREST-style controllers
- * - vertical-slice: Feature-sliced architecture (all layers co-located per feature)
- */
-export const ArchitectureTargetSchema = z.enum([
-  "clean",
-  "clean-lite",
-  "clean-lite-ps",
-  "vertical-slice",
-]);
-
-export type ArchitectureTarget = z.infer<typeof ArchitectureTargetSchema>;
-
-// ============================================================================
-// Backend Pipeline
-// ============================================================================
-
-/**
- * Backend pipeline configuration
- *
- * Controls NestJS / Clean Architecture code generation.
- */
-export const BackendPipelineSchema = z.object({
-  /** Whether the backend pipeline is active */
-  enabled: z.boolean().default(true),
-  /** Architecture pattern to generate. Defaults to 'clean'. */
-  architecture: ArchitectureTargetSchema.optional().default("clean"),
-});
-
-export type BackendPipeline = z.infer<typeof BackendPipelineSchema>;
-
-// ============================================================================
-// Frontend Pipeline
-// ============================================================================
-
-/**
- * Frontend pipeline configuration
- *
- * Controls Electric SQL collection, hook, and metadata generation.
- */
-export const FrontendPipelineSchema = z.object({
-  /** Whether the frontend pipeline is active */
-  enabled: z.boolean().default(true),
-  /**
-   * Named preset that collapses the ~12 individual frontend config knobs
-   * into a single opinionated bundle. Resolved elsewhere in the codegen.
-   * Examples: 'tanstack-electric'
-   */
-  preset: z.string().optional(),
-});
-
-export type FrontendPipeline = z.infer<typeof FrontendPipelineSchema>;
-
-// ============================================================================
-// Shared Pipeline
-// ============================================================================
-
-/**
- * Shared pipeline configuration
- *
- * Controls generation of Zod entity schemas in shared packages (packages/db).
- */
-export const SharedPipelineSchema = z.object({
-  /** Whether the shared pipeline is active */
-  enabled: z.boolean().default(true),
-});
-
-export type SharedPipeline = z.infer<typeof SharedPipelineSchema>;
 
 // ============================================================================
 // Generate Config
@@ -95,9 +17,9 @@ export type SharedPipeline = z.infer<typeof SharedPipelineSchema>;
  * Top-level entity generation toggle schema.
  *
  * The `generate` block in `codegen.config.yaml` controls which pipelines the
- * entity generator walks and which coarse-grained outputs it produces. It is
- * intentionally narrower than the `pipelines` block — these are user-facing
- * switches, not pipeline-internal wiring.
+ * entity generator walks and which coarse-grained outputs it produces. These
+ * are the user-facing generation switches (`generate.frontend` is the single
+ * frontend gate since ADR-038 FE-1 dropped the dead `pipelines:` block).
  *
  * Keys validated here:
  * - `architecture`: which backend architecture flavor to emit. Selects one of
@@ -160,38 +82,6 @@ export const PathsConfigSchema = z
 export type PathsConfig = z.infer<typeof PathsConfigSchema>;
 
 // ============================================================================
-// Top-Level Pipelines Config
-// ============================================================================
-
-/**
- * Complete pipelines configuration block
- *
- * All pipelines are optional — omitting a pipeline keeps the existing behavior
- * (no structured pipeline config, generation driven by individual toggles).
- *
- * Example in codegen.config.yaml:
- *
- * ```yaml
- * pipelines:
- *   backend:
- *     enabled: true
- *     architecture: clean-lite-ps
- *   frontend:
- *     enabled: true
- *     preset: tanstack-electric
- *   shared:
- *     enabled: true
- * ```
- */
-export const PipelinesConfigSchema = z.object({
-  backend: BackendPipelineSchema.optional(),
-  frontend: FrontendPipelineSchema.optional(),
-  shared: SharedPipelineSchema.optional(),
-});
-
-export type PipelinesConfig = z.infer<typeof PipelinesConfigSchema>;
-
-// ============================================================================
 // Patterns Config (ADR-031, PATTERN-5)
 // ============================================================================
 
@@ -241,31 +131,3 @@ export type PatternsConfig = z.infer<typeof PatternsConfigSchema>;
 export const RuntimeModeSchema = z.enum(['package', 'vendored']).default('package');
 
 export type RuntimeMode = z.infer<typeof RuntimeModeSchema>;
-
-// ============================================================================
-// Validation Helpers
-// ============================================================================
-
-/**
- * Parse and validate a pipelines config block.
- * @throws ZodError if validation fails
- */
-export function validatePipelinesConfig(data: unknown): PipelinesConfig {
-  return PipelinesConfigSchema.parse(data);
-}
-
-/**
- * Safely validate a pipelines config block.
- * Returns { success: true, data } or { success: false, error }.
- */
-export function safeValidatePipelinesConfig(data: unknown): {
-  success: boolean;
-  data?: PipelinesConfig;
-  error?: z.ZodError;
-} {
-  const result = PipelinesConfigSchema.safeParse(data);
-  if (result.success) {
-    return { success: true, data: result.data };
-  }
-  return { success: false, error: result.error };
-}

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -20,7 +20,6 @@ import {
   getLayoutConfig,
   getDatabaseDialect,
   getProjectConfig,
-  getPipelinesConfig,
   getGenerateConfig,
 } from "../../../src/config/paths.mjs";
 import { getNamingConfig } from "../../../src/config/naming-config.mjs";

--- a/test/fixtures/codegen.config.yaml
+++ b/test/fixtures/codegen.config.yaml
@@ -50,16 +50,6 @@ locations:
     path: packages/api/src/constants
     import: "@api/constants"
 
-pipelines:
-  backend:
-    enabled: true
-    architecture: clean
-  frontend:
-    enabled: true
-    preset: dealbrain
-  shared:
-    enabled: true
-
 generate:
   architecture: clean
   frontend: false


### PR DESCRIPTION
## ADR-038 FE-1 — schema + naming groundwork

First of the FE-1..FE-4 stack (see `docs/specs/2026-06-04-frontend-pipeline-rebuild.md`).

- `entity.sync: api | electric` — per-entity frontend sync mode in `EntityConfigSchema` (sibling to `surface:`/`context:`; `offline` deferred per spec OQ-6)
- `src/parser/entity-registry.ts` — cross-entity naming registry; plurals read from YAML, never derived (kills the 3-way pluralization divergence at the root)
- Deleted the dead `pipelines:` config surface (`PipelinesConfigSchema`, config-loader validation, `getPipelinesConfig`) — `generate.frontend` is the single gate

### Validation
| Gate | Result |
|---|---|
| `just test-unit` | 2574 pass / 0 fail |
| `bun run typecheck` | no new errors (3 pre-existing in junction.ts/barrel-generator.ts, byte-identical to base) |
| `just test-baseline` | pass — no emission change |
| Scope | 12 files, 1:1 with spec Files table |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
