### PR TITLE
fix(jobs): mode-aware standalone worker scaffold — AppModule composition, src/ emission (#513)

### DIFF
--- a/.ai-docs/specs/513.md
+++ b/.ai-docs/specs/513.md
@@ -1,0 +1,90 @@
+# Spec — #513: jobs worker.ejs.t scaffold is vendored-centric — unusable in package mode
+
+- **Issue:** https://github.com/pattern-stack/codegen-patterns/issues/513
+- **Status:** approved (verbal, Doug 2026-06-06 — Gate 1 satisfied by handing this spec path to /develop)
+- **Branch:** `feat/513-worker-scaffold-package-mode` off `origin/main`
+- **Reference impl:** swe-brain `src/worker.ts` (sdlc-patterns#131, `worker_mode: standalone` adoption)
+
+## Problem (three defects, one template)
+
+`templates/subsystem/jobs/worker.ejs.t` + `src/cli/shared/jobs-scaffold-locals.ts`:
+
+1. **Vendored-only imports.** Emits `@shared/subsystems/jobs/job-worker.module` + `@generated/subsystems`. In `runtime: package` (the DEFAULT, ADR-037) neither resolves — the runtime lives at `@pattern-stack/codegen/runtime/subsystems/jobs/index` (see `makeModuleImport`, `subsystem-barrel-generator.ts:523`).
+2. **Repo-root emission.** `workerPath = path.resolve(cwd, 'worker.ts')` (`jobs-scaffold-locals.ts:86`) → outside `include: ["src/**/*"]` → silently escapes typecheck.
+3. **Empty handler DI surface.** Wires `SUBSYSTEM_MODULES` + `JobWorkerModule.forRoot(...)` but NOT the consumer's handler-providing modules. Handlers are Nest providers; the scaffolded worker boots with zero handlers registered.
+
+## Design
+
+### D1 — Compose around AppModule (kills defect 3, and most of defect 1)
+
+```ts
+@Module({
+  imports: [
+    AppModule, // consumer root — DatabaseModule + SUBSYSTEM_MODULES + handler modules
+    JobWorkerModule.forRoot({ mode: 'standalone', allPools: true, <mirrored opts> }),
+  ],
+})
+export class WorkerAppModule {}
+```
+
+- `import { AppModule } from './app.module'` — relative, **mode-agnostic** (worker now sits next to `app.module.ts`). Drops `DatabaseModule`, `SUBSYSTEM_MODULES`, `@generated/subsystems` imports entirely.
+- Importing AppModule whole = permanent handler-DI parity with the API process (swe-brain-proven composition).
+- `export class WorkerAppModule` (named export) so boot-checks/e2e can import the module without side effects.
+- Bootstrap gated on `import.meta.main` (bun-first; documented run command stays `bun src/worker.ts`).
+
+### D2 — One remaining mode-aware import, via the existing resolver
+
+`JobWorkerModule` import threads through `runtimeImport(mode, 'subsystems/jobs/index')` (`src/cli/shared/runtime-import.ts:70`):
+- package → `@pattern-stack/codegen/runtime/subsystems/jobs/index` (matches `makeModuleImport`'s non-events path; the top-level `/subsystems` barrel does NOT re-export JobWorkerModule)
+- vendored → `@shared/subsystems/jobs/index` (vendored jobs barrel exports `JobWorkerModule`, `runtime/subsystems/jobs/index.ts:147`)
+
+Computed in `resolveJobsScaffoldLocals` as a new local `jobWorkerModuleImport: string`; resolve mode via `resolveRuntimeMode(config)`. No new resolver functions.
+
+### D3 — Emit at `src/worker.ts`
+
+`workerPath = path.resolve(cwd, 'src', 'worker.ts')` — hardcoded `src/`, **matching the sibling convention already in this resolver** (`mainTsPath = src/main.ts`, init-scaffold's `src/app.module.ts`). Inside default tsconfig include → typechecked. (If `paths.backend_src` ever threads into this resolver, `mainTsPath`/`workerPath` move together — out of scope here.)
+
+### D4 — Mirror backend + extensions into the standalone forRoot
+
+Without this, a standalone worker silently loses `listen_notify`/`poll_interval_ms` (drizzle) or `backend: 'bullmq'` + its extension block — and standalone is the claim path where these matter most. The embedded composer already builds exactly these clauses (`subsystem-barrel-generator.ts:324` jobs composer).
+
+- Export from `subsystem-barrel-generator.ts`: `drizzleJobsExtensions`, `drizzleExtensionsClause`, `jsonToTs` (currently module-private).
+- New local `workerForRootOpts: string` in `jobs-scaffold-locals.ts`, built the same way the embedded branch builds its parts, but with `mode: 'standalone'` first and `allPools: true` last (always — reserved-lane drain rationale in the template header stays). Shape:
+  - drizzle default: `{ mode: 'standalone', allPools: true }`
+  - drizzle + knobs: `{ mode: 'standalone', domainModuleExtensions: { drizzle: {...} }, allPools: true }`
+  - bullmq: `{ mode: 'standalone', backend: 'bullmq', domainModuleExtensions: { bullmq: {...} }, allPools: true }`
+- Template renders `JobWorkerModule.forRoot(<%- workerForRootOpts %>)`.
+
+### D5 — Header/doc truth
+
+- Template header: rewrite for the AppModule composition; keep the reserved-pools/`allPools` rationale; add two notes: (a) this entrypoint is for `worker_mode: standalone` — in embedded mode AppModule already runs the worker, booting this file would double-spawn; (b) booting a consumer AppModule twice in one process throws `DuplicateSchemaError` (per-process OpenApiRegistry singleton) — multi-rung boot validation must spawn child processes.
+- `main-hook.ejs.t`: "use worker.ts at the project root" → `src/worker.ts`.
+- `prompt.js`: default `workerPath` fallback → `src/worker.ts`; doc comment updated.
+
+## File-by-file
+
+| File | Change |
+|---|---|
+| `templates/subsystem/jobs/worker.ejs.t` | Rewrite per D1/D2/D4/D5. Imports: `reflect-metadata`, `Logger, Module` (@nestjs/common), `NestFactory` (@nestjs/core), `AppModule` from `./app.module`, `JobWorkerModule` from `<%= jobWorkerModuleImport %>`. Keep SIGTERM/SIGINT graceful-shutdown block verbatim. `bootstrap()` call wrapped in `if (import.meta.main)`. |
+| `src/cli/shared/jobs-scaffold-locals.ts` | `workerPath` → `src/worker.ts` (D3); new locals `jobWorkerModuleImport` (D2) + `workerForRootOpts` (D4); thread both through `localsToHygenArgs`. |
+| `src/cli/shared/subsystem-barrel-generator.ts` | Export `drizzleJobsExtensions`, `drizzleExtensionsClause`, `jsonToTs`. No behavior change. |
+| `templates/subsystem/jobs/prompt.js` | Pass through the two new args; update `workerPath` fallback + comment. |
+| `templates/subsystem/jobs/main-hook.ejs.t` | Path text fix (D5). |
+| `src/__tests__/cli/jobs-scaffold-locals.test.ts` | Update `workerPath` expectations; add cases: package vs vendored `jobWorkerModuleImport`; `workerForRootOpts` for drizzle-default / drizzle+listen_notify / bullmq. |
+| `docs/specs/JOB-6.md` | Post-implementation truth: worker location, AppModule composition, mode-aware import (living-docs rule). |
+| `.claude/skills/jobs/*` (SKILL.md, orchestrator-and-worker.md, pools-and-config.md) | Fix any "worker.ts at project root" / `bun worker.ts` references → `src/worker.ts`, `bun src/worker.ts`. Grep-driven. |
+| `test/run-test.ts` + any other root-`worker.ts` references | Grep `worker\.ts` repo-wide; update stale paths. |
+
+## Out of scope
+
+- `paths.backend_src` threading into `mainTsPath`/`workerPath` (whole-resolver concern; would move both).
+- Gating worker emission on `worker_mode` (JOB-6 chose always-emit; header note covers the embedded clash).
+- Node `import.meta.main` portability (generated projects are bun-run).
+- No legacy/`unless_exists` migration handling for consumers with a root `worker.ts` (no-backwards-compat policy).
+
+## Verification
+
+1. `just test-unit` — locals + barrel-generator suites green.
+2. `just test-smoke` — fresh scaffold (package mode default): `src/worker.ts` emitted, **included in typecheck**, compiles against `./app.module` + package runtime. This is the load-bearing check — the old root emission was never typechecked.
+3. Grep gate: emitted worker in smoke tree contains no `@shared/subsystems` (package mode) and no `@generated/subsystems` (either mode).
+4. `just test-baseline` — expected untouched (jobs scaffold isn't in baseline fixtures); run as regression backstop.

--- a/.claude/skills/jobs/SKILL.md
+++ b/.claude/skills/jobs/SKILL.md
@@ -58,7 +58,7 @@ runtime/subsystems/jobs/
   jobs-domain.module.ts              # JOB-5: DynamicModule wiring tokens
   job-worker.module.ts               # JOB-5: lifecycle, validator, registry scan
   pool-config.loader.ts              # JOB-5: reads codegen.config.yaml: jobs.pools
-templates/subsystem/jobs/            # JOB-6: main scaffold (worker.ts, main hook, schema)
+templates/subsystem/jobs/            # JOB-6: main scaffold (src/worker.ts, main hook, schema)
 templates/subsystem/jobs-config/     # #121 (F13): config-block inject, invoked independently
                                      #   - `subsystem install jobs --force` alone preserves an
                                      #     existing `jobs:` block

--- a/.claude/skills/jobs/phase-roadmap.md
+++ b/.claude/skills/jobs/phase-roadmap.md
@@ -13,7 +13,7 @@ Delivered by `JOB-1` through `JOB-8`:
 - Backends: Drizzle (production) + Memory (tests).
 - Base types: `JobHandlerBase`, `JobContext`, `@JobHandler`, `ParentClosePolicy`.
 - NestJS modules: `JobsDomainModule.forRoot()`, `JobWorkerModule.forRoot()`.
-- Worker entrypoints: embedded hook in `main.ts` + standalone `worker.ts`.
+- Worker entrypoints: embedded hook in `main.ts` + standalone `src/worker.ts`.
 - Pool config loader (five framework defaults + user pools).
 - Boot-time registry validator (Drizzle mode).
 - `scopeable: true` entity flag → generated `ScopeEntityType` TS union.

--- a/.claude/skills/jobs/pools-and-config.md
+++ b/.claude/skills/jobs/pools-and-config.md
@@ -96,7 +96,7 @@ Field semantics:
 | `backend` | `JobsDomainModule.forRoot` | `'drizzle'` or `'memory'`. BullMQ is a reserved slot only. |
 | `extensions.<backend>.*` | Backend class during init | Each backend reads only its own key. Unknown keys for the active backend warn, don't error (core/extension principle — swap is non-destructive). |
 | `multi_tenant` | `JobsDomainModule.forRoot` | Threads `JOBS_MULTI_TENANT` token through. Default `false`. When `true`, service methods require `tenantId` (see JOB-8). |
-| `worker_mode` | Informational + scaffold hint | `embedded` means `JobWorkerModule` imported by `AppModule`; `standalone` means run `worker.ts` separately. Switching does not change generated code — both entrypoints are always emitted. |
+| `worker_mode` | Informational + scaffold hint | `embedded` means `JobWorkerModule` imported by `AppModule`; `standalone` means run `src/worker.ts` (`bun src/worker.ts`) separately. Switching does not change generated code — both entrypoints are always emitted. |
 | `pools.<name>.queue` | `JobWorker` | Identifier written into `job_run.pool`. Must be unique across pools. |
 | `pools.<name>.concurrency` | `JobWorker` | Per-process max in-flight. Horizontal scale multiplies. |
 | `pools.<name>.reserved` | `PoolConfigLoader` | Framework-only. User configs cannot enable. Framework pools cannot have it disabled. |
@@ -187,9 +187,9 @@ Both entrypoints are always scaffolded by JOB-6. The choice is operational.
 - Simplest deploy; good default for dev and small installs.
 - `jobs.worker_mode: embedded` in config is informational / hint.
 
-**Standalone** (run `worker.ts` as a separate process):
+**Standalone** (run `src/worker.ts` as a separate process — `bun src/worker.ts`):
 - `main.ts` does not import `JobWorkerModule`.
-- `worker.ts` boots a bare NestJS application context (no HTTP listener) with only `DatabaseModule` + `JobsDomainModule.forRoot(...)` + `JobWorkerModule.forRoot({ mode: 'standalone' })`.
+- `src/worker.ts` boots a NestJS application context (no HTTP listener) that imports the consumer's root `AppModule` (DI parity with the API process) + `JobWorkerModule.forRoot({ mode: 'standalone', allPools: true, … })`. It lands inside the default tsconfig `src/**` include so it is typechecked (#513).
 - Scale workers independently from the API; CPU spikes on one side don't stall the other.
 
 Switching is an operational change plus the config `worker_mode` toggle. **No regeneration needed — both files ship regardless.**

--- a/docs/specs/JOB-6.md
+++ b/docs/specs/JOB-6.md
@@ -1,10 +1,19 @@
-# JOB-6 — Hygen Scaffold Templates: `worker.ts`, `main.ts` Hook, Config Block
+# JOB-6 — Hygen Scaffold Templates: `src/worker.ts`, `main.ts` Hook, Config Block
 
 **Issue:** JOB-6
 **Status:** Implemented
-**Last Updated:** 2026-04-19
+**Last Updated:** 2026-06-06 (#513 — worker location + composition + mode-aware import)
 **Depends on:** JOB-1 (schema file templated here), JOB-5 (module names must be stable)
 **Blocks:** JOB-8 (multi-tenancy opt-in — tenant_id column conditional lives in this template)
+
+> **#513 revision (2026-06-06).** The standalone worker moved from repo-root
+> `worker.ts` to `src/worker.ts`, was rewritten to compose around the consumer's
+> `AppModule` (handler-DI parity with the API process), and its single remaining
+> runtime import (`JobWorkerModule`) now routes through the ADR-037 mode-aware
+> resolver (package vs vendored). The body below is updated to that post-#513
+> truth; the original 2026-04-19 design (root location, bare
+> `DatabaseModule`+`JobsDomainModule` composition, hard-coded `@shared` import)
+> is superseded. See `.ai-docs/specs/513.md`.
 
 ## Overview
 
@@ -22,7 +31,7 @@ ADR-022: "Codegen emits both `main.ts` and `worker.ts` on scaffold. A consumer w
 SubsystemInstallCommand.execute()
   ├── copyRuntime()                            ← existing
   └── invokeHygen({ generator: 'subsystem', action: 'jobs' })
-        ├── worker.ejs.t                       → <cwd>/worker.ts (create; skip if exists)
+        ├── worker.ejs.t                       → <cwd>/src/worker.ts (create; skip if exists)
         ├── main-hook.ejs.t                    → inject into <cwd>/src/main.ts (once)
         └── codegen-config-jobs-block.ejs.t    → append to <cwd>/codegen.config.yaml (once)
 ```
@@ -31,7 +40,7 @@ SubsystemInstallCommand.execute()
 
 | File | Action | Purpose |
 |---|---|---|
-| `templates/subsystem/jobs/worker.ejs.t` | create | Produces `worker.ts` at project root |
+| `templates/subsystem/jobs/worker.ejs.t` | create | Produces `src/worker.ts` (#513: was repo-root; now next to `app.module.ts`, inside the default tsconfig include) |
 | `templates/subsystem/jobs/main-hook.ejs.t` | create | Injects embedded-mode comment block |
 | `templates/subsystem/jobs/codegen-config-jobs-block.ejs.t` | create | Appends `jobs:` config block |
 | `templates/subsystem/jobs/job-orchestration.schema.ejs.t` | create | **Templated schema: conditional EJS block for `tenantId` column gated on `jobs.multi_tenant` (Q1 2026-04-19)** — overrides/replaces the always-emit runtime source file landed in JOB-1 when scaffolded into a consumer project |
@@ -52,6 +61,10 @@ interface JobsScaffoldLocals {
   mainTsPath: string;       // default 'src/main.ts'
   configPath: string;       // default 'codegen.config.yaml'
   workerExists: boolean;    // computed in CLI via fs.existsSync; used in worker template skip_if
+  // #513 additions:
+  workerPath: string;       // 'src/worker.ts' (was repo-root 'worker.ts')
+  jobWorkerModuleImport: string;  // mode-aware (ADR-037): package → '@pattern-stack/codegen/runtime/subsystems/jobs/index'; vendored → '@shared/subsystems/jobs/index'
+  workerForRootOpts: string;      // pre-serialised JobWorkerModule.forRoot(<opts>) literal; mirrors the embedded composer's backend/extension clauses, mode:'standalone' first, allPools:true last
 }
 ```
 
@@ -75,20 +88,30 @@ native primitive for "create once, never overwrite" and matches the
 intended semantics exactly. The CLI still computes `workerExists` for
 dry-run reporting and for the templates-locals unit tests.
 
-Content (template body): minimal NestJS `NestFactory.createApplicationContext` bootstrap — no `app.listen()`. Imports `JobWorkerModule`, `DatabaseModule`, `JobsDomainModule`. Inline `WorkerAppModule` with:
+Content (template body): minimal NestJS `NestFactory.createApplicationContext` bootstrap — no `app.listen()`. Imports `JobWorkerModule` (mode-aware specifier) and the consumer's `AppModule` (relative `./app.module`). **#513 composition** — `WorkerAppModule` imports `AppModule` whole (handler-DI parity with the API process) plus a single `JobWorkerModule.forRoot(<opts>)`:
 
 ```ts
+import { AppModule } from './app.module';
+import { JobWorkerModule } from '<%= jobWorkerModuleImport %>';
+
 @Module({
   imports: [
-    DatabaseModule,
-    JobsDomainModule.forRoot({ backend: 'drizzle' }),
-    JobWorkerModule.forRoot({ mode: 'standalone' }),
+    AppModule, // DatabaseModule + SUBSYSTEM_MODULES + handler modules
+    JobWorkerModule.forRoot(<%- workerForRootOpts %>), // e.g. { mode: 'standalone', allPools: true }
   ],
 })
-class WorkerAppModule {}
+export class WorkerAppModule {}
 ```
 
-SIGTERM handler: set flag, `await app.close()`, bounded by `SHUTDOWN_TIMEOUT_MS = 30000`. `bootstrap()` called at bottom; errors → `process.exit(1)`.
+- **AppModule composition** kills the original "empty handler DI surface" defect — a bare `DatabaseModule`+`JobsDomainModule` worker registered zero `@JobHandler` providers. Importing `AppModule` gives the worker the SAME DI graph as the HTTP process. The module is a NAMED export so boot-checks / e2e can import it without side effects.
+- **`workerForRootOpts`** is built in `jobs-scaffold-locals.ts` by mirroring the embedded composer's backend + extension clauses (`subsystem-barrel-generator.ts`), but with `mode: 'standalone'` first and `allPools: true` last — so a standalone worker keeps `listen_notify`/`poll_interval_ms` (drizzle) or `backend: 'bullmq'` + its extension block, and always drains the reserved `events_*` lanes.
+- **`jobWorkerModuleImport`** is the only mode-aware import (ADR-037, via `runtimeImport(mode, 'subsystems/jobs/index')`): package → `@pattern-stack/codegen/runtime/subsystems/jobs/index`, vendored → `@shared/subsystems/jobs/index`. `AppModule` is imported relatively, so it is mode-agnostic.
+
+`bootstrap()` is gated on `if (import.meta.main)` (bun-first) so importing the module doesn't spawn a worker; the documented run command is `bun src/worker.ts`.
+
+SIGTERM/SIGINT handler: set flag, `await app.close()`, bounded by `SHUTDOWN_TIMEOUT_MS = 30000`; errors → `process.exit(1)`.
+
+**Operational notes (#513).** This entrypoint is for `worker_mode: standalone` only — in embedded mode `AppModule` already runs the worker, so booting this file too would double-spawn against the same pools. Also: booting a consumer `AppModule` twice in one process throws `DuplicateSchemaError` (per-process `OpenApiRegistry` singleton), so multi-rung boot validation must spawn child processes, not import both modules into one.
 
 ### `main-hook.ejs.t`
 
@@ -107,7 +130,7 @@ Body (a commented guidance block injected after `NestFactory.create(...)`):
 // JOBS — Embedded worker mode (optional)
 // To run the job worker in-process (single-process deploy), add to AppModule imports:
 //   JobWorkerModule.forRoot({ mode: 'embedded' })
-// For standalone worker (separate process), use worker.ts at the project root.
+// For standalone worker (separate process), run src/worker.ts (bun src/worker.ts).
 // See codegen.config.yaml jobs.worker_mode to toggle the documented default.
 ```
 
@@ -217,7 +240,7 @@ jobs:
 ## Implementation Steps
 
 1. **Create `templates/subsystem/jobs/`** — no prompt.js needed; subsystem templates called directly by CLI.
-2. **Write `worker.ejs.t`** — front-matter `to`, `skip_if: workerExists`; body as above. Import path `@shared/subsystems/jobs` (consumer-side location after `copyRuntime`).
+2. **Write `worker.ejs.t`** — front-matter `to: <%= workerPath %>` (= `src/worker.ts`), `unless_exists: true`; body as above. The `JobWorkerModule` import is the mode-aware `<%= jobWorkerModuleImport %>` (#513 — was hard-coded `@shared/subsystems/jobs`); `AppModule` is imported relatively.
 3. **Write `main-hook.ejs.t`** — front-matter `to`, `inject: true`, `after: "NestFactory.create"`, `skip_if: "JobWorkerModule"`; body as above.
 4. **Write `codegen-config-jobs-block.ejs.t`** — front-matter `to`, `inject: true`, `append: true`, `skip_if: "jobs:"`; body as above.
 5. **Write `job-orchestration.schema.ejs.t`** — front-matter `to`, `force: true`; body as above (EJS port of runtime source with `<% if (multiTenant) { %>` gate around `tenantId` column).
@@ -225,7 +248,7 @@ jobs:
    - Modify `copyRuntime` (or its job-subsystem path) to **skip** `job-orchestration.schema.ts` — Hygen template owns emission
    - After `copyRuntime(...)`: `if (this.name === 'jobs' && !this.dryRun)`
    - Resolve template locals from config + cwd (read `jobs.multi_tenant` from `codegen.config.yaml`; default `false` if block absent — matches first-install case)
-   - Compute `workerExists` via `fs.existsSync(path.join(ctx.cwd, 'worker.ts'))`
+   - Compute `workerExists` via `fs.existsSync(path.join(ctx.cwd, 'src', 'worker.ts'))` (#513)
    - Call `invokeHygen({ generator: 'subsystem', action: 'jobs', args: [...], cwd: ctx.cwd })`
    - On Hygen failure: warn but exit 0 — runtime files already written; partial scaffold > hard failure
    - Dry-run: print files Hygen would emit; skip actual invocation
@@ -245,16 +268,16 @@ jobs:
 2. `just gen-subsystem jobs` → exits 0.
 3. Assert post-run state:
    - `shared/subsystems/jobs/` populated with executor-layer runtime files
-   - `worker.ts` at project root — imports `JobWorkerModule.forRoot({ mode: 'standalone' })`, no `app.listen()`
+   - `src/worker.ts` (#513) — imports `AppModule` (relative) + `JobWorkerModule.forRoot({ mode: 'standalone', allPools: true, … })`, no `app.listen()`, `bootstrap()` gated on `import.meta.main`
    - `codegen.config.yaml` — contains full `jobs:` block with all five pools
    - `src/main.ts` (if exists) — contains commented JOBS guidance block
 4. Second run of `just gen-subsystem jobs`:
-   - `worker.ts` not overwritten (skip_if)
+   - `src/worker.ts` not overwritten (`unless_exists`)
    - `codegen.config.yaml` has no duplicate `jobs:` block
    - `src/main.ts` has no duplicate comment block
 
 **Criteria from issue list:**
-- [x] `worker.ts` imports `JobWorkerModule`; boots NestJS app context without HTTP listener
+- [x] `src/worker.ts` imports `JobWorkerModule` + composes `AppModule`; boots NestJS app context without HTTP listener (#513)
 - [x] Config block has five default pools with `reserved: true` on `events_*` three
 - [x] `just test-baseline` passes
 - [x] `job-orchestration.schema.ejs.t` rendered with `multiTenant: false` emits a schema file with NO `tenantId` column and NO references to `tenant_id`; rendered with `multiTenant: true` emits the column with the `// scaffold-time conditional — see JOB-8` comment (Q1 resolved 2026-04-19)
@@ -275,7 +298,7 @@ No Docker required. Hygen invocation tested via baseline fixture in CI.
 - **No upgrade path needed** — no existing users; fresh-install is the only path
 - **Does not** generate user-job handler classes — ADR-022 explicitly rejects jobs-as-YAML
 - **Does not** modify `src/main.ts` beyond commented block — uncommenting = consumer decision
-- `worker.ts` uses hard-coded `@shared/subsystems/jobs` import path — non-standard `paths.subsystems` config would produce wrong path; flagged as known limitation, not blocking; follow-up can make path template-variable-driven
+- ~~`worker.ts` uses hard-coded `@shared/subsystems/jobs` import path~~ **Resolved by #513.** The worker's `JobWorkerModule` import now routes through the ADR-037 mode-aware resolver (package → `@pattern-stack/codegen/runtime/subsystems/jobs/index`, vendored → `@shared/subsystems/jobs/index`); `AppModule` is imported relatively. (`workerPath`/`mainTsPath` still hard-code `src/`; threading `paths.backend_src` into this resolver remains out of scope — it would move both together.)
 
 ## Open Questions (non-blocking)
 

--- a/src/__tests__/cli/jobs-scaffold-locals.test.ts
+++ b/src/__tests__/cli/jobs-scaffold-locals.test.ts
@@ -6,13 +6,17 @@
  *   - multi_tenant: true honored
  *   - worker_mode: 'standalone' honored
  *   - custom `paths.subsystems` flows into schemaPath
- *   - workerExists: '' when worker.ts absent, 'true' when present
+ *   - workerExists: '' when src/worker.ts absent, 'true' when present
+ *   - jobWorkerModuleImport is mode-aware (package vs vendored) — #513
+ *   - workerForRootOpts mirrors the embedded composer's backend/extension
+ *     clauses with mode:standalone first + allPools last — #513
  *   - localsToHygenArgs serialises booleans safely (skip_if contract)
  */
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
 
 import {
+	encodeWorkerForRootOpts,
 	localsToHygenArgs,
 	resolveJobsScaffoldLocals,
 	type JobsScaffoldLocals,
@@ -39,7 +43,17 @@ describe('resolveJobsScaffoldLocals', () => {
 		expect(locals.appName).toBe('project-fixture');
 		expect(locals.mainTsPath).toBe(path.resolve(CWD, 'src/main.ts'));
 		expect(locals.configPath).toBe(path.resolve(CWD, 'codegen.config.yaml'));
-		expect(locals.workerPath).toBe(path.resolve(CWD, 'worker.ts'));
+		// #513: worker now lands at src/worker.ts (inside the default tsconfig
+		// include, next to app.module.ts).
+		expect(locals.workerPath).toBe(path.resolve(CWD, 'src', 'worker.ts'));
+		// #513: default (no `runtime` key) is package mode (ADR-037), and the
+		// standalone forRoot defaults to the bare drizzle shape.
+		expect(locals.jobWorkerModuleImport).toBe(
+			'@pattern-stack/codegen/runtime/subsystems/jobs/index',
+		);
+		expect(locals.workerForRootOpts).toBe(
+			"{ mode: 'standalone', allPools: true }",
+		);
 		// Default derives from `backend_src` (fallback 'src') when
 		// `paths.subsystems` is unset — matches `project init` layout.
 		expect(locals.schemaPath).toBe(
@@ -121,6 +135,82 @@ describe('resolveJobsScaffoldLocals', () => {
 		expect(bogus.workerMode).toBe('embedded');
 	});
 
+	test('jobWorkerModuleImport: package mode (default) resolves the package runtime subpath', () => {
+		// No `runtime` key → package mode (ADR-037). The JobWorkerModule is NOT on
+		// the top-level `/subsystems` barrel; it resolves via the per-subsystem
+		// runtime index.
+		const pkg = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(pkg.jobWorkerModuleImport).toBe(
+			'@pattern-stack/codegen/runtime/subsystems/jobs/index',
+		);
+	});
+
+	test('jobWorkerModuleImport: vendored mode resolves the @shared jobs barrel', () => {
+		const vendored = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: { runtime: 'vendored' } as any,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(vendored.jobWorkerModuleImport).toBe(
+			'@shared/subsystems/jobs/index',
+		);
+	});
+
+	test('workerForRootOpts: drizzle default → mode:standalone + allPools only', () => {
+		const drizzleDefault = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: null,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(drizzleDefault.workerForRootOpts).toBe(
+			"{ mode: 'standalone', allPools: true }",
+		);
+	});
+
+	test('workerForRootOpts: drizzle listen_notify/poll_interval knobs flow into domainModuleExtensions', () => {
+		const withKnobs = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: {
+				jobs: {
+					backend: 'drizzle',
+					extensions: {
+						drizzle: { listen_notify: true, poll_interval_ms: 500 },
+					},
+				},
+			} as any,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		// mode first, allPools last, knobs mirrored as camelCase between them.
+		expect(withKnobs.workerForRootOpts).toBe(
+			"{ mode: 'standalone', domainModuleExtensions: { drizzle: { listenNotify: true, pollIntervalMs: 500 } }, allPools: true }",
+		);
+	});
+
+	test('workerForRootOpts: bullmq backend threads backend + its extension block', () => {
+		const bullmq = resolveJobsScaffoldLocals({
+			cwd: CWD,
+			config: {
+				jobs: {
+					backend: 'bullmq',
+					extensions: { bullmq: { redis_url: 'redis://localhost:6379' } },
+				},
+			} as any,
+			fileExists: () => false,
+			readFile: () => null,
+		});
+		expect(bullmq.workerForRootOpts).toBe(
+			"{ mode: 'standalone', backend: 'bullmq', domainModuleExtensions: { bullmq: { redis_url: 'redis://localhost:6379' } }, allPools: true }",
+		);
+	});
+
 	test('custom paths.subsystems flows into schemaPath', () => {
 		const locals = resolveJobsScaffoldLocals({
 			cwd: CWD,
@@ -136,7 +226,7 @@ describe('resolveJobsScaffoldLocals', () => {
 		);
 	});
 
-	test('workerExists only probes worker.ts at project root', () => {
+	test('workerExists only probes src/worker.ts', () => {
 		const probed: string[] = [];
 		const locals = resolveJobsScaffoldLocals({
 			cwd: CWD,
@@ -147,7 +237,7 @@ describe('resolveJobsScaffoldLocals', () => {
 			},
 			readFile: () => null,
 		});
-		expect(probed).toEqual([path.resolve(CWD, 'worker.ts')]);
+		expect(probed).toEqual([path.resolve(CWD, 'src', 'worker.ts')]);
 		expect(locals.workerExists).toBe(true);
 	});
 
@@ -203,7 +293,10 @@ describe('localsToHygenArgs', () => {
 		mainTsPath: '/abs/src/main.ts',
 		configPath: '/abs/codegen.config.yaml',
 		workerExists: false,
-		workerPath: '/abs/worker.ts',
+		workerPath: '/abs/src/worker.ts',
+		jobWorkerModuleImport:
+			'@pattern-stack/codegen/runtime/subsystems/jobs/index',
+		workerForRootOpts: "{ mode: 'standalone', allPools: true }",
 		schemaPath: '/abs/shared/subsystems/jobs/job-orchestration.schema.ts',
 		mainHookInjected: false,
 	};
@@ -238,11 +331,36 @@ describe('localsToHygenArgs', () => {
 			'--configPath',
 			'--workerExists',
 			'--workerPath',
+			'--jobWorkerModuleImport',
+			'--workerForRootOpts',
 			'--schemaPath',
 			'--mainHookInjected',
 		]) {
 			expect(args).toContain(flag);
 		}
+	});
+
+	test('jobWorkerModuleImport passes through verbatim; workerForRootOpts is base64-encoded', () => {
+		const args = localsToHygenArgs(base);
+		const importIdx = args.indexOf('--jobWorkerModuleImport');
+		expect(importIdx).toBeGreaterThanOrEqual(0);
+		expect(args[importIdx + 1]).toBe(
+			'@pattern-stack/codegen/runtime/subsystems/jobs/index',
+		);
+		// #513: the TS-literal opts are base64-encoded across the hygen arg
+		// boundary (yargs would otherwise shred the `{ … }` syntax). The encoded
+		// value must round-trip back to the source string.
+		const optsIdx = args.indexOf('--workerForRootOpts');
+		expect(optsIdx).toBeGreaterThanOrEqual(0);
+		const encoded = args[optsIdx + 1];
+		expect(encoded).toBe(
+			encodeWorkerForRootOpts("{ mode: 'standalone', allPools: true }"),
+		);
+		expect(Buffer.from(encoded, 'base64').toString('utf-8')).toBe(
+			"{ mode: 'standalone', allPools: true }",
+		);
+		// The encoded form must NOT contain raw braces/colons that yargs mangles.
+		expect(encoded).not.toContain('{');
 	});
 
 	test('localsToHygenArgs serialises mainHookInjected empty-string when false', () => {
@@ -258,7 +376,7 @@ describe('localsToHygenArgs', () => {
 
 	test('paths pass through as absolute', () => {
 		const args = localsToHygenArgs(base);
-		expect(args).toContain('/abs/worker.ts');
+		expect(args).toContain('/abs/src/worker.ts');
 		expect(args).toContain('/abs/src/main.ts');
 		expect(args).toContain('/abs/codegen.config.yaml');
 		expect(args).toContain('/abs/shared/subsystems/jobs/job-orchestration.schema.ts');

--- a/src/cli/shared/jobs-scaffold-locals.ts
+++ b/src/cli/shared/jobs-scaffold-locals.ts
@@ -15,6 +15,12 @@ import path from 'node:path';
 
 import type { CodegenConfig } from './context.js';
 import { resolveSubsystemsRootFromConfig } from './subsystems-path.js';
+import { resolveRuntimeMode, runtimeImport } from './runtime-import.js';
+import {
+	drizzleJobsExtensions,
+	drizzleExtensionsClause,
+	jsonToTs,
+} from './subsystem-barrel-generator.js';
 
 export interface JobsScaffoldLocals {
 	/** Fallback basename for logs; not rendered in templates today. */
@@ -29,8 +35,20 @@ export interface JobsScaffoldLocals {
 	configPath: string;
 	/** Existence check for the standalone worker entrypoint; used by `skip_if`. */
 	workerExists: boolean;
-	/** Where `worker.ejs.t` writes the worker bootstrap. */
+	/** Where `worker.ejs.t` writes the worker bootstrap. Sits at `src/worker.ts`
+	 * (next to `app.module.ts`) so it lands inside the default tsconfig include
+	 * and the relative `./app.module` import resolves (#513). */
 	workerPath: string;
+	/** Mode-aware import specifier for `JobWorkerModule` (ADR-037, #513). Package
+	 * mode → `@pattern-stack/codegen/runtime/subsystems/jobs/index`; vendored →
+	 * `@shared/subsystems/jobs/index`. The only mode-dependent import the worker
+	 * carries — `AppModule` is imported relatively. */
+	jobWorkerModuleImport: string;
+	/** Pre-serialised `JobWorkerModule.forRoot(<opts>)` options literal for the
+	 * standalone worker (#513). Mirrors the embedded composer's backend +
+	 * extension clauses, with `mode: 'standalone'` first and `allPools: true`
+	 * last (reserved-lane drain). */
+	workerForRootOpts: string;
 	/** Where `job-orchestration.schema.ejs.t` writes the scaffolded schema. */
 	schemaPath: string;
 	/** Sentinel-based idempotence flag for `main-hook.ejs.t`'s `skip_if`. */
@@ -83,7 +101,12 @@ export function resolveJobsScaffoldLocals(
 
 	const subsystemsRoot = resolveSubsystemsRootFromConfig(cwd, config);
 
-	const workerPath = path.resolve(cwd, 'worker.ts');
+	// #513: the worker sits at `src/worker.ts`, next to `app.module.ts`. The old
+	// repo-root location escaped the default `include: ["src/**/*"]` tsconfig so
+	// the file was never typechecked, and the relative `./app.module` import the
+	// AppModule-composition (D1) needs only resolves from `src/`. Sibling
+	// convention with `mainTsPath = src/main.ts`.
+	const workerPath = path.resolve(cwd, 'src', 'worker.ts');
 	const mainTsPath = path.resolve(cwd, 'src/main.ts');
 	const configPath = path.resolve(cwd, 'codegen.config.yaml');
 	const schemaPath = path.resolve(
@@ -104,9 +127,62 @@ export function resolveJobsScaffoldLocals(
 		configPath,
 		workerExists: fileExists(workerPath),
 		workerPath,
+		jobWorkerModuleImport: resolveJobWorkerModuleImport(config),
+		workerForRootOpts: resolveWorkerForRootOpts(jobsBlock),
 		schemaPath,
 		mainHookInjected,
 	};
+}
+
+/**
+ * #513 — resolve the mode-aware `JobWorkerModule` import for the standalone
+ * worker (ADR-037). Routes through the shared `runtimeImport` resolver against
+ * `subsystems/jobs/index` (NOT the top-level `/subsystems` barrel, which
+ * re-exports only `EventsModule` in package mode — see `makeModuleImport`):
+ *   - package  → `@pattern-stack/codegen/runtime/subsystems/jobs/index`
+ *   - vendored → `@shared/subsystems/jobs/index`
+ */
+function resolveJobWorkerModuleImport(config: CodegenConfig | null): string {
+	return runtimeImport(resolveRuntimeMode(config), 'subsystems/jobs/index');
+}
+
+/**
+ * #513 — build the `JobWorkerModule.forRoot(<opts>)` options literal for the
+ * standalone worker. Mirrors the embedded composer's backend + extension
+ * clauses (`subsystem-barrel-generator.ts` jobs composer) so a standalone
+ * worker doesn't silently lose `listen_notify` / `poll_interval_ms` (drizzle)
+ * or `backend: 'bullmq'` + its extension block. Two invariants distinguish it
+ * from the embedded branch: `mode: 'standalone'` is always first, and
+ * `allPools: true` is always last — the standalone process is the sole worker,
+ * so it MUST drain the reserved `events_*` lanes (the bridge fanout footgun).
+ *
+ * Shapes:
+ *   - drizzle default → `{ mode: 'standalone', allPools: true }`
+ *   - drizzle + knobs → `{ mode: 'standalone', domainModuleExtensions: { drizzle: {...} }, allPools: true }`
+ *   - bullmq          → `{ mode: 'standalone', backend: 'bullmq', domainModuleExtensions: { bullmq: {...} }, allPools: true }`
+ */
+function resolveWorkerForRootOpts(
+	jobsBlock: Record<string, unknown>,
+): string {
+	const backend = (jobsBlock.backend as string | undefined) ?? 'drizzle';
+	const parts = [`mode: 'standalone'`];
+	if (backend === 'bullmq') {
+		parts.push(`backend: 'bullmq'`);
+		const bullExt = (
+			jobsBlock.extensions as { bullmq?: Record<string, unknown> } | undefined
+		)?.bullmq;
+		if (bullExt) {
+			parts.push(`domainModuleExtensions: { bullmq: ${jsonToTs(bullExt)} }`);
+		}
+	} else {
+		const workerExtClause = drizzleExtensionsClause(
+			drizzleJobsExtensions(backend, jobsBlock),
+			'domainModuleExtensions',
+		);
+		if (workerExtClause) parts.push(workerExtClause);
+	}
+	parts.push(`allPools: true`);
+	return `{ ${parts.join(', ')} }`;
 }
 
 function normaliseWorkerMode(raw: unknown): 'embedded' | 'standalone' {
@@ -119,10 +195,24 @@ function normaliseMultiTenant(raw: unknown): boolean {
 }
 
 /**
+ * #513 — `workerForRootOpts` is a TS object literal (`{ mode: 'standalone', … }`).
+ * Hygen's yargs-based CLI parser interprets the `{ … : … }` syntax as nested
+ * object/dot-notation and shreds it (the value reaches `prompt.js` as `{`).
+ * Base64 over the arg boundary keeps the literal opaque to yargs; `prompt.js`
+ * decodes it back to the source string before EJS interpolation. The resolver's
+ * `workerForRootOpts` field stays the plain, unit-tested string — only the argv
+ * crossing is encoded.
+ */
+export function encodeWorkerForRootOpts(opts: string): string {
+	return Buffer.from(opts, 'utf-8').toString('base64');
+}
+
+/**
  * Serialise locals to the `--flag value` argv pairs Hygen consumes. Booleans
  * become `'true'` / `'false'`; numeric / string values pass through. Paths
  * are forwarded as absolute so Hygen's `to:` front-matter resolves relative
- * to them, not to Hygen's `cwd`.
+ * to them, not to Hygen's `cwd`. `workerForRootOpts` is base64-encoded — see
+ * `encodeWorkerForRootOpts`.
  */
 export function localsToHygenArgs(locals: JobsScaffoldLocals): string[] {
 	return [
@@ -133,6 +223,8 @@ export function localsToHygenArgs(locals: JobsScaffoldLocals): string[] {
 		'--configPath', locals.configPath,
 		'--workerExists', workerSkipValue(locals.workerExists),
 		'--workerPath', locals.workerPath,
+		'--jobWorkerModuleImport', locals.jobWorkerModuleImport,
+		'--workerForRootOpts', encodeWorkerForRootOpts(locals.workerForRootOpts),
 		'--schemaPath', locals.schemaPath,
 		'--mainHookInjected', workerSkipValue(locals.mainHookInjected),
 	];

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -119,7 +119,7 @@ function quoteOpts(opts: Record<string, unknown>): string {
  * barrel. Only handles the value shapes that appear under
  * `jobs.extensions.bullmq` (strings, numbers, booleans, nested objects).
  */
-function jsonToTs(value: unknown): string {
+export function jsonToTs(value: unknown): string {
 	if (value === null || value === undefined) return 'undefined';
 	if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`;
 	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
@@ -153,7 +153,7 @@ type DrizzleJobsExt = {
  * Returns `undefined` when no knob is set (so the generated call stays minimal
  * and off-by-default). Only the drizzle/default backend reads these.
  */
-function drizzleJobsExtensions(
+export function drizzleJobsExtensions(
 	backend: string,
 	cfg: Record<string, unknown> | undefined,
 ): DrizzleJobsExt | undefined {
@@ -181,7 +181,7 @@ function drizzleJobsExtensions(
  * emits the enqueue notify) and `JobWorkerModule.forRoot` (so the spawned worker
  * holds the listener + honors `pollIntervalMs`).
  */
-function drizzleExtensionsClause(
+export function drizzleExtensionsClause(
 	ext: DrizzleJobsExt | undefined,
 	key: 'extensions' | 'domainModuleExtensions',
 ): string {

--- a/templates/subsystem/jobs/main-hook.ejs.t
+++ b/templates/subsystem/jobs/main-hook.ejs.t
@@ -7,5 +7,5 @@ skip_if: "<%= mainHookInjected %>"
   // JOBS — Embedded worker mode (optional)
   // To run the job worker in-process (single-process deploy), add to AppModule imports:
   //   JobWorkerModule.forRoot({ mode: 'embedded' })
-  // For standalone worker (separate process), use worker.ts at the project root.
+  // For standalone worker (separate process), run src/worker.ts (bun src/worker.ts).
   // See codegen.config.yaml jobs.worker_mode to toggle the documented default.

--- a/templates/subsystem/jobs/prompt.js
+++ b/templates/subsystem/jobs/prompt.js
@@ -9,6 +9,7 @@
  * Invoked via:
  *   bunx hygen subsystem jobs \
  *     --workerPath <abs> --workerExists <'true'|''> \
+ *     --jobWorkerModuleImport <specifier> --workerForRootOpts <ts-literal> \
  *     --mainTsPath <abs> --configPath <abs> --schemaPath <abs> \
  *     --multiTenant <'true'|'false'> --workerMode <embedded|standalone> \
  *     --appName <string>
@@ -23,6 +24,28 @@ function coerceBool(raw) {
   return false;
 }
 
+// #513: the CLI base64-encodes --workerForRootOpts because Hygen's yargs parser
+// mangles a raw `{ mode: 'standalone', … }` TS literal (the braces/colons are
+// read as nested object syntax). Decode it back to the source string here. A
+// direct hygen invocation that passes a non-encoded value (or omits it) falls
+// back to the plain default below.
+function decodeWorkerForRootOpts(raw) {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return "{ mode: 'standalone', allPools: true }";
+  }
+  try {
+    const decoded = Buffer.from(raw, "base64").toString("utf-8");
+    // Re-encoding round-trips iff `raw` was valid base64 of the decoded bytes;
+    // guards against a hand-passed plain literal being treated as base64.
+    if (Buffer.from(decoded, "utf-8").toString("base64") === raw) {
+      return decoded;
+    }
+  } catch {
+    /* fall through to raw */
+  }
+  return raw;
+}
+
 export default {
   prompt: async ({ args }) => {
     return {
@@ -34,7 +57,17 @@ export default {
       // Hygen's skip_if treats any non-empty string as truthy, so we send an
       // empty string when the file doesn't exist (CLI already does this).
       workerExists: args.workerExists ?? "",
-      workerPath: args.workerPath ?? "worker.ts",
+      // #513: the worker lands at `src/worker.ts` (inside the default tsconfig
+      // include, next to `app.module.ts`); the CLI always passes an absolute
+      // --workerPath, this fallback only guards a direct hygen invocation.
+      workerPath: args.workerPath ?? "src/worker.ts",
+      // #513: mode-aware JobWorkerModule import + the pre-serialised
+      // forRoot(<opts>) literal (the only mode-dependent import the worker
+      // carries — AppModule is imported relatively).
+      jobWorkerModuleImport:
+        args.jobWorkerModuleImport ??
+        "@pattern-stack/codegen/runtime/subsystems/jobs/index",
+      workerForRootOpts: decodeWorkerForRootOpts(args.workerForRootOpts),
       schemaPath:
         args.schemaPath ?? "shared/subsystems/jobs/job-orchestration.schema.ts",
       // @generated DO-NOT-EDIT banner — the jobs subsystem schema is

--- a/templates/subsystem/jobs/worker.ejs.t
+++ b/templates/subsystem/jobs/worker.ejs.t
@@ -5,31 +5,42 @@ unless_exists: true
 /**
  * Standalone job worker entrypoint — emitted by `codegen subsystem install jobs`.
  *
- * Boots a Nest application context (NO HTTP listener) wiring the full
- * subsystem barrel (`SUBSYSTEM_MODULES` — events + jobs + bridge + integration, in
- * dependency order) plus `JobWorkerModule.forRoot({ mode: 'standalone',
- * allPools: true })`. Run with:
+ * Boots a Nest application context (NO HTTP listener) that composes the
+ * consumer's root `AppModule` plus `JobWorkerModule.forRoot({ mode:
+ * 'standalone', allPools: true, … })`. Run with:
  *
- *   bun worker.ts
+ *   bun src/worker.ts
  *
- * Why the barrel + `allPools`:
- *   - The events subsystem's outbox drain and the bridge's fanout wrappers
- *     run as `job_run` rows in the RESERVED `events_*` pools. A worker that
- *     only polls the non-reserved pools (`interactive`, `batch`, …) leaves
- *     those lanes stranded — `BridgeDeliveryHandler` never fires and durable
- *     event→job fanout silently stops.
+ * Why import `AppModule` whole:
+ *   - Job handlers are Nest providers registered by the consumer's handler
+ *     modules (and the subsystem barrel). Composing around `AppModule` gives
+ *     this worker the SAME DI graph as the HTTP process — every `@JobHandler`
+ *     resolves its dependencies here exactly as it would in the API. A bare
+ *     `SUBSYSTEM_MODULES`-only worker boots with an empty handler surface.
+ *   - `AppModule` already wires `DatabaseModule` + `SUBSYSTEM_MODULES` (events +
+ *     jobs + bridge + integration, dependency-ordered), so the worker needs no
+ *     mode-aware barrel import — only `JobWorkerModule` itself.
+ *
+ * Why `allPools: true`:
+ *   - The events subsystem's outbox drain and the bridge's fanout wrappers run
+ *     as `job_run` rows in the RESERVED `events_*` pools. A worker that only
+ *     polls the non-reserved pools (`interactive`, `batch`, …) strands those
+ *     lanes — `BridgeDeliveryHandler` never fires and durable event→job fanout
+ *     silently stops.
  *   - `allPools: true` activates every pool in the resolved config, reserved
  *     lanes included, so this single standalone process drains both user work
  *     and the framework's reserved lanes.
- *   - Importing `SUBSYSTEM_MODULES` (rather than `JobsDomainModule` alone)
- *     registers `EVENT_BUS` / `JOB_ORCHESTRATOR` / `BRIDGE_*` so the
- *     framework `@framework/bridge_delivery` handler resolves its DI deps.
- *     `BridgeModule`'s reserved-pool guard short-circuits to pass because
- *     `allPools` is set.
  *
- * Embedded mode (single-process) is configured by importing
- * `JobWorkerModule.forRoot({ mode: 'embedded' })` inside AppModule instead —
- * see the commented guidance injected into `src/main.ts`.
+ * STANDALONE ONLY: this entrypoint is for `jobs.worker_mode: standalone`. In
+ * embedded mode the worker already runs inside `AppModule` (via the
+ * `JobWorkerModule.forRoot({ mode: 'embedded' })` the barrel composes), so
+ * booting this file too would double-spawn the worker against the same pools.
+ *
+ * DO NOT boot `AppModule` twice in one process: a consumer `AppModule`
+ * registers an OpenAPI document against the per-process `OpenApiRegistry`
+ * singleton, which throws `DuplicateSchemaError` on the second registration.
+ * Multi-rung boot validation (e.g. "does the worker boot AND does the API
+ * boot?") must spawn CHILD PROCESSES, not import both modules into one.
  *
  * SIGTERM triggers graceful shutdown bounded by SHUTDOWN_TIMEOUT_MS; after the
  * timeout the process exits hard so orchestrators (systemd, Kubernetes) can
@@ -39,26 +50,23 @@ import 'reflect-metadata';
 import { Logger, Module } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 
-import { DatabaseModule } from '@shared/database/database.module';
-import { JobWorkerModule } from '@shared/subsystems/jobs/job-worker.module';
-import { SUBSYSTEM_MODULES } from '@generated/subsystems';
+import { AppModule } from './app.module';
+import { JobWorkerModule } from '<%= jobWorkerModuleImport %>';
 
 const SHUTDOWN_TIMEOUT_MS = 30_000;
 
 @Module({
   imports: [
-    DatabaseModule,
-    // Events + Jobs + Bridge + Integration (dependency-ordered) from the generated
-    // barrel. This is the same composition AppModule imports — keeping the
-    // worker's DI graph identical to the HTTP app's so handlers resolve the
-    // same way in both processes.
-    ...SUBSYSTEM_MODULES,
+    // Consumer root — DatabaseModule + SUBSYSTEM_MODULES + handler modules.
+    // Importing it whole keeps the worker's DI graph identical to the HTTP app's
+    // so every `@JobHandler` resolves the same way in both processes.
+    AppModule,
     // `allPools: true` drains the reserved `events_*` lanes (events outbox +
     // bridge wrappers) alongside the user pools.
-    JobWorkerModule.forRoot({ mode: 'standalone', allPools: true }),
+    JobWorkerModule.forRoot(<%- workerForRootOpts %>),
   ],
 })
-class WorkerAppModule {}
+export class WorkerAppModule {}
 
 async function bootstrap(): Promise<void> {
   const logger = new Logger('JobWorker');
@@ -98,8 +106,12 @@ async function bootstrap(): Promise<void> {
   logger.log('job worker started (standalone mode, all pools)');
 }
 
-bootstrap().catch((err) => {
-  // eslint-disable-next-line no-console
-  console.error('failed to bootstrap job worker', err);
-  process.exit(1);
-});
+// Gated so the module can be imported by boot-checks / e2e without spawning a
+// worker; `bun src/worker.ts` runs it as the entrypoint.
+if (import.meta.main) {
+  bootstrap().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('failed to bootstrap job worker', err);
+    process.exit(1);
+  });
+}

--- a/test/run-test.ts
+++ b/test/run-test.ts
@@ -239,11 +239,11 @@ function runCodegen() {
   // under `runtime/subsystems/jobs/generated/` (already in OUTPUT_PATHS).
   //
   // The non-schema templates are muted by pointing their injection targets
-  // at a throwaway sandbox and pre-creating a `worker.ts` there so the
-  // `unless_exists: true` guard fires.
+  // at a throwaway sandbox and pre-creating `src/worker.ts` there so the
+  // `unless_exists: true` guard fires (#513: worker emits at src/worker.ts).
   const sandbox = join(ROOT, 'test/.jobs-baseline-sandbox');
   mkdirSync(join(sandbox, 'src'), { recursive: true });
-  writeFileSync(join(sandbox, 'worker.ts'), '// placeholder — keeps Hygen unless_exists satisfied\n');
+  writeFileSync(join(sandbox, 'src/worker.ts'), '// placeholder — keeps Hygen unless_exists satisfied\n');
   // main.ts and codegen.config.yaml are intentionally absent so the inject
   // templates print "Cannot inject" and exit non-zero? They don't: Hygen
   // logs the warning and continues. We verify this in the walkthrough.
@@ -269,7 +269,7 @@ function runCodegen() {
         `--mainTsPath "${join(sandbox, 'src/main.ts')}" ` +
         `--configPath "${join(sandbox, 'codegen.config.yaml')}" ` +
         `--workerExists true ` +
-        `--workerPath "${join(sandbox, 'worker.ts')}" ` +
+        `--workerPath "${join(sandbox, 'src/worker.ts')}" ` +
         `--schemaPath "${v.out}" ` +
         // Silence the `mainHookInjected is not defined` EJS error in
         // `templates/subsystem/jobs/main-hook.ejs.t`. The baseline's


### PR DESCRIPTION
## Summary

The standalone job worker scaffold (`templates/subsystem/jobs/worker.ejs.t`) was vendored-centric and unusable in package mode (the ADR-037 default). This rewrites it to compose around the consumer's root `AppModule`, emit at `src/worker.ts`, and resolve its one runtime import mode-aware. Implements `.ai-docs/specs/513.md` (D1–D5).

## The three defects fixed

1. **Vendored-only imports** — emitted `@shared/subsystems/jobs/job-worker.module` + `@generated/subsystems`, neither of which resolves in package mode (runtime lives at `@pattern-stack/codegen/runtime/subsystems/jobs/index`). Now the single remaining runtime import (`JobWorkerModule`) routes through the ADR-037 resolver (`runtimeImport(mode, 'subsystems/jobs/index')`): package → `@pattern-stack/codegen/runtime/subsystems/jobs/index`, vendored → `@shared/subsystems/jobs/index`. `AppModule` is imported relatively (mode-agnostic).
2. **Repo-root emission** — `worker.ts` landed at the project root, outside the default `include: ["src/**/*"]` tsconfig, so it silently escaped typecheck. Now emits at `src/worker.ts` (next to `app.module.ts`) → inside the include → typechecked.
3. **Empty handler DI surface** — composed only `DatabaseModule` + `SUBSYSTEM_MODULES`, not the consumer's handler-providing modules, so the worker booted with zero `@JobHandler` providers. Now `WorkerAppModule` imports `AppModule` whole → permanent handler-DI parity with the API process.

Also (D4): `workerForRootOpts` now mirrors the embedded composer's backend + extension clauses (drizzle `listen_notify`/`poll_interval_ms`, bullmq + its block) with `mode: 'standalone'` first and `allPools: true` last (reserved-lane drain). (D5): header rewritten; documents the standalone-only / embedded double-spawn clash and the `DuplicateSchemaError` per-process `OpenApiRegistry` constraint. `bootstrap()` gated on `import.meta.main` (named module export so boot-checks/e2e can import without side effects).

## Implementation note (base64 arg encoding)

The `forRoot` opts are a TS object literal (`{ mode: 'standalone', … }`). Hygen's yargs CLI parser reads the `{ … : … }` syntax as nested object/dot-notation and shreds it (the value reached `prompt.js` as `{`, rendering `forRoot({)`). The opts are now base64-encoded across the arg boundary (`encodeWorkerForRootOpts` in the resolver, decoded in `prompt.js`); the resolver's `workerForRootOpts` field stays the plain, unit-tested string.

## Verification

- `test-unit` — **2945 pass, 0 fail, 3 skip** (185 files).
- `test-smoke-subsystems` (vendored; installs jobs, patches `worker_mode: standalone`) — **PASS**: `src/worker.ts` emitted, full consumer-tree `tsc --noEmit` clean, programmatic AppModule boot verified. This is the real worker exerciser and is the load-bearing typecheck of the emitted worker.
- `test-smoke` — **PASS** (base smoke; does not install jobs, so does not emit the worker — see scope note below).
- `test-baseline` — **PASS** (jobs schema single/multi-tenant fixtures unchanged; run-test sandbox worker placeholder moved to `src/worker.ts`).
- Grep gate — **clean in both modes**: package-mode render has no `@shared/subsystems`; neither mode has `@generated/subsystems`.
- `tsc -p tsconfig.build.json` — the 3 remaining errors are pre-existing (`junction.ts`, `barrel-generator.ts`; untouched here), consistent with the known repo-wide-tsc-broken state.

## Scope note (follow-up needed)

In **package mode** (the ADR-037 default), `SubsystemInstallCommand.executePackageMode` short-circuits the entire hygen scaffold — so the worker is **never emitted** in package mode today (only vendored mode emits it). This PR makes the worker package-**correct** (mode-aware import, AppModule composition, `src/` location) so it is right *when* emitted, and the mode-aware import is unit-tested. Wiring the worker into the package-mode install path requires extending `executePackageMode` (emit only the worker template, skip the vendored schema template package mode deliberately doesn't own) — that is `src/cli/commands/subsystem.ts`, outside the approved file-by-file list for this spec, so it's deferred to a follow-up. The spec's verification framing ("package mode default: `src/worker.ts` emitted") assumed the scaffold runs in package mode; it does not. `docs/specs/JOB-6.md` was updated to post-implementation truth.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
