### PR TITLE
ci(publish): npm publish on merge to main — trusted publishing + tarball smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   push:
     branches: [main]
 
+# PR runs cancel stale siblings; main pushes QUEUE instead — cancelling a
+# main run could kill the publish job mid-upload. The publish job's
+# already-on-npm check makes queued runs cheap no-ops.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -43,3 +46,48 @@ jobs:
           path: test/gen/
           retention-days: 14
           if-no-files-found: ignore
+
+  # Publish to npm on every merge to main, gated on green tests. Runs the
+  # tarball smoke (#190), then publishes the root + each opted-in workspace
+  # package IFF its version isn't already on npm — so merges without a
+  # version bump are fast no-ops, and a bump to any one package publishes
+  # exactly that package (independent versioning, ADR-036 §8).
+  #
+  # Auth is npm trusted publishing (OIDC) — no NPM_TOKEN secret. Each package
+  # must list this repo + ci.yml as a trusted publisher on npmjs.com.
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 20
+    permissions:
+      id-token: write # mint the OIDC token npm exchanges for publish credentials
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.x
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Update npm (trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install dependencies
+        run: just install
+
+      - name: Publish (tarball smoke + publish-if-bumped)
+        run: just publish-ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,12 @@ just db-up                           # Start Postgres
 just db-push                         # Push schema
 just db-down                         # Stop Postgres
 
-# Release
+# Release — merging a version bump to main publishes automatically (CI `publish`
+# job: tarball smoke gate + publish-if-version-not-on-npm, per package).
 just bump patch                      # Bump version (patch | minor | major)
-just release                         # Tag + push
+just test-post-publish               # Tarball smoke: pack + install + verify consumer contract
+just publish-ci --dry-run            # Validate the full publish without uploading
+just publish                         # Manual fallback: publish origin/main from a pristine worktree
 ```
 
 ## Architecture

--- a/justfile
+++ b/justfile
@@ -135,6 +135,13 @@ compare:
 test-family:
     bun test "{{justfile_directory()}}/test/scaffold/tests/crm-entity-repository.test.ts" "{{justfile_directory()}}/test/scaffold/tests/activity-entity-repository.test.ts" "{{justfile_directory()}}/test/scaffold/tests/metadata-entity-repository.test.ts"
 
+# Tarball smoke (#190): build + pack every publishable package, install the
+# tarballs into a fresh tmp project via npm, verify the consumer contract
+# (files manifest, exports, bins, peer ranges). Catches the
+# works-from-checkout-broken-from-tarball class. Gates `just publish-ci`.
+test-post-publish:
+    bun test/post-publish/run-tarball-smoke.ts
+
 # Run scaffold integration tests (requires Docker)
 test-integration:
     bun test/scaffold/run-integration.ts
@@ -280,43 +287,81 @@ publish *flags:
 
     mise exec -- bun install
 
-    # Always build the root first — its dist/ is what the surface packages'
-    # declaration (.d.ts) builds resolve `@pattern-stack/codegen/subsystems`
-    # against, whether or not the root itself is (re)published this run.
-    mise exec -- bun run build
+    # The smoke gate + publish loop live in publish-ci — same path CI takes
+    # on merge to main; this recipe only adds the pristine-worktree wrapper.
+    mise exec -- just publish-ci {{flags}}
 
-    # Publish one package iff its version isn't already on npm — independent
-    # versioning (ADR-036 §8), so releasing one surface package doesn't force a
-    # root or sibling bump. Already-published versions are skipped, not errors.
-    publish_pkg() {
+# Publish the CURRENT CHECKOUT to npm — the CI entry point (runs on every
+# push to main; see .github/workflows/ci.yml `publish` job). Assumes deps are
+# installed and bun/npm are on PATH. Locally, prefer `just publish`, which
+# wraps this in a pristine origin/main worktree.
+#
+# Gate: the tarball smoke (#190) builds + packs everything and verifies the
+# consumer contract BEFORE anything uploads — a bad tarball aborts the run.
+#
+# Then publish one package iff its version isn't already on npm — independent
+# versioning (ADR-036 §8), so releasing one surface package doesn't force a
+# root or sibling bump. Already-published versions are skipped, not errors.
+# This registry check is also what makes "publish on every merge" safe: a
+# merge without a version bump is a fast no-op.
+#
+# Pass `--dry-run` to pack + validate every tarball WITHOUT uploading:
+#   just publish-ci --dry-run
+publish-ci *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Pass 1 — registry check. Emit "dir|name|ver" for every publishable
+    # package whose version isn't on npm yet; skip messages go to stderr so
+    # they reach the user without polluting the list. Root first — its dist/
+    # is what the surface packages' .d.ts builds resolve
+    # @pattern-stack/codegen/subsystems against, so publish order matters.
+    consider() {
         local dir="$1" name="$2" ver="$3" on_npm
-        on_npm=$( ( cd "${dir}" && mise exec -- npm view "${name}@${ver}" version 2>/dev/null ) || true )
+        on_npm=$(npm view "${name}@${ver}" version 2>/dev/null || true)
         if [ "${on_npm}" = "${ver}" ]; then
-            echo "↷ skip ${name}@${ver} (already on npm)"
-            return 0
+            echo "↷ skip ${name}@${ver} (already on npm)" >&2
+        else
+            echo "${dir}|${name}|${ver}"
         fi
-        echo "Publishing ${name}@${ver} from ${dir}"
-        ( cd "${dir}" && mise exec -- npm publish {{flags}} )
-        echo "✓ ${name}@${ver}"
     }
 
-    # 1. Root package.
-    publish_pkg "." "@pattern-stack/codegen" "${version}"
+    list_unpublished() {
+        consider "." "@pattern-stack/codegen" "$(jq -r .version package.json)"
+        # Each opted-in workspace package (publishConfig.access: public), at its
+        # own version. Private / unmarked (graph-components, generated api/db) skip.
+        local pkgjson dir name ver priv access
+        for pkgjson in packages/*/package.json; do
+            dir=$(dirname "${pkgjson}")
+            name=$(jq -r '.name' "${pkgjson}")
+            ver=$(jq -r '.version' "${pkgjson}")
+            priv=$(jq -r '.private // false' "${pkgjson}")
+            access=$(jq -r '.publishConfig.access // ""' "${pkgjson}")
+            if [ "${priv}" = "true" ] || [ "${access}" != "public" ]; then
+                echo "↷ skip ${name} (not opted in: private=${priv} access=${access:-none})" >&2
+                continue
+            fi
+            consider "${dir}" "${name}" "${ver}"
+        done
+    }
 
-    # 2. Each opted-in workspace package (publishConfig.access: public), at its
-    #    own version. Private / unmarked (graph-components, generated api/db) skip.
-    for pkgjson in packages/*/package.json; do
-        dir=$(dirname "${pkgjson}")
-        name=$(jq -r '.name' "${pkgjson}")
-        ver=$(jq -r '.version' "${pkgjson}")
-        priv=$(jq -r '.private // false' "${pkgjson}")
-        access=$(jq -r '.publishConfig.access // ""' "${pkgjson}")
-        if [ "${priv}" = "true" ] || [ "${access}" != "public" ]; then
-            echo "↷ skip ${name} (not opted in: private=${priv} access=${access:-none})"
-            continue
-        fi
-        publish_pkg "${dir}" "${name}" "${ver}"
-    done
+    to_publish=$(list_unpublished)
+    if [ -z "${to_publish}" ]; then
+        echo "✓ Nothing to publish — every package version is already on npm."
+        exit 0
+    fi
+
+    # Gate: tarball smoke (#190) — builds + packs everything, installs into a
+    # fresh tmp project, verifies the consumer contract. A bad tarball aborts
+    # here, before anything uploads.
+    bun test/post-publish/run-tarball-smoke.ts
+
+    # Pass 2 — publish, in list order (root before surface packages).
+    while IFS='|' read -r dir name ver; do
+        echo "Publishing ${name}@${ver} from ${dir}"
+        ( cd "${dir}" && npm publish {{flags}} )
+        echo "✓ ${name}@${ver}"
+    done <<< "${to_publish}"
 
     echo "✓ Done."
 

--- a/packages/codegen-calendar/package.json
+++ b/packages/codegen-calendar/package.json
@@ -19,7 +19,11 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -27,7 +31,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
+    "@pattern-stack/codegen": ">=0.20.0 <1.0.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-crm/package.json
+++ b/packages/codegen-crm/package.json
@@ -19,7 +19,11 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -27,7 +31,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0"
+    "@pattern-stack/codegen": ">=0.20.0 <1.0.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-mail/package.json
+++ b/packages/codegen-mail/package.json
@@ -19,7 +19,11 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -27,7 +31,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
+    "@pattern-stack/codegen": ">=0.20.0 <1.0.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-messaging/package.json
+++ b/packages/codegen-messaging/package.json
@@ -19,7 +19,11 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -27,7 +31,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
+    "@pattern-stack/codegen": ">=0.20.0 <1.0.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/codegen-transcript/package.json
+++ b/packages/codegen-transcript/package.json
@@ -19,7 +19,11 @@
       "import": "./dist/testing/index.js"
     }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
@@ -27,7 +31,7 @@
     "prepublishOnly": "bun run build"
   },
   "peerDependencies": {
-    "@pattern-stack/codegen": "^0.13.0 || ^0.14.0"
+    "@pattern-stack/codegen": ">=0.20.0 <1.0.0"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/test/post-publish/run-tarball-smoke.ts
+++ b/test/post-publish/run-tarball-smoke.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env bun
+/**
+ * Tarball Smoke (#190 — packaging-drift class)
+ *
+ * Smoke tests run against the repo checkout; this runner tests what consumers
+ * actually receive from npm. Two releases shipped broken because of exactly
+ * this gap:
+ *   - 0.3.0: `runtimeRoot()` assumed top-level `runtime/`; the tarball only
+ *     had `dist/runtime/`.
+ *   - 0.4.1: `VENDORED_RUNTIME_FILES` read raw `.ts` source, but `files:`
+ *     excluded `runtime/`, so tarballs had only compiled `.js`.
+ *
+ * What it does:
+ *   1. Builds + `npm pack`s every publishable package (root + workspace
+ *      packages with `publishConfig.access: public`).
+ *   2. Installs ALL tarballs together into a fresh tmp project via npm —
+ *      which also exercises the surface packages' peerDependency range
+ *      against the root tarball's actual version.
+ *   3. Verifies the installed root package: files-manifest essentials
+ *      (dist/runtime, raw runtime/*.ts, templates/, consumer-skills/),
+ *      every `exports` entry imports under node, both bins run `--help`.
+ *   4. Verifies each surface package's `.` and `./testing` exports import.
+ *
+ * Run via `just test-post-publish`; gates uploads inside `just publish-ci`.
+ * Self-contained on a fresh checkout (builds everything it packs).
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '../..');
+if (!existsSync(join(ROOT, 'justfile')) || !existsSync(join(ROOT, 'templates'))) {
+  throw new Error(`ROOT does not look like the codegen-patterns repo root: ${ROOT}`);
+}
+
+interface Pkg {
+  dir: string;
+  name: string;
+  version: string;
+}
+
+function run(cmd: string, cwd: string): void {
+  execSync(cmd, { cwd, stdio: 'inherit' });
+}
+
+/** Run a command, returning { ok, output } instead of throwing. */
+function tryRun(cmd: string[], cwd: string): { ok: boolean; output: string } {
+  const res = spawnSync(cmd[0], cmd.slice(1), { cwd, encoding: 'utf-8' });
+  return {
+    ok: res.status === 0,
+    output: `${res.stdout ?? ''}${res.stderr ?? ''}`.trim(),
+  };
+}
+
+const failures: string[] = [];
+function check(label: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    console.log(`  ✗ ${label}${detail ? `\n      ${detail.split('\n').join('\n      ')}` : ''}`);
+    failures.push(label);
+  }
+}
+
+// ─── 1. Discover publishable packages ────────────────────────────────────────
+
+const rootManifest = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
+const rootPkg: Pkg = { dir: ROOT, name: rootManifest.name, version: rootManifest.version };
+
+const surfacePkgs: Pkg[] = readdirSync(join(ROOT, 'packages'))
+  .map((entry) => join(ROOT, 'packages', entry))
+  .filter((dir) => existsSync(join(dir, 'package.json')))
+  .map((dir) => ({ dir, manifest: JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8')) }))
+  .filter(({ manifest }) => manifest.private !== true && manifest.publishConfig?.access === 'public')
+  .map(({ dir, manifest }) => ({ dir, name: manifest.name, version: manifest.version }));
+
+console.log(`Tarball smoke: ${rootPkg.name}@${rootPkg.version} + ${surfacePkgs.length} surface packages\n`);
+
+// ─── 2. Build + pack everything ──────────────────────────────────────────────
+
+const stageDir = mkdtempSync(join(tmpdir(), 'codegen-tarball-smoke-'));
+process.on('exit', () => rmSync(stageDir, { recursive: true, force: true }));
+
+// Root builds first — the surface packages' .d.ts builds resolve
+// @pattern-stack/codegen/subsystems against its dist/ (ADR-036 §8).
+console.log('Building + packing...');
+const tarballs: string[] = [];
+for (const pkg of [rootPkg, ...surfacePkgs]) {
+  run('bun run build', pkg.dir);
+  const packJson = execSync(`npm pack --json --pack-destination ${stageDir}`, {
+    cwd: pkg.dir,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  const [{ filename }] = JSON.parse(packJson);
+  tarballs.push(join(stageDir, filename));
+  console.log(`  packed ${pkg.name}@${pkg.version}`);
+}
+
+// ─── 3. Install all tarballs into a fresh tmp project ───────────────────────
+
+// One combined install: surface packages resolve their @pattern-stack/codegen
+// peer against the ROOT TARBALL's version, so a stale peer range fails here
+// instead of in a consumer's session. npm auto-installs the root's peers
+// (NestJS, hygen, ...), exercising peer resolution end-to-end.
+const projectDir = join(stageDir, 'consumer');
+console.log('\nInstalling tarballs into fresh consumer project...');
+mkdirSync(projectDir, { recursive: true });
+writeFileSync(
+  join(projectDir, 'package.json'),
+  JSON.stringify({ name: 'tarball-smoke-consumer', private: true, type: 'module' }, null, 2),
+);
+run(
+  `npm install --no-audit --no-fund --loglevel=error ${tarballs.map((t) => `"${t}"`).join(' ')}`,
+  projectDir,
+);
+
+// ─── 4. Verify the installed root package ────────────────────────────────────
+
+const installedRoot = join(projectDir, 'node_modules', '@pattern-stack', 'codegen');
+
+console.log(`\n${rootPkg.name} — files manifest:`);
+check('dist/src/index.js', existsSync(join(installedRoot, 'dist/src/index.js')));
+check(
+  'dist/runtime/subsystems/index.js (0.3.0 bug class)',
+  existsSync(join(installedRoot, 'dist/runtime/subsystems/index.js')),
+);
+const rawRuntimeTs = existsSync(join(installedRoot, 'runtime'))
+  ? readdirSync(join(installedRoot, 'runtime'), { recursive: true }).filter((f) =>
+      String(f).endsWith('.ts'),
+    )
+  : [];
+check(
+  `runtime/ ships raw .ts sources (0.4.1 bug class) — ${rawRuntimeTs.length} files`,
+  rawRuntimeTs.length > 0,
+);
+check('templates/entity/new/prompt.js', existsSync(join(installedRoot, 'templates/entity/new/prompt.js')));
+check('consumer-skills/', existsSync(join(installedRoot, 'consumer-skills')));
+
+console.log(`\n${rootPkg.name} — exports resolve under node:`);
+for (const spec of [
+  '@pattern-stack/codegen',
+  '@pattern-stack/codegen/subsystems',
+  '@pattern-stack/codegen/runtime/shared/openapi',
+]) {
+  const res = tryRun(['node', '--input-type=module', '-e', `await import('${spec}')`], projectDir);
+  check(`import('${spec}')`, res.ok, res.ok ? undefined : res.output);
+}
+
+console.log(`\n${rootPkg.name} — bins execute:`);
+for (const bin of ['codegen', 'cdp']) {
+  const res = tryRun([join(projectDir, 'node_modules', '.bin', bin), '--help'], projectDir);
+  check(`${bin} --help`, res.ok, res.ok ? undefined : res.output);
+}
+
+// ─── 5. Verify each surface package's exports ───────────────────────────────
+
+for (const pkg of surfacePkgs) {
+  console.log(`\n${pkg.name}@${pkg.version} — exports resolve under node:`);
+  for (const spec of [pkg.name, `${pkg.name}/testing`]) {
+    const res = tryRun(['node', '--input-type=module', '-e', `await import('${spec}')`], projectDir);
+    check(`import('${spec}')`, res.ok, res.ok ? undefined : res.output);
+  }
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+console.log('');
+if (failures.length > 0) {
+  console.error(`✗ Tarball smoke FAILED — ${failures.length} check(s):`);
+  for (const f of failures) console.error(`    - ${f}`);
+  process.exit(1);
+}
+console.log('✓ Tarball smoke passed — published tarballs match the consumer contract.');


### PR DESCRIPTION
## What

Merging a version bump to `main` now publishes to npm automatically — gated on green tests and a tarball smoke check.

- **`publish` job in ci.yml** — `needs: test`, push-to-main only. Auth is **npm trusted publishing (OIDC)**: `id-token: write`, no `NPM_TOKEN` secret to store or rotate.
- **"Only on version bumps", enforced at the registry** — `just publish-ci` pass-1 checks npm for all 6 publishable package versions (root + 5 surface, independent versioning per ADR-036 §8) and exits in seconds when nothing is new. Only unpublished versions trigger the smoke + upload. No tag flow, no path filters.
- **Tarball smoke gate** (`test/post-publish/run-tarball-smoke.ts`, `just test-post-publish`) — packs all 6 packages, installs the tarballs into a fresh tmp project via npm, verifies the consumer contract: files-manifest essentials (`dist/runtime` = 0.3.0 bug class, raw `runtime/*.ts` = 0.4.1 bug class, `templates/`, `consumer-skills/`), all root exports import under node, both bins execute, each surface package's `.`/`./testing` exports import, and peer ranges resolve against the actual root tarball. Partially addresses #190 — the packaging-drift class; the full consumer-workflow smoke (project init → entity new → tsc) remains open.
- **Main CI runs queue instead of cancel** — a rapid second merge can't kill a publish mid-upload; queued runs no-op via the registry check.
- **`just publish` delegates to `publish-ci`** inside its pristine origin/main worktree — manual and CI publishes share one code path.

## Drive-by fix

All five surface packages pinned `peerDependencies["@pattern-stack/codegen"]` at `^0.13.0 || ^0.14.0` against a root at 0.20.x — ERESOLVE for any npm consumer. Now `>=0.20.0 <1.0.0`, validated by the smoke's combined tarball install. (Lands on npm with each package's next version bump.)

## Verified

- Tarball smoke: full local run, 25/25 checks pass (root manifest, exports, bins; all 5 surface packages' exports; peer resolution)
- No-op path: `just publish-ci --dry-run` with all versions already published → early exit in seconds
- ci.yml parses; `publish-ci` bash syntax checked

## Before the first real bump merge

Trusted publishing needs one-time config on npmjs.com for each of the 6 packages (Settings → Trusted Publisher → GitHub Actions): org `pattern-stack`, repo `codegen-patterns`, workflow filename `ci.yml`, environment blank. Until then, the publish job fails at upload time on bump merges (no-op merges unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
