### PR TITLE
fix(events): scheduler slot insert uses bare ON CONFLICT DO NOTHING — no Postgres ERROR per colliding tick (#498)

### DIFF
--- a/runtime/subsystems/events/event-bus.drizzle-backend.ts
+++ b/runtime/subsystems/events/event-bus.drizzle-backend.ts
@@ -401,18 +401,34 @@ export class DrizzleEventBus implements IEventBus, IEventReadPort, OnModuleInit,
 
     // The idempotency guard is the partial UNIQUE expression index
     // `idx_domain_events_schedule_slot` on (type, metadata->>'scheduleSlot').
-    // Drizzle 0.45's typed `onConflictDoNothing({ target })` only accepts
-    // columns, so it can't name an expression index — we instead let the
-    // insert run and treat a unique-violation (SQLSTATE 23505) as the
-    // already-materialised no-op. This is the exactly-one-per-slot invariant:
-    // a concurrent or repeat materialise of the same slot loses the race at
-    // the DB and reports `created: false`.
+    // Use a BARE (no-target) `ON CONFLICT DO NOTHING`: Drizzle 0.45's typed
+    // `onConflictDoNothing({ target })` only accepts columns so it can't NAME
+    // the expression index, but the no-arg form emits target-less
+    // `ON CONFLICT DO NOTHING`, which Postgres applies to ANY unique
+    // constraint/index — including this expression index. `.returning({ id })`
+    // then gives us the rowcount discriminator: zero rows back == the slot was
+    // already materialised (DO NOTHING fired), so `created: false`. This keeps
+    // the happy path off the exception channel — a repeat materialise no longer
+    // raises SQLSTATE 23505, so Postgres logs no scary `duplicate key value
+    // violates unique constraint` ERROR line on every colliding boot/tick.
+    //
+    // The unique-violation catch is retained as a fallback for the genuine
+    // concurrent-insert race window (two sessions clear the conflict check and
+    // both attempt the insert in the same instant) and for backends whose
+    // driver surfaces a 23505 rather than honouring DO NOTHING; in both cases
+    // it collapses to the same `created: false` no-op.
+    let inserted: Array<{ id: string }>;
     try {
-      await this.db.insert(domainEvents).values(values);
+      inserted = await this.db
+        .insert(domainEvents)
+        .values(values)
+        .onConflictDoNothing()
+        .returning({ id: domainEvents.id });
     } catch (err) {
       if (isUniqueViolation(err)) return { created: false };
       throw err;
     }
+    if (inserted.length === 0) return { created: false };
 
     // Wake the drainer for an already-due tick. A future slot waits for polling.
     if (spec.slotStart.getTime() <= Date.now()) {

--- a/src/__tests__/runtime/subsystems/event-bus.spec.ts
+++ b/src/__tests__/runtime/subsystems/event-bus.spec.ts
@@ -923,3 +923,168 @@ describe('DrizzleEventBus — BRIDGE-4 drain modification', () => {
     expect(m.updateWhereWasCalled).toBe(true);
   });
 });
+
+// ============================================================================
+// DrizzleEventBus — ADR-039 scheduled-event materialisation idempotency
+// (mocked Drizzle client — no Docker)
+//
+// Regression guard for the "scary ERROR on every colliding boot tick" defect:
+// the slot insert must go through `ON CONFLICT DO NOTHING` (bare, no-target —
+// the idempotency guard is an EXPRESSION unique index, so Drizzle's typed
+// `target` form can't name it) and decide created/no-op from the RETURNING
+// rowcount, NOT from a caught SQLSTATE 23505. A repeat materialise must not
+// raise a unique violation on the happy path — otherwise Postgres logs a
+// `duplicate key value violates unique constraint` ERROR line per collision.
+// ============================================================================
+
+describe('DrizzleEventBus — materializeScheduledEvent ON CONFLICT', () => {
+  /**
+   * Mock insert chain that records the builder methods actually called and
+   * lets a test choose the terminal `.returning()` outcome:
+   *   - `returnedRows`: rows the DB returns (1 row = won the slot, 0 = DO NOTHING fired)
+   *   - `throwOnReturning`: an error to throw from `.returning()` (race-window fallback)
+   */
+  function makeMaterializeMockDb(opts: {
+    returnedRows?: Array<{ id: string }>;
+    throwOnReturning?: unknown;
+  }) {
+    const calls = { values: 0, onConflictDoNothing: 0, returning: 0 };
+    let valuesArg: Record<string, unknown> | undefined;
+
+    const insertBuilder = {
+      values: mock((arg: Record<string, unknown>) => {
+        calls.values++;
+        valuesArg = arg;
+        return insertBuilder;
+      }),
+      onConflictDoNothing: mock((arg?: unknown) => {
+        calls.onConflictDoNothing++;
+        // The fix uses the BARE no-target form: assert no target was named.
+        if (arg !== undefined) {
+          throw new Error(
+            `expected a bare onConflictDoNothing() for the expression index, ` +
+              `got a target: ${JSON.stringify(arg)}`,
+          );
+        }
+        return insertBuilder;
+      }),
+      returning: mock(async () => {
+        calls.returning++;
+        if (opts.throwOnReturning !== undefined) throw opts.throwOnReturning;
+        return opts.returnedRows ?? [];
+      }),
+    };
+
+    const db = {
+      insert: mock(() => insertBuilder),
+      // materialize never selects/updates; stub them so the bus constructs.
+      select: mock(() => ({})),
+      update: mock(() => ({})),
+      transaction: mock(async (cb: (tx: unknown) => Promise<unknown>) => cb(db)),
+    };
+
+    return {
+      db,
+      get calls() {
+        return calls;
+      },
+      get valuesArg() {
+        return valuesArg;
+      },
+    };
+  }
+
+  const spec = {
+    type: 'reconcile_due',
+    slotKey: '@schedule/reconcile_due/1750000000000',
+    slotStart: new Date('2026-06-05T15:00:00Z'),
+    direction: 'inbound',
+    pool: 'events_inbound',
+  };
+
+  it('inserts the slot row via bare onConflictDoNothing() + returning (no exception path)', async () => {
+    const m = makeMaterializeMockDb({ returnedRows: [{ id: 'evt-1' }] });
+    const bus = new DrizzleEventBus(m.db as never, { backend: 'drizzle' });
+
+    const r = await bus.materializeScheduledEvent!(spec);
+
+    expect(r.created).toBe(true);
+    // The happy path went through ON CONFLICT DO NOTHING + RETURNING, not a
+    // bare insert relying on a caught unique violation.
+    expect(m.calls.values).toBe(1);
+    expect(m.calls.onConflictDoNothing).toBe(1);
+    expect(m.calls.returning).toBe(1);
+    // Slot key stamped on metadata.scheduleSlot (the expression-index column).
+    expect((m.valuesArg?.metadata as Record<string, unknown>)?.['scheduleSlot']).toBe(
+      spec.slotKey,
+    );
+    expect((m.valuesArg?.metadata as Record<string, unknown>)?.['triggerSource']).toBe(
+      'schedule',
+    );
+  });
+
+  it('treats a conflicting slot (zero RETURNING rows) as created:false WITHOUT throwing', async () => {
+    // DO NOTHING fired → no rows back. The old insert-and-catch would have let
+    // Postgres raise 23505 (and log an ERROR); the fix never reaches that path.
+    const m = makeMaterializeMockDb({ returnedRows: [] });
+    const bus = new DrizzleEventBus(m.db as never, { backend: 'drizzle' });
+
+    const r = await bus.materializeScheduledEvent!(spec);
+
+    expect(r.created).toBe(false);
+    expect(m.calls.onConflictDoNothing).toBe(1);
+    expect(m.calls.returning).toBe(1);
+  });
+
+  it('a double materialise of the same slot yields exactly one created (the second is a no-op)', async () => {
+    // First call wins (1 row), second call conflicts (0 rows) — neither throws.
+    let first = true;
+    const m = makeMaterializeMockDb({});
+    // Swap the returning outcome per call: win then conflict.
+    (m.db.insert as ReturnType<typeof mock>).mockImplementation(() => ({
+      values: () => ({
+        onConflictDoNothing: () => ({
+          returning: async () => {
+            if (first) {
+              first = false;
+              return [{ id: 'evt-1' }];
+            }
+            return [];
+          },
+        }),
+      }),
+    }));
+    const bus = new DrizzleEventBus(m.db as never, { backend: 'drizzle' });
+
+    const a = await bus.materializeScheduledEvent!(spec);
+    const b = await bus.materializeScheduledEvent!(spec);
+
+    expect(a.created).toBe(true);
+    expect(b.created).toBe(false);
+  });
+
+  it('falls back to created:false on a genuine concurrent 23505 race (catch retained)', async () => {
+    // DO NOTHING covers the common collision, but two sessions can both clear
+    // the gate and one still loses with a real unique violation. The retained
+    // catch maps that to the same no-op rather than propagating.
+    const m = makeMaterializeMockDb({
+      throwOnReturning: { code: '23505', message: 'duplicate key' },
+    });
+    const bus = new DrizzleEventBus(m.db as never, { backend: 'drizzle' });
+
+    const r = await bus.materializeScheduledEvent!(spec);
+
+    expect(r.created).toBe(false);
+  });
+
+  it('re-throws a non-unique-violation insert error', async () => {
+    const m = makeMaterializeMockDb({
+      throwOnReturning: { code: '23502', message: 'not-null violation' },
+    });
+    const bus = new DrizzleEventBus(m.db as never, { backend: 'drizzle' });
+
+    await expect(bus.materializeScheduledEvent!(spec)).rejects.toMatchObject({
+      code: '23502',
+    });
+  });
+});


### PR DESCRIPTION
Closes #498.

## Problem

The ADR-039 `EventScheduler` (0.20.x) dedupes schedule slots via a partial UNIQUE expression index on `domain_events`: `idx_domain_events_schedule_slot ON (type, (metadata ->> 'scheduleSlot'))`. `DrizzleEventBus.materializeScheduledEvent` did a **bare insert + catch** of SQLSTATE 23505 to treat a slot collision as a no-op:

```ts
try {
  await this.db.insert(domainEvents).values(values);
} catch (err) {
  if (isUniqueViolation(err)) return { created: false };
  throw err;
}
```

Behaviorally correct (slots stay exactly-once), but every colliding boot/tick raised a unique violation at the DB, which Postgres logs as:

```
ERROR:  duplicate key value violates unique constraint "idx_domain_events_schedule_slot"
```

Dogfood-observed in swe-brain (2026-06-06): two such ERROR lines per boot (one per recurring schedule), plus one per colliding tick. Pure noise — the slot processes fine — but it looks like a real failure and trains operators to ignore `ERROR` lines.

## Fix

The idempotency guard is an *expression* unique index, so Drizzle 0.45's typed `onConflictDoNothing({ target })` can't name it — but the **bare, no-target** `.onConflictDoNothing()` emits target-less `ON CONFLICT DO NOTHING`, which Postgres applies to any unique constraint/index including this one (Drizzle's `onConflictDoNothing(config?)` makes config optional; its own JSDoc shows the no-arg form). Switch to `.onConflictDoNothing().returning({ id })` and decide created/no-op from the RETURNING rowcount (0 rows = DO NOTHING fired) — the same rowcount-discriminator the bridge drain hook already uses.

The `isUniqueViolation` catch is **retained** as a fallback for the genuine concurrent-insert race window (two sessions both clear the gate, one still loses with a real 23505) and for drivers that surface 23505 rather than honouring DO NOTHING. The happy path no longer touches the exception channel, so no Postgres ERROR line.

Doc comments on both the method and the scheduler class JSDoc — which already *claimed* `ON CONFLICT DO NOTHING` — are now accurate.

## Tests

New `DrizzleEventBus — materializeScheduledEvent ON CONFLICT` describe block (mocked Drizzle client, no Docker):
- happy path goes through bare `onConflictDoNothing()` + `returning()` → `created: true` on 1 row;
- conflicting slot (0 RETURNING rows) → `created: false` **without throwing**;
- double-materialise of the same slot → exactly one `created`;
- retained 23505 catch still collapses a genuine race to `created: false`;
- a non-unique-violation insert error still propagates.

## Gates (by exit code)
- `bun test src/__tests__/runtime/subsystems/event-bus.spec.ts` → 51 pass / 0 fail
- `bun test .../event-scheduler.unit.spec.ts` → 23 pass / 0 fail
- `just test-unit` → 2804 pass / 0 fail (179 files)
- `bun run typecheck` → only 3 **pre-existing** errors in `junction.ts`/`barrel-generator.ts` (present on `origin/main`, untouched by this diff); the changed `runtime/` file is clean.

No biome/lint gate exists in this repo (CI is `just test-all`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)