### PR TITLE
docs(rfcs): RFC-0004 intake stub — canonical-type ownership (#489)

### DIFF
--- a/.ai-docs/stacks/assembly-default-sinks/specs/489.md
+++ b/.ai-docs/stacks/assembly-default-sinks/specs/489.md
@@ -1,0 +1,96 @@
+---
+issue: 489
+github_issue: https://github.com/pattern-stack/codegen-patterns/issues/489
+status: strategy-approved
+stack: assembly-default-sinks
+related:
+  - .ai-docs/research/assembly-default-sinks.md            # canonical_type_ownership framing + #482/#485 coupling
+  - docs/rfcs/RFC-0002-integration-module-assembly-emission.md  # §4 names "B"/RFC-0004 + the join-key model precondition
+  - docs/rfcs/RFC-0003-incremental-read-enumerate-hydrate.md   # "generated base, author fills the seam" precedent
+supersedes: none
+---
+
+# 489 — RFC-0004 intake stub: canonical-type ownership (future track, doc-only)
+
+## TL;DR
+
+Create a single new doc — `docs/rfcs/RFC-0004-canonical-type-ownership.md` — at **Status: Stub**.
+It records the *problem* (codegen should own the `Canonical*` types and adopt the join-key model)
+and the *coupling* (#482, #485, RFC-0002 §4). It contains **no design, no decomposition, no schema** —
+the stub is an intake placeholder so the future track has a home and a stable number. This is the one
+doc-only leaf of the `assembly-default-sinks` stack; it depends on nothing and can land any time.
+
+**This is NOT the RFC.** The implementer writes the stub described here, not the design it points at.
+
+## Scope (hard boundary)
+
+In scope (the entire deliverable):
+- One new file: `docs/rfcs/RFC-0004-canonical-type-ownership.md`.
+- Bold-field header block (NOT frontmatter) per the `project-documentation` skill.
+- A problem statement and a coupling section. Nothing else.
+
+Explicitly out of scope (the stub MUST NOT contain any of these):
+- Any design, mechanism, or decomposition of canonical-type ownership.
+- Any schema, type signature, or code block describing the future shape.
+- The RFC-0002 §4 revision note — that lands in the `sink-seam-split` leaf, not here.
+- Any generator work. There is no code in this leaf.
+
+## Filename & number
+
+- **File:** `docs/rfcs/RFC-0004-canonical-type-ownership.md`
+- **Number is free:** confirmed — `docs/rfcs/` holds only `RFC-0001`, `RFC-0002`, `RFC-0003`. No `RFC-0004*` exists. (Re-verify with `Glob docs/rfcs/RFC-0004*` before writing, per `project-documentation` rule 4.)
+- **Title:** `RFC-0004 — Canonical-Type Ownership` (kebab slug `canonical-type-ownership`). If a tighter slug reads better at write time, the implementer may pick one — keep `RFC-0004-` prefix and the canonical-type-ownership concept.
+
+## Status decision
+
+`Stub` **is** a sanctioned status — the spec taxonomy in the `project-documentation` skill reads
+`Stub → Draft → Implemented | Shipped → Superseded by …`. Use `**Status:** Stub` verbatim. No closer
+substitute is needed.
+
+## Header block (the exact shape to emit)
+
+Bold-field block, not YAML frontmatter. Required fields and values:
+
+```
+# RFC-0004 — Canonical-Type Ownership
+
+**Status:** Stub
+**Date:** 2026-06-06
+**Owner:** Doug
+**Related:** RFC-0002, RFC-0003, ADR-036, #482, #485
+```
+
+Rationale for each `Related:` entry (do not inline this rationale into the stub — it is context for the writer):
+- **RFC-0002** — its §4 explicitly defers this work as "B" / provisionally RFC-0004 and names the join-key model as the precondition for fully-mechanical interaction-surface sinks.
+- **RFC-0003** — the "generated base, author fills the seam" precedent; this stack's sink seam mirrors it.
+- **ADR-036** — the decision under which `Canonical*` types are today hand-authored in surface packages (the status quo RFC-0004 would replace).
+- **#482** — surface-package generalization; gates whether `Canonical*` types can be generated for a surface with no package (e.g. `document`).
+- **#485** — this stack's intake; ships the mapping against *imported* canonicals, where RFC-0004 would make codegen *emit* those canonicals.
+
+## Section skeleton
+
+Two body sections only (after the header block). Keep each to a few sentences — this is a stub.
+
+1. **`## Problem`** — must cover, in prose:
+   - Codegen should **own** the `Canonical*` types. Today they are hand-authored in surface packages (per ADR-036); the generated sink mapping in this stack type-checks against *imported* canonicals.
+   - Owning them means adopting the **join-key model** (store external FK keys as columns, resolve via downstream read-only joins, retire ingest-time FK resolution) — a pattern-layer change to the Integrated repo write contract + query layer, not a sink-emission change.
+   - RFC-0002 §4 named this as the **precondition** for fully-mechanical interaction-surface sinks *beyond* the column-copy convention the `assembly-default-sinks` stack relies on.
+
+2. **`## Coupling`** — must record, in prose:
+   - **#482** — surface-package generalization gates whether `Canonical*` types can be generated for a surface that has no package today (the `document` case). If #482 generalizes surface-package emission to also generate `Canonical*` from YAML, that directly unblocks the fully-mechanical sink; the two are coupled.
+   - **#485** — this stack ships the mapping against IMPORTED canonicals; RFC-0004 would make codegen emit those canonicals (the only "exists because it did before" residue the Addendum identified, safe to defer because the generated mapping type-checks against the imported canonical, so drift is a compile error).
+
+A one-line closing note that the stub is intentionally undesigned (e.g. *"This is an intake stub — design and decomposition are deferred to the Draft promotion."*) is acceptable and reinforces the boundary. No further sections.
+
+## Tests / validation
+
+None beyond doc review. No code, no generator output, no snapshot churn. Acceptance is structural:
+- File exists at `docs/rfcs/RFC-0004-canonical-type-ownership.md` with `**Status:** Stub`.
+- Header is the bold-field style (not frontmatter), with the `Related:` set above.
+- Body has a `## Problem` and `## Coupling` covering the points above; no design/schema/decomposition.
+- RFC-0004 number collision re-checked at write time.
+
+## Open questions
+
+None. The scope, filename, status, header, and section skeleton are all fixed by this spec and the issue body.
+The only writer latitude is the exact kebab slug and the prose wording — both bounded above.

--- a/docs/rfcs/RFC-0004-canonical-type-ownership.md
+++ b/docs/rfcs/RFC-0004-canonical-type-ownership.md
@@ -1,0 +1,18 @@
+# RFC-0004 — Canonical-Type Ownership
+
+**Status:** Stub
+**Date:** 2026-06-06
+**Owner:** Doug
+**Related:** RFC-0002, RFC-0003, ADR-036, #482, #485
+
+## Problem
+
+Codegen should own the `Canonical*` types. Today they are hand-authored in surface packages (per ADR-036); the generated sink mapping in the `assembly-default-sinks` stack type-checks against *imported* canonicals. Owning them means adopting the **join-key model** — store external FK keys as columns, resolve via downstream read-only joins, retire ingest-time FK resolution. This is a pattern-layer change to the Integrated repo write contract and query layer, not a sink-emission change. RFC-0002 §4 named this the **precondition** for fully-mechanical interaction-surface sinks beyond the column-copy convention the `assembly-default-sinks` stack relies on.
+
+## Coupling
+
+**#482** — surface-package generalization gates whether `Canonical*` types can be generated for a surface that has no package today (the `document` case). If #482 generalizes surface-package emission to also generate `Canonical*` from YAML, that directly unblocks the fully-mechanical sink; the two are coupled and should be coordinated.
+
+**#485** — the `assembly-default-sinks` stack ships the mapping against imported canonicals; RFC-0004 would make codegen emit those canonicals. The only residue identified is safe to defer: the generated mapping type-checks against the imported canonical, so any drift between the hand-authored canonical and the entity's fields is a compile error, not a silent mismatch.
+
+This is an intake stub — design and decomposition are deferred to the Draft promotion.


### PR DESCRIPTION
## Summary

- Creates `docs/rfcs/RFC-0004-canonical-type-ownership.md` at **Status: Stub**
- Bold-field header block (not YAML frontmatter) per house style, with Related: RFC-0002, RFC-0003, ADR-036, #482, #485
- `## Problem` section: codegen should own `Canonical*` types; today hand-authored per ADR-036; join-key model is the precondition (RFC-0002 §4)
- `## Coupling` section: #482 (surface-package generalization gates canonical-type generation for package-less surfaces) and #485 (this stack ships against imported canonicals; RFC-0004 would emit them)
- Doc-only leaf of the `assembly-default-sinks` stack — no code, no version bump, no tests

## Spec

`.ai-docs/stacks/assembly-default-sinks/specs/489.md`

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
