### PR TITLE
chore(release): bump 0.23.0 → 0.24.0 — publish EMIT-CHANGES

### DIFF
--- a/.ai-docs/handoff.md
+++ b/.ai-docs/handoff.md
@@ -1,17 +1,11 @@
-# Handoff — 2026-06-05 — ADR-038 frontend pipeline rebuild shipped; consumer test next
+# Handoff — 2026-06-06 — EMIT-CHANGES merged (#506); bump PR publishes 0.24.0
 
-**Branch:** local `feat/frontend-pipeline-rebuild` in worktree `reflective-yawning-clarke` — just an alias of main tip `67f817a`; its remote is deleted. Branch fresh from `main` for new work.
-**Last action:** ADR-038 frontend pipeline rebuild merged to main via #468 (no-squash; carries the FE-1..FE-4 squash stack #462/#467/#465/#466) + bump to **0.18.0**. Hygen frontend templates deleted; whole-set TS emitter at `src/emitters/frontend/` runs as the `entity new` post-step (covers `gen-all`).
-**Next action:** Consumer test of the emitter — in a consumer (swe-brain is bun-linked; or `codegen-pattern-demo-app`): get codegen 0.18.0, set `generate.frontend: true`, run `entity new --all`, install pairing deps (`@pattern-stack/frontend-patterns@alpha` + TanStack set — README "Frontend generation" table), typecheck the consumer frontend.
-**Obstacles:**
-- ~~publish~~ **0.18.0 is live on npm and tarball-verified** (2026-06-05): `latest` = 0.18.0, `dist/src/cli/index.js` carries the emitter, `templates/entity/new/` ships only backend + clean-lite-ps. No publish work remains.
-- Two contracts only a real consumer can verify: (1) `@repo/db/entities` exports plain `<Class>` — emitter assumes plain; one-line flip in `emit-api.ts`/`emit-collections.ts` if it's `<Class>Entity` (parent spec FE-4 notes); (2) `frontend-patterns@0.2.0-alpha.18` + TanStack pairing installs and typechecks in practice.
-- `EntityStoreProvider` mounting is documented, not scaffolded (parent spec OQ-4) — likely the first thing the consumer test trips on.
+**Branch:** `chore/bump-0.24.0` (worktree `memoized-riding-puddle`)
+**Last action:** Fixed PR #506 CI (`31432b1` events-baseline recapture for the message.yaml `emit_changes` opt-in; `5709ad9` integration-emit re-snapshot — feature commit `c377b67` had captured its snapshot from a stale pre-#503/#505 checkout, source was fine). Doug merged #506 → main `cb6d0d3` before the version bump landed on the branch, so EMIT-CHANGES is on main **unpublished** (main at 0.23.0). Cherry-picked the stranded bump to `chore/bump-0.24.0` and opened a PR.
+**Next action:** Merge the `chore/bump-0.24.0` PR — its merge auto-publishes 0.24.0. CHANGELOG `[Unreleased]` cut into `[0.24.0]` (EMIT-CHANGES) + `[0.23.0]` (CLAIM-HB-1 + lease tuning, which had shipped unrecorded).
+**Obstacles:** none
 
 ## Notes
-- Prior handoff (May-31, Track D round-2/B + swe-brain migration) is superseded — RFC-0002 shipped in 0.13.x; see git history for that handoff.
-- Key docs: `docs/adrs/ADR-038-frontend-pipeline-rebuild.md`; `docs/specs/2026-06-04-frontend-pipeline-rebuild.md` (status: implemented; carries per-stage implementation notes + the dbEntities contract decision); per-stage specs `ai-docs/specs/fe-{1..4}-*.md` (committed — archive once the consumer test passes).
-- Coverage: `test/frontend-golden/` golden tree + `src/__tests__/emitters/frontend/` (111 emitter tests). E2E replay proof: fresh project, irregular plural person→people, byte-identical re-runs, zero naive-plural leakage.
-- Pre-existing typecheck debt on main, unowned: `src/cli/commands/junction.ts:58,190`, `src/cli/shared/barrel-generator.ts:212` (TS2339 on Junction def fields).
-- Parked follow-ups (parent-spec OQs): doctor dep-check, electric `where` scoping + soft-delete shape filter, declarative-query api-client finders, `offline`/Dexie mode, frontend-patterns `sync/` package split.
-- Reference design lives at `pattern-stack/pattern-stack` → `tools/cli/src/pts/codegen/` (pts generator + SPEC-unified-entity-store.md); memory `original-frontend-generator-pts` has the map.
+- Per CLAUDE.md living-docs rule, sanity-check `docs/specs/EMIT-CHANGES-1.md` reflects post-implementation truth at merge.
+- CI annotation (non-blocking): `actions/checkout@v4` runs Node 20; GitHub forces Node 24 from **2026-06-16** — bump checkout in `.github/workflows/ci.yml` before then.
+- Parked track (handoff 2026-06-05, see `7a5ed07`): ADR-038 frontend emitter consumer test — in a consumer (swe-brain bun-linked, or codegen-pattern-demo-app), `generate.frontend: true` + `entity new --all` + pairing deps + typecheck. Two contracts only a consumer can verify: `@repo/db/entities` plain `<Class>` export assumption; `frontend-patterns@alpha` + TanStack pairing typechecks. Likely first trip: `EntityStoreProvider` mounting (OQ-4, documented not scaffolded).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
-
-### Fixed
-
-- **Jobs: claim heartbeat (CLAIM-HB-1) — long-running handlers are no longer
-  swept mid-flight.** The drizzle `JobWorker` stamped `claimed_at` once at claim
-  and never renewed it, while `sweepStaleClaims` reset any `running` row whose
-  `claimed_at` aged past `staleThresholdMs` (default 5 min) back to `pending`.
-  Consequence: ANY handler that legitimately ran longer than the threshold was
-  silently re-queued and re-claimed by a second worker, running CONCURRENTLY
-  with the still-live (uncancellable) original. Discovered by the swe-brain
-  dogfood: a 365-day Gmail backfill could never finish inside 5 min, so it
-  re-spawned a fresh concurrent mailbox walk every ~6 min for 5 days (writes
-  were idempotent upserts, so no corruption — but a non-idempotent handler would
-  have corrupted). Fix: a live worker now tracks its in-flight run IDs and bumps
-  `claimed_at = now()` for them every `claimHeartbeatIntervalMs` (new
-  `JobWorkerOptions` knob, default `staleThresholdMs / 3`). The sweeper now
-  fires only for genuinely dead workers (renewal stopped) — its documented
-  "stranded by a crashed worker" intent.
+## [0.24.0] — 2026-06-06
 
 ### Added
 
@@ -41,6 +23,28 @@ All notable changes to this project will be documented in this file.
   is `_edited`, NOT `_updated` (swe-brain ADR-0009 B1). Entities that don't opt in
   are byte-for-byte unchanged (the emitter token stays unbound). Generalizes the
   emission swe-brain hand-built in its sinks. See `docs/specs/EMIT-CHANGES-1.md`.
+
+## [0.23.0] — 2026-06-06
+
+### Fixed
+
+- **Jobs: claim heartbeat (CLAIM-HB-1) — long-running handlers are no longer
+  swept mid-flight.** The drizzle `JobWorker` stamped `claimed_at` once at claim
+  and never renewed it, while `sweepStaleClaims` reset any `running` row whose
+  `claimed_at` aged past `staleThresholdMs` (default 5 min) back to `pending`.
+  Consequence: ANY handler that legitimately ran longer than the threshold was
+  silently re-queued and re-claimed by a second worker, running CONCURRENTLY
+  with the still-live (uncancellable) original. Discovered by the swe-brain
+  dogfood: a 365-day Gmail backfill could never finish inside 5 min, so it
+  re-spawned a fresh concurrent mailbox walk every ~6 min for 5 days (writes
+  were idempotent upserts, so no corruption — but a non-idempotent handler would
+  have corrupted). Fix: a live worker now tracks its in-flight run IDs and bumps
+  `claimed_at = now()` for them every `claimHeartbeatIntervalMs` (new
+  `JobWorkerOptions` knob, default `staleThresholdMs / 3`). The sweeper now
+  fires only for genuinely dead workers (renewal stopped) — its documented
+  "stranded by a crashed worker" intent.
+
+### Added
 
 - **Jobs: consumer-threadable lease tuning.** `jobs.extensions.drizzle` now
   accepts `stale_threshold_ms`, `stale_sweeper_interval_ms`, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
EMIT-CHANGES (#506) merged to main at 0.23.0 — the version bump was pushed to the feature branch ~1 min after the squash-merge, so it stranded. This carries it to main:

- `package.json` 0.23.0 → 0.24.0 — merging this auto-publishes via the CI publish job
- CHANGELOG: cut `[Unreleased]` into `[0.24.0]` (EMIT-CHANGES) and `[0.23.0]` (CLAIM-HB-1 + lease tuning, which shipped in 0.23.0 unrecorded)
- `.ai-docs/handoff.md` refreshed (session handoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
