### PR TITLE
test(post-publish): run the full consumer workflow from the packed tarball

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ Auto-detect: `just scan` generates a config from project conventions.
 - **Unit tests**: `just test-unit` — base classes, subsystems, scanner, schema (~200ms)
 - **Integration tests**: `just test-family` / `just test-integration` — real Postgres via Docker
 - **Smoke test**: `just test-smoke` — end-to-end scaffold + generate + typecheck on a fresh tmp project (~60-120s)
+- **Tarball smoke**: `just test-post-publish` — pack all publishable packages, install into a fresh tmp project via npm, verify the consumer contract (files manifest, exports, bins, peer ranges), then re-run the smoke harness with the CLI/templates/runtime coming from the installed tarball (`SMOKE_TARBALL` mode). Gates every CI publish via `just publish-ci`. Catches the works-from-checkout-broken-from-tarball class (#190)
 - **Baseline tests**: `just test-baseline` — generate from `test/fixtures/` into repo-root `packages/api/` and compare to `test/baseline/` snapshots. Two-pass generation (first pass seeds `packages/api/src/domain/*.entity.ts` files so second-pass `targetExists` checks resolve cross-entity references). Start from pristine state — the runner wipes the generated directories on each run.
 - **CI**: `just test-all` (unit + baseline + smoke) runs on every PR to `main` and every push to `main` (`.github/workflows/ci.yml`)
 - **241+ total tests**, all passing

--- a/justfile
+++ b/justfile
@@ -137,7 +137,9 @@ test-family:
 
 # Tarball smoke (#190): build + pack every publishable package, install the
 # tarballs into a fresh tmp project via npm, verify the consumer contract
-# (files manifest, exports, bins, peer ranges). Catches the
+# (files manifest, exports, bins, peer ranges), then run the FULL consumer
+# workflow from the tarball (run-smoke.ts in SMOKE_TARBALL mode: project init
+# → entity new → subsystem installs → tsc → /docs-json). Catches the
 # works-from-checkout-broken-from-tarball class. Gates `just publish-ci`.
 test-post-publish:
     bun test/post-publish/run-tarball-smoke.ts

--- a/test/post-publish/run-tarball-smoke.ts
+++ b/test/post-publish/run-tarball-smoke.ts
@@ -20,6 +20,10 @@
  *      (dist/runtime, raw runtime/*.ts, templates/, consumer-skills/),
  *      every `exports` entry imports under node, both bins run `--help`.
  *   4. Verifies each surface package's `.` and `./testing` exports import.
+ *   5. Runs the full consumer workflow FROM the tarball (test/smoke/run-smoke.ts
+ *      in SMOKE_TARBALL mode): project init → entity new --all → subsystem
+ *      installs → tsc → /docs-json. Contents checks (1-4) prove the files
+ *      ship; this proves they work (0.3.0 / 0.4.1 / 0.6.0-#266 bug classes).
  *
  * Run via `just test-post-publish`; gates uploads inside `just publish-ci`.
  * Self-contained on a fresh checkout (builds everything it packs).
@@ -171,6 +175,25 @@ for (const pkg of surfacePkgs) {
     const res = tryRun(['node', '--input-type=module', '-e', `await import('${spec}')`], projectDir);
     check(`import('${spec}')`, res.ok, res.ok ? undefined : res.output);
   }
+}
+
+// ─── 6. Consumer-workflow smoke from the tarball (#190 full scope) ──────────
+
+// Re-run the end-to-end smoke harness in tarball mode: project init →
+// entity new --all → subsystem installs → tsc → /docs-json, with the CLI,
+// templates, vendored runtime, and examples/ all coming from the packed
+// tarball instead of the checkout. This is what actually exercises
+// runtimeRoot() resolution (0.3.0), vendoring from runtime/*.ts (0.4.1),
+// and template-time src/ imports (0.6.0 / #266) — the contents checks above
+// prove the files ship; this proves they work.
+console.log('\nConsumer-workflow smoke from tarball (test/smoke/run-smoke.ts, SMOKE_TARBALL):');
+{
+  const res = spawnSync('bun', [join(ROOT, 'test/smoke/run-smoke.ts')], {
+    cwd: ROOT,
+    stdio: 'inherit',
+    env: { ...process.env, SMOKE_TARBALL: tarballs[0] },
+  });
+  check('consumer workflow from tarball (init → entity new → subsystems → tsc → openapi)', res.status === 0);
 }
 
 // ─── Summary ─────────────────────────────────────────────────────────────────

--- a/test/smoke/run-smoke.ts
+++ b/test/smoke/run-smoke.ts
@@ -28,6 +28,27 @@ import path from 'node:path';
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
 const CLI_PATH = path.join(REPO_ROOT, 'src', 'cli', 'index.ts');
 
+// #190 tarball mode: when SMOKE_TARBALL points at a packed
+// @pattern-stack/codegen tarball, the smoke installs it into the tmp project
+// and runs the CLI from node_modules — so the CLI, hygen templates, vendored
+// runtime sources, and examples/ all come from what consumers actually
+// receive, not the repo checkout. This is the only mode that catches the
+// works-from-checkout-broken-from-tarball class (0.3.0 runtimeRoot, 0.4.1
+// missing runtime/*.ts, 0.6.0 prompt.js importing unshipped src/ — #266).
+// Run under bun, matching real consumers (`.js`→`.ts` extension resolution
+// inside templates only exists in bun).
+const TARBALL = process.env.SMOKE_TARBALL ?? '';
+if (TARBALL && !fs.existsSync(TARBALL)) {
+	console.error(`SMOKE_TARBALL does not exist: ${TARBALL}`);
+	process.exit(2);
+}
+const INSTALLED_CLI = 'node_modules/@pattern-stack/codegen/dist/src/cli/index.js';
+
+/** CLI invocation prefix — repo checkout by default, installed package in tarball mode. */
+function cli(tmpDir: string): string {
+	return TARBALL ? `bun ${path.join(tmpDir, INSTALLED_CLI)}` : `bun ${CLI_PATH}`;
+}
+
 // CGP-62: `--scenario` selects which fixture set the smoke generates against.
 // `default` (no flag) preserves the historical behavior. `relationship`
 // swaps in `test/smoke/fixtures/crm/` (account self-ref + cross-entity
@@ -196,9 +217,12 @@ function filterConsumerErrors(output: string, tmpDir: string): string[] {
 		if (vendoredConnectionsPattern.test(line)) {
 			continue;
 		}
-		// Also tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
-		// barrel import — the smoke project doesn't `bun add` the package.
-		if (line.includes("'@pattern-stack/codegen/")) {
+		// Tolerate the `@pattern-stack/codegen/runtime/subsystems/auth`
+		// barrel import — but ONLY in checkout mode, where the smoke project
+		// doesn't `bun add` the package. In tarball mode (#190) the package IS
+		// installed, so these imports must resolve; filtering them there would
+		// mask exactly the bug class the tarball smoke exists to catch.
+		if (!TARBALL && line.includes("'@pattern-stack/codegen/")) {
 			continue;
 		}
 
@@ -369,6 +393,14 @@ async function main(): Promise<number> {
 		run(`bun add ${RUNTIME_DEPS.join(' ')}`, tmpDir);
 		run(`bun add -D ${DEV_DEPS.join(' ')}`, tmpDir);
 
+		// 2.5. Tarball mode (#190): install the packed @pattern-stack/codegen —
+		// every subsequent CLI call runs from node_modules, exercising the
+		// published files manifest instead of the checkout.
+		if (TARBALL) {
+			run(`bun add ${TARBALL}`, tmpDir);
+			log(`tarball mode: CLI runs from ${INSTALLED_CLI}`);
+		}
+
 		// 3. Run `codegen project init --yes --with-tsconfig`
 		//    tsconfig.json already exists (bun init), so init will merge aliases.
 		//    `--runtime vendored` (ADR-037): this smoke is the VENDORED consumer
@@ -376,7 +408,7 @@ async function main(): Promise<number> {
 		//    connections (which vendor more), and compiles against `@shared/*`. The
 		//    new `package` default would skip vendoring and break the base-class
 		//    imports, so the mode is pinned to match what this flow exercises.
-		run(`bun ${CLI_PATH} project init --yes --with-tsconfig --runtime vendored`, tmpDir);
+		run(`${cli(tmpDir)} project init --yes --with-tsconfig --runtime vendored`, tmpDir);
 
 		// 4. Copy smoke fixtures into entities/.
 		const fixtureFiles = fs.readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.yaml'));
@@ -402,10 +434,10 @@ async function main(): Promise<number> {
 		// `clpExistingHasMany` check and ensures many() calls are emitted for
 		// all targets, not just those that happen to be generated first.
 		// (Mirrors the baseline test's two-pass strategy in test/run-test.ts.)
-		run(`bun ${CLI_PATH} entity new --all --force`, tmpDir);
+		run(`${cli(tmpDir)} entity new --all --force`, tmpDir);
 		if (SCENARIO === 'relationship') {
 			log('second pass (relationship scenario — seeds clpExistingHasMany)');
-			run(`bun ${CLI_PATH} entity new --all --force`, tmpDir);
+			run(`${cli(tmpDir)} entity new --all --force`, tmpDir);
 		}
 
 		// 5.1. CGP-62 — under the `relationship` scenario, assert the
@@ -427,7 +459,7 @@ async function main(): Promise<number> {
 		// No siblings installed in this smoke — observability must typecheck
 		// standalone because its @Optional() sibling injections degrade to
 		// empty results when ports are absent (per OBS-5 contract).
-		run(`bun ${CLI_PATH} subsystem install observability`, tmpDir);
+		run(`${cli(tmpDir)} subsystem install observability`, tmpDir);
 
 		// Verify install artifacts appeared.
 		const configYamlPath = path.join(tmpDir, 'codegen.config.yaml');
@@ -453,7 +485,7 @@ async function main(): Promise<number> {
 		//   - `auth:` block into codegen.config.yaml;
 		//   - AuthModule.forRoot TODO into app.module.ts;
 		//   - INTEGRATION_TOKEN_ENCRYPTION_KEY + AUTH_REDIRECT_URI_BASE into .env.config.
-		run(`bun ${CLI_PATH} subsystem install auth`, tmpDir);
+		run(`${cli(tmpDir)} subsystem install auth`, tmpDir);
 
 		const configYamlAfterAuth = fs.readFileSync(configYamlPath, 'utf8');
 		if (!configYamlAfterAuth.includes('auth:')) {
@@ -480,7 +512,7 @@ async function main(): Promise<number> {
 		//   - examples/auth-integrations/definitions/entities/connection.yaml →
 		//       <paths.entities>/integration.yaml (defaults to definitions/entities/);
 		//   - ConnectionsAuthModule TODO into app.module.ts.
-		run(`bun ${CLI_PATH} subsystem install auth-integrations`, tmpDir);
+		run(`${cli(tmpDir)} subsystem install auth-integrations`, tmpDir);
 
 		// #303 fix #5: vendor target is `<modules>/connections/` with
 		// subfolders (`adapters/`, `facade/`, `oauth/use-cases/`). Assert


### PR DESCRIPTION
## What

Completes #190's remaining scope: the publish gate now runs the **full consumer workflow from the packed tarball**, not just contents checks.

- **`SMOKE_TARBALL` mode in `test/smoke/run-smoke.ts`** — when set to a packed `@pattern-stack/codegen` tarball, the harness `bun add`s it into the tmp project and runs every CLI call from `node_modules`: CLI, hygen templates, vendored runtime sources, and `examples/` all come from what consumers actually receive. Checkout mode (no env var) is behaviorally identical to before — CI's `test-smoke` is unaffected.
- **Chained into the publish gate** — `run-tarball-smoke.ts` runs the harness as its final phase, so `just publish-ci` now proves the tarball *works* before anything uploads: `project init` → `entity new --all` → subsystem installs (observability, auth, auth-integrations) → `tsc --noEmit` → programmatic `/docs-json`.
- **Filter hardening** — in tarball mode the `'@pattern-stack/codegen/` import-error tolerance is disabled: the package IS installed there, so those imports must resolve; filtering them would mask exactly the bug class this exists to catch.

## Why this closes both issues

All three shipped packaging bugs were behavioral, not just manifest gaps: `runtimeRoot()` resolution (0.3.0), vendoring from raw `runtime/*.ts` (0.4.1), and template-time `src/` imports (0.6.0 / #266). Contents checks prove files ship; only running the consumer flow from the tarball proves they work.

Verified locally: full `just test-post-publish` passes end-to-end — hygen templates executed from the installed package (the `prompt.js` → `src/config/*.mjs` / `src/patterns/*` imports resolve), entity generation produced 7 OpenAPI schemas / 4 paths, tsc clean. That run is the verification #266 was waiting on: the `files:` globs added after 0.6.0 do work from a real tarball.

Closes #190
Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
