### PR TITLE
fix(jobs,events): LISTEN/NOTIFY listener survives app.close() — race-safe teardown (LISTEN-NOTIFY-2, 0.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.2] — 2026-06-04
+
+**Shutdown leak fix** (LISTEN-NOTIFY-2; swe-brain dogfood). With
+`listen_notify: true` (the LISTEN/NOTIFY wake extension shipped in 0.16.0), a
+Nest app that booted and then `app.close()`d — e.g. a boot-check / CI smoke step —
+never exited: at least one `LISTEN codegen_jobs_wake` client survived
+`app.close()`, holding an ESTABLISHED Postgres socket open forever (two swe-brain
+CI runs hung for hours). Backward-compatible; affects only consumers that opted
+into `listen_notify`.
+
+### Fixed
+
+- **`PgNotifyListener.stop()` is race-safe against an in-flight `connect()`**
+  (LISTEN-NOTIFY-2 RC1 — the defect that actually fired). `connect()` checked
+  `this.stopped` only at entry, then `await pool.connect()`, wired handlers,
+  issued `LISTEN`, and assigned `this.client` last. A `stop()` arriving during
+  the checkout await ran `releaseClient()` against a still-null `this.client`
+  (released nothing); the resuming `connect()` then assigned the client and
+  issued `LISTEN` — leaking a checked-out connection with no owner left to
+  release it. With 5–6 listeners (one per jobs pool + the events drainer) all
+  starting at bootstrap and a tight `app.close()`, the race fired on ~1 of 6
+  listeners — exactly the observed signature (one survivor, the rest clean).
+  Now `connect()` re-checks `stopped` after the checkout AND after `LISTEN`,
+  destroying the just-acquired client and bailing before assignment; `stop()`
+  tracks and awaits the in-flight connect promise before its own release, so
+  `app.close()` can't return while a checkout is still mid-flight. Releases use
+  `release(true)` (destroy) so a half-listening socket is never reused.
+- **`JobWorker.onModuleDestroy` stops the wake listener on EVERY destroy path**
+  (LISTEN-NOTIFY-2 RC2 — latent). The listener `stop()` lived only on the first
+  (non-`shuttingDown`) branch, so a SIGTERM-then-Nest double-destroy hit the
+  `if (this.shuttingDown) { …; return; }` early return and skipped it, leaking
+  the listener under the normal SIGTERM shutdown path. Teardown is now an
+  idempotent `stopNotifyListener()` called unconditionally at the top of every
+  destroy. `DrizzleEventBus` already stopped its listener unconditionally; it
+  shared `PgNotifyListener` and so benefits from the RC1 fix directly.
+
 ## [0.17.1] — 2026-06-04
 
 **Two dogfood fixes that bit the same swe-brain mutation drain** (ADR-0009

--- a/docs/specs/LISTEN-NOTIFY-2.md
+++ b/docs/specs/LISTEN-NOTIFY-2.md
@@ -1,0 +1,132 @@
+# LISTEN-NOTIFY-2 — shutdown leak: a `LISTEN %wake%` listener survives `app.close()`
+
+**Issue:** swe-brain dogfood — boot-check / CI hang on `@pattern-stack/codegen` 0.17.1
+**Status:** Implemented
+**Last Updated:** 2026-06-04
+**Depends on:** LISTEN-NOTIFY-1 (0.16.0 — the wake listener this hardens)
+**Related ADR:** ADR-022 (Job Orchestration — §Drizzle extensions), ADR-024 (Events Domain)
+**Version:** 0.17.2 (patch)
+
+## Overview
+
+LISTEN-NOTIFY-1 (0.16.0) added `PgNotifyListener` — a dedicated `pg.PoolClient`
+that issues `LISTEN codegen_jobs_wake` / `codegen_events_wake` to wake the poll
+loop on commit. One listener per jobs pool worker + one for the events drainer.
+
+The swe-brain dogfood found that a NestJS app booted via
+`NestFactory.createApplicationContext(AppModule)`, then `app.close()`d (its
+`boot-check.ts`, also a CI step), **never exits**: at least one
+`LISTEN codegen_jobs_wake` client survives `app.close()`, holding an ESTABLISHED
+pg socket open forever. Two swe-brain CI runs hung for hours.
+
+Evidence: 22 s after close, `lsof` showed exactly one TCP connection to Postgres;
+`pg_stat_activity` showed that backend's last query was `LISTEN codegen_jobs_wake`
+(started at boot). The events listener and the *other* pool workers' listeners
+cleaned up — only **one** of six jobs listeners survived. A healthy running app
+shows 6 LISTEN backends (1 events + 5 jobs pools), one per pool worker.
+
+## Root cause
+
+Two defects in the shared listener teardown; the **first is what actually fired**
+in the swe-brain sample, the second is a latent hardening:
+
+### RC1 (fired) — `stop()` races an in-flight `connect()`
+
+`PgNotifyListener.connect()` checked `this.stopped` only at *entry*. The body
+then `await this.opts.pool.connect()`, wired handlers, issued `LISTEN`, and
+**finally** assigned `this.client = client`. A `stop()` arriving during the
+`pool.connect()` await ran `releaseClient()`, which saw `this.client === null`
+(nothing checked out yet) and returned. The in-flight `connect()` then resumed,
+assigned the client, and issued `LISTEN` — **leaking a checked-out connection
+holding `LISTEN <channel>` with no owner left to release it.**
+
+With 5–6 listeners all starting at bootstrap and `app.close()` arriving
+~immediately (a boot-check), this race fires on ~1 of 6 listeners — exactly the
+observed signature (one survivor, the rest clean). The race is timing-sensitive:
+a close with even a ~250 ms settle delay usually lets `connect()` finish first
+(so `stop()` finds an assigned client and releases it); a *tight* close — the
+boot-check shape — reliably loses the race on one listener.
+
+### RC2 (latent) — `JobWorker.onModuleDestroy` early-return skipped listener stop
+
+`JobWorker.onModuleDestroy()` has a double-fire guard: SIGTERM invokes
+`onModuleDestroy`, then Nest invokes it again, hitting
+`if (this.shuttingDown) { await this.drainInFlight(); return; }`. The
+`notifyListener.stop()` call lived **only on the first (non-`shuttingDown`)
+branch**, so a SIGTERM-then-Nest double-destroy (or any path that set
+`shuttingDown` before the listener was stopped) skipped the listener teardown.
+Not the trigger in the boot-check sample (no SIGTERM there), but a real leak
+under the standard SIGTERM shutdown path.
+
+`DrizzleEventBus.onModuleDestroy` already stopped its listener unconditionally
+and has no double-fire path, but it shares `PgNotifyListener` and was therefore
+equally exposed to RC1 (it just didn't fire in the sample).
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `runtime/subsystems/jobs/pg-notify.ts` | edit | RC1 fix. Split `connect()` into a tracked `connecting` promise + `doConnect()`. Re-check `this.stopped` AFTER `pool.connect()` resolves and AFTER `LISTEN` — if stopped, release the raw client and bail before assignment. `stop()` awaits the in-flight `connecting` promise before its own `releaseClient()`. New `releaseRawClient()` helper shared by the normal release path + the race bail-outs. |
+| `runtime/subsystems/jobs/job-worker.ts` | edit | RC2 fix. Hoist listener teardown into `stopNotifyListener()` (idempotent) and call it on EVERY `onModuleDestroy` path, including the `shuttingDown` early return. |
+| `src/__tests__/runtime/subsystems/listen-notify.spec.ts` | edit | §6 — deterministic unit proof of RC1: a controllable `pool.connect()` / `LISTEN` gate forces the race; asserts the checked-out client is released and `LISTEN` never survives. Plus a test that `stop()` does not resolve while a checkout is in flight. |
+| `test/integration/listen-notify-shutdown-leak.drizzle.integration.test.ts` | create | Integration falsifier: boots a real Nest context (jobs allPools + events, `listen_notify` on) against a Postgres testcontainer, `app.close()`s in a loop, asserts zero surviving `LISTEN %wake%` backends in `pg_stat_activity`. |
+| `justfile` | edit | `test-listen-notify-leak-integration` recipe. |
+| `CHANGELOG.md` | edit | 0.17.2 entry. |
+| `package.json` | edit | version bump → 0.17.2 (done at release time / by Doug). |
+
+## Decisions
+
+### D1 — Re-check `stopped` after every await in `connect()`, not just at entry
+
+The checkout (`pool.connect()`) and the `LISTEN` round-trip are both async
+suspension points where a `stop()` can interleave. Each is followed by an
+`if (this.stopped) { releaseRawClient(client); return; }` guard so a stop that
+lands in either window destroys the just-acquired client and never assigns it.
+`release(true)` (destroy) is used so a half-listening socket is never returned to
+the pool for reuse.
+
+### D2 — `stop()` awaits the in-flight `connect()`
+
+Tracking `this.connecting` (set for the duration of `doConnect()`) lets `stop()`
+`await` it before releasing. This guarantees `stop()` (and therefore
+`onModuleDestroy` / `app.close()`) does not return while a checkout is still
+mid-flight — without it, `app.close()` could resolve, the process could move to
+exit, and a resuming `connect()` could still issue `LISTEN` on a doomed socket.
+`stopped` is set *first* (before the await) so the awaited `connect()` self-bails
+via D1; the await is purely a teardown barrier.
+
+### D3 — Listener stop on every JobWorker destroy path
+
+`onModuleDestroy` now calls `stopNotifyListener()` unconditionally at the top,
+before the `shuttingDown` early-return branch. The helper nulls
+`notifyListener` first so a second invocation (SIGTERM + Nest) no-ops. Combined
+with D1/D2 the worker releases its listener exactly once, on whichever destroy
+path arrives first, even under double-fire.
+
+### D4 — Falsifier must fire the race, not pass by luck
+
+A single-listener, single-run, settle-delayed close passes pre-fix (the race
+window closes before `stop()`). The proof therefore comes in two forms:
+- **Unit (deterministic):** a hand-gated `pool.connect()` / `LISTEN` holds the
+  checkout open precisely across the `stop()` call — the race fires every run.
+  These three tests fail pre-fix, pass post-fix.
+- **Integration (real path):** 6 real listeners (5 jobs pools + 1 events) +
+  repeated *tight* `app.close()` cycles against a real Postgres. The no-settle
+  variant reliably leaks pre-fix (the suite times out — the exact boot-check
+  hang); both variants pass post-fix with zero `LISTEN %wake%` survivors.
+
+## Tests
+
+| Test | Asserts |
+|------|---------|
+| `listen-notify.spec` §6 (3 cases) | RC1: stop()-during-`pool.connect()` releases the client + never LISTENs; stop()-during-`LISTEN` releases the client; `stop()` does not resolve while a checkout is in flight (then releases it). All FAIL pre-fix, PASS post-fix. |
+| `listen-notify-shutdown-leak.drizzle.integration` (2 cases) | Real Nest boot (6 LISTEN backends) → `app.close()` → zero surviving `LISTEN %wake%` in `pg_stat_activity`, over repeated cycles; one settled + one tight-race variant. Tight variant times out (leaks) pre-fix; both pass post-fix. Skips gracefully without Docker. |
+| existing `listen-notify.spec` §1–§5 | unchanged green (no behaviour change to the happy path). |
+| `just test-unit` (2574 tests) | unchanged green. |
+
+## Consumer follow-up
+
+swe-brain shipped a consumer-side mitigation — an explicit `process.exit(0)` in
+its `boot-check.ts` (commit `f283b6c`) — to stop the CI hang. Once 0.17.2 is
+published and consumed, that mitigation is **revertible**: the framework now
+releases the listener on close, so the process exits on its own.

--- a/justfile
+++ b/justfile
@@ -160,6 +160,15 @@ test-obs-integration:
 test-jobs-fnkey-integration:
     bun test "{{justfile_directory()}}/test/integration/jobs-fn-concurrency-key.drizzle.integration.test.ts"
 
+# LISTEN-NOTIFY-2 (0.17.2) — `app.close()` leaves ZERO surviving LISTEN %wake%
+# backends. Boots a real Nest context with listen_notify ON (jobs + events)
+# against a real Postgres (testcontainers), closes it, and asserts pg_stat_activity
+# shows no orphaned listener sockets. Spins its own ephemeral postgres:16; skips
+# gracefully when Docker is unavailable. NOT in test-unit/CI unit run. Proves the
+# swe-brain boot-check / CI hang (a stop() racing PgNotifyListener.connect()) is gone.
+test-listen-notify-leak-integration:
+    bun test "{{justfile_directory()}}/test/integration/listen-notify-shutdown-leak.drizzle.integration.test.ts"
+
 # Run the full scaffold validation (Docker + codegen + NestJS + CRUD)
 validate:
     bash test/scaffold/validate.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/jobs/job-worker.ts
+++ b/runtime/subsystems/jobs/job-worker.ts
@@ -317,6 +317,17 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleDestroy(): Promise<void> {
+    // LISTEN-NOTIFY-2 — release the listener connection on EVERY destroy path,
+    // including the `shuttingDown` early-return below (reached when SIGTERM and
+    // Nest's onModuleDestroy both fire) and a destroy with no prior SIGTERM.
+    // Previously this lived only on the first (non-shuttingDown) branch, so a
+    // double-fire — or a stop() that raced the listener's own in-flight
+    // connect() — left a `LISTEN codegen_jobs_wake` socket open past
+    // `app.close()`, hanging the process. `PgNotifyListener.stop()` is itself
+    // idempotent + connect-race-safe (LISTEN-NOTIFY-2). Best-effort; a failure
+    // here doesn't block the drain.
+    await this.stopNotifyListener();
+
     if (this.shuttingDown) {
       // Still drain, but don't tear intervals down twice.
       await this.drainInFlight();
@@ -332,17 +343,6 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
       this.sweeperTimer = null;
     }
     process.removeListener('SIGTERM', this.sigtermHandler);
-
-    // LISTEN-NOTIFY-1 — release the listener connection so the process can exit
-    // cleanly. Best-effort; a failure here doesn't block the drain.
-    if (this.notifyListener) {
-      try {
-        await this.notifyListener.stop();
-      } catch (err) {
-        this.logger.error(`notify listener stop failed: ${(err as Error).message}`);
-      }
-      this.notifyListener = null;
-    }
 
     await this.drainInFlight();
 
@@ -368,6 +368,24 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
       Promise.allSettled([...this.inFlight]).then(() => undefined),
       timeout,
     ]);
+  }
+
+  /**
+   * LISTEN-NOTIFY-2 — stop + drop the wake listener. Idempotent: a second call
+   * (SIGTERM + Nest destroy) finds `notifyListener` already null and no-ops.
+   * `PgNotifyListener.stop()` is itself race-safe against an in-flight
+   * `connect()`, so even a destroy that arrives microseconds after `start()`
+   * releases the listener socket rather than leaking it.
+   */
+  private async stopNotifyListener(): Promise<void> {
+    const listener = this.notifyListener;
+    if (!listener) return;
+    this.notifyListener = null;
+    try {
+      await listener.stop();
+    } catch (err) {
+      this.logger.error(`notify listener stop failed: ${(err as Error).message}`);
+    }
   }
 
   // ============================================================================

--- a/runtime/subsystems/jobs/pg-notify.ts
+++ b/runtime/subsystems/jobs/pg-notify.ts
@@ -111,6 +111,17 @@ export class PgNotifyListener {
   private readonly backoffMaxMs: number;
   /** WARN-once gate so a flapping listener doesn't spam the log. */
   private warnedDown = false;
+  /**
+   * LISTEN-NOTIFY-2 — the in-flight `connect()` promise, set while a checkout is
+   * mid-`await`. `stop()` awaits it so a `stop()` that races a still-resolving
+   * `connect()` can't return before the connect either assigns `this.client`
+   * (then released by `releaseClient`) or self-releases the checked-out client.
+   * Without this, a `stop()` arriving during `pool.connect()`'s await saw
+   * `this.client === null` (nothing to release), then `connect()` resumed,
+   * assigned the client, and issued `LISTEN` — leaking an ESTABLISHED socket
+   * holding `LISTEN <channel>` forever past `app.close()`.
+   */
+  private connecting: Promise<void> | null = null;
 
   constructor(private readonly opts: PgNotifyListenerOptions) {
     this.logger = new Logger(`PgNotifyListener(${opts.label})`);
@@ -125,20 +136,56 @@ export class PgNotifyListener {
     await this.connect();
   }
 
-  /** Stop listening + release the connection. Safe to call repeatedly. */
+  /**
+   * Stop listening + release the connection. Safe to call repeatedly and
+   * race-safe against an in-flight `connect()` (LISTEN-NOTIFY-2): it sets
+   * `stopped` first (so a resuming `connect()` self-releases its checkout),
+   * then awaits any in-flight connect, then releases whatever client landed.
+   */
   async stop(): Promise<void> {
     this.stopped = true;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    // Await an in-flight checkout so we don't return while a client is still
+    // mid-`pool.connect()`. The resuming `connect()` sees `stopped` and either
+    // self-releases its checkout or assigns `this.client`; either way the
+    // `releaseClient()` below mops up.
+    const inflight = this.connecting;
+    if (inflight) {
+      try {
+        await inflight;
+      } catch {
+        // connect failures are handled inside connect(); ignore here.
+      }
+    }
     await this.releaseClient();
   }
 
   private async connect(): Promise<void> {
     if (this.stopped) return;
+    // Track this checkout so a racing stop() can await it (LISTEN-NOTIFY-2).
+    const attempt = this.doConnect();
+    this.connecting = attempt;
+    try {
+      await attempt;
+    } finally {
+      if (this.connecting === attempt) this.connecting = null;
+    }
+  }
+
+  private async doConnect(): Promise<void> {
     try {
       const client = await this.opts.pool.connect();
+      // Re-check AFTER the await resolves: a stop() may have fired while this
+      // checkout was in flight. If so, release the just-checked-out client
+      // right here and bail BEFORE wiring handlers / issuing LISTEN — otherwise
+      // we'd leak an ESTABLISHED listener socket past shutdown (LISTEN-NOTIFY-2).
+      if (this.stopped) {
+        await this.releaseRawClient(client);
+        return;
+      }
       client.on('notification', (msg) => {
         if (msg.channel !== this.opts.channel) return;
         try {
@@ -154,6 +201,11 @@ export class PgNotifyListener {
         this.handleDrop();
       });
       await client.query(`LISTEN ${this.opts.channel}`);
+      // A stop() could have fired during the LISTEN round-trip too — same guard.
+      if (this.stopped) {
+        await this.releaseRawClient(client);
+        return;
+      }
       this.client = client;
       // Recovery: only announce if we had previously warned about being down.
       if (this.warnedDown) {
@@ -202,11 +254,19 @@ export class PgNotifyListener {
     const client = this.client;
     this.client = null;
     if (!client) return;
+    await this.releaseRawClient(client);
+  }
+
+  /**
+   * Tear down a raw checked-out client (LISTEN-NOTIFY-2). Used both by the
+   * normal `releaseClient()` path and by the connect-vs-stop race bail-outs,
+   * where the client was checked out but never assigned to `this.client`.
+   * Destroys (`release(true)`) so a half-listening socket is never reused.
+   */
+  private async releaseRawClient(client: PgListenClient): Promise<void> {
     try {
       client.removeAllListeners?.('notification');
       client.removeAllListeners?.('error');
-      // A listener client is a checked-out pool connection; release it back
-      // with `release(true)` (destroy) so a half-broken socket isn't reused.
       if (client.release) client.release(true);
       else if (client.end) await client.end();
     } catch {

--- a/src/__tests__/runtime/subsystems/listen-notify.spec.ts
+++ b/src/__tests__/runtime/subsystems/listen-notify.spec.ts
@@ -386,3 +386,148 @@ describe('PgNotifyListener — degradation + recovery', () => {
     await listener.stop();
   });
 });
+
+// ─── 6. PgNotifyListener — stop()/connect() race (LISTEN-NOTIFY-2) ─────────────
+//
+// The shutdown leak: a stop() that fires while connect() is mid-`pool.connect()`
+// used to see `this.client === null` (nothing to release), then connect()
+// resumed, assigned the client, and issued `LISTEN` — leaking an ESTABLISHED
+// listener socket past `app.close()`. These tests force the race deterministically
+// with a controllable `pool.connect()` / `LISTEN` (manual promises) and assert the
+// checked-out client is RELEASED and `LISTEN` is never wired into a surviving
+// client. Pre-fix all three fail; post-fix all pass.
+
+describe('PgNotifyListener — stop() racing an in-flight connect() (LISTEN-NOTIFY-2)', () => {
+  /** A controllable client whose checkout + LISTEN we can gate by hand. */
+  function makeControllableClient() {
+    const listenCalls: string[] = [];
+    let released = false;
+    const client = {
+      query: mock(async (text: string) => {
+        if (text.startsWith('LISTEN')) listenCalls.push(text);
+        return {};
+      }),
+      on: mock(() => {}),
+      removeAllListeners: mock(() => {}),
+      release: mock(() => {
+        released = true;
+      }),
+    };
+    return {
+      client,
+      listenCalls,
+      get released() {
+        return released;
+      },
+    };
+  }
+
+  it('releases the checked-out client when stop() fires during pool.connect()', async () => {
+    const ctl = makeControllableClient();
+    // Gate the checkout: connect() awaits this until we resolve it.
+    let resolveConnect!: (c: unknown) => void;
+    const connectGate = new Promise((res) => {
+      resolveConnect = res;
+    });
+    const pool = {
+      connect: mock(() => connectGate),
+    };
+
+    const listener = new PgNotifyListener({
+      channel: JOBS_WAKE_CHANNEL,
+      pool: pool as never,
+      label: 'race',
+      onNotify: () => {},
+    });
+
+    // start() kicks off connect(); it parks on the gated pool.connect().
+    const starting = listener.start();
+    // stop() arrives WHILE the checkout is in flight (the race window).
+    const stopping = listener.stop();
+    // Now let the checkout resolve — connect() resumes and MUST notice stopped.
+    resolveConnect(ctl.client);
+
+    await Promise.all([starting, stopping]);
+
+    // Pre-fix: connect() assigned the client and issued LISTEN → leak.
+    // Post-fix: the resumed connect() sees `stopped`, releases the client,
+    // and never wires LISTEN.
+    expect(ctl.released).toBe(true);
+    expect(ctl.listenCalls).toEqual([]);
+  });
+
+  it('releases the client when stop() fires during the LISTEN round-trip', async () => {
+    const listenCalls: string[] = [];
+    let released = false;
+    let resolveListen!: () => void;
+    const listenGate = new Promise<void>((res) => {
+      resolveListen = res;
+    });
+    const client = {
+      query: mock(async (text: string) => {
+        if (text.startsWith('LISTEN')) {
+          listenCalls.push(text);
+          await listenGate; // park inside LISTEN
+        }
+        return {};
+      }),
+      on: mock(() => {}),
+      removeAllListeners: mock(() => {}),
+      release: mock(() => {
+        released = true;
+      }),
+    };
+    const pool = { connect: mock(async () => client) };
+
+    const listener = new PgNotifyListener({
+      channel: JOBS_WAKE_CHANNEL,
+      pool: pool as never,
+      label: 'race-listen',
+      onNotify: () => {},
+    });
+
+    const starting = listener.start();
+    // Let the checkout resolve + LISTEN begin, then fire stop() mid-LISTEN.
+    await new Promise((r) => setTimeout(r, 0));
+    const stopping = listener.stop();
+    resolveListen();
+
+    await Promise.all([starting, stopping]);
+
+    // The client must be released even though LISTEN was issued — the post-LISTEN
+    // stopped-recheck destroys the socket so nothing survives shutdown.
+    expect(released).toBe(true);
+  });
+
+  it('stop() awaits an in-flight connect() (no early return that leaves a checkout dangling)', async () => {
+    const ctl = makeControllableClient();
+    let resolveConnect!: (c: unknown) => void;
+    const connectGate = new Promise((res) => {
+      resolveConnect = res;
+    });
+    const pool = { connect: mock(() => connectGate) };
+
+    const listener = new PgNotifyListener({
+      channel: JOBS_WAKE_CHANNEL,
+      pool: pool as never,
+      label: 'race-await',
+      onNotify: () => {},
+    });
+
+    void listener.start();
+    let stopResolved = false;
+    const stopping = listener.stop().then(() => {
+      stopResolved = true;
+    });
+
+    // stop() must NOT resolve while the checkout is still pending — otherwise
+    // app.close() returns before the listener is actually torn down.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(stopResolved).toBe(false);
+
+    resolveConnect(ctl.client);
+    await stopping;
+    expect(stopResolved).toBe(true);
+    expect(ctl.released).toBe(true);
+  });
+});

--- a/test/integration/listen-notify-shutdown-leak.drizzle.integration.test.ts
+++ b/test/integration/listen-notify-shutdown-leak.drizzle.integration.test.ts
@@ -1,0 +1,323 @@
+/**
+ * LISTEN-NOTIFY-2 (0.17.2) — `app.close()` must leave ZERO surviving
+ * `LISTEN %wake%` backends, against a REAL Postgres (testcontainers).
+ *
+ * The dogfood leak (swe-brain boot-check on 0.17.1): with `listen_notify: true`
+ * on the drizzle jobs backend (and events), a Nest app that boots, resolves
+ * providers, and calls `app.close()` never exits — at least one
+ * `LISTEN codegen_jobs_wake` client survives close, holding an ESTABLISHED pg
+ * socket forever. A healthy running app shows N+1 LISTEN backends (one events
+ * drainer + one per jobs pool worker); after close there must be zero.
+ *
+ * Root cause: a `stop()` racing an in-flight `PgNotifyListener.connect()` — the
+ * checkout resolved AFTER `releaseClient()` ran, so the resumed connect()
+ * assigned the client and issued `LISTEN`, leaking it. With 5 jobs pools + 1
+ * events drainer all starting at bootstrap and `app.close()` arriving ~at once,
+ * the race fires on ~1 of 6 listeners. This falsifier reproduces the real path
+ * (full Nest context, real pg sockets, real LISTEN) and asserts the leak is
+ * gone. The deterministic unit-level proof of the race seam lives in
+ * `src/__tests__/runtime/subsystems/listen-notify.spec.ts` §6.
+ *
+ * Self-contained / CI-friendly: spins its own ephemeral `postgres:16` via
+ * testcontainers and skips gracefully (not fails) when Docker is unavailable —
+ * mirrors `jobs-fn-concurrency-key.drizzle.integration.test.ts`. NOT part of
+ * `just test-unit`; run via `just test-listen-notify-leak-integration`.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Wait } from 'testcontainers';
+import { Global, Module, type DynamicModule } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+import { DRIZZLE } from '../../runtime/constants/tokens';
+import { EventsModule } from '../../runtime/subsystems/events/events.module';
+import { JobWorkerModule } from '../../runtime/subsystems/jobs/job-worker.module';
+import {
+  JobHandlerBase,
+  JOB_HANDLER_REGISTRY,
+  type JobContext,
+  type JobHandlerMeta,
+} from '../../runtime/subsystems/jobs/job-handler.base';
+import type { DrizzleClient } from '../../runtime/types/drizzle';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Docker availability probe → skip gracefully when absent.
+// ────────────────────────────────────────────────────────────────────────────
+
+async function dockerIsAvailable(): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(['docker', 'info'], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+    return (await proc.exited) === 0;
+  } catch {
+    return false;
+  }
+}
+
+const DOCKER_OK = await dockerIsAvailable();
+if (!DOCKER_OK) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[listen-notify-leak integration] Docker not available — skipping testcontainers Postgres suite.',
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// DDL — jobs (job + job_run) AND the events outbox. Mirrors the schema files
+// closely enough to boot the worker module + events drainer end-to-end.
+// ────────────────────────────────────────────────────────────────────────────
+
+const DDL = /* sql */ `
+DO $$ BEGIN
+  CREATE TYPE job_run_status AS ENUM
+    ('pending','running','waiting','completed','failed','timed_out','canceled');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_collision_mode AS ENUM ('queue','reject','replace');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_replay_from AS ENUM ('scratch','last_step','last_checkpoint');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_parent_close_policy AS ENUM ('terminate','cancel','abandon');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_wait_kind AS ENUM ('signal');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+DO $$ BEGIN
+  CREATE TYPE job_trigger_source AS ENUM ('manual','schedule','event','parent');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+CREATE TABLE IF NOT EXISTS job (
+  type                     text PRIMARY KEY,
+  version                  integer NOT NULL DEFAULT 1,
+  pool                     text NOT NULL,
+  scope_entity_type        text,
+  retry_policy             jsonb NOT NULL,
+  timeout_ms               integer,
+  concurrency_key_template text,
+  collision_mode           job_collision_mode NOT NULL DEFAULT 'queue',
+  dedupe_key_template      text,
+  dedupe_window_ms         integer,
+  priority_default         integer NOT NULL DEFAULT 0,
+  replay_from              job_replay_from NOT NULL DEFAULT 'last_checkpoint',
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS job_run (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_type            text NOT NULL REFERENCES job(type),
+  job_version         integer NOT NULL,
+  parent_run_id       uuid REFERENCES job_run(id),
+  root_run_id         uuid NOT NULL,
+  parent_close_policy job_parent_close_policy NOT NULL DEFAULT 'terminate',
+  scope_entity_type   text,
+  scope_entity_id     text,
+  tenant_id           text,
+  tags                jsonb NOT NULL DEFAULT '{}',
+  pool                text NOT NULL,
+  priority            integer NOT NULL DEFAULT 0,
+  concurrency_key     text,
+  dedupe_key          text,
+  status              job_run_status NOT NULL DEFAULT 'pending',
+  input               jsonb NOT NULL,
+  output              jsonb,
+  error               jsonb,
+  trigger_source      job_trigger_source NOT NULL,
+  trigger_ref         text,
+  run_at              timestamptz NOT NULL DEFAULT now(),
+  started_at          timestamptz,
+  finished_at         timestamptz,
+  claimed_at          timestamptz,
+  attempts            integer NOT NULL DEFAULT 0,
+  wait_kind           job_wait_kind,
+  resume_token        text,
+  wait_deadline       timestamptz,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS domain_events (
+  id            uuid PRIMARY KEY,
+  type          text NOT NULL,
+  aggregate_id  text NOT NULL,
+  aggregate_type text NOT NULL,
+  payload       jsonb NOT NULL,
+  occurred_at   timestamptz NOT NULL,
+  processed_at  timestamptz,
+  status        text NOT NULL DEFAULT 'pending',
+  error         text,
+  metadata      jsonb,
+  pool          text,
+  direction     text,
+  tier          text NOT NULL DEFAULT 'domain',
+  tenant_id     text,
+  CONSTRAINT domain_events_tier_routing_check
+    CHECK (tier in ('domain','audit')
+      AND ((tier = 'audit') = (pool is null and direction is null)))
+);
+`;
+
+// A trivial handler so the worker module's boot validator + spawn proceed.
+const JOB_TYPE = 'listen_notify_leak_noop';
+class NoopHandler extends JobHandlerBase<Record<string, unknown>, void> {
+  async run(_ctx: JobContext<Record<string, unknown>>): Promise<void> {}
+}
+const META: JobHandlerMeta<Record<string, unknown>> = { pool: 'batch' };
+
+// ────────────────────────────────────────────────────────────────────────────
+// Container + connection string.
+// ────────────────────────────────────────────────────────────────────────────
+
+let container: import('@testcontainers/postgresql').StartedPostgreSqlContainer;
+let connectionString: string;
+
+beforeAll(async () => {
+  if (!DOCKER_OK) return;
+  const { PostgreSqlContainer } = await import('@testcontainers/postgresql');
+  container = await new PostgreSqlContainer('postgres:16')
+    .withWaitStrategy(Wait.forHealthCheck())
+    .withStartupTimeout(60_000)
+    .start();
+  connectionString = container.getConnectionUri();
+
+  const ddlPool = new Pool({ connectionString });
+  await ddlPool.query(DDL);
+  await ddlPool.end();
+
+  // Register the noop handler once for all boots in this suite.
+  JOB_HANDLER_REGISTRY.set(JOB_TYPE, {
+    type: JOB_TYPE,
+    meta: META as JobHandlerMeta<unknown>,
+    handlerClass: NoopHandler as unknown as new (
+      ...args: unknown[]
+    ) => JobHandlerBase<unknown>,
+  });
+}, 90_000);
+
+afterAll(async () => {
+  JOB_HANDLER_REGISTRY.delete(JOB_TYPE);
+  await container?.stop();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Count surviving LISTEN %wake% backends via a SEPARATE pg connection (so the
+// observer itself is never counted). Polls briefly to allow async teardown.
+// ────────────────────────────────────────────────────────────────────────────
+
+async function countWakeListeners(observer: Pool): Promise<number> {
+  const { rows } = await observer.query<{ c: string }>(
+    `SELECT count(*)::text AS c
+       FROM pg_stat_activity
+      WHERE query ILIKE 'LISTEN %wake%'
+        AND state = 'idle'`,
+  );
+  return Number(rows[0]?.c ?? '0');
+}
+
+async function pollUntilZeroWakeListeners(
+  observer: Pool,
+  timeoutMs = 5_000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await countWakeListeners(observer);
+  while (last > 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 100));
+    last = await countWakeListeners(observer);
+  }
+  return last;
+}
+
+// One app module wiring both subsystems with listen_notify ON. The DRIZZLE
+// provider is exposed via a @Global() module so the (global) EventsModule and
+// JobsDomainModule contexts can both inject it — mirrors the consumer's own
+// global DatabaseModule.
+function makeAppModule(db: DrizzleClient): DynamicModule {
+  @Global()
+  @Module({
+    providers: [{ provide: DRIZZLE, useValue: db }],
+    exports: [DRIZZLE],
+  })
+  class DatabaseModule {}
+
+  @Module({
+    imports: [
+      DatabaseModule,
+      EventsModule.forRoot({ backend: 'drizzle', listenNotify: true }),
+      JobWorkerModule.forRoot({
+        backend: 'drizzle',
+        mode: 'embedded',
+        allPools: true, // → one worker (one listener) per framework pool
+        domainModuleExtensions: { drizzle: { listenNotify: true } },
+      }),
+    ],
+  })
+  class AppModule {}
+  return { module: AppModule } as unknown as DynamicModule;
+}
+
+const maybe = DOCKER_OK ? describe : describe.skip;
+
+maybe('LISTEN-NOTIFY-2 — app.close() releases every wake listener', () => {
+  it('boots a real Nest context (6 LISTEN backends), then close() leaves zero', async () => {
+    // Dedicated observer connection — never counted by the LISTEN query.
+    const observer = new Pool({ connectionString, max: 1 });
+
+    try {
+      // Loop several boot/close cycles so the connect-vs-stop race actually
+      // fires (a single run can pass by luck). Each cycle: boot → confirm
+      // listeners came up → close → assert zero survive.
+      for (let cycle = 0; cycle < 5; cycle++) {
+        const pool = new Pool({ connectionString });
+        const db = drizzle(pool) as unknown as DrizzleClient;
+
+        const app = await NestFactory.createApplicationContext(
+          makeAppModule(db),
+          { logger: false },
+        );
+
+        // Healthy app: events drainer (1) + one worker per framework pool (5)
+        // = 6 LISTEN backends. Allow a beat for the listeners to issue LISTEN.
+        await new Promise((r) => setTimeout(r, 250));
+        const live = await countWakeListeners(observer);
+        expect(live).toBeGreaterThan(0);
+
+        // The race window: close arrives while listeners may still be
+        // mid-connect. This is the exact swe-brain boot-check shape.
+        await app.close();
+        await pool.end();
+
+        const survivors = await pollUntilZeroWakeListeners(observer);
+        expect(survivors).toBe(0);
+      }
+    } finally {
+      await observer.end();
+    }
+  }, 120_000);
+
+  it('survives an immediate close() with no settle delay (tight race)', async () => {
+    const observer = new Pool({ connectionString, max: 1 });
+    try {
+      for (let cycle = 0; cycle < 5; cycle++) {
+        const pool = new Pool({ connectionString });
+        const db = drizzle(pool) as unknown as DrizzleClient;
+        const app = await NestFactory.createApplicationContext(
+          makeAppModule(db),
+          { logger: false },
+        );
+        // NO settle delay — close() races the listeners' in-flight connect()s
+        // as hard as possible. This is what made ~1 of 6 leak pre-fix.
+        await app.close();
+        await pool.end();
+        const survivors = await pollUntilZeroWakeListeners(observer);
+        expect(survivors).toBe(0);
+      }
+    } finally {
+      await observer.end();
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## What

Fixes a shutdown leak found by the **swe-brain dogfood** on `@pattern-stack/codegen` 0.17.1. With `listen_notify: true` (the LISTEN/NOTIFY wake extension shipped in 0.16.0), a NestJS app that boots and then `app.close()`s — e.g. a boot-check / CI smoke step — **never exits**: at least one `LISTEN codegen_jobs_wake` client survives `app.close()`, holding an ESTABLISHED Postgres socket open forever. Two swe-brain CI runs hung for hours.

A healthy running app shows 6 LISTEN backends (1 events drainer + 5 jobs pool workers); after `app.close()` there must be **zero**. The leak left exactly one survivor.

## Root cause

**RC1 (the defect that actually fired) — `stop()` races an in-flight `connect()`.**
`PgNotifyListener.connect()` checked `this.stopped` only at *entry*, then `await pool.connect()`, wired handlers, issued `LISTEN`, and assigned `this.client` **last**. A `stop()` arriving during the checkout await ran `releaseClient()` against a still-null `this.client` (released nothing); the resuming `connect()` then assigned the client and issued `LISTEN` — leaking a checked-out connection with no owner left to release it. With 5–6 listeners all starting at bootstrap and a tight `app.close()`, the race fires on ~1 of 6 listeners — the observed signature.

**RC2 (latent) — `JobWorker.onModuleDestroy` early-return skipped listener stop.**
The listener `stop()` lived only on the first (non-`shuttingDown`) branch, so a SIGTERM-then-Nest double-destroy hit `if (this.shuttingDown) { …; return; }` and skipped it. Not the boot-check trigger, but a real leak under the standard SIGTERM path.

## Fix

- `PgNotifyListener`: `connect()` split into a tracked `connecting` promise + `doConnect()`; re-checks `stopped` **after** the checkout AND **after** `LISTEN`, destroying the just-acquired client and bailing before assignment. `stop()` awaits the in-flight connect before its own release, so `app.close()` can't return while a checkout is mid-flight. Releases use `release(true)` (destroy) so a half-listening socket is never reused.
- `JobWorker.onModuleDestroy`: teardown hoisted into an idempotent `stopNotifyListener()` called on **every** destroy path. `DrizzleEventBus` already stopped its listener unconditionally; it shares `PgNotifyListener` so it inherits the RC1 fix directly.

## Falsifier (fails before, passes after)

- **Unit (deterministic):** `listen-notify.spec` §6 — a hand-gated `pool.connect()` / `LISTEN` forces the race every run. 3 cases; **all fail pre-fix, pass post-fix**.
- **Integration (real path):** `listen-notify-shutdown-leak.drizzle.integration` — real Nest boot (6 LISTEN backends, jobs allPools + events, `listen_notify` on) against a Postgres testcontainer; repeated `app.close()` cycles assert zero surviving `LISTEN %wake%` in `pg_stat_activity`. The tight-race variant **times out (leaks) pre-fix** — the exact boot-check hang — and passes post-fix. Skips gracefully without Docker; run via `just test-listen-notify-leak-integration`.
- Full unit suite green (2574 tests).

## Notes

- Spec: `docs/specs/LISTEN-NOTIFY-2.md`. CHANGELOG + version bump to **0.17.2** (patch) included; **not published** (OTP belongs to Doug).
- swe-brain has a consumer-side mitigation — explicit `process.exit(0)` in its `boot-check.ts` (commit `f283b6c`) — that is **revertible** once 0.17.2 is consumed.
- Pre-existing on `main` (NOT touched here): 3 schema-v2 typecheck errors in `src/cli/commands/junction.ts` + `src/cli/shared/barrel-generator.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)