### PR TITLE
feat(frontend-emitter): FieldMeta enrichment — ui-hint passthrough, key-field curation, family bundles, EAV type contract (0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-06-06
+
+**FieldMeta enrichment (ADR-040, Phase A of type-aware rendering).** The
+frontend emitter's per-entity field metadata now carries enough vocabulary for
+consumers to build metadata-driven rendering (the swe-brain renderer kit
+consumes this in its Phase B). All additive.
+
+### Added
+
+- **Full `ui_*` hint passthrough.** `ui_group`, `ui_visible`, `ui_placeholder`,
+  `ui_help`, and `ui_format` were accepted by the schema but dropped before
+  emission. They now survive parser → derivation → emitted `FieldMeta`
+  (`group` / `visible` / `placeholder` / `help` / `format`). `format` was
+  previously only ever the hardcoded timestamp `{ dateFormat: 'relative' }`;
+  authored `ui_format` now passes through.
+- **Key-field curation (qField parity).** New YAML keys `ui_key_field` +
+  `ui_key_field_order` surface as `isKeyField` / `keyFieldOrder` on the row
+  (the qField / EAV `field_definitions` names — one vocabulary, multiple
+  homes), and `<camel>Metadata` gains `keyFields`: the ordered curated
+  field-name list (sorted by `keyFieldOrder`, declaration order for ties) that
+  drives card/preview field selection.
+- **Family/behavior common-field bundles** (timestamps precedent): the
+  `soft_delete` behavior now contributes a `deletedAt` row
+  (datetime / tertiary / relative); entities whose declared fields carry the
+  synced/integrated shape (both `external_id` AND `provider`) get
+  `group: 'external_sync'` defaulted onto those fields (plus
+  `provider_metadata` when present) — a derivation default only, authored
+  `ui_group` always wins. Behavior-contributed columns (not in the parsed
+  field map) still get no rows: the emitter never emits a row for a column it
+  cannot see.
+- **EAV `data_type` → `FieldType` contract.** `EAV_DATA_TYPE_TO_FIELD_TYPE`
+  (`string→text, integer/decimal→number, boolean→boolean, date→date,
+  datetime→datetime, json→json, reference→reference, picklist→enum,
+  multipicklist→enum`; multi-select rendering is consumer-side) is exported
+  from the package root AND emitted into every generated
+  `fields/field-meta.ts`, rendered from the same source object so the copies
+  cannot drift. See ADR-040 for the convergence story
+  (qField/CatalogField ↔ codegen FieldMeta ↔ EAV `field_definitions`).
+
+### Tests
+
+- emit-fields suite: hint passthrough (incl. author-override-beats-default and
+  string escaping), key-field curation + `keyFields` ordering, soft_delete /
+  external-sync bundles, EAV contract completeness vs the emitted copy.
+- Frontend golden fixtures now exercise the new surface; the snapshot locks
+  curation ordering (`first_name` before `email` despite declaration order),
+  the `deletedAt` bundle, and the `external_sync` group default.
+
 ## [0.20.2] — 2026-06-06
 
 Two consumer-found fixes (dogfooding swe-brain on 0.20.1).

--- a/docs/adrs/ADR-040-field-metadata-vocabulary-convergence.md
+++ b/docs/adrs/ADR-040-field-metadata-vocabulary-convergence.md
@@ -1,0 +1,88 @@
+# ADR-040 — Field-Metadata Vocabulary Convergence (FieldMeta ↔ qField ↔ EAV `field_definitions`)
+
+**Status:** Accepted
+**Date:** 2026-06-06
+**Owner:** Doug
+**Related:** ADR-038 (frontend pipeline rebuild — the FieldMeta emitter this enriches), `examples/eav/field_definition.yaml` (the EAV starter), swe-brain `query-surface-poc` (qField/CatalogField — the consumer driving parity)
+
+---
+
+## Context
+
+Three systems describe "what a field means for rendering," each grown
+independently:
+
+1. **codegen FieldMeta** — emitted per entity into the generated frontend
+   (`fields/<name>.ts`, ADR-038). Derived from YAML `ui_*` hints + heuristics.
+2. **qField / CatalogField** (swe-brain query-surface-poc) — attribute-level
+   metadata stamped on Drizzle columns: `label / description / selectOptions /
+   isKeyField / keyFieldOrder / group / isVisible`. Deliberately mirrors the
+   EAV `field_definitions` table so native columns and EAV fields share one
+   metadata layer.
+3. **EAV `field_definitions`** — a *runtime* schema row per custom or
+   sync-discovered field, with a `data_type` enum (`string / integer / decimal /
+   boolean / date / datetime / json / reference / picklist / multipicklist`).
+
+Consumers building metadata-driven rendering (the swe-brain renderer kit) need
+all three to speak ONE vocabulary: a renderer keyed on FieldMeta must render an
+EAV field without a parallel code path, and curation flags authored in YAML
+must mean the same thing as curation flags in a `field_definitions` row.
+
+Before this ADR, codegen's FieldMeta dropped most of the parsed `ui_*` hints
+(group/visible/placeholder/help/format never emitted), had no curation concept,
+and had no stated relationship to the EAV `data_type` vocabulary.
+
+## Decision
+
+**One vocabulary, multiple homes.** The field-metadata property names are a
+shared contract; each home stores them where it naturally lives:
+
+| Concept | YAML (codegen) | FieldMeta (emitted) | qField (swe-brain) | EAV row |
+|---|---|---|---|---|
+| Display label | `ui_label` | `label` | `label` | `label` |
+| Help/meaning | `ui_help` | `help` | `description` | `description` |
+| Enum options | `choices` | `choices` | `selectOptions` | `picklist_values` |
+| Curated field | `ui_key_field` | `isKeyField` | `isKeyField` | `isKeyField` |
+| Curation order | `ui_key_field_order` | `keyFieldOrder` | `keyFieldOrder` | `keyFieldOrder` |
+| Layout group | `ui_group` | `group` | `group` | `group` |
+| Visibility | `ui_visible` | `visible` | `isVisible` | `isVisible` |
+
+Concretely, in codegen:
+
+1. **Full `ui_*` passthrough.** `ui_group` / `ui_visible` / `ui_placeholder` /
+   `ui_help` / `ui_format` now survive parser → derivation → emission.
+2. **Key-field curation.** New YAML keys `ui_key_field` / `ui_key_field_order`
+   surface as `isKeyField` / `keyFieldOrder` (qField's names, chosen for
+   catalog convergence) and roll up into `<camel>Metadata.keyFields` — the
+   ordered curated-field list that drives card/preview selection.
+3. **Family/behavior bundles** (timestamps precedent): `soft_delete` ⇒ a
+   `deletedAt` row; the explicit `external_id` + `provider` shape ⇒
+   `group: 'external_sync'` as a derivation default (authored `ui_group` wins).
+4. **EAV `data_type` → `FieldType` contract.** `EAV_DATA_TYPE_TO_FIELD_TYPE`
+   maps the EAV vocabulary onto the rendering vocabulary:
+   `string→text, integer/decimal→number, boolean→boolean, date→date,
+   datetime→datetime, json→json, reference→reference, picklist→enum,
+   multipicklist→enum`. Multi-select rendering is consumer-side (the renderer
+   checks the EAV row's cardinality, not the FieldType). The source of truth
+   lives in `src/emitters/frontend/field-meta.ts`, is re-exported from the
+   package root, and is emitted verbatim into every generated
+   `fields/field-meta.ts` so consumer apps hold it locally — rendered from the
+   same object, so the copies cannot drift.
+
+## Consequences
+
+- A renderer written against `FieldMeta` + `EAV_DATA_TYPE_TO_FIELD_TYPE`
+  serves native columns and EAV fields with one code path (swe-brain renderer
+  kit, Phase B).
+- The names `isKeyField` / `keyFieldOrder` intentionally break codegen's own
+  `ui_*`-to-camelCase symmetry (`ui_key_field` → `isKeyField`, not `keyField`)
+  — cross-system parity beats local consistency.
+- No EAV *serving* wiring ships here: this is the vocabulary contract only.
+  How field_definitions rows reach the frontend catalog is the consumer's
+  (or a future pattern's) concern — see the `EavPattern` TODO in
+  `examples/eav/field_definition.yaml`.
+- Columns contributed by the `external_id_tracking` BEHAVIOR are not in the
+  parsed field map and still get no FieldMeta rows (only explicitly declared
+  fields do). If the integrated family later needs emitted rows for
+  behavior-contributed columns, extend the bundle mechanism in
+  `emit-fields.ts` — never emit a row for a column the emitter cannot see.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/emitters/frontend/emit-fields.test.ts
+++ b/src/__tests__/emitters/frontend/emit-fields.test.ts
@@ -1,19 +1,24 @@
 /**
- * Frontend emitter — field metadata tests (ADR-038, FE-3).
+ * Frontend emitter — field metadata tests (ADR-038, FE-3; enriched per ADR-040).
  *
  * Two layers: pure UI-derivation unit tests (label humanization, importance
- * heuristic, type inference, choices, FK reference) and the rendered metadata
- * shape (primaryFields / searchFields / defaultSort / capabilities / timestamps
- * rows / belongs_to relation rows).
+ * heuristic, type inference, choices, FK reference, ui-hint passthrough,
+ * key-field curation, external-sync defaults, the EAV contract) and the
+ * rendered metadata shape (primaryFields / keyFields / searchFields /
+ * defaultSort / capabilities / timestamps + soft_delete rows / belongs_to
+ * relation rows).
  */
 
 import { describe, expect, it } from 'bun:test';
 import {
 	deriveFieldMeta,
 	formatLabel,
+	hasExternalSyncShape,
 	inferUiImportance,
 	inferUiType,
 	isEntityRefField,
+	EAV_DATA_TYPE_TO_FIELD_TYPE,
+	type FieldType,
 } from '../../../emitters/frontend/field-meta';
 import {
 	buildFieldMetaTypeFile,
@@ -204,5 +209,249 @@ describe('emit-fields — entity metadata file', () => {
 		// read is never gated.
 		expect(offOut).toContain('list: true,');
 		expect(offOut).toContain('get: true,');
+	});
+});
+
+describe('field-meta — ui hint passthrough (ADR-040)', () => {
+	it('passes group / visible / placeholder / help / format through verbatim', () => {
+		const meta = deriveFieldMeta(
+			field('email', {
+				ui: {
+					group: 'contact',
+					visible: false,
+					placeholder: 'name@example.com',
+					help: 'Primary contact address.',
+					format: { mask: 'lowercase' },
+				},
+			}),
+		);
+		expect(meta.group).toBe('contact');
+		expect(meta.visible).toBe(false);
+		expect(meta.placeholder).toBe('name@example.com');
+		expect(meta.help).toBe('Primary contact address.');
+		expect(meta.format).toEqual({ mask: 'lowercase' });
+	});
+
+	it('omits the keys entirely when unset (no undefined noise)', () => {
+		const meta = deriveFieldMeta(field('email'));
+		expect('group' in meta).toBe(false);
+		expect('visible' in meta).toBe(false);
+		expect('placeholder' in meta).toBe(false);
+		expect('help' in meta).toBe(false);
+		expect('format' in meta).toBe(false);
+	});
+
+	it('defaults.group fills only where the author left ui_group unset', () => {
+		const defaulted = deriveFieldMeta(field('external_id'), { group: 'external_sync' });
+		expect(defaulted.group).toBe('external_sync');
+
+		const authored = deriveFieldMeta(
+			field('external_id', { ui: { group: 'integrations' } }),
+			{ group: 'external_sync' },
+		);
+		expect(authored.group).toBe('integrations');
+	});
+});
+
+describe('field-meta — key-field curation (ADR-040)', () => {
+	it('ui_key_field surfaces as isKeyField + keyFieldOrder', () => {
+		const meta = deriveFieldMeta(
+			field('email', { ui: { keyField: true, keyFieldOrder: 2 } }),
+		);
+		expect(meta.isKeyField).toBe(true);
+		expect(meta.keyFieldOrder).toBe(2);
+	});
+
+	it('keyFieldOrder without keyField is dropped; non-key fields stay bare', () => {
+		const orphanOrder = deriveFieldMeta(field('email', { ui: { keyFieldOrder: 3 } }));
+		expect('isKeyField' in orphanOrder).toBe(false);
+		expect('keyFieldOrder' in orphanOrder).toBe(false);
+
+		const plain = deriveFieldMeta(field('email'));
+		expect('isKeyField' in plain).toBe(false);
+	});
+});
+
+describe('field-meta — external-sync shape detection (ADR-040)', () => {
+	it('requires BOTH external_id and provider', () => {
+		expect(hasExternalSyncShape(['external_id', 'provider', 'name'])).toBe(true);
+		expect(hasExternalSyncShape(['external_id', 'name'])).toBe(false);
+		expect(hasExternalSyncShape(['provider', 'name'])).toBe(false);
+		expect(hasExternalSyncShape([])).toBe(false);
+	});
+});
+
+describe('field-meta — EAV data_type → FieldType contract (ADR-040)', () => {
+	it('covers the full EAV data_type vocabulary', () => {
+		expect(Object.keys(EAV_DATA_TYPE_TO_FIELD_TYPE).sort()).toEqual(
+			[
+				'boolean',
+				'date',
+				'datetime',
+				'decimal',
+				'integer',
+				'json',
+				'multipicklist',
+				'picklist',
+				'reference',
+				'string',
+			].sort(),
+		);
+	});
+
+	it('maps both picklist and multipicklist to enum (multi-select is consumer-side)', () => {
+		expect(EAV_DATA_TYPE_TO_FIELD_TYPE.picklist).toBe('enum');
+		expect(EAV_DATA_TYPE_TO_FIELD_TYPE.multipicklist).toBe('enum');
+	});
+
+	it('every value is a member of the FieldType union', () => {
+		const fieldTypes: FieldType[] = [
+			'text', 'textarea', 'number', 'boolean', 'date', 'datetime', 'email',
+			'url', 'password', 'money', 'percentage', 'json', 'enum', 'reference',
+			'entity',
+		];
+		for (const v of Object.values(EAV_DATA_TYPE_TO_FIELD_TYPE)) {
+			expect(fieldTypes).toContain(v);
+		}
+	});
+});
+
+describe('emit-fields — type file (ADR-040 additions)', () => {
+	it('declares the enriched optional surface on FieldMeta', () => {
+		const out = buildFieldMetaTypeFile();
+		expect(out).toContain('group?: string;');
+		expect(out).toContain('visible?: boolean;');
+		expect(out).toContain('placeholder?: string;');
+		expect(out).toContain('help?: string;');
+		expect(out).toContain('isKeyField?: boolean;');
+		expect(out).toContain('keyFieldOrder?: number;');
+	});
+
+	it('emits the EAV contract rendered from the source constant (no drift)', () => {
+		const out = buildFieldMetaTypeFile();
+		expect(out).toContain('export type EavDataType =');
+		expect(out).toContain(
+			'export const EAV_DATA_TYPE_TO_FIELD_TYPE: Record<EavDataType, FieldType> = {',
+		);
+		for (const [k, v] of Object.entries(EAV_DATA_TYPE_TO_FIELD_TYPE)) {
+			expect(out).toContain(`\t${k}: '${v}',`);
+			expect(out).toContain(`| '${k}'`);
+		}
+	});
+});
+
+describe('emit-fields — ui hints + key fields in the rendered file (ADR-040)', () => {
+	function curatedCtx() {
+		const contact = entry('contact', 'contacts');
+		const parsed = parsedMap(
+			parsedEntity(contact, {
+				fields: new Map([
+					// email declared FIRST but ordered second — locks the sort.
+					['email', field('email', { ui: { keyField: true, keyFieldOrder: 1, placeholder: "name@example.com", help: "The contact's address." } })],
+					['name', field('name', { required: true, ui: { keyField: true, keyFieldOrder: 0 } })],
+					['notes', field('notes', { ui: { group: 'detail', visible: false, format: { rows: 4 } } })],
+				]),
+			}),
+		);
+		return { contact, c: ctx([contact], {}, parsed) };
+	}
+
+	it('renders the hint keys and escapes quotes in strings', () => {
+		const { contact, c } = curatedCtx();
+		const out = buildEntityFieldsFile(contact, c);
+		expect(out).toContain("placeholder: 'name@example.com',");
+		expect(out).toContain("help: 'The contact\\'s address.',");
+		expect(out).toContain("group: 'detail',");
+		expect(out).toContain('visible: false,');
+		expect(out).toContain('format: {"rows":4},');
+	});
+
+	it('renders isKeyField/keyFieldOrder rows and the ordered keyFields list', () => {
+		const { contact, c } = curatedCtx();
+		const out = buildEntityFieldsFile(contact, c);
+		expect(out).toContain('isKeyField: true,');
+		expect(out).toContain('keyFieldOrder: 0,');
+		// keyFields sorted by keyFieldOrder: name (0) before email (1) despite
+		// email being declared first.
+		expect(out).toContain("keyFields: [\n\t\t'name',\n\t\t'email',\n\t],");
+	});
+
+	it('emits an empty keyFields list when nothing is curated', () => {
+		const plain = entry('tag', 'tags');
+		const c = ctx([plain], {}, parsedMap(parsedEntity(plain)));
+		const out = buildEntityFieldsFile(plain, c);
+		expect(out).toContain('keyFields: [\n\n\t],');
+	});
+});
+
+describe('emit-fields — behavior/family bundles (ADR-040)', () => {
+	it('soft_delete behavior contributes a deletedAt row (datetime/tertiary/relative)', () => {
+		const e = entry('doc', 'docs');
+		const c = ctx([e], {}, parsedMap(parsedEntity(e, { behaviors: ['soft_delete'] })));
+		const out = buildEntityFieldsFile(e, c);
+		expect(out).toContain('deletedAt: {');
+		expect(out).toContain("field: 'deletedAt',");
+		expect(out).toContain("label: 'Deleted',");
+		expect(out).toContain("format: { dateFormat: 'relative' },");
+	});
+
+	it('no deletedAt row without the behavior', () => {
+		const e = entry('doc', 'docs');
+		const c = ctx([e], {}, parsedMap(parsedEntity(e)));
+		expect(buildEntityFieldsFile(e, c)).not.toContain('deletedAt: {');
+	});
+
+	it('external_id+provider(+provider_metadata) default to group external_sync', () => {
+		const e = entry('deal', 'deals');
+		const c = ctx(
+			[e],
+			{},
+			parsedMap(
+				parsedEntity(e, {
+					fields: new Map([
+						['name', field('name', { required: true })],
+						['external_id', field('external_id', { nullable: true })],
+						['provider', field('provider', { nullable: true })],
+						['provider_metadata', field('provider_metadata', { type: 'json', nullable: true })],
+					]),
+				}),
+			),
+		);
+		const out = buildEntityFieldsFile(e, c);
+		const matches = out.match(/group: 'external_sync',/g) ?? [];
+		expect(matches.length).toBe(3);
+		// the non-bookkeeping field is untouched
+		expect(out).not.toMatch(/name: \{[^}]*group:/);
+	});
+
+	it('authored ui_group beats the external_sync default; no gate ⇒ no default', () => {
+		const e = entry('deal', 'deals');
+		const authored = ctx(
+			[e],
+			{},
+			parsedMap(
+				parsedEntity(e, {
+					fields: new Map([
+						['external_id', field('external_id', { ui: { group: 'integrations' } })],
+						['provider', field('provider')],
+					]),
+				}),
+			),
+		);
+		const authoredOut = buildEntityFieldsFile(e, authored);
+		expect(authoredOut).toContain("group: 'integrations',");
+		expect(authoredOut).toContain("group: 'external_sync',"); // provider still defaulted
+
+		// provider alone (no external_id) ⇒ shape gate fails ⇒ no default.
+		const ungated = ctx(
+			[e],
+			{},
+			parsedMap(
+				parsedEntity(e, {
+					fields: new Map([['provider', field('provider')]]),
+				}),
+			),
+		);
+		expect(buildEntityFieldsFile(e, ungated)).not.toContain('external_sync');
 	});
 });

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -40,6 +40,13 @@ export interface ParsedField {
 		sortable?: boolean;
 		filterable?: boolean;
 		visible?: boolean;
+		placeholder?: string;
+		help?: string;
+		format?: Record<string, unknown>;
+		/** Curated/displayed field (qField `isKeyField` parity, ADR-040). */
+		keyField?: boolean;
+		/** Sort position within the key-field set (qField `keyFieldOrder`). */
+		keyFieldOrder?: number;
 	};
 }
 

--- a/src/emitters/frontend/emit-fields.ts
+++ b/src/emitters/frontend/emit-fields.ts
@@ -17,6 +17,24 @@
  * `['repository','rest','trpc']`) and set `create/update/delete` to
  * `expose.includes('repository') || expose.includes('trpc')`. `list`/`get` stay
  * always-true (read is never gated).
+ *
+ * Family/behavior common-field bundles (ADR-040), mirroring the timestamps
+ * precedent (behavior-contributed columns exist in the generated table but not
+ * in the parsed field map, so the emitter contributes their rows):
+ * - `soft_delete` behavior ⇒ a `deletedAt` row (datetime / tertiary /
+ *   `format: { dateFormat: 'relative' }`), exactly like createdAt/updatedAt.
+ * - Entities whose DECLARED fields carry the synced/integrated shape (both
+ *   `external_id` AND `provider` present) ⇒ those fields (plus
+ *   `provider_metadata` when present) default to `group: 'external_sync'`.
+ *   A derivation default only — an authored `ui_group` always wins. Columns
+ *   contributed by the `external_id_tracking` BEHAVIOR are not in the parsed
+ *   map and get no rows (we never emit a row for a column we cannot see).
+ *
+ * Key-field curation (ADR-040): `ui_key_field` / `ui_key_field_order` surface
+ * as `isKeyField` / `keyFieldOrder` on the row, and the `<camel>Metadata`
+ * object gains `keyFields` — the ordered curated field-name list (sorted by
+ * `keyFieldOrder`, declaration order for ties / unordered) that drives
+ * card/preview field selection in consumers.
  */
 
 import { join } from 'node:path';
@@ -26,7 +44,11 @@ import { sortEntities } from './types';
 import { withBanner, writeFile } from './emit-utils';
 import {
 	deriveFieldMeta,
+	hasExternalSyncShape,
 	isEntityRefField,
+	EAV_DATA_TYPE_TO_FIELD_TYPE,
+	EXTERNAL_SYNC_FIELDS,
+	EXTERNAL_SYNC_GROUP,
 	type DerivedFieldMeta,
 } from './field-meta';
 import { resolvableRels } from './emit-store';
@@ -34,11 +56,20 @@ import { resolvableRels } from './emit-store';
 const SOURCE_DESC_SET = 'the entity set';
 
 /**
- * `fields/field-meta.ts` — the self-contained metadata TYPE file. Exactly the
+ * `fields/field-meta.ts` — the self-contained metadata module. Exactly the
  * properties the metadata objects use (`field`/`label`/`type`/`importance`,
- * optional `sortable`/`filterable`/`format`/`choices`/`reference`).
+ * the optional ui-hint surface, key-field curation) plus the EAV
+ * `data_type` → `FieldType` rendering contract (`EAV_DATA_TYPE_TO_FIELD_TYPE`,
+ * rendered from the source-of-truth constant in `field-meta.ts` so the
+ * emitted copy cannot drift).
  */
 export function buildFieldMetaTypeFile(): string {
+	const eavKeys = Object.keys(EAV_DATA_TYPE_TO_FIELD_TYPE);
+	const eavUnion = eavKeys.map((k) => `\t| '${k}'`).join('\n');
+	const eavEntries = Object.entries(EAV_DATA_TYPE_TO_FIELD_TYPE)
+		.map(([k, v]) => `\t${k}: '${v}',`)
+		.join('\n');
+
 	const body = `/**
  * Field metadata types for DataGrid, forms, and admin surfaces.
  */
@@ -70,10 +101,35 @@ export interface FieldMeta<T = unknown> {
 \timportance: FieldImportance;
 \tsortable?: boolean;
 \tfilterable?: boolean;
+\t/** Layout grouping (e.g. 'external_sync'). */
+\tgroup?: string;
+\t/** \`false\` ⇒ hidden by default. Absent means visible. */
+\tvisible?: boolean;
+\tplaceholder?: string;
+\t/** Help/description text shown alongside the field. */
+\thelp?: string;
 \tformat?: Record<string, unknown>;
 \tchoices?: string[];
 \treference?: string;
+\t/** Curated/displayed field — drives card & preview field selection. */
+\tisKeyField?: boolean;
+\t/** Sort position within the key-field set. */
+\tkeyFieldOrder?: number;
 }
+
+/** EAV \`field_definitions.data_type\` vocabulary. */
+export type EavDataType =
+${eavUnion};
+
+/**
+ * EAV \`field_definitions.data_type\` → \`FieldType\` rendering contract: an EAV
+ * field renders through the same vocabulary as a native column. Note both
+ * \`picklist\` and \`multipicklist\` map to \`enum\` — multi-select rendering is a
+ * consumer-side concern (check the EAV row's cardinality, not the FieldType).
+ */
+export const EAV_DATA_TYPE_TO_FIELD_TYPE: Record<EavDataType, FieldType> = {
+${eavEntries}
+};
 `;
 	return withBanner(SOURCE_DESC_SET, body);
 }
@@ -83,33 +139,66 @@ function hasTimestamps(parsed: ParsedEntity | undefined): boolean {
 	return parsed?.behaviors.includes('timestamps') ?? false;
 }
 
+/** Whether the entity's behaviors include `soft_delete`. */
+function hasSoftDelete(parsed: ParsedEntity | undefined): boolean {
+	return parsed?.behaviors.includes('soft_delete') ?? false;
+}
+
 /**
  * The displayable, derived field-meta list for an entity: every parsed field
- * except `id` and entity_ref internals, in parser order.
+ * except `id` and entity_ref internals, in parser order. When the declared
+ * fields carry the external-sync shape (see `hasExternalSyncShape`), the
+ * bookkeeping fields default to `group: 'external_sync'` — authored `ui_group`
+ * wins.
  */
 function displayFields(parsed: ParsedEntity | undefined): DerivedFieldMeta[] {
 	if (!parsed) return [];
+	const syncShape = hasExternalSyncShape(parsed.fields.keys());
 	const out: DerivedFieldMeta[] = [];
 	for (const field of parsed.fields.values()) {
 		if (field.name === 'id') continue;
 		if (isEntityRefField(field)) continue;
-		out.push(deriveFieldMeta(field));
+		const defaults =
+			syncShape && EXTERNAL_SYNC_FIELDS.has(field.name)
+				? { group: EXTERNAL_SYNC_GROUP }
+				: undefined;
+		out.push(deriveFieldMeta(field, defaults));
 	}
 	return out;
+}
+
+/** Escape a string for emission inside a single-quoted TS literal. */
+function quote(s: string): string {
+	return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 /** Render one `FieldMeta` object literal (omits absent optional keys). */
 function renderFieldMeta(meta: DerivedFieldMeta): string {
 	const lines = [
 		`\t\tfield: '${meta.field}',`,
-		`\t\tlabel: '${meta.label}',`,
+		`\t\tlabel: '${quote(meta.label)}',`,
 		`\t\ttype: '${meta.type}' as FieldType,`,
 		`\t\timportance: '${meta.importance}' as FieldImportance,`,
 	];
 	if (meta.sortable) lines.push('\t\tsortable: true,');
 	if (meta.filterable) lines.push('\t\tfilterable: true,');
+	if (meta.group !== undefined) lines.push(`\t\tgroup: '${quote(meta.group)}',`);
+	if (meta.visible !== undefined) lines.push(`\t\tvisible: ${meta.visible},`);
+	if (meta.placeholder !== undefined) {
+		lines.push(`\t\tplaceholder: '${quote(meta.placeholder)}',`);
+	}
+	if (meta.help !== undefined) lines.push(`\t\thelp: '${quote(meta.help)}',`);
+	if (meta.format !== undefined) {
+		lines.push(`\t\tformat: ${JSON.stringify(meta.format)},`);
+	}
 	if (meta.choices) lines.push(`\t\tchoices: ${JSON.stringify(meta.choices)},`);
 	if (meta.reference) lines.push(`\t\treference: '${meta.reference}',`);
+	if (meta.isKeyField) {
+		lines.push('\t\tisKeyField: true,');
+		if (meta.keyFieldOrder !== undefined) {
+			lines.push(`\t\tkeyFieldOrder: ${meta.keyFieldOrder},`);
+		}
+	}
 	return `\t${meta.field}: {\n${lines.join('\n')}\n\t},`;
 }
 
@@ -132,8 +221,10 @@ export function buildEntityFieldsFile(
 	const fields = displayFields(parsed);
 	const rels = resolvableRels(entity, ctx);
 	const ts = hasTimestamps(parsed);
+	const sd = hasSoftDelete(parsed);
 
-	// FieldMeta map entries: fields, then belongs_to relation rows, then ts rows.
+	// FieldMeta map entries: fields, then belongs_to relation rows, then the
+	// behavior-contributed rows (timestamps, soft_delete).
 	const fieldEntries = fields.map(renderFieldMeta);
 
 	const relEntries = rels.map(
@@ -165,10 +256,38 @@ export function buildEntityFieldsFile(
 			]
 		: [];
 
-	const allEntries = [...fieldEntries, ...relEntries, ...tsEntries].join('\n');
+	// soft_delete behavior contributes a deleted_at column — same precedent as
+	// the timestamps rows above (column exists in the generated table, not in
+	// the parsed field map, so the emitter contributes the row).
+	const sdEntries = sd
+		? [
+				`\tdeletedAt: {
+\t\tfield: 'deletedAt',
+\t\tlabel: 'Deleted',
+\t\ttype: 'datetime' as FieldType,
+\t\timportance: 'tertiary' as FieldImportance,
+\t\tformat: { dateFormat: 'relative' },
+\t},`,
+			]
+		: [];
+
+	const allEntries = [...fieldEntries, ...relEntries, ...tsEntries, ...sdEntries].join(
+		'\n',
+	);
 
 	const primaryFields = fields
 		.filter((f) => f.importance === 'primary')
+		.map((f) => `\t\t'${f.field}',`)
+		.join('\n');
+	// Key-field curation (ADR-040): ordered by keyFieldOrder, declaration order
+	// for ties / unordered (stable sort). Only YAML-declared fields participate.
+	const keyFields = fields
+		.filter((f) => f.isKeyField)
+		.sort(
+			(a, b) =>
+				(a.keyFieldOrder ?? Number.MAX_SAFE_INTEGER) -
+				(b.keyFieldOrder ?? Number.MAX_SAFE_INTEGER),
+		)
 		.map((f) => `\t\t'${f.field}',`)
 		.join('\n');
 	const searchFields = fields
@@ -199,6 +318,9 @@ export const ${camelName}Metadata = {
 
 \tprimaryFields: [
 ${primaryFields}
+\t],
+\tkeyFields: [
+${keyFields}
 \t],
 \tsearchFields: [
 ${searchFields}

--- a/src/emitters/frontend/field-meta.ts
+++ b/src/emitters/frontend/field-meta.ts
@@ -37,14 +37,15 @@ export type FieldImportance = 'primary' | 'secondary' | 'tertiary';
 
 /**
  * Derived UI metadata for one field — the shape the fields emitter renders into
- * a `FieldMeta` object. `choices`/`reference` are present only when the field
- * has them (so the emitter can omit empty keys, matching the template's
- * conditional emission).
+ * a `FieldMeta` object. Optional keys are present only when the field has them
+ * (so the emitter can omit empty keys, matching the template's conditional
+ * emission).
  *
- * `format` is intentionally absent: the old template emitted `format` from a raw
- * `field.ui_format` that the parser does NOT carry onto `ParsedField` (only the
- * hardcoded timestamp `format: { dateFormat: 'relative' }` survives, emitted
- * directly by `emit-fields.ts`).
+ * The full YAML `ui_*` hint surface passes through (ADR-040): `group`,
+ * `visible`, `placeholder`, `help`, and `format` come straight from the
+ * author's YAML; `isKeyField`/`keyFieldOrder` carry key-field curation
+ * (`ui_key_field` / `ui_key_field_order`) under the qField / EAV
+ * `field_definitions` names so all three homes share one vocabulary.
  */
 export interface DerivedFieldMeta {
 	field: string; // camelCase property name
@@ -53,8 +54,24 @@ export interface DerivedFieldMeta {
 	importance: FieldImportance;
 	sortable: boolean;
 	filterable: boolean;
+	group?: string;
+	visible?: boolean;
+	placeholder?: string;
+	help?: string;
+	format?: Record<string, unknown>;
 	choices?: string[];
 	reference?: string; // FK target table (from foreign_key)
+	isKeyField?: boolean;
+	keyFieldOrder?: number;
+}
+
+/**
+ * Derivation defaults a caller can supply from entity-level context (the
+ * external-sync bundle in `emit-fields.ts` is the one current user). Author
+ * YAML always wins over a default — these fill gaps, never override.
+ */
+export interface FieldMetaDefaults {
+	group?: string;
 }
 
 const CAMEL = (s: string): string =>
@@ -154,10 +171,18 @@ export function isEntityRefField(field: ParsedField): boolean {
  * Derive the full UI metadata for one field. The `id` field is filtered by the
  * caller (the template skipped it); this returns metadata for any non-skipped
  * field. `reference` is the FK target table (the registry resolves display
- * names elsewhere). `choices` carries explicit enum choices; `format` passes
- * through `ui.format`.
+ * names elsewhere). `choices` carries explicit enum choices.
+ *
+ * Authored `ui_*` hints pass through verbatim: `group` / `visible` /
+ * `placeholder` / `help` / `format`. `defaults` fills entity-level derivation
+ * defaults (currently `group`) only where the author left the hint unset.
+ * `keyFieldOrder` is emitted only alongside `isKeyField: true` — an order
+ * without curation is meaningless.
  */
-export function deriveFieldMeta(field: ParsedField): DerivedFieldMeta {
+export function deriveFieldMeta(
+	field: ParsedField,
+	defaults: FieldMetaDefaults = {},
+): DerivedFieldMeta {
 	const hasChoices = Array.isArray(field.choices) && field.choices.length > 0;
 	const meta: DerivedFieldMeta = {
 		field: CAMEL(field.name),
@@ -167,7 +192,90 @@ export function deriveFieldMeta(field: ParsedField): DerivedFieldMeta {
 		sortable: field.ui.sortable ?? false,
 		filterable: field.ui.filterable ?? false,
 	};
+	const group = field.ui.group ?? defaults.group;
+	if (group !== undefined) meta.group = group;
+	if (field.ui.visible !== undefined) meta.visible = field.ui.visible;
+	if (field.ui.placeholder !== undefined) meta.placeholder = field.ui.placeholder;
+	if (field.ui.help !== undefined) meta.help = field.ui.help;
+	if (field.ui.format !== undefined) meta.format = field.ui.format;
 	if (hasChoices) meta.choices = field.choices;
 	if (field.foreignKey) meta.reference = field.foreignKey.table;
+	if (field.ui.keyField) {
+		meta.isKeyField = true;
+		if (field.ui.keyFieldOrder !== undefined) {
+			meta.keyFieldOrder = field.ui.keyFieldOrder;
+		}
+	}
 	return meta;
 }
+
+// ============================================================================
+// External-sync shape (family/behavior bundle, ADR-040)
+// ============================================================================
+
+/** Default `group` applied to external-sync bookkeeping fields. */
+export const EXTERNAL_SYNC_GROUP = 'external_sync';
+
+/**
+ * The field names that make up the synced/integrated bookkeeping shape — the
+ * columns the `external_id_tracking` behavior contributes when authors declare
+ * them explicitly in YAML instead. `provider_metadata` rides along: it only
+ * receives the default when the gate below detects the shape.
+ */
+export const EXTERNAL_SYNC_FIELDS: ReadonlySet<string> = new Set([
+	'external_id',
+	'provider',
+	'provider_metadata',
+]);
+
+/**
+ * Whether an entity's declared fields carry the synced/integrated shape:
+ * BOTH `external_id` AND `provider` present. When true, the fields emitter
+ * defaults `group: 'external_sync'` onto the `EXTERNAL_SYNC_FIELDS` rows
+ * (a derivation default — an authored `ui_group` always wins).
+ *
+ * Conservative by design: this inspects only fields that exist in the parsed
+ * map. Columns contributed by the `external_id_tracking` BEHAVIOR are not in
+ * the parsed field map and therefore get no FieldMeta rows at all (same as
+ * before ADR-040) — we never emit a row for a column we cannot see.
+ */
+export function hasExternalSyncShape(fieldNames: Iterable<string>): boolean {
+	const names = new Set(fieldNames);
+	return names.has('external_id') && names.has('provider');
+}
+
+// ============================================================================
+// EAV data_type → FieldType contract (ADR-040)
+// ============================================================================
+
+/**
+ * The EAV `field_definitions.data_type` vocabulary → frontend `FieldType`
+ * rendering contract. This is the rallying point for external-system field
+ * types: an EAV row's `data_type` maps through this table to the same
+ * rendering vocabulary native columns use, so one renderer serves both.
+ *
+ * Notes:
+ * - `picklist` AND `multipicklist` both map to `enum` — multi-select rendering
+ *   is a consumer-side concern (the renderer checks the EAV row's cardinality,
+ *   not the FieldType).
+ * - `string` maps to `text`; EAV has no textarea heuristic (no `max_length`).
+ *
+ * The same constant is emitted into the generated `fields/field-meta.ts` (see
+ * `buildFieldMetaTypeFile`) so consumer apps get it locally, rendered from
+ * THIS object — the two cannot drift.
+ */
+export const EAV_DATA_TYPE_TO_FIELD_TYPE = {
+	string: 'text',
+	integer: 'number',
+	decimal: 'number',
+	boolean: 'boolean',
+	date: 'date',
+	datetime: 'datetime',
+	json: 'json',
+	reference: 'reference',
+	picklist: 'enum',
+	multipicklist: 'enum',
+} as const satisfies Record<string, FieldType>;
+
+/** The EAV `field_definitions.data_type` vocabulary. */
+export type EavDataType = keyof typeof EAV_DATA_TYPE_TO_FIELD_TYPE;

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,3 +186,12 @@ export {
 // Importing this barrel has the side effect of pre-registering the five
 // library-shipped patterns (Base / Integrated / Activity / Knowledge / Metadata).
 export * from './patterns';
+
+// Re-export the field-metadata vocabulary contract (ADR-040): the EAV
+// `field_definitions.data_type` → frontend `FieldType` mapping. The same
+// constant is emitted into generated apps' `fields/field-meta.ts`; this export
+// serves tooling that consumes `@pattern-stack/codegen` directly.
+export {
+	EAV_DATA_TYPE_TO_FIELD_TYPE,
+	type EavDataType,
+} from './emitters/frontend/field-meta';

--- a/src/parser/load-entities.ts
+++ b/src/parser/load-entities.ts
@@ -35,6 +35,31 @@ import {
 	type RelationshipDefinition,
 	type RelationshipTypes,
 } from '../schema/relationship-definition.schema';
+import type { FieldDefinition } from '../schema/entity-definition.schema';
+
+/**
+ * Map the YAML `ui_*` keys onto `ParsedField.ui`. Shared by the entity and
+ * relationship-definition field parsers so the two cannot drift. Carries the
+ * full UI-hint surface (label/type/importance/group/sortable/filterable/
+ * visible/placeholder/help/format) plus key-field curation
+ * (`ui_key_field` / `ui_key_field_order`, ADR-040).
+ */
+function parseUiMetadata(fieldDef: FieldDefinition): ParsedField['ui'] {
+	return {
+		label: fieldDef.ui_label,
+		type: fieldDef.ui_type,
+		importance: fieldDef.ui_importance,
+		group: fieldDef.ui_group,
+		sortable: fieldDef.ui_sortable,
+		filterable: fieldDef.ui_filterable,
+		visible: fieldDef.ui_visible,
+		placeholder: fieldDef.ui_placeholder,
+		help: fieldDef.ui_help,
+		format: fieldDef.ui_format,
+		keyField: fieldDef.ui_key_field,
+		keyFieldOrder: fieldDef.ui_key_field_order,
+	};
+}
 
 export interface LoadEntitiesResult {
 	entities: ParsedEntity[];
@@ -95,15 +120,7 @@ function transformToEntity(result: LoadResult): ParsedEntity {
 				min: fieldDef.min,
 				max: fieldDef.max,
 			},
-			ui: {
-				label: fieldDef.ui_label,
-				type: fieldDef.ui_type,
-				importance: fieldDef.ui_importance,
-				group: fieldDef.ui_group,
-				sortable: fieldDef.ui_sortable,
-				filterable: fieldDef.ui_filterable,
-				visible: fieldDef.ui_visible,
-			},
+			ui: parseUiMetadata(fieldDef),
 		};
 		entity.fields.set(name, field);
 	}
@@ -372,15 +389,7 @@ function transformToRelationshipDefinition(
 					min: fieldDef.min,
 					max: fieldDef.max,
 				},
-				ui: {
-					label: fieldDef.ui_label,
-					type: fieldDef.ui_type,
-					importance: fieldDef.ui_importance,
-					group: fieldDef.ui_group,
-					sortable: fieldDef.ui_sortable,
-					filterable: fieldDef.ui_filterable,
-					visible: fieldDef.ui_visible,
-				},
+				ui: parseUiMetadata(fieldDef),
 			};
 			fields.set(name, field);
 		}

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -138,6 +138,11 @@ const UiMetadataSchema = z.object({
   ui_placeholder: z.string().optional(),
   ui_help: z.string().optional(),
   ui_format: z.record(z.unknown()).optional(),
+  // Key-field curation (ADR-040): curated/displayed fields that drive card &
+  // preview surfaces. Names mirror qField / EAV `field_definitions`
+  // (`isKeyField` / `keyFieldOrder`) — one metadata vocabulary, multiple homes.
+  ui_key_field: z.boolean().optional(),
+  ui_key_field_order: z.number().optional(),
 });
 
 // ============================================================================

--- a/test/frontend-golden/entities/person.yaml
+++ b/test/frontend-golden/entities/person.yaml
@@ -1,6 +1,12 @@
 # Golden frontend fixture — explicit-plural entity (persons, not "persons" derived).
 # Exercises registry-resolved naming: FK consumers must use `persons` from THIS
 # YAML, never a re-pluralization of the string "person".
+#
+# Also exercises the ADR-040 FieldMeta enrichment surface:
+# - ui-hint passthrough (ui_group / ui_visible / ui_placeholder / ui_help)
+# - key-field curation (ui_key_field / ui_key_field_order — first_name is
+#   ordered BEFORE email despite declaration order, locking the sort)
+# - the soft_delete behavior bundle (deletedAt row).
 entity:
   name: person
   plural: persons
@@ -14,19 +20,30 @@ fields:
     required: true
     index: true
     foreign_key: tenants.id
+    ui_group: system
+    ui_visible: false
 
   email:
     type: string
     required: true
     max_length: 255
     index: true
+    ui_placeholder: name@example.com
+    ui_help: Primary contact address.
+    ui_key_field: true
+    ui_key_field_order: 1
 
   first_name:
     type: string
     required: true
     max_length: 100
+    ui_key_field: true
+    ui_key_field_order: 0
 
   last_name:
     type: string
     required: true
     max_length: 100
+
+behaviors:
+  - soft_delete

--- a/test/frontend-golden/entities/user.yaml
+++ b/test/frontend-golden/entities/user.yaml
@@ -2,6 +2,11 @@
 # `user belongs_to person` must resolve the target name from the registry:
 # the resolver/lookup/store wiring references `persons` (person.plural), proving
 # no plural is ever derived from the string "person" at emit time.
+#
+# Also exercises the ADR-040 external-sync bundle: explicit external_id +
+# provider fields ⇒ both (plus provider_metadata, if present) default to
+# group: 'external_sync' — and `keyFields: []` stays emitted (empty) when no
+# field is curated.
 entity:
   name: user
   plural: users
@@ -28,6 +33,17 @@ fields:
     required: true
     index: true
     foreign_key: persons.id
+
+  external_id:
+    type: string
+    nullable: true
+    max_length: 255
+    index: true
+
+  provider:
+    type: string
+    nullable: true
+    max_length: 64
 
 relationships:
   person:

--- a/test/frontend-golden/snapshot/fields/field-meta.ts
+++ b/test/frontend-golden/snapshot/fields/field-meta.ts
@@ -32,7 +32,50 @@ export interface FieldMeta<T = unknown> {
 	importance: FieldImportance;
 	sortable?: boolean;
 	filterable?: boolean;
+	/** Layout grouping (e.g. 'external_sync'). */
+	group?: string;
+	/** `false` ⇒ hidden by default. Absent means visible. */
+	visible?: boolean;
+	placeholder?: string;
+	/** Help/description text shown alongside the field. */
+	help?: string;
 	format?: Record<string, unknown>;
 	choices?: string[];
 	reference?: string;
+	/** Curated/displayed field — drives card & preview field selection. */
+	isKeyField?: boolean;
+	/** Sort position within the key-field set. */
+	keyFieldOrder?: number;
 }
+
+/** EAV `field_definitions.data_type` vocabulary. */
+export type EavDataType =
+	| 'string'
+	| 'integer'
+	| 'decimal'
+	| 'boolean'
+	| 'date'
+	| 'datetime'
+	| 'json'
+	| 'reference'
+	| 'picklist'
+	| 'multipicklist';
+
+/**
+ * EAV `field_definitions.data_type` → `FieldType` rendering contract: an EAV
+ * field renders through the same vocabulary as a native column. Note both
+ * `picklist` and `multipicklist` map to `enum` — multi-select rendering is a
+ * consumer-side concern (check the EAV row's cardinality, not the FieldType).
+ */
+export const EAV_DATA_TYPE_TO_FIELD_TYPE: Record<EavDataType, FieldType> = {
+	string: 'text',
+	integer: 'number',
+	decimal: 'number',
+	boolean: 'boolean',
+	date: 'date',
+	datetime: 'datetime',
+	json: 'json',
+	reference: 'reference',
+	picklist: 'enum',
+	multipicklist: 'enum',
+};

--- a/test/frontend-golden/snapshot/fields/person.ts
+++ b/test/frontend-golden/snapshot/fields/person.ts
@@ -10,6 +10,8 @@ export const personFields: Record<string, FieldMeta<Person>> = {
 		label: 'Tenant Id',
 		type: 'reference' as FieldType,
 		importance: 'secondary' as FieldImportance,
+		group: 'system',
+		visible: false,
 		reference: 'tenants',
 	},
 	email: {
@@ -17,18 +19,31 @@ export const personFields: Record<string, FieldMeta<Person>> = {
 		label: 'Email',
 		type: 'email' as FieldType,
 		importance: 'primary' as FieldImportance,
+		placeholder: 'name@example.com',
+		help: 'Primary contact address.',
+		isKeyField: true,
+		keyFieldOrder: 1,
 	},
 	firstName: {
 		field: 'firstName',
 		label: 'First Name',
 		type: 'text' as FieldType,
 		importance: 'primary' as FieldImportance,
+		isKeyField: true,
+		keyFieldOrder: 0,
 	},
 	lastName: {
 		field: 'lastName',
 		label: 'Last Name',
 		type: 'text' as FieldType,
 		importance: 'primary' as FieldImportance,
+	},
+	deletedAt: {
+		field: 'deletedAt',
+		label: 'Deleted',
+		type: 'datetime' as FieldType,
+		importance: 'tertiary' as FieldImportance,
+		format: { dateFormat: 'relative' },
 	},
 };
 
@@ -44,6 +59,10 @@ export const personMetadata = {
 		'email',
 		'firstName',
 		'lastName',
+	],
+	keyFields: [
+		'firstName',
+		'email',
 	],
 	searchFields: [
 

--- a/test/frontend-golden/snapshot/fields/user.ts
+++ b/test/frontend-golden/snapshot/fields/user.ts
@@ -25,6 +25,20 @@ export const userFields: Record<string, FieldMeta<User>> = {
 		importance: 'secondary' as FieldImportance,
 		reference: 'persons',
 	},
+	externalId: {
+		field: 'externalId',
+		label: 'External Id',
+		type: 'text' as FieldType,
+		importance: 'secondary' as FieldImportance,
+		group: 'external_sync',
+	},
+	provider: {
+		field: 'provider',
+		label: 'Provider',
+		type: 'text' as FieldType,
+		importance: 'secondary' as FieldImportance,
+		group: 'external_sync',
+	},
 	person: {
 		field: 'person',
 		label: 'Person',
@@ -44,6 +58,9 @@ export const userMetadata = {
 
 	primaryFields: [
 		'email',
+	],
+	keyFields: [
+
 	],
 	searchFields: [
 


### PR DESCRIPTION
**Phase A of the FieldMeta / type-aware-rendering plan (ADR-040). Targets 0.21.0 (minor — all additive).**

## Why

Consumer apps (concretely: the swe-brain renderer kit, its Phase B) need to build metadata-driven rendering on top of the generated `fields/<entity>.ts` metadata. Today the emitter drops most of the parsed `ui_*` hints, has no curation concept, and has no stated relationship to the EAV `field_definitions.data_type` vocabulary. This PR makes the emitted `FieldMeta` the rendering contract — one vocabulary across qField/CatalogField (swe-brain), codegen FieldMeta, and EAV `field_definitions`.

## The four changes

### 1. Full `ui_*` hint passthrough
`ui_group` / `ui_visible` / `ui_placeholder` / `ui_help` / `ui_format` were accepted by the schema (and partially by the parser) but never emitted. They now survive parser → `ParsedField.ui` → `DerivedFieldMeta` → emitted row (`group` / `visible` / `placeholder` / `help` / `format`). `format` previously existed only as the hardcoded timestamp `{ dateFormat: 'relative' }`; authored `ui_format` now passes through. The two identical ui-parse sites (entity + relationship-definition fields) were deduped into one `parseUiMetadata` helper so they can't drift.

### 2. Key-field curation (qField parity)
New YAML keys `ui_key_field: boolean` + `ui_key_field_order: number` flow schema → parser → `ParsedField.ui` → FieldMeta `isKeyField` / `keyFieldOrder` — deliberately qField's names (not codegen's `ui_*` camelCase symmetry) for catalog convergence. The `<camel>Metadata` object gains `keyFields`: the ordered curated field-name list (sorted by `keyFieldOrder`, declaration order for ties; always emitted, empty when nothing is curated). This drives card/preview field selection in consumers.

### 3. Family/behavior common-field bundles
Mirroring the timestamps precedent (behavior-contributed columns exist in the generated table but not in the parsed field map, so the emitter contributes the rows):
- `soft_delete` behavior ⇒ a `deletedAt` row (datetime / tertiary / `format: { dateFormat: 'relative' }`).
- Entities whose **declared** fields carry the synced/integrated shape (both `external_id` AND `provider`) ⇒ those fields, plus `provider_metadata` when present, default to `group: 'external_sync'`. A derivation default only — an authored `ui_group` always wins.

Conservative by design: columns contributed by the `external_id_tracking` BEHAVIOR are invisible to the frontend emitter and still get no rows — we never emit a row for a column the emitter cannot see (documented in the emitter docstring and ADR-040's consequences).

### 4. EAV `data_type` → `FieldType` contract
`EAV_DATA_TYPE_TO_FIELD_TYPE` — `string→text, integer/decimal→number, boolean→boolean, date→date, datetime→datetime, json→json, reference→reference, picklist→enum, multipicklist→enum` (multi-select rendering is consumer-side; the renderer checks the EAV row's cardinality, not the FieldType). Source of truth lives in `src/emitters/frontend/field-meta.ts` (`as const satisfies Record<string, FieldType>`), re-exported from the package root, AND rendered into every generated `fields/field-meta.ts` from the same object — the copies cannot drift. No EAV serving wiring ships here; this is the rallying contract only.

**ADR-040** (`docs/adrs/ADR-040-field-metadata-vocabulary-convergence.md`) records the convergence story: qField/CatalogField ↔ codegen FieldMeta ↔ EAV `field_definitions` — one vocabulary, multiple homes.

## Review artifact

The frontend-golden snapshot diff is deliberately the review surface — fixtures were extended so every feature appears in it:
- `fields/field-meta.ts`: the enriched interface + the emitted EAV contract.
- `fields/person.ts`: hint passthrough (`group`/`visible` on tenantId, `placeholder`/`help` on email), curation rows, `keyFields: ['firstName', 'email']` (order beats declaration), the `deletedAt` bundle.
- `fields/user.ts`: `external_sync` group default on externalId/provider, empty `keyFields: []`.

## Consumer story

swe-brain's renderer kit (Phase B) keys rendering off `FieldMeta.type` + `importance` + `group` + `keyFields`, and serves EAV custom fields through `EAV_DATA_TYPE_TO_FIELD_TYPE` — one renderer code path for native columns and EAV rows.

## Gates

- `just test-unit` — 2715 pass (34 in the emit-fields suite, incl. the new passthrough/curation/bundle/EAV cases)
- `just test-baseline` — pass
- `just test-smoke` — PASS
- `just test-smoke-subsystems` — PASS
- `bun run typecheck` — 3 errors, byte-identical to pristine main (pre-existing junction typing from #359; this diff doesn't touch junction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
