### PR TITLE
fix(jobs): claim heartbeat — stop the stale sweeper re-queueing live long-running handlers (#500)

### DIFF
--- a/.claude/skills/jobs/orchestrator-and-worker.md
+++ b/.claude/skills/jobs/orchestrator-and-worker.md
@@ -75,13 +75,14 @@ Note the per-row update is **self-protecting**: each `UPDATE ... WHERE status NO
 ### `onModuleInit`
 
 1. `setInterval(() => void this.pollAndProcess(), opts.pollIntervalMs ?? 1000)`.
-2. `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs ?? 60_000)`.
-3. Register SIGTERM handler → `this.gracefulStop(...)`.
+2. `setInterval(() => void this.renewClaims(), opts.claimHeartbeatIntervalMs ?? staleThresholdMs/3)` — the claim heartbeat (CLAIM-HB-1).
+3. `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs ?? 60_000)`.
+4. Register SIGTERM handler → `this.gracefulStop(...)`.
 
 `pollAndProcess()`:
 - If `shuttingDown` or `inFlight.size >= pool.concurrency`, return immediately.
 - `const claimed = await this.claimNext(pool.queue)`. If `null`, return.
-- Wrap `processRun(claimed)` in a promise, add to `inFlight`, remove in `.finally`.
+- Add `claimed.id` to `inFlightRunIds` (the heartbeat's renewal set), wrap `processRun(claimed)` in a promise, add to `inFlight`, and in `.finally` remove from BOTH sets. The id leaves the renewal set on every settle path (success/failure/release) so the heartbeat never bumps a run this worker no longer owns.
 
 ### The claim query
 
@@ -176,9 +177,21 @@ fn(stepId, fn, opts?) {
 
 **Step-clearing must be atomic with the run status reset.** See JOB-3 transaction-boundary table: replay memoization reset needs a transaction.
 
+## Claim heartbeat (CLAIM-HB-1)
+
+A live worker renews the lease on its in-flight runs so a long-running handler is not mistaken for a crash. `renewClaims()` fires every `claimHeartbeatIntervalMs` (default `staleThresholdMs / 3`) and, for the runs in `inFlightRunIds`, runs one UPDATE:
+
+```sql
+UPDATE job_run
+SET claimed_at = now(), updated_at = now()
+WHERE id IN (...) AND status = 'running';
+```
+
+The `status='running'` guard makes renewal a safe no-op for a run that was already swept-and-reclaimed elsewhere or has settled. No-ops cheaply (no query) when nothing is in flight. This is the fix for the dogfood incident where a 5-min stale threshold re-queued a multi-hour Gmail backfill every few minutes, spawning concurrent zombie walks. **Without the heartbeat the sweeper recovers LIVE work; with it, only dead-worker work.**
+
 ## Stale-claim sweeper
 
-Crashed workers strand their `claimed_at` rows. Each `JobWorker` runs an interval:
+Crashed workers strand their `claimed_at` rows — once the worker dies, `renewClaims` stops bumping its runs, so they age past the threshold. Each `JobWorker` runs an interval:
 
 ```sql
 UPDATE job_run
@@ -189,7 +202,9 @@ RETURNING id;
 
 Each `UPDATE` is atomic, and the `WHERE claimed_at < threshold` clause prevents double-recovery — once a row resets to `pending`, it no longer matches. Multiple workers running their own sweeper is safe (per JOB-3 OQ-2 resolution). No leader election needed.
 
-Invariant: **`staleThresholdMs >= 2 * max_handler_duration`.** Otherwise live work gets "recovered" mid-flight and runs twice. If your handler can legitimately run for hours, raise the threshold accordingly or split the work.
+Invariant (post CLAIM-HB-1): **`claimHeartbeatIntervalMs < staleThresholdMs`** (with margin for missed beats — the default `/3` leaves two). Handler duration is NO LONGER bounded by the threshold: a live worker renews the lease, so the threshold now bounds *dead-worker recovery latency*, not how long a handler may run. (The old `staleThresholdMs >= 2 × max_handler_duration` rule was the bug — it was unmet in practice and silently re-ran live work.) Tune via `jobs.extensions.drizzle.{stale_threshold_ms, stale_sweeper_interval_ms, claim_heartbeat_interval_ms}` — see `pools-and-config.md`.
+
+> **Residual gap (deferred):** there is no *fencing* yet. If a worker is paused long enough (GC, debugger, full event-loop stall) to miss every beat without dying, the sweeper can still reclaim its run, and the original attempt — when it un-pauses — will write its completion/steps with no token check. Fencing (a claim-token column guarding all writes) is the CLAIM-HB-1 follow-up — issue #501. The heartbeat eliminates the *common* case (long-but-healthy handlers); fencing closes the *pathological* stall case.
 
 `attempts` is **not** incremented by stale recovery — memoization is what protects already-completed steps. Treat sweep as "release the claim," not "count a failure."
 

--- a/.claude/skills/jobs/pools-and-config.md
+++ b/.claude/skills/jobs/pools-and-config.md
@@ -51,6 +51,10 @@ jobs:
     drizzle:
       # listen_notify: true          # LISTEN-NOTIFY-1: Postgres LISTEN/NOTIFY wakes the worker on enqueue-commit, alongside polling. Off by default; needs a direct (non-transaction-pooler) connection.
       poll_interval_ms: 1000
+      # ── Claim lease / heartbeat (CLAIM-HB-1) ──
+      # stale_threshold_ms: 300000          # dead-worker recovery window (5 min). NOT a max-handler bound — the heartbeat protects live runs.
+      # stale_sweeper_interval_ms: 60000    # how often the sweeper scans for stranded rows
+      # claim_heartbeat_interval_ms: 100000 # lease-renewal cadence (default = stale_threshold_ms / 3)
     # bullmq:                        # Reserved slot — backend not yet implemented
     #   bull_board:
     #     enabled: true
@@ -159,6 +163,10 @@ interface JobsDomainModuleOptions {
     drizzle?: {
       listenNotify?: boolean;
       pollIntervalMs?: number;
+      // CLAIM-HB-1 — lease tuning. All optional.
+      staleThresholdMs?: number;          // dead-worker recovery window. Default 300_000.
+      staleSweeperIntervalMs?: number;    // sweeper scan cadence. Default 60_000.
+      claimHeartbeatIntervalMs?: number;  // lease renewal cadence. Default staleThresholdMs / 3.
     };
     // bullmq?: ...  // Phase 6+
   };
@@ -201,7 +209,7 @@ Tenant-aware fair queuing is Phase 6 polish; Phase 1 is FIFO within pool.
 ## Horizontal scale notes
 
 - **Handler upsert** under concurrent boots uses `ON CONFLICT (type) DO UPDATE SET … , updated_at = now()` (JOB-3 OQ-3). Last-writer-wins is safe because all instances of the same binary produce identical metadata.
-- **Stale sweeper** is per-worker; each `UPDATE ... WHERE claimed_at < threshold` is self-protecting. No leader election. See `orchestrator-and-worker.md` §"Stale-claim sweeper".
+- **Stale sweeper** is per-worker; each `UPDATE ... WHERE claimed_at < threshold` is self-protecting. No leader election. A live worker renews `claimed_at` for its in-flight runs (the CLAIM-HB-1 heartbeat), so the sweeper only recovers genuinely dead-worker rows. See `orchestrator-and-worker.md` §"Claim heartbeat" + §"Stale-claim sweeper".
 - **BullMQ queue naming** (once BullMQ backend lands): if two apps share a Redis, default queue names collide. A `jobs.queue_prefix` knob is noted in ADR-022 §"Open implementation questions" as a future addition. Not in Phase 1.
 
 ## Events-lane cross-reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Jobs: claim heartbeat (CLAIM-HB-1) — long-running handlers are no longer
+  swept mid-flight.** The drizzle `JobWorker` stamped `claimed_at` once at claim
+  and never renewed it, while `sweepStaleClaims` reset any `running` row whose
+  `claimed_at` aged past `staleThresholdMs` (default 5 min) back to `pending`.
+  Consequence: ANY handler that legitimately ran longer than the threshold was
+  silently re-queued and re-claimed by a second worker, running CONCURRENTLY
+  with the still-live (uncancellable) original. Discovered by the swe-brain
+  dogfood: a 365-day Gmail backfill could never finish inside 5 min, so it
+  re-spawned a fresh concurrent mailbox walk every ~6 min for 5 days (writes
+  were idempotent upserts, so no corruption — but a non-idempotent handler would
+  have corrupted). Fix: a live worker now tracks its in-flight run IDs and bumps
+  `claimed_at = now()` for them every `claimHeartbeatIntervalMs` (new
+  `JobWorkerOptions` knob, default `staleThresholdMs / 3`). The sweeper now
+  fires only for genuinely dead workers (renewal stopped) — its documented
+  "stranded by a crashed worker" intent.
+
+### Added
+
+- **Jobs: consumer-threadable lease tuning.** `jobs.extensions.drizzle` now
+  accepts `stale_threshold_ms`, `stale_sweeper_interval_ms`, and
+  `claim_heartbeat_interval_ms`, threaded through the subsystem barrel generator
+  into both `JobsDomainModule.forRoot` and `JobWorkerModule.forRoot` (camelCase
+  runtime keys). All optional; the worker defaults the heartbeat to a third of
+  the stale threshold.
+
+> **Deferred (CLAIM-HB-1 follow-up):** fencing — a claim token on `job_run` so a
+> swept-and-reclaimed run cannot be double-completed by a zombie attempt that
+> finishes after the sweep. Needs a schema/migration change + write-site guards;
+> tracked as issue #501. The heartbeat closes the practical
+> re-claim-loop bug; fencing hardens the residual crash-recovery race.
+
 ## [0.21.0] — 2026-06-06
 
 **FieldMeta enrichment (ADR-040, Phase A of type-aware rendering).** The

--- a/docs/specs/JOB-3.md
+++ b/docs/specs/JOB-3.md
@@ -104,6 +104,7 @@ e. Return the updated `JobRun`.
 
 **`onModuleInit()`:**
 - Start the polling loop: `setInterval(() => void this.pollAndProcess(), opts.pollIntervalMs)` (default 1000ms)
+- Start the claim heartbeat (CLAIM-HB-1): `setInterval(() => void this.renewClaims(), opts.claimHeartbeatIntervalMs)` (default `staleThresholdMs / 3`)
 - Start stale-claim sweeper: `setInterval(() => void this.sweepStaleClaims(), opts.staleSweeperIntervalMs)` (default 60s)
 - Register SIGTERM handler
 
@@ -154,14 +155,20 @@ g. Remove promise from `inFlight` in finally.
 - If `status === 'completed'`, return `step.output` (memoized).
 - Otherwise: record `running` step. Call `await fn()`. On success, upsert `completed` with `output`. On error, upsert `failed`; rethrow.
 
+**`renewClaims()` (CLAIM-HB-1 — claim heartbeat):**
+- The worker keeps an `inFlightRunIds: Set<string>` of the runs it currently has executing (added when `pollAndProcess` dispatches `processRun`, removed in that promise's `finally` on every settle path — success, failure, retry-release, concurrency-defer).
+- Each beat: if non-empty, `UPDATE job_run SET claimed_at=now(), updated_at=now() WHERE id IN (...) AND status='running'`. The `status='running'` guard makes the renewal a safe no-op for a row that was already swept-and-reclaimed elsewhere or has settled. Best-effort: a missed beat just retries next interval (the threshold leaves several beats of slack).
+- This is what lets a legitimately long-running handler keep its claim. Without it, `sweepStaleClaims` re-queued ANY run that out-lived `staleThresholdMs` mid-flight and a second worker ran it concurrently with the still-live zombie (dogfood incident, swe-brain 2026-06-06: a 365-day Gmail backfill re-spawned a concurrent walk every ~6 min for 5 days).
+
 **`sweepStaleClaims()`:**
 - `UPDATE job_run SET status='pending', claimed_at=null WHERE status='running' AND claimed_at < now() - $staleThresholdMs RETURNING id`. Log each at `warn`. Safe concurrency: each update is atomic; `WHERE claimed_at < threshold` prevents double-recovery.
+- With the heartbeat in place this fires ONLY for runs whose worker died (renewal stopped). A live worker renews `claimed_at` faster than the threshold, so a long-but-alive run is never a candidate — this restores the sweeper to its documented "stranded by a crashed worker" intent.
 
 **`onModuleDestroy()` / SIGTERM:**
 - Set `shuttingDown = true`.
 - Await `Promise.allSettled([...this.inFlight])` with `shutdownTimeoutMs` (default 30000).
 - For runs still `running` past timeout: `UPDATE job_run SET status='pending', claimed_at=null`. Next worker reclaims.
-- Clear stale sweeper interval.
+- Clear the poll, heartbeat, and stale-sweeper intervals.
 
 ## Transaction Boundaries
 
@@ -203,7 +210,9 @@ g. Remove promise from `inFlight` in finally.
 ## Open Questions (with proposed resolutions)
 
 **OQ-2 — Stale-claim sweeper placement. Resolved 2026-04-19.**
-Resolution: sweeper runs on every `JobWorker` instance (per-pool), wired via `setInterval` in `onModuleInit`. The sweep query uses `FOR UPDATE SKIP LOCKED`, making concurrent sweepers across horizontally-scaled workers safe — a row is recovered at most once. Singleton rejected: adds coordination complexity (leader election) without meaningful advantage at Phase 1 scale. Document invariant: `staleThresholdMs >= 2 * max_handler_duration`.
+Resolution: sweeper runs on every `JobWorker` instance (per-pool), wired via `setInterval` in `onModuleInit`. The sweep query uses `FOR UPDATE SKIP LOCKED`, making concurrent sweepers across horizontally-scaled workers safe — a row is recovered at most once. Singleton rejected: adds coordination complexity (leader election) without meaningful advantage at Phase 1 scale.
+
+> **Revision 2026-06-06 (CLAIM-HB-1).** The original invariant `staleThresholdMs >= 2 × max_handler_duration` was wrong — `claimed_at` was stamped once at claim and never renewed, so ANY handler out-living the threshold was swept and re-claimed concurrently (no fencing → the zombie still wrote its result). The fix introduces a claim heartbeat (`renewClaims`): a live worker bumps `claimed_at` for in-flight runs every `claimHeartbeatIntervalMs` (default `staleThresholdMs / 3`), so the threshold is now a *worker-liveness* window, not a max-handler-duration bound. The invariant becomes `claimHeartbeatIntervalMs < staleThresholdMs` (with margin for missed beats); handler duration is no longer constrained by the threshold. Full fencing (claim-token so a swept run can't be double-completed) is deferred — see issue #501.
 
 **OQ-3 — `job` table upsert under horizontal scale.**
 Proposed: `ON CONFLICT (type) DO UPDATE SET pool = EXCLUDED.pool, retry_policy = EXCLUDED.retry_policy, version = EXCLUDED.version, updated_at = now()`. Last-writer-wins. All instances of the same app version produce identical metadata — concurrent upserts are harmless. `DO NOTHING` is rejected: under rolling deploy, old-version instance A could leave a stale row that new-version instance B cannot overwrite. Advisory locks rejected: add latency + leak risk.
@@ -226,7 +235,9 @@ These were resolved during implementation. Kept here so JOB-4 (memory parity) an
 
 - **Concurrency-queue release mechanism.** When a `queue`-mode run is claimed but another run with the same `concurrency_key` is already `running`, the worker releases the claim by transitioning the row back to `pending` with `claimed_at=null, started_at=null`. The next poll re-evaluates. No separate "queued" flag — the `status='pending'` + matching-key check is sufficient and keeps the state model flat.
 
-- **Stale-sweeper placement (OQ-2).** Per-worker. The candidate select uses `FOR UPDATE SKIP LOCKED`, so simultaneous sweepers across multiple workers never collide on the same row. Invariant: `staleThresholdMs >= 2 × max_handler_duration`.
+- **Stale-sweeper placement (OQ-2).** Per-worker. The candidate select uses `FOR UPDATE SKIP LOCKED`, so simultaneous sweepers across multiple workers never collide on the same row. Invariant (post CLAIM-HB-1): `claimHeartbeatIntervalMs < staleThresholdMs` — the heartbeat renews live claims, so the threshold bounds *dead-worker recovery latency*, not handler duration. (Superseded the original `staleThresholdMs >= 2 × max_handler_duration`; see the OQ-2 revision note.)
+
+- **Claim heartbeat (CLAIM-HB-1, 2026-06-06).** `JobWorker.renewClaims` bumps `claimed_at` for in-flight runs on a `claimHeartbeatIntervalMs` timer (default `staleThresholdMs / 3`) so a long-but-alive handler is never swept. The renewal UPDATE is `status='running'`-guarded (a swept-and-reclaimed run isn't touched). In-flight runs are tracked in `inFlightRunIds`, deregistered in `pollAndProcess`'s settle `finally`. Knobs `staleThresholdMs` / `staleSweeperIntervalMs` / `claimHeartbeatIntervalMs` thread from consumer YAML (`jobs.extensions.drizzle.{stale_threshold_ms, stale_sweeper_interval_ms, claim_heartbeat_interval_ms}`) through the barrel generator → `JobWorkerModule.forRoot`. **Fencing (claim-token so a zombie can't double-complete a reclaimed run) is deferred** to a follow-up — it needs a schema column + guards on every write site.
 
 - **`nextStepSeq` allocation.** SELECT-max-plus-one at step-record time. Per-run step counts are typically <100; the in-memory counter alternative drifts if the worker crashes mid-run and a replacement worker resumes via stale-claim sweep.
 

--- a/runtime/subsystems/jobs/job-worker.module.ts
+++ b/runtime/subsystems/jobs/job-worker.module.ts
@@ -261,6 +261,11 @@ export class JobWorkerOrchestrator implements OnModuleInit, OnModuleDestroy {
           this.options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS,
         pollIntervalMs: drizzleExt?.pollIntervalMs,
         listenNotify: drizzleExt?.listenNotify,
+        // CLAIM-HB-1 — lease tuning knobs. All optional; the worker defaults
+        // claimHeartbeatIntervalMs to staleThresholdMs/3 when omitted.
+        staleSweeperIntervalMs: drizzleExt?.staleSweeperIntervalMs,
+        staleThresholdMs: drizzleExt?.staleThresholdMs,
+        claimHeartbeatIntervalMs: drizzleExt?.claimHeartbeatIntervalMs,
       };
       const worker = this.options.workerFactory
         ? this.options.workerFactory(workerOptions)

--- a/runtime/subsystems/jobs/job-worker.ts
+++ b/runtime/subsystems/jobs/job-worker.ts
@@ -2,11 +2,12 @@
  * JobWorker — backend-agnostic tick loop for the job orchestration domain
  * (ADR-022, JOB-3).
  *
- * One worker instance per active pool. On `onModuleInit` it starts two
- * intervals: the poll loop (claim → process → repeat) and the stale-claim
- * sweeper. On `onModuleDestroy` / SIGTERM it drains in-flight work and
- * releases still-`running` rows back to `pending` so a replacement worker
- * can resume with step memoization intact.
+ * One worker instance per active pool. On `onModuleInit` it starts three
+ * intervals: the poll loop (claim → process → repeat), the claim heartbeat
+ * (CLAIM-HB-1 — renews `claimed_at` for in-flight runs so a long handler isn't
+ * swept), and the stale-claim sweeper. On `onModuleDestroy` / SIGTERM it drains
+ * in-flight work and releases still-`running` rows back to `pending` so a
+ * replacement worker can resume with step memoization intact.
  *
  * The claim query is the beating heart: `SELECT … FOR UPDATE SKIP LOCKED`
  * inside a single transaction. Multiple worker processes share the table
@@ -54,10 +55,29 @@ export interface JobWorkerOptions {
   /** Stale sweep interval in ms. Default 60_000. */
   staleSweeperIntervalMs?: number;
   /**
-   * Threshold beyond which a `running` row is presumed stranded by a
-   * crashed worker. Default 5 min. Must be >= 2× max handler duration.
+   * Threshold beyond which a `running` row whose `claimed_at` has NOT been
+   * renewed is presumed stranded by a crashed worker, and the sweeper resets
+   * it to `pending`. Default 5 min.
+   *
+   * With the claim heartbeat (CLAIM-HB-1) in place this is a *liveness*
+   * threshold — a live worker bumps `claimed_at` every
+   * `claimHeartbeatIntervalMs`, so a long-running-but-alive handler is NEVER
+   * swept; only a row whose worker died (process crash/SIGKILL, no clean
+   * shutdown reset) ages past the threshold. It therefore no longer needs to
+   * be `>= 2× max handler duration` — it just needs to exceed a few missed
+   * heartbeats (default leaves a 3× heartbeat margin).
    */
   staleThresholdMs?: number;
+  /**
+   * CLAIM-HB-1 — interval at which this worker bumps `claimed_at = now()` for
+   * every run it currently holds in flight (one batched UPDATE). This is the
+   * lease renewal that keeps a legitimately long-running handler from being
+   * swept by `sweepStaleClaims`. Default `staleThresholdMs / 3` so a row
+   * survives up to two missed renewals before the sweeper acts. MUST be
+   * comfortably less than `staleThresholdMs` or live runs will be re-queued
+   * mid-flight.
+   */
+  claimHeartbeatIntervalMs?: number;
   /** Max ms to wait for in-flight drain on SIGTERM. Default 30_000. */
   shutdownTimeoutMs?: number;
   /**
@@ -78,6 +98,12 @@ const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_STALE_SWEEPER_INTERVAL_MS = 60_000;
 const DEFAULT_STALE_THRESHOLD_MS = 5 * 60_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000;
+/**
+ * CLAIM-HB-1 — the heartbeat fires at `staleThresholdMs / DIVISOR`, leaving
+ * `DIVISOR - 1` missed-renewal margin before the sweeper presumes the worker
+ * dead. 3 gives two missed beats of slack while keeping the renewal cheap.
+ */
+const CLAIM_HEARTBEAT_DIVISOR = 3;
 
 const TERMINAL_STATUSES: JobRunRow['status'][] = [
   'completed',
@@ -172,6 +198,26 @@ export function buildStaleSweepQuery(
     .for('update', { skipLocked: true });
 }
 
+/**
+ * CLAIM-HB-1 — build the heartbeat renewal UPDATE. Bumps `claimed_at = now()`
+ * (and `updated_at`) for the given run IDs, but ONLY rows still `status =
+ * 'running'`: a row this worker thinks it owns may have been swept and
+ * reclaimed by another worker (now running elsewhere), or already moved to a
+ * terminal state — the status guard makes the renewal a safe no-op in both
+ * cases rather than resurrecting a lease the worker no longer holds. Exported so
+ * tests can inspect `.toSQL()` without a live DB.
+ */
+export function buildClaimRenewQuery(
+  db: DrizzleClient,
+  runIds: string[],
+  now: Date = new Date(),
+) {
+  return db
+    .update(jobRuns)
+    .set({ claimedAt: now, updatedAt: now })
+    .where(and(inArray(jobRuns.id, runIds), eq(jobRuns.status, 'running')));
+}
+
 // ─── Error serialisation ───────────────────────────────────────────────────
 
 function serialiseError(err: unknown, attempt: number, retryable: boolean) {
@@ -191,14 +237,25 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(JobWorker.name);
   private shuttingDown = false;
   private readonly inFlight = new Set<Promise<void>>();
+  /**
+   * CLAIM-HB-1 — the set of run IDs this worker currently has executing. The
+   * heartbeat renews `claimed_at` for exactly these; a run is added when its
+   * `processRun` is dispatched and removed when its execution settles (success,
+   * failure, retry-release, or concurrency-defer). Kept separate from
+   * `inFlight` (which tracks the wrapper Promises for drain) because the
+   * heartbeat needs the IDs, not the promises.
+   */
+  private readonly inFlightRunIds = new Set<string>();
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private sweeperTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private sigtermHandled = false;
   private readonly sigtermHandler: () => void;
 
   private readonly pollIntervalMs: number;
   private readonly staleSweeperIntervalMs: number;
   private readonly staleThresholdMs: number;
+  private readonly claimHeartbeatIntervalMs: number;
   private readonly shutdownTimeoutMs: number;
 
   // LISTEN-NOTIFY-1 — dedicated listener + debounce state. `null` when
@@ -222,6 +279,12 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
     this.staleSweeperIntervalMs =
       options.staleSweeperIntervalMs ?? DEFAULT_STALE_SWEEPER_INTERVAL_MS;
     this.staleThresholdMs = options.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
+    // CLAIM-HB-1 — default to a third of the stale threshold so a row tolerates
+    // two missed renewals before the sweeper acts. A consumer-supplied value is
+    // honored verbatim (it's their call if they want it tighter/looser).
+    this.claimHeartbeatIntervalMs =
+      options.claimHeartbeatIntervalMs ??
+      Math.max(1, Math.floor(this.staleThresholdMs / CLAIM_HEARTBEAT_DIVISOR));
     this.shutdownTimeoutMs =
       options.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
     this.listenNotifyEnabled = options.listenNotify ?? false;
@@ -245,6 +308,12 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
     this.sweeperTimer = setInterval(() => {
       void this.sweepStaleClaims();
     }, this.staleSweeperIntervalMs);
+    // CLAIM-HB-1 — renew the claim lease on in-flight runs so a legitimately
+    // long-running handler is not swept mid-flight. No-ops cheaply (no UPDATE)
+    // when nothing is in flight.
+    this.heartbeatTimer = setInterval(() => {
+      void this.renewClaims();
+    }, this.claimHeartbeatIntervalMs);
     process.on('SIGTERM', this.sigtermHandler);
 
     // LISTEN-NOTIFY-1 — start the wake listener ALONGSIDE the poll timer (never
@@ -342,6 +411,10 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
       clearInterval(this.sweeperTimer);
       this.sweeperTimer = null;
     }
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
     process.removeListener('SIGTERM', this.sigtermHandler);
 
     await this.drainInFlight();
@@ -406,11 +479,21 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
     if (!claimed) return;
 
     const run = claimed;
-    const promise = this.processRun(run).catch((err) => {
-      this.logger.error(
-        `processRun(${run.id}) unhandled: ${(err as Error).message}`,
-      );
-    });
+    // CLAIM-HB-1 — register the run as in-flight so the heartbeat renews its
+    // lease, and deregister the moment its execution settles (success, failure,
+    // retry-release, concurrency-defer — every path out of processRun). Held in
+    // a `finally` so an unhandled throw can't strand the id in the renew set and
+    // keep bumping `claimed_at` for a run this worker no longer owns.
+    this.inFlightRunIds.add(run.id);
+    const promise = this.processRun(run)
+      .catch((err) => {
+        this.logger.error(
+          `processRun(${run.id}) unhandled: ${(err as Error).message}`,
+        );
+      })
+      .finally(() => {
+        this.inFlightRunIds.delete(run.id);
+      });
     this.inFlight.add(promise);
     promise.finally(() => {
       this.inFlight.delete(promise);
@@ -487,6 +570,37 @@ export class JobWorker implements OnModuleInit, OnModuleDestroy {
       });
     } catch (err) {
       this.logger.error(`sweepStaleClaims failed: ${(err as Error).message}`);
+    }
+  }
+
+  // ============================================================================
+  // Claim heartbeat (CLAIM-HB-1)
+  // ============================================================================
+
+  /**
+   * Renew the claim lease on every run this worker currently has in flight by
+   * bumping `claimed_at = now()` in a single UPDATE. This is what keeps
+   * `sweepStaleClaims` from re-queueing a legitimately long-running handler:
+   * the sweeper only resets rows whose `claimed_at` has aged past the threshold,
+   * and a live worker keeps renewing. When the worker process dies, renewal
+   * stops, the row ages out, and the sweeper correctly recovers it — its
+   * documented "stranded by a crashed worker" intent.
+   *
+   * No-ops (no query) when nothing is in flight. The `status = 'running'` guard
+   * inside the UPDATE means a run that was swept-and-reclaimed elsewhere (or has
+   * already settled) is not touched.
+   */
+  async renewClaims(): Promise<void> {
+    if (this.shuttingDown) return;
+    const ids = [...this.inFlightRunIds];
+    if (ids.length === 0) return;
+    try {
+      await buildClaimRenewQuery(this.db, ids, new Date());
+    } catch (err) {
+      // Best-effort: a transient failure just means this beat was missed. The
+      // staleThreshold leaves several beats of slack before the sweeper acts,
+      // and the next beat retries.
+      this.logger.error(`renewClaims failed: ${(err as Error).message}`);
     }
   }
 

--- a/runtime/subsystems/jobs/jobs-domain.module.ts
+++ b/runtime/subsystems/jobs/jobs-domain.module.ts
@@ -59,6 +59,25 @@ export interface DrizzleBackendExtensions {
   listenNotify?: boolean;
   /** Polling interval (ms). Default 1000. */
   pollIntervalMs?: number;
+  /**
+   * CLAIM-HB-1 — stale-claim sweep interval (ms). How often each worker scans
+   * for `running` rows whose lease has expired. Default 60_000.
+   */
+  staleSweeperIntervalMs?: number;
+  /**
+   * CLAIM-HB-1 — stale-claim threshold (ms). A `running` row whose `claimed_at`
+   * has not been renewed within this window is presumed stranded by a dead
+   * worker and reset to `pending`. A LIVE worker renews the lease every
+   * `claimHeartbeatIntervalMs`, so this only catches genuine crashes. Default
+   * 300_000 (5 min).
+   */
+  staleThresholdMs?: number;
+  /**
+   * CLAIM-HB-1 — claim heartbeat interval (ms). How often a worker bumps
+   * `claimed_at` for its in-flight runs to keep them from being swept. Must be
+   * comfortably below `staleThresholdMs`. Default `staleThresholdMs / 3`.
+   */
+  claimHeartbeatIntervalMs?: number;
 }
 
 export interface JobsDomainModuleOptions {

--- a/src/__tests__/cli/subsystem-barrel-generator.test.ts
+++ b/src/__tests__/cli/subsystem-barrel-generator.test.ts
@@ -398,6 +398,31 @@ describe('buildSubsystemBarrel', () => {
 		);
 	});
 
+	test('jobs `extensions.drizzle` claim-heartbeat knobs (CLAIM-HB-1) thread into both forRoots', () => {
+		const out = buildSubsystemBarrel(
+			[inst('jobs')],
+			{
+				jobs: {
+					backend: 'drizzle',
+					worker_mode: 'embedded',
+					extensions: {
+						drizzle: {
+							stale_threshold_ms: 1_800_000,
+							stale_sweeper_interval_ms: 30_000,
+							claim_heartbeat_interval_ms: 120_000,
+						},
+					},
+				},
+			},
+			subsystemsRel,
+		);
+		// Snake_case YAML → camelCase runtime keys, on the embedded worker path.
+		expect(out.content).toContain('staleThresholdMs: 1800000');
+		expect(out.content).toContain('staleSweeperIntervalMs: 30000');
+		expect(out.content).toContain('claimHeartbeatIntervalMs: 120000');
+		expect(out.content).toContain('domainModuleExtensions: { drizzle:');
+	});
+
 	test('jobs drizzle extensions thread `pollIntervalMs` alone (listen_notify omitted → off by default)', () => {
 		const out = buildSubsystemBarrel(
 			[inst('jobs')],

--- a/src/__tests__/runtime/subsystems/job-worker.claim-heartbeat.spec.ts
+++ b/src/__tests__/runtime/subsystems/job-worker.claim-heartbeat.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Claim heartbeat (CLAIM-HB-1) — lease renewal for in-flight runs.
+ *
+ * The bug (dogfood-discovered, swe-brain 2026-06-06): `claimed_at` was stamped
+ * once at claim and never renewed, while `sweepStaleClaims` reset any `running`
+ * row whose `claimed_at` aged past `staleThresholdMs` (default 5 min) back to
+ * `pending`. ANY handler that legitimately ran longer than the threshold was
+ * silently re-queued mid-flight and re-claimed by a second worker, so the live
+ * attempt and the zombie ran concurrently. A 365-day Gmail backfill could never
+ * finish inside 5 min, so it re-spawned a fresh concurrent walk every ~6 min for
+ * days.
+ *
+ * The fix: a live worker tracks the run IDs it has in flight and bumps
+ * `claimed_at = now()` for them every `claimHeartbeatIntervalMs` (default
+ * `staleThresholdMs / 3`). A long-but-alive run is therefore NEVER swept; only a
+ * row whose worker DIED (renewal stops) ages out — the sweeper's documented
+ * "stranded by a crashed worker" intent.
+ *
+ * These are unit tests: no Postgres. A stub Drizzle client records the renewal
+ * UPDATE; the worker's timers are never started (we drive `renewClaims` /
+ * `pollAndProcess` directly) so the tests are deterministic.
+ */
+import 'reflect-metadata';
+import { describe, expect, it } from 'bun:test';
+import { drizzle } from 'drizzle-orm/pg-proxy';
+
+import {
+  JobWorker,
+  type JobWorkerOptions,
+  buildClaimRenewQuery,
+} from '../../../../runtime/subsystems/jobs/job-worker';
+import type { JobRunRow } from '../../../../runtime/subsystems/jobs/job-orchestration.schema';
+import type { DrizzleClient } from '../../../../runtime/types/drizzle';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** A no-op pg-proxy drizzle client, used only for `.toSQL()` inspection. */
+function inspectableDb(): DrizzleClient {
+  return drizzle(async () => ({ rows: [] })) as unknown as DrizzleClient;
+}
+
+/**
+ * A stub Drizzle client that records every `update().set().where()` chain so a
+ * test can assert what the heartbeat wrote. The chain is awaitable (the worker
+ * `await`s the builder); awaiting resolves once the chain is recorded.
+ */
+function recordingDb(): {
+  db: DrizzleClient;
+  updates: Array<{ set: Record<string, unknown> }>;
+} {
+  const updates: Array<{ set: Record<string, unknown> }> = [];
+  const db = {
+    update() {
+      const record: { set: Record<string, unknown> } = { set: {} };
+      const chain = {
+        set(values: Record<string, unknown>) {
+          record.set = values;
+          return chain;
+        },
+        where() {
+          // The worker awaits the result of `.where(...)`; record on resolve.
+          updates.push(record);
+          return Promise.resolve(undefined);
+        },
+      };
+      return chain;
+    },
+  } as unknown as DrizzleClient;
+  return { db, updates };
+}
+
+/** Construct a JobWorker with a given db + options; timers are NOT started. */
+function makeWorker(
+  db: DrizzleClient,
+  options: Partial<JobWorkerOptions> = {},
+): JobWorker {
+  const opts: JobWorkerOptions = {
+    pool: 'batch',
+    concurrency: 5,
+    ...options,
+  };
+  return new JobWorker(
+    db,
+    {} as never,
+    {} as never,
+    {} as never,
+    opts,
+    {} as never,
+  );
+}
+
+/** Read the private in-flight run-id set without widening source visibility. */
+function inFlightRunIds(worker: JobWorker): Set<string> {
+  return (worker as unknown as { inFlightRunIds: Set<string> }).inFlightRunIds;
+}
+
+/** Resolve the worker's effective heartbeat interval (private field). */
+function heartbeatInterval(worker: JobWorker): number {
+  return (worker as unknown as { claimHeartbeatIntervalMs: number })
+    .claimHeartbeatIntervalMs;
+}
+
+// ─── 1. buildClaimRenewQuery — SQL invariants ─────────────────────────────────
+
+describe('buildClaimRenewQuery — SQL invariants', () => {
+  const db = inspectableDb();
+  const { sql, params } = buildClaimRenewQuery(
+    db,
+    ['run-a', 'run-b'],
+    new Date('2026-06-06T00:00:00.000Z'),
+  ).toSQL();
+  const normalised = sql.toUpperCase().replace(/\s+/g, ' ');
+
+  it('UPDATEs job_run setting claimed_at (the lease renewal)', () => {
+    expect(normalised).toContain('UPDATE');
+    expect(normalised).toContain('"CLAIMED_AT" =');
+  });
+
+  it('also bumps updated_at', () => {
+    expect(normalised).toContain('"UPDATED_AT" =');
+  });
+
+  it('scopes to the supplied run ids', () => {
+    expect(normalised).toContain('"ID" IN');
+    expect(params).toContain('run-a');
+    expect(params).toContain('run-b');
+  });
+
+  it('guards on status = running so a swept-and-reclaimed run is untouched', () => {
+    expect(normalised).toContain('"STATUS" =');
+    expect(params).toContain('running');
+  });
+});
+
+// ─── 2. renewClaims — issues an UPDATE only for in-flight runs ─────────────────
+
+describe('JobWorker.renewClaims — lease renewal', () => {
+  it('no-ops (no UPDATE) when nothing is in flight', async () => {
+    const { db, updates } = recordingDb();
+    const worker = makeWorker(db);
+    await worker.renewClaims();
+    expect(updates.length).toBe(0);
+  });
+
+  it('issues exactly one UPDATE bumping claimed_at for the in-flight runs', async () => {
+    const { db, updates } = recordingDb();
+    const worker = makeWorker(db);
+    inFlightRunIds(worker).add('run-1');
+    inFlightRunIds(worker).add('run-2');
+
+    await worker.renewClaims();
+
+    expect(updates.length).toBe(1);
+    expect(updates[0]?.set.claimedAt).toBeInstanceOf(Date);
+    expect(updates[0]?.set.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not renew once shutting down', async () => {
+    const { db, updates } = recordingDb();
+    const worker = makeWorker(db);
+    inFlightRunIds(worker).add('run-1');
+    (worker as unknown as { shuttingDown: boolean }).shuttingDown = true;
+
+    await worker.renewClaims();
+    expect(updates.length).toBe(0);
+  });
+});
+
+// ─── 3. Heartbeat interval defaulting ─────────────────────────────────────────
+
+describe('JobWorker — claimHeartbeatIntervalMs defaulting', () => {
+  it('defaults to staleThresholdMs / 3 so a run survives two missed beats', () => {
+    const worker = makeWorker(inspectableDb(), { staleThresholdMs: 300_000 });
+    expect(heartbeatInterval(worker)).toBe(100_000);
+  });
+
+  it('honors an explicit consumer-supplied interval verbatim', () => {
+    const worker = makeWorker(inspectableDb(), {
+      staleThresholdMs: 300_000,
+      claimHeartbeatIntervalMs: 15_000,
+    });
+    expect(heartbeatInterval(worker)).toBe(15_000);
+  });
+
+  it('is always at least 1ms even at a pathologically small threshold', () => {
+    const worker = makeWorker(inspectableDb(), { staleThresholdMs: 1 });
+    expect(heartbeatInterval(worker)).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── 4. In-flight lifecycle — registered while running, cleared on settle ─────
+
+describe('JobWorker — in-flight run-id lifecycle (heartbeat scope)', () => {
+  /**
+   * Drive `pollAndProcess` with a stubbed `claimNext` (returns one run) and a
+   * controllable `processRun` (a deferred promise). This is the exact wrapper
+   * under test: the run id must be in the renew set WHILE the handler runs (so a
+   * long handler keeps getting its lease renewed and is never swept) and gone
+   * once execution settles (so the heartbeat stops touching a run this worker no
+   * longer owns).
+   */
+  function makeLifecycleWorker(): {
+    worker: JobWorker;
+    resolveRun: () => void;
+    rejectRun: (e: unknown) => void;
+    processStarted: Promise<void>;
+  } {
+    const worker = makeWorker(inspectableDb());
+    const run = { id: 'run-long' } as unknown as JobRunRow;
+
+    // Always hand back the same run on the first claim, then nothing.
+    let claimed = false;
+    (worker as unknown as { claimNext: () => Promise<JobRunRow | null> }).claimNext =
+      async () => {
+        if (claimed) return null;
+        claimed = true;
+        return run;
+      };
+
+    let resolveRun!: () => void;
+    let rejectRun!: (e: unknown) => void;
+    let markStarted!: () => void;
+    const processStarted = new Promise<void>((res) => {
+      markStarted = res;
+    });
+    const settle = new Promise<void>((res, rej) => {
+      resolveRun = () => res();
+      rejectRun = (e) => rej(e);
+    });
+    (worker as unknown as { processRun: (r: JobRunRow) => Promise<void> }).processRun =
+      async () => {
+        markStarted();
+        await settle;
+      };
+
+    return { worker, resolveRun, rejectRun, processStarted };
+  }
+
+  it('registers the run while the handler runs, so a long run stays renewable', async () => {
+    const { worker, resolveRun, processStarted } = makeLifecycleWorker();
+
+    await worker.pollAndProcess();
+    await processStarted;
+
+    // Handler is "still running" (settle not resolved) — its lease must renew.
+    expect(inFlightRunIds(worker).has('run-long')).toBe(true);
+
+    resolveRun();
+    // Let the finally hooks flush.
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(inFlightRunIds(worker).has('run-long')).toBe(false);
+  });
+
+  it('clears the run from the renew set after a SUCCESSFUL settle', async () => {
+    const { worker, resolveRun, processStarted } = makeLifecycleWorker();
+    await worker.pollAndProcess();
+    await processStarted;
+    resolveRun();
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(inFlightRunIds(worker).size).toBe(0);
+  });
+
+  it('clears the run from the renew set even when processRun THROWS', async () => {
+    const { worker, rejectRun, processStarted } = makeLifecycleWorker();
+    await worker.pollAndProcess();
+    await processStarted;
+    rejectRun(new Error('handler blew up'));
+    await new Promise<void>((r) => setTimeout(r, 0));
+    // The unhandled-error catch + finally must still deregister the id, so the
+    // heartbeat never keeps bumping a run this worker no longer owns.
+    expect(inFlightRunIds(worker).has('run-long')).toBe(false);
+  });
+});

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -134,24 +134,43 @@ function jsonToTs(value: unknown): string {
 }
 
 /**
- * LISTEN-NOTIFY-1 — extract the drizzle extension knobs (`listen_notify`,
- * `poll_interval_ms`) from `jobs.extensions.drizzle` and map them to the
- * camelCase runtime shape. Returns `undefined` when neither knob is set (so the
- * generated call stays minimal and off-by-default). Only the drizzle/default
- * backend reads these.
+ * Camel-cased shape of the drizzle jobs backend extension knobs that flow into
+ * the generated `forRoot` calls. Snake_case YAML keys map 1:1 to these.
+ */
+type DrizzleJobsExt = {
+	listenNotify?: boolean;
+	pollIntervalMs?: number;
+	staleSweeperIntervalMs?: number;
+	staleThresholdMs?: number;
+	claimHeartbeatIntervalMs?: number;
+};
+
+/**
+ * LISTEN-NOTIFY-1 / CLAIM-HB-1 — extract the drizzle extension knobs from
+ * `jobs.extensions.drizzle` (`listen_notify`, `poll_interval_ms`,
+ * `stale_sweeper_interval_ms`, `stale_threshold_ms`,
+ * `claim_heartbeat_interval_ms`) and map them to the camelCase runtime shape.
+ * Returns `undefined` when no knob is set (so the generated call stays minimal
+ * and off-by-default). Only the drizzle/default backend reads these.
  */
 function drizzleJobsExtensions(
 	backend: string,
 	cfg: Record<string, unknown> | undefined,
-): { listenNotify?: boolean; pollIntervalMs?: number } | undefined {
+): DrizzleJobsExt | undefined {
 	if (backend !== 'drizzle') return undefined;
 	const drizzle = (cfg?.extensions as { drizzle?: Record<string, unknown> } | undefined)
 		?.drizzle;
 	if (!drizzle) return undefined;
-	const out: { listenNotify?: boolean; pollIntervalMs?: number } = {};
+	const out: DrizzleJobsExt = {};
 	if (typeof drizzle.listen_notify === 'boolean') out.listenNotify = drizzle.listen_notify;
 	if (typeof drizzle.poll_interval_ms === 'number')
 		out.pollIntervalMs = drizzle.poll_interval_ms;
+	if (typeof drizzle.stale_sweeper_interval_ms === 'number')
+		out.staleSweeperIntervalMs = drizzle.stale_sweeper_interval_ms;
+	if (typeof drizzle.stale_threshold_ms === 'number')
+		out.staleThresholdMs = drizzle.stale_threshold_ms;
+	if (typeof drizzle.claim_heartbeat_interval_ms === 'number')
+		out.claimHeartbeatIntervalMs = drizzle.claim_heartbeat_interval_ms;
 	return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -163,7 +182,7 @@ function drizzleJobsExtensions(
  * holds the listener + honors `pollIntervalMs`).
  */
 function drizzleExtensionsClause(
-	ext: { listenNotify?: boolean; pollIntervalMs?: number } | undefined,
+	ext: DrizzleJobsExt | undefined,
 	key: 'extensions' | 'domainModuleExtensions',
 ): string {
 	if (!ext) return '';
@@ -181,7 +200,7 @@ function quoteBullmqDomainOpts(input: {
 	backend: string;
 	multiTenant: boolean;
 	bullExt: Record<string, unknown> | undefined;
-	drizzleExt?: { listenNotify?: boolean; pollIntervalMs?: number } | undefined;
+	drizzleExt?: DrizzleJobsExt | undefined;
 }): string {
 	const { backend, multiTenant, bullExt, drizzleExt } = input;
 	if (backend === 'bullmq' && bullExt) {

--- a/templates/subsystem/jobs-config/codegen-config-jobs-block.ejs.t
+++ b/templates/subsystem/jobs-config/codegen-config-jobs-block.ejs.t
@@ -30,6 +30,17 @@ jobs:
       #                            # are simply never received and the worker
       #                            # degrades to polling.
       poll_interval_ms: 1000       # interval-poll heartbeat (the wake fallback)
+      # ── Claim lease / heartbeat (CLAIM-HB-1) ──
+      # A live worker renews `claimed_at` for its in-flight runs every
+      # `claim_heartbeat_interval_ms`, so a legitimately long-running handler is
+      # NEVER swept; only a row whose worker died ages past
+      # `stale_threshold_ms` and is reset to `pending` by the sweeper. Raise the
+      # threshold only if you expect worker-crash recovery to wait longer; the
+      # heartbeat (not the threshold) is what protects long handlers.
+      # stale_threshold_ms: 300000          # dead-worker recovery window (5 min)
+      # stale_sweeper_interval_ms: 60000    # how often the sweeper scans
+      # claim_heartbeat_interval_ms: 100000 # lease renewal cadence
+      #                                     # (default = stale_threshold_ms / 3)
     # bullmq:                      # Example shape for Phase 6+ BullMQ backend.
     #   bull_board:                # Mount Bull Board admin UI.
     #     enabled: true


### PR DESCRIPTION
Closes #500. Follow-up fencing work tracked in #501.

## The bug

The drizzle `JobWorker` (`runtime/subsystems/jobs/job-worker.ts`) stamps `claimed_at` exactly **once**, at claim time, and never renews it. `sweepStaleClaims` runs every `staleSweeperIntervalMs` (default 60s) and resets any `running` row whose `claimed_at` is older than `staleThresholdMs` (default **5 min**) back to `pending`. There is no heartbeat between those two facts.

Consequence: **any handler that legitimately runs longer than the threshold is silently re-queued mid-flight.** The in-flight execution can't be cancelled, so a second worker claims the row and runs the handler **concurrently with the still-live original**. There's no fencing either — when the zombie finishes, it writes its completion/steps anyway, racing the live attempt.

The spec/skill even documented the tell-tale invariant `staleThresholdMs >= 2 × max_handler_duration` — i.e. the threshold was being asked to bound handler duration, which the worker has no way to enforce.

### Dogfood evidence (swe-brain, 2026-06-06)

A Gmail full-backfill job (a 365-day mailbox walk) could never finish inside the 5-min threshold:

- every ~6 min the sweeper reset it to `pending`,
- a worker re-claimed and started a **fresh concurrent mailbox walk**,
- this looped for **5 days** (2026-06-01 → 2026-06-06),
- the sync cursor was frozen the entire time (each attempt restarted from the same cursor),
- thousands of duplicate Gmail API fetches accrued.

Writes were idempotent upserts, so no data corruption — but a non-idempotent handler in the same spot would corrupt, and the duplicate-work + frozen-cursor failure is bad on its own.

## The fix (heartbeat-scoped)

A live worker now renews the lease on the runs it has in flight:

- **In-flight tracking** — `JobWorker.inFlightRunIds: Set<string>`. A run id is added when `pollAndProcess` dispatches `processRun`, and removed in that promise's `.finally` on **every** settle path (success, failure, retry-release, concurrency-defer). The `finally` guarantees an unhandled throw can't strand an id and keep bumping `claimed_at` for a run this worker no longer owns.
- **Heartbeat** — a new interval (`claimHeartbeatIntervalMs`, default `staleThresholdMs / 3`) calls `renewClaims()`, which runs one `UPDATE job_run SET claimed_at=now(), updated_at=now() WHERE id IN (...) AND status='running'`. The `status='running'` guard makes renewal a safe no-op for a row that was already swept-and-reclaimed elsewhere or has settled. No-ops cheaply (no query) when nothing is in flight; best-effort (a missed beat just retries — the threshold leaves several beats of slack).
- **Sweeper restored to intent** — with renewal in place, `sweepStaleClaims` only catches genuinely dead workers (renewal stopped). The old `staleThresholdMs >= 2× max_handler_duration` rule is gone; the new invariant is `claimHeartbeatIntervalMs < staleThresholdMs`.
- **Consumer-threadable** — `staleThresholdMs`, `staleSweeperIntervalMs`, and the new `claimHeartbeatIntervalMs` flow from YAML (`jobs.extensions.drizzle.{stale_threshold_ms, stale_sweeper_interval_ms, claim_heartbeat_interval_ms}`) through `subsystem-barrel-generator.ts` into both `JobsDomainModule.forRoot` and `JobWorkerModule.forRoot`, matching the existing `listen_notify`/`poll_interval_ms` path. Package-mode consumers (swe-brain) pick these up via the generated subsystems barrel.

## Deferred: fencing (#501)

A claim-token / claim-epoch column on `job_run`, set at claim, with all run writes guarding on token match so a swept-and-reclaimed run can't be double-completed by a zombie that finishes after the sweep. This needs a **jobs-subsystem schema/migration change** plus guards at every write site — invasive enough that I kept it out of this PR so the heartbeat (which closes the practical re-claim loop and needs no migration) ships immediately. Tracked in #501. The heartbeat fixes long-but-healthy handlers; fencing closes the residual pathological-stall race (a worker that misses every beat without dying).

## Tests (`bun test`, exit 0)

New `job-worker.claim-heartbeat.spec.ts` (no Postgres — stub drizzle client + direct method drive):
- `buildClaimRenewQuery` SQL invariants: UPDATEs `job_run`, sets `claimed_at` + `updated_at`, `id IN` the supplied ids, **guarded on `status='running'`**.
- `renewClaims`: no UPDATE when nothing in flight; exactly one UPDATE bumping `claimed_at`/`updated_at` when runs are in flight; no-op while shutting down.
- heartbeat interval defaulting (`staleThresholdMs/3`; explicit value honored; floor of 1ms).
- in-flight lifecycle: a run is in the renew set **while the handler runs** (so a long run stays renewable, would NOT be swept), and is cleared after a successful settle **and even when `processRun` throws**.

Plus a barrel-generator test asserting the three new knobs thread snake→camel into the generated `forRoot` calls.

Gates run by exit code: full `bun test src/__tests__/` green (2813 pass / 0 fail). `bun run typecheck` shows only 3 **pre-existing** errors in `junction.ts` / `barrel-generator.ts` (confirmed present on clean `origin/main`, unrelated to jobs) — zero new.

## Do NOT merge yet

Merging this repo's `main` auto-publishes to npm. The swe-brain consumer wants to validate via `bun link` before this lands. Holding for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)