### PR TITLE
fix(sink-emitter): delete deprecated shim + legacy fallback; durable provenance citations (#491 follow-up)

### DIFF
--- a/.ai-docs/stacks/assembly-default-sinks/specs/491.md
+++ b/.ai-docs/stacks/assembly-default-sinks/specs/491.md
@@ -63,7 +63,7 @@ carries **four author seams** woven into otherwise-mechanical method bodies:
 
 | # | Seam | Where it lives today (single file) | What "regenerate the file" would clobber |
 |---|---|---|---|
-| 1 | **Canonical widening** | `export type <E>Canonical = <E>IntegrationProjection;` (the alias the author re-points to `CanonicalMessage`) | the author's widened alias |
+| 1 | **Canonical widening** | `export type <E>Canonical = <E>IntegrationProjection;` (the alias the author re-points to `CanonicalMessage`) — **DELETED in Shape C**; widening now via subclass type-arg (`extends <E>SinkBase<YourCanonical>`) | the author's widened alias |
 | 2 | **FK activation** | the `<writeKey>: null,` + SEAM lines in the upsert `write` object (#487) — author replaces `null` with `record.<writeKey>` post-widen | the author's `record.<writeKey>` edits |
 | 3 | **Typed-json narrowing** | the `// SEAM (typed json …)` find-view lines (#488) — author narrows `unknown → MyType[]` | the author's narrowing |
 | 4 | **Null-coercion on widen** | bare find-view passthrough lines (#488) — author adds `?? ''` / `?? 'unknown'` where they widened a member to non-null | the author's coercions |

--- a/src/__tests__/clean-lite-ps/490-sink-knobs-contract.test.ts
+++ b/src/__tests__/clean-lite-ps/490-sink-knobs-contract.test.ts
@@ -42,7 +42,7 @@ import {
 import {
   buildSinkInput,
 } from '../../cli/shared/adapter-emission-generator';
-import { generateDefaultSink } from '../../cli/shared/sink-emission-generator';
+import { generateSinkBase } from '../../cli/shared/sink-emission-generator';
 
 // ============================================================================
 // Shared fixtures
@@ -86,34 +86,28 @@ const messageDef = {
 };
 
 /** Extract the defaultMessageToCanonicalView (or any entity's) view function body from
- *  the @generated base file. In the #491 two-file seam, the view lives in the standalone
- *  default function (not in findByExternalId — that method just calls this.toCanonicalView).
- *  Falls back to slicing from `async findByExternalId(` for backwards-compat with old callers.
+ *  the @generated base file. The view lives in the standalone default function
+ *  `default<E>ToCanonicalView` — not in `findByExternalId`, which just calls
+ *  `this.toCanonicalView(row)`.
  */
 function findBody(out: string): string {
   // #491 Shape C: the view is in the standalone function `function default<E>ToCanonicalView`.
   const viewFnMarker = 'ToCanonicalView(';
   const fnStart = out.indexOf(viewFnMarker);
-  if (fnStart !== -1) {
-    // Find the function's closing `}\n` at top-level indentation.
-    const bodyStart = out.indexOf('{', fnStart);
-    // Walk from bodyStart to find the matching closing brace.
-    let depth = 0;
-    let i = bodyStart;
-    while (i < out.length) {
-      if (out[i] === '{') depth++;
-      else if (out[i] === '}') {
-        depth--;
-        if (depth === 0) break;
-      }
-      i++;
+  // Find the function's closing `}` at top-level indentation.
+  const bodyStart = out.indexOf('{', fnStart);
+  // Walk from bodyStart to find the matching closing brace.
+  let depth = 0;
+  let i = bodyStart;
+  while (i < out.length) {
+    if (out[i] === '{') depth++;
+    else if (out[i] === '}') {
+      depth--;
+      if (depth === 0) break;
     }
-    return out.slice(bodyStart, i + 1);
+    i++;
   }
-  // Legacy fallback: old single-file format used findByExternalId as the anchor.
-  const start = out.indexOf('async findByExternalId(');
-  const end = out.indexOf('\n  }\n', start);
-  return out.slice(start, end + 4);
+  return out.slice(bodyStart, i + 1);
 }
 
 // ============================================================================
@@ -172,7 +166,7 @@ describe('#490 contract (a): both derivations exclude conversationExternalId fro
   // Emitted write object (now in defaultMessageBuildWrite standalone function) must not
   // include the excluded field. #491: no more `const write: ...` in a single-method body;
   // the write body is inside the `defaultMessageBuildWrite` function in the @generated base.
-  const sinkOut = generateDefaultSink(sinkInput); // shim → generateSinkBase
+  const sinkOut = generateSinkBase(sinkInput);
 
   it('emitted write function does not enumerate conversationExternalId', () => {
     // Extract defaultMessageBuildWrite function body (up to the next export function).
@@ -249,7 +243,7 @@ describe('#490 contract (c): find VIEW KEEPS excluded conversationExternalId as 
     expect(names).toContain('conversationExternalId');
   });
 
-  const sinkOut = generateDefaultSink(sinkInput);
+  const sinkOut = generateSinkBase(sinkInput);
 
   it('find view ENUMERATES conversationExternalId: row.conversationExternalId (bare passthrough)', () => {
     expect(findBody(sinkOut)).toContain('conversationExternalId: row.conversationExternalId,');
@@ -341,7 +335,7 @@ describe('#490 contract (d): resolveSoftDeleteBoolean + deleteMode agree', () =>
       { ...messageDef, integration: { sink: { delete: 'noop' } } } as Parameters<typeof buildSinkInput>[0],
       'messaging', 'slack', '../messaging/message.repository',
     );
-    const sinkOut = generateDefaultSink(sinkInput);
+    const sinkOut = generateSinkBase(sinkInput);
     const deleteBody = sinkOut.slice(
       sinkOut.indexOf('async softDeleteByExternalId('),
       sinkOut.indexOf('\n  }\n', sinkOut.indexOf('async softDeleteByExternalId(')),
@@ -356,7 +350,7 @@ describe('#490 contract (d): resolveSoftDeleteBoolean + deleteMode agree', () =>
       { ...messageDef, integration: { sink: { delete: 'soft' } } } as Parameters<typeof buildSinkInput>[0],
       'messaging', 'slack', '../messaging/message.repository',
     );
-    const sinkOut = generateDefaultSink(sinkInput);
+    const sinkOut = generateSinkBase(sinkInput);
     expect(sinkOut).toContain(
       'return this.repo.softDeleteByExternalId(externalId, this.provider);',
     );

--- a/src/__tests__/cli/sink-emission-generator.test.ts
+++ b/src/__tests__/cli/sink-emission-generator.test.ts
@@ -42,7 +42,6 @@ import { describe, it, expect } from "bun:test";
 import {
   generateSinkBase,
   generateSinkSubclass,
-  generateDefaultSink,
   type SinkEmitInput,
 } from "../../cli/shared/sink-emission-generator";
 import { fkWriteKey } from "../../cli/shared/adapter-emission-generator";
@@ -947,19 +946,3 @@ describe("generateSinkBase — #490 exclusion does not affect localFkColumns or 
   });
 });
 
-// ============================================================================
-// generateDefaultSink — legacy shim compatibility
-// ============================================================================
-
-describe("generateDefaultSink — legacy shim (delegates to generateSinkBase)", () => {
-  it("returns the same output as generateSinkBase", () => {
-    const input = contactInput();
-    expect(generateDefaultSink(input)).toBe(generateSinkBase(input));
-  });
-
-  it("still hard-errors for non-Integrated pattern", () => {
-    expect(() =>
-      generateDefaultSink(contactInput({ pattern: "Base" })),
-    ).toThrow(/pattern: Integrated/);
-  });
-});

--- a/src/cli/shared/adapter-emission-generator.ts
+++ b/src/cli/shared/adapter-emission-generator.ts
@@ -1194,7 +1194,7 @@ export function fkWriteKey(
  * nullable-aware tsType); FK external keys are one `<relationKey>ExternalId` per
  * `belongs_to`. Uses {@link fkWriteKey} for the derivation so the write-key
  * matches the template's write-type member name for all three FK shapes.
- * The `generateDefaultSink` emitter throws if `pattern` is not
+ * The `generateSinkBase`/`generateSinkSubclass` emitters throw if `pattern` is not
  * `Integrated` — the caller pre-filters, so this is only reached for Integrated.
  */
 export function buildSinkInput(

--- a/src/cli/shared/sink-emission-generator.ts
+++ b/src/cli/shared/sink-emission-generator.ts
@@ -17,7 +17,9 @@
  *
  * ## Why Shape C (the generic/cast trilemma — RESOLVED)
  *
- * The probe (`/tmp/sink-trilemma/probe_BConly.ts`, TS 6.0.3 --strict, exit 0) proved:
+ * RFC-0002 §4 describes the trilemma; `src/__tests__/cli/sink-widened-canonical.gate.test.ts`
+ * (§3b gate) runs `tsc --noEmit` on the emitted base + widened + projection-default subclasses
+ * to prove it compiles cast-free on every CI run. Shape A fails TS2322; Shape C compiles:
  *   - Shape A FAILS — a generic base with a default-bodied seam typed `TCanonical` is
  *     TS2322: the literal `{…projection…}` is not assignable to `TCanonical` when
  *     the subclass widens it to an unrelated canonical type.
@@ -397,9 +399,9 @@ ${findViewBody}
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class ${n.sinkBaseClass}<TCanonical = ${n.projectionType}>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -499,19 +501,3 @@ export class ${n.sinkClass} extends ${n.sinkBaseClass} {
 `;
 }
 
-// ============================================================================
-// Legacy export — kept for any call-site that hasn't migrated to the two-file
-// split yet. Delegates to generateSinkBase (the plumbing is identical; the
-// subclass is a separate call). This is NOT the canonical path — use
-// generateSinkBase + generateSinkSubclass via emitAdapters.
-// ============================================================================
-
-/**
- * @deprecated Use {@link generateSinkBase} + {@link generateSinkSubclass} instead.
- *   This shim returns only the base file text for legacy call-sites in tests
- *   that import `generateDefaultSink` by name. It will be removed once all
- *   call-sites migrate to the two-function API.
- */
-export function generateDefaultSink(input: SinkEmitInput): string {
-  return generateSinkBase(input);
-}

--- a/test/integration-emit/__snapshots__/snapshot.test.ts.snap
+++ b/test/integration-emit/__snapshots__/snapshot.test.ts.snap
@@ -344,9 +344,9 @@ export function defaultMeetingToCanonicalView(row: MeetingIntegrationProjection)
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class MeetingSinkBase<TCanonical = MeetingIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -957,9 +957,9 @@ export function defaultAccountToCanonicalView(row: AccountIntegrationProjection)
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class AccountSinkBase<TCanonical = AccountIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -1082,9 +1082,9 @@ export function defaultContactToCanonicalView(row: ContactIntegrationProjection)
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class ContactSinkBase<TCanonical = ContactIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -1214,9 +1214,9 @@ export function defaultLeadToCanonicalView(row: LeadIntegrationProjection): Lead
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class LeadSinkBase<TCanonical = LeadIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -1342,9 +1342,9 @@ export function defaultMessageToCanonicalView(row: MessageIntegrationProjection)
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class MessageSinkBase<TCanonical = MessageIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -1473,9 +1473,9 @@ export function defaultOpportunityToCanonicalView(row: OpportunityIntegrationPro
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class OpportunitySinkBase<TCanonical = OpportunityIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -1907,9 +1907,9 @@ export function defaultEmailToCanonicalView(row: EmailIntegrationProjection): Em
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class EmailSinkBase<TCanonical = EmailIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(
@@ -2309,9 +2309,9 @@ export function defaultTranscriptToCanonicalView(row: TranscriptIntegrationProje
 // Abstract base — the three IIntegrationSink methods are CONCRETE (machinery: provider
 // assert, repo delegation, #490 knob-driven delete). The two protected abstract seams are
 // typed at TCanonical with NO body — a default body returning TCanonical would be TS2322
-// (the probe proved this: /tmp/sink-trilemma/probe_BConly.ts, Shape A failure). The bodies
-// live in the standalone functions above; the emit-once subclass wires them in one line each.
-// No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
+// (Shape A failure — see RFC-0002 §4 and the §3b gate: sink-widened-canonical.gate.test.ts).
+// The bodies live in the standalone functions above; the emit-once subclass wires them in one
+// line each. No @Injectable() — the assembly binds via useFactory (OQ2 CLOSED, #491).
 export abstract class TranscriptSinkBase<TCanonical = TranscriptIntegrationProjection>
   implements IIntegrationSink<TCanonical> {
   constructor(


### PR DESCRIPTION
Follow-up to #503 (issue #491) — carries the Gate 2.5 fixup commit (`82c5876`) that was stranded when #503 was merged at its pre-fixup head (`8904187`) while the fixup push was in flight.

Contents (review-adjudicated, both Gate 2.5 lenses):
- **Delete the `generateDefaultSink` `@deprecated` shim** — parallel-old-and-new API with only in-repo test callers (CLAUDE.md: no backwards compat). Test call-sites repointed at `generateSinkBase`; "legacy shim compatibility" describe block removed.
- **Drop the `findBody` legacy-fallback branch** in `490-sink-knobs-contract.test.ts` — dead defensive code, no old callers.
- **Durable provenance in shipped comments** — emitted base files cited the absolute temp path `/tmp/sink-trilemma/probe_BConly.ts`; replaced with RFC-0002 §4 + the §3b gate test. Snapshot re-baseline is comment-only.
- Spec §Interfaces comment aligned with the emitted form (the `<Entity>Canonical` alias is deleted; widening happens via the subclass type argument).

Gates on the branch head: `just test-unit` 2912/0 (3 skip) · integration-emit 52/0 · §3b 4/0 · targeted 150/0.

Refs #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
