### PR TITLE
fix(events,barrel): ADR-039 boot-tick race + ObservabilityModule.forRoot emission (#473; 0.20.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.2] — 2026-06-06
+
+Two consumer-found fixes (dogfooding swe-brain on 0.20.1).
+
+### Fixed
+
+- **ADR-039 boot tick was lost to a module-init race.** `EventSchedulerLifecycle`
+  ran `materializeBoot()` from `onModuleInit`, which fires during the EVENTS
+  module's own init — BEFORE later modules (notably `BridgeModule`, whose
+  outbox-drain hook turns a scheduled event into `bridge_delivery` rows) finish
+  wiring. With `listenNotify` the boot row drained within ~3ms and was marked
+  `processed` with ZERO deliveries and no error (verified live: slot
+  `@schedule/reconcile_due/1780707600000` processed 3ms after materialisation,
+  zero `bridge_delivery` rows for `reconcile-poll#0`; the in-loop tick at the
+  next slot boundary delivered correctly — boot-only loss). **Fix:** the
+  lifecycle now defers to `onApplicationBootstrap` (fires after all modules'
+  `onModuleInit` + every hook is attached), so the boot tick drains against the
+  fully-wired pipeline. The tick interval start moved with it (both passes live
+  in `EventScheduler.start()`). Regression tests assert the hook surface is
+  `onApplicationBootstrap` (not `onModuleInit`) and that a boot-materialised
+  scheduled event reaches a subscriber attached after init.
+- **#473 — `subsystem install observability` never wired `ObservabilityModule`.**
+  The install added `observability` to `subsystems.install` but the barrel
+  emitter had no composer, so `ObservabilityModule.forRoot` was never emitted
+  into `SUBSYSTEM_MODULES` — consumers hand-wired it in `app.module.ts` (like
+  Auth). **Fix:** added an `observability` composer. It emits
+  `ObservabilityModule.forRoot()` (no `backend`/`multiTenant` — a combiner per
+  ADR-025 owns no durable state), imported package- or vendored-aware, and is
+  ordered LAST in `COMPOSABLE_ORDER` so its `forRoot` registers AFTER the
+  events/jobs/bridge/integration read ports it composes via `@Optional()` DI.
+  The `observability.reporters` block (OBS-6) is threaded into `forRoot` only
+  when a reporter is `enabled: true` (off-by-default, mirroring the
+  `listen_notify` / `differ` clauses); the default install stays a bare
+  `ObservabilityModule.forRoot()`. Closes #473.
+
+### Tests
+
+- `subsystem-barrel-generator` tests: observability composer coverage (both
+  modes, combiner ordering after the composed siblings, reporters threaded only
+  when enabled).
+- **Subsystems smoke now asserts forRoot presence per installed subsystem** (not
+  just events' `eventRegistry`) — it installs observability too and fails if the
+  real generated barrel is missing any installed subsystem's `forRoot` or if
+  observability isn't ordered after the read ports. Both gap classes (the
+  scheduler threading and the missing observability wiring) survived because
+  nothing end-to-end checked per-subsystem wiring.
+
 ## [0.20.1] — 2026-06-06
 
 **Fix: the subsystems barrel never threaded `eventRegistry` into

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/subsystems/events/events.module.ts
+++ b/runtime/subsystems/events/events.module.ts
@@ -51,8 +51,8 @@ import {
   Module,
   Optional,
   type DynamicModule,
+  type OnApplicationBootstrap,
   type OnModuleDestroy,
-  type OnModuleInit,
   type Provider,
   type Type,
 } from '@nestjs/common';
@@ -190,13 +190,30 @@ export interface EventsModuleOptions {
 
 /**
  * Lifecycle holder for the `EventScheduler` (ADR-039). Registered as a provider
- * on the drizzle/memory `forRoot` branches; Nest drives `onModuleInit` (after
- * the bus is constructed) and `onModuleDestroy`. Reads the scheduled-event set
- * from the threaded `eventRegistry` and starts the materialiser. No-op when
- * nothing declared `schedule:`, or under the redis backend (no outbox history).
+ * on the drizzle/memory `forRoot` branches. Reads the scheduled-event set from
+ * the threaded `eventRegistry` and starts the materialiser. No-op when nothing
+ * declared `schedule:`, or under the redis backend (no outbox history).
+ *
+ * **Why `onApplicationBootstrap`, not `onModuleInit` (boot-tick race fix).**
+ * `start()` runs `materializeBoot()`, which inserts the current slot's
+ * `domain_events` row. With `listenNotify` enabled the outbox drain consumes
+ * that row within milliseconds — so it MUST NOT run until every other module
+ * has attached its outbox hooks. `onModuleInit` fires during the EVENTS
+ * module's own init, BEFORE later modules (notably `BridgeModule`, which
+ * attaches the bridge outbox-drain hook) finish initialising. The result was a
+ * silent boot-only loss: the boot tick drained to `processed` with ZERO
+ * `bridge_delivery` rows and no error (verified live in swe-brain on 0.20.1 —
+ * slot `@schedule/reconcile_due/...` processed 3ms after materialisation, no
+ * deliveries; the in-loop tick at the next slot delivered correctly).
+ *
+ * `onApplicationBootstrap` fires AFTER all modules' `onModuleInit` complete and
+ * every hook is attached — the boot tick is then drained against the fully
+ * wired pipeline. The tick interval starts here too (it lives inside `start()`,
+ * and keeping both passes on the same hook keeps the boot/interval contract in
+ * one place).
  */
 @Injectable()
-export class EventSchedulerLifecycle implements OnModuleInit, OnModuleDestroy {
+export class EventSchedulerLifecycle implements OnApplicationBootstrap, OnModuleDestroy {
   private readonly logger = new Logger(EventSchedulerLifecycle.name);
   private scheduler: EventScheduler | null = null;
 
@@ -207,7 +224,7 @@ export class EventSchedulerLifecycle implements OnModuleInit, OnModuleDestroy {
     private readonly opts: EventsModuleOptions | null = null,
   ) {}
 
-  async onModuleInit(): Promise<void> {
+  async onApplicationBootstrap(): Promise<void> {
     const registry = this.opts?.eventRegistry;
     if (!registry) return;
     if (typeof this.bus.materializeScheduledEvent !== 'function') return; // redis

--- a/src/__tests__/cli/subsystem-barrel-generator.test.ts
+++ b/src/__tests__/cli/subsystem-barrel-generator.test.ts
@@ -49,18 +49,18 @@ describe('buildSubsystemBarrel', () => {
 
 	test('installed-but-no-composer-only set still emits DynamicModule import (#smoke-fix)', () => {
 		// Repro of the smoke regression: a project whose install set contains
-		// only non-composer subsystems (observability + auth + auth-integrations
-		// in the actual smoke; observability alone is sufficient to trigger the
-		// pre-fix bug). `allCalls` is empty, so the prior code returned
-		// `HEADER + 'export const SUBSYSTEM_MODULES: DynamicModule[] = [];'`
-		// with no `DynamicModule` import. tsc TS2304.
+		// only non-composer subsystems (auth / auth-integrations). `allCalls` is
+		// empty, so the prior code returned `HEADER + 'export const
+		// SUBSYSTEM_MODULES: DynamicModule[] = [];'` with no `DynamicModule`
+		// import. tsc TS2304. (#473: observability now HAS a composer, so `auth`
+		// is the composer-less example.)
 		const out = buildSubsystemBarrel(
-			[inst('observability')],
+			[inst('auth')],
 			{},
 			subsystemsRel,
 		);
 		expect(out.emitted).toEqual([]);
-		expect(out.skipped).toContain('observability');
+		expect(out.skipped).toContain('auth');
 		// Imports MUST include the DynamicModule type alias …
 		expect(out.content).toContain(
 			"import type { DynamicModule } from '@nestjs/common';",
@@ -232,15 +232,15 @@ describe('buildSubsystemBarrel', () => {
 	});
 
 	test('installed subsystem without a composer is listed in `skipped`', () => {
-		// `observability` / `auth` aren't in COMPOSABLE_ORDER yet — they should
-		// register as skipped, not silently dropped.
+		// `auth` has no composer — it should register as skipped, not silently
+		// dropped. (#473: observability now HAS a composer; `auth` is the example.)
 		const out = buildSubsystemBarrel(
-			[inst('events'), inst('observability')],
+			[inst('events'), inst('auth')],
 			{ events: {} },
 			subsystemsRel,
 		);
 		expect(out.emitted).toEqual(['events']);
-		expect(out.skipped).toContain('observability');
+		expect(out.skipped).toContain('auth');
 	});
 
 	test('#4: an `incomplete` subsystem is NOT emitted (no phantom forRoot import)', () => {
@@ -674,5 +674,85 @@ describe('buildSubsystemBarrel — package mode (ADR-037)', () => {
 			// And the symbol must be imported (no dangling reference).
 			expect(out.content).toMatch(/import \{ eventRegistry \} from '[^']+'/);
 		}
+	});
+
+	// ─── #473: observability composer ────────────────────────────────────────
+
+	test('observability composer emits ObservabilityModule.forRoot() (vendored)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('observability')],
+			{},
+			subsystemsRel,
+			'vendored',
+		);
+		expect(out.emitted).toEqual(['observability']);
+		expect(out.content).toContain(
+			"import { ObservabilityModule } from './shared/subsystems/observability/observability.module';",
+		);
+		// No reporter enabled → bare forRoot (matches the off-by-default scaffold).
+		expect(out.content).toContain('ObservabilityModule.forRoot(),');
+		// No backend/multiTenant — it's a combiner with no durable state.
+		expect(out.content).not.toMatch(/ObservabilityModule\.forRoot\(\{[^}]*backend/);
+	});
+
+	test('observability composer emits ObservabilityModule.forRoot() (package)', () => {
+		const out = buildSubsystemBarrel(
+			[inst('observability')],
+			{},
+			subsystemsRel,
+			'package',
+		);
+		expect(out.content).toContain(
+			"import { ObservabilityModule } from '@pattern-stack/codegen/runtime/subsystems/observability/index';",
+		);
+		expect(out.content).toContain('ObservabilityModule.forRoot(),');
+	});
+
+	test('observability registers AFTER the read ports it composes (jobs/bridge/integration)', () => {
+		const out = buildSubsystemBarrel(
+			[
+				inst('observability'),
+				inst('integration'),
+				inst('bridge'),
+				inst('jobs'),
+				inst('events'),
+			], // deliberately unsorted input
+			{
+				events: {},
+				jobs: { worker_mode: 'standalone' },
+				bridge: {},
+				integration: {},
+			},
+			subsystemsRel,
+		);
+		expect(out.emitted).toEqual(['events', 'jobs', 'bridge', 'integration', 'observability']);
+		const idx = (frag: string) => out.content.indexOf(frag);
+		// ObservabilityModule.forRoot must appear after every composed sibling's forRoot.
+		const obs = idx('ObservabilityModule.forRoot');
+		expect(obs).toBeGreaterThan(idx('JobsDomainModule.forRoot'));
+		expect(obs).toBeGreaterThan(idx('BridgeModule.forRoot'));
+		expect(obs).toBeGreaterThan(idx('IntegrationModule.forRoot'));
+		expect(obs).toBeGreaterThan(idx('EventsModule.forRoot'));
+	});
+
+	test('observability threads reporters config only when a reporter is enabled', () => {
+		// Off-by-default scaffold (enabled: false) → bare forRoot.
+		const off = buildSubsystemBarrel(
+			[inst('observability')],
+			{ observability: { reporters: { bridgeMetrics: { enabled: false, intervalMs: 60000, windowHours: 24 } } } },
+			subsystemsRel,
+		);
+		expect(off.content).toContain('ObservabilityModule.forRoot(),');
+		expect(off.content).not.toContain('reporters');
+
+		// Operator opts in (enabled: true) → reporters block threaded.
+		const on = buildSubsystemBarrel(
+			[inst('observability')],
+			{ observability: { reporters: { bridgeMetrics: { enabled: true, intervalMs: 60000, windowHours: 1 } } } },
+			subsystemsRel,
+		);
+		expect(on.content).toContain(
+			'ObservabilityModule.forRoot({ reporters: { bridgeMetrics: { enabled: true, intervalMs: 60000, windowHours: 1 } } }),',
+		);
 	});
 });

--- a/src/__tests__/runtime/subsystems/event-scheduler.unit.spec.ts
+++ b/src/__tests__/runtime/subsystems/event-scheduler.unit.spec.ts
@@ -30,6 +30,7 @@ import {
 } from '../../../../runtime/subsystems/events/event-scheduler';
 import { MemoryEventBus } from '../../../../runtime/subsystems/events/event-bus.memory-backend';
 import { ScheduleConfigError } from '../../../../runtime/subsystems/events/events-errors';
+import { EventSchedulerLifecycle } from '../../../../runtime/subsystems/events/events.module';
 import type { DomainEvent } from '../../../../runtime/subsystems/events/event-bus.protocol';
 
 const HOUR = 3_600_000;
@@ -362,5 +363,74 @@ describe('scheduledEventsFromRegistry + resolveScheduledEvent (Group 7)', () => 
         contact_created: { direction: 'change', pool: 'events_change' },
       }),
     ).toEqual([]);
+  });
+});
+
+// ─── 8. boot-tick race fix (0.20.2) ─────────────────────────────────────────
+//
+// The 0.20.1 bug: `EventSchedulerLifecycle` ran `materializeBoot()` from
+// `onModuleInit`, which fires during the EVENTS module's own init — BEFORE
+// later modules (notably BridgeModule, whose outbox-drain hook is what turns a
+// scheduled event into bridge_delivery rows) finish wiring. With listenNotify
+// the boot row drained within ~3ms and was marked processed with ZERO
+// deliveries (silent boot-only loss). Fix: defer to `onApplicationBootstrap`,
+// which fires after ALL modules' onModuleInit + every hook is attached.
+
+describe('EventSchedulerLifecycle — boot-tick ordering (Group 8)', () => {
+  const registry = {
+    reconcile_due: {
+      schedule: { every: '1h' },
+      direction: 'inbound',
+      pool: 'events_inbound',
+    },
+  };
+
+  it('uses onApplicationBootstrap, NOT onModuleInit (the ordering contract)', () => {
+    const lifecycle = new EventSchedulerLifecycle(new MemoryEventBus(), {
+      backend: 'memory',
+      eventRegistry: registry,
+    });
+    // The fix's whole point: the boot pass must run on the bootstrap hook so it
+    // fires after every module's onModuleInit (bridge hook attached). Assert the
+    // hook surface directly so a regression that moves it back to onModuleInit
+    // (re-opening the race) fails here.
+    expect(typeof (lifecycle as unknown as { onApplicationBootstrap?: unknown }).onApplicationBootstrap).toBe('function');
+    expect((lifecycle as unknown as { onModuleInit?: unknown }).onModuleInit).toBeUndefined();
+  });
+
+  it('onApplicationBootstrap materialises the boot tick to a subscriber attached after init', async () => {
+    // Model the race: a "downstream hook" (stands in for the bridge outbox
+    // drain) subscribes AFTER the lifecycle is constructed — i.e. after the
+    // EVENTS module init would have run. Under the old onModuleInit timing the
+    // boot row would already have been emitted+drained before this subscribe;
+    // under onApplicationBootstrap the subscribe is in place first, so the boot
+    // tick reaches it.
+    const bus = new MemoryEventBus();
+    const lifecycle = new EventSchedulerLifecycle(bus, {
+      backend: 'memory',
+      eventRegistry: registry,
+    });
+
+    // (init phase complete) → later module attaches its hook:
+    const delivered: string[] = [];
+    bus.subscribe('reconcile_due', async (e) => {
+      delivered.push(e.metadata?.['scheduleSlot'] as string);
+    });
+
+    // (bootstrap phase) → boot tick fires against the fully-wired pipeline.
+    await lifecycle.onApplicationBootstrap();
+
+    expect(delivered.length).toBe(1);
+    expect(delivered[0]).toMatch(/^@schedule\/reconcile_due\//);
+
+    await lifecycle.onModuleDestroy(); // stop the interval timer
+  });
+
+  it('is a no-op when no eventRegistry is threaded (no scheduler spawned)', async () => {
+    const bus = new MemoryEventBus();
+    const lifecycle = new EventSchedulerLifecycle(bus, { backend: 'memory' });
+    await lifecycle.onApplicationBootstrap();
+    expect(bus.publishedEvents.length).toBe(0);
+    await lifecycle.onModuleDestroy();
   });
 });

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -12,11 +12,12 @@
  * Every `entity new` / `subsystem install` invocation fully regenerates the
  * file from `codegen.config.yaml` + the detected install set. Deterministic.
  *
- * Today's coverage: events, jobs (+ job-worker embedded mode), bridge, integration.
- * Auth / auth-integrations / observability are out of scope; their AppModule
- * wiring still goes by hand (each has init-time options the generator can't
- * synthesize from config alone). Add a composer entry below when ready to
- * include them.
+ * Today's coverage: events, jobs (+ job-worker embedded mode), bridge,
+ * integration, observability (#473 — the combiner, ordered last).
+ * Auth / auth-integrations are still out of scope; their AppModule wiring goes
+ * by hand (each has init-time options — e.g. Auth's env `redirectUriBase` — the
+ * generator can't synthesize from config alone). Add a composer entry below
+ * when ready to include them.
  */
 
 import fs from 'node:fs';
@@ -415,6 +416,24 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 			calls: [`\tIntegrationModule.forRoot({ ${parts.join(', ')} }),`],
 		};
 	},
+
+	// #473 — observability combiner (ADR-025). NO `backend` / `multiTenant`:
+	// it owns no durable state — portability is inherited from whichever
+	// backends the composed siblings run (see `ObservabilityModule` docblock).
+	// The only `forRoot` option is `reporters` (OBS-6); thread the config
+	// block's `reporters:` when a reporter is enabled, else emit a bare
+	// `forRoot()`. Ordered LAST in `COMPOSABLE_ORDER` so it registers after the
+	// read ports it composes via `@Optional()` DI.
+	observability: ({ moduleImport, cfg }) => {
+		const reportersClause = observabilityReportersClause(cfg);
+		const opts = reportersClause ? `{ ${reportersClause} }` : '';
+		return {
+			imports: [
+				`import { ObservabilityModule } from '${moduleImport('observability', 'observability.module')}';`,
+			],
+			calls: [`\tObservabilityModule.forRoot(${opts}),`],
+		};
+	},
 };
 
 /**
@@ -439,6 +458,32 @@ function integrationDifferClause(cfg: Record<string, unknown> | undefined): stri
 	if (unignore.length > 0) inner.unignore = unignore;
 	if (Object.keys(inner).length === 0) return '';
 	return `differ: ${jsonToTs(inner)}`;
+}
+
+/**
+ * #473 / OBS-6 — resolve the `reporters: {...}` clause for
+ * `ObservabilityModule.forRoot(...)` from the `observability:` config block, or
+ * `''` when no reporter is meaningfully enabled. Off-by-default, mirroring the
+ * `listen_notify` / `differ` clauses: a fresh install scaffolds
+ * `reporters.bridgeMetrics.enabled: false`, so the default barrel stays a bare
+ * `ObservabilityModule.forRoot()` (the issue's expected shape) and the config is
+ * threaded only once an operator flips a reporter on. The config keys are
+ * already camelCase (`bridgeMetrics`, `intervalMs`, `windowHours`) and map 1:1
+ * to `ObservabilityModuleOptions.reporters`, so the block passes through verbatim.
+ */
+function observabilityReportersClause(
+	cfg: Record<string, unknown> | undefined,
+): string {
+	const reporters = cfg?.reporters as Record<string, unknown> | undefined;
+	if (!reporters || typeof reporters !== 'object') return '';
+	const enabled: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(reporters)) {
+		if (value && typeof value === 'object' && (value as { enabled?: unknown }).enabled === true) {
+			enabled[key] = value;
+		}
+	}
+	if (Object.keys(enabled).length === 0) return '';
+	return `reporters: ${jsonToTs(enabled)}`;
 }
 
 const PACKAGE = '@pattern-stack/codegen';
@@ -472,7 +517,18 @@ function makeModuleImport(
 			: `${PACKAGE}/runtime/subsystems/${subsystem}/index`;
 }
 
-const COMPOSABLE_ORDER: SubsystemName[] = ['events', 'jobs', 'bridge', 'integration'];
+// #473 — `observability` is LAST: it is a combiner (ADR-025) that composes the
+// jobs / bridge / integration read ports via `@Optional()` DI, so its module
+// must register AFTER them in `SUBSYSTEM_MODULES` (matches the consumer-wiring
+// order documented on `ObservabilityModule`). It owns no durable state / no
+// generated registry, so there is no schema-barrel or stub-guard concern.
+const COMPOSABLE_ORDER: SubsystemName[] = [
+	'events',
+	'jobs',
+	'bridge',
+	'integration',
+	'observability',
+];
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/test/smoke/run-smoke-subsystems.ts
+++ b/test/smoke/run-smoke-subsystems.ts
@@ -195,6 +195,11 @@ async function main(): Promise<number> {
 		run(`bun ${CLI_PATH} subsystem install events`, tmpDir);
 		run(`bun ${CLI_PATH} subsystem install jobs`, tmpDir);
 		run(`bun ${CLI_PATH} subsystem install bridge`, tmpDir);
+		// #473 — observability is a combiner (ADR-025) that composes the read
+		// ports above via @Optional() DI. Installing it here exercises the
+		// composer the issue added (it must emit ObservabilityModule.forRoot
+		// AFTER the four infra subsystems in SUBSYSTEM_MODULES).
+		run(`bun ${CLI_PATH} subsystem install observability`, tmpDir);
 
 		// 5a-prep. The jobs install scaffold defaults `worker_mode: embedded`
 		//   in codegen.config.yaml, which has the barrel emit
@@ -260,11 +265,43 @@ async function main(): Promise<number> {
 		}
 		const barrelPath = path.join(tmpDir, 'src/generated/subsystems.ts');
 		const barrel = fs.readFileSync(barrelPath, 'utf-8');
-		if (!barrel.includes('BridgeModule.forRoot')) {
-			throw new Error(
-				`generated barrel does not include BridgeModule.forRoot(...) after install:\n${barrel}`,
-			);
+
+		// 0.20.x (#472/#473) — EVERY installed subsystem with a composer must emit
+		// its `forRoot` into SUBSYSTEM_MODULES. This class of gap (install adds a
+		// config entry but the barrel never wires the module) has now bitten twice
+		// — events' scheduler (#471/#472) and observability (#473) — and survived
+		// because nothing end-to-end asserted forRoot presence per subsystem.
+		// Assert the module-name → forRoot mapping for everything this smoke
+		// installs (the four infra subsystems + the observability combiner).
+		const expectedForRoots: Record<string, string> = {
+			events: 'EventsModule.forRoot',
+			jobs: 'JobsDomainModule.forRoot',
+			bridge: 'BridgeModule.forRoot',
+			observability: 'ObservabilityModule.forRoot',
+		};
+		for (const [name, frag] of Object.entries(expectedForRoots)) {
+			if (!barrel.includes(frag)) {
+				throw new Error(
+					`generated barrel does not include ${frag}(...) after ` +
+						`installing '${name}' (install added the config entry but the ` +
+						`barrel never wired the module):\n${barrel}`,
+				);
+			}
 		}
+
+		// #473 — observability is a combiner: its forRoot MUST register AFTER the
+		// read ports it composes (it consumes their tokens via @Optional() DI).
+		// Assert it comes after jobs/bridge in the emitted SUBSYSTEM_MODULES.
+		const obsIdx = barrel.indexOf('ObservabilityModule.forRoot');
+		for (const before of ['JobsDomainModule.forRoot', 'BridgeModule.forRoot']) {
+			if (obsIdx < barrel.indexOf(before)) {
+				throw new Error(
+					`ObservabilityModule.forRoot must register AFTER ${before} ` +
+						`(combiner composes its read port via @Optional() DI):\n${barrel}`,
+				);
+			}
+		}
+
 		// ADR-039 / 0.20.1 — the barrel MUST thread the consumer's generated
 		// `eventRegistry` into `EventsModule.forRoot`, or `EventSchedulerLifecycle`
 		// never spawns and scheduled events silently don't tick (the 0.20.0 gap


### PR DESCRIPTION
## What

Two consumer-found fixes (dogfooding swe-brain on 0.20.1), one PR / one version (0.20.2).

### Fix 1 — ADR-039 boot tick is lost to a module-init race (new find, verified live)

`EventSchedulerLifecycle` ran `materializeBoot()` from **`onModuleInit`**, which fires during the EVENTS module's own init — **before** later modules (notably `BridgeModule`, whose outbox-drain hook turns a scheduled event into `bridge_delivery` rows) finish wiring. With `listenNotify` the materialized boot row drained within ~3ms — before the bridge hook was attached — so the boot tick was marked `processed` with **zero bridge deliveries and no error**.

Evidence from swe-brain: `domain_events` row `@schedule/reconcile_due/1780707600000` had `processed_at` 3ms after materialization, **zero** `bridge_delivery` rows for `reconcile-poll#0`; the 02:00 in-loop tick created the `job_run` correctly. Boot-only loss.

**Fix:** the lifecycle now defers to **`onApplicationBootstrap`** (Nest fires it after *all* modules' `onModuleInit` complete and every hook/DI edge is wired), so the boot tick drains against the fully-wired pipeline. The tick-interval start moved with it (both passes live in `EventScheduler.start()`, kept on one hook for a single boot/interval contract).

Regression tests:
- assert the lifecycle hook surface is `onApplicationBootstrap` and **not** `onModuleInit` (a regression that moves it back fails here);
- assert a boot-materialized scheduled event reaches a subscriber attached *after* init (models the bridge hook attaching post-init).

### Fix 2 — #473: `subsystem install observability` never wired `ObservabilityModule`

The install added `observability` to `subsystems.install`, but the barrel emitter had no composer, so `ObservabilityModule.forRoot` was never emitted into `SUBSYSTEM_MODULES` — consumers hand-wired it in `app.module.ts` (like Auth). **Closes #473.**

**Fix:** added an `observability` composer:
- emits `ObservabilityModule.forRoot()` — **no** `backend`/`multiTenant` (a combiner per ADR-025 owns no durable state), imported from `@pattern-stack/codegen/runtime/subsystems/observability/index` (package) or the vendored `observability.module` (vendored);
- ordered **LAST** in `COMPOSABLE_ORDER` so its `forRoot` registers **after** the events/jobs/bridge/integration read ports it composes via `@Optional()` DI;
- threads the `observability.reporters` block (OBS-6) only when a reporter is `enabled: true` (off-by-default, mirroring `listen_notify` / `differ`); default install stays a bare `ObservabilityModule.forRoot()`.

## Emitted barrel (regenerated package-mode fixture, all subsystems installed)

```ts
export const SUBSYSTEM_MODULES: DynamicModule[] = [
	EventsModule.forRoot({ backend: 'drizzle', multiTenant: false, typedBus: TypedEventBus, eventRegistry }),
	JobsDomainModule.forRoot({ backend: 'drizzle', extensions: { drizzle: { pollIntervalMs: 1000 } } }),
	JobWorkerModule.forRoot({ mode: 'embedded', domainModuleExtensions: { drizzle: { pollIntervalMs: 1000 } }, allPools: true }),
	BridgeModule.forRoot({ backend: 'drizzle', multiTenant: false, registry: bridgeRegistry }),
	IntegrationModule.forRoot({ backend: 'drizzle', multiTenant: false }),
	ObservabilityModule.forRoot(),
];
// import { ObservabilityModule } from '@pattern-stack/codegen/runtime/subsystems/observability/index';
```

ObservabilityModule.forRoot() is last, after the read ports it composes.

## Closing the blind spot

Both gap classes (the #472 scheduler threading and this missing observability wiring) survived because nothing end-to-end asserted per-subsystem wiring. The subsystems smoke now **installs observability** and asserts **forRoot presence for every installed subsystem** + observability's combiner ordering, on the real generated barrel. The boot check boots the AppModule with the scheduler now on `onApplicationBootstrap`.

## Gates

- `test-unit` 2697 pass / 0 fail
- `test-baseline` ✅
- `test-smoke` PASS
- `test-smoke-subsystems` PASS (observability installed — consumer tree typechecks, AppModule boots with ObservabilityModule wired, all per-subsystem forRoot + ordering assertions pass)
- typecheck clean (only the 3 pre-existing `src/cli` junction errors)

Version 0.20.1 → 0.20.2. **Do not merge — Doug publishes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)