### PR TITLE
docs(jobs): record #513 deviations in both specs; fix stale worker.ts comment (stranded from #516)

### DIFF
--- a/.ai-docs/specs/513.md
+++ b/.ai-docs/specs/513.md
@@ -85,6 +85,51 @@ Without this, a standalone worker silently loses `listen_notify`/`poll_interval_
 ## Verification
 
 1. `just test-unit` — locals + barrel-generator suites green.
-2. `just test-smoke` — fresh scaffold (package mode default): `src/worker.ts` emitted, **included in typecheck**, compiles against `./app.module` + package runtime. This is the load-bearing check — the old root emission was never typechecked.
-3. Grep gate: emitted worker in smoke tree contains no `@shared/subsystems` (package mode) and no `@generated/subsystems` (either mode).
+2. `just test-smoke-subsystems` — fresh **vendored** scaffold that installs jobs and patches `jobs.worker_mode: standalone`: `src/worker.ts` emitted, **included in the full-tree typecheck** (`tsc --noEmit --skipLibCheck`), and the programmatic AppModule boot succeeds. This is the load-bearing check — the old root emission was never typechecked. (NB: the base `just test-smoke` does NOT install jobs, so it never emits the worker; and package mode never reaches this scaffold at all — see Post-implementation §2. The vendored subsystems smoke is the only path that emits + typechecks the worker today.)
+3. Grep gate: emitted worker contains no `@shared/subsystems` (package mode) and no `@generated/subsystems` (either mode). Verified by rendering the worker template directly in both modes (the package-mode render uses `@pattern-stack/codegen/runtime/subsystems/jobs/index`; the vendored render uses `@shared/subsystems/jobs/index`; neither emits `@generated/subsystems`).
 4. `just test-baseline` — expected untouched (jobs scaffold isn't in baseline fixtures); run as regression backstop.
+
+## Post-implementation (discovered during build — living-docs)
+
+### 1. Base64 arg-boundary encoding for `workerForRootOpts` (NEW — not in the original design)
+
+`workerForRootOpts` is a TS object literal (`{ mode: 'standalone', allPools: true }`).
+Hygen's underlying yargs CLI parser reads the `{ … : … }` syntax as nested
+object / dot-notation and **shreds it** — the value reached `prompt.js` as `{`,
+rendering `JobWorkerModule.forRoot({)` and tripping `TS1136: Property assignment
+expected` (caught by `test-smoke-subsystems`). The original design assumed the
+literal could be threaded as a plain `--flag value` arg; it cannot.
+
+Fix: the literal is base64-encoded across the hygen arg boundary and decoded back
+before EJS interpolation:
+- `encodeWorkerForRootOpts(opts)` in `src/cli/shared/jobs-scaffold-locals.ts` —
+  applied inside `localsToHygenArgs` to the `--workerForRootOpts` value only
+  (`jobWorkerModuleImport` is a plain specifier with no brace/colon syntax, so it
+  passes through untouched).
+- `decodeWorkerForRootOpts(raw)` in `templates/subsystem/jobs/prompt.js` —
+  base64-decodes, with a round-trip guard so a hand-passed plain literal (direct
+  hygen invocation) still works, and a plain-literal default when the arg is absent.
+
+The resolver's `workerForRootOpts` field stays the plain, unit-tested string; only
+the argv crossing is encoded. The `localsToHygenArgs` unit test asserts the encoded
+round-trip (and that the encoded form carries no raw `{`).
+
+### 2. Package mode never reaches this scaffold (#517)
+
+In `runtime: package` mode (the ADR-037 default), `SubsystemInstallCommand`
+short-circuits via `executePackageMode` (`src/cli/commands/subsystem.ts:382`) and
+returns BEFORE `runJobsScaffold` ever runs — package mode vendors no files, so the
+entire hygen scaffold flow (worker, main-hook, schema template) is skipped. **The
+worker is therefore never emitted in package mode today.** This PR makes the worker
+package-*correct* (the mode-aware `jobWorkerModuleImport` resolves to the package
+runtime, the AppModule composition is mode-agnostic) and that branch is exercised
+by unit tests + a direct template render, but it is **unit-test-only** until the
+package-mode install path is wired to emit the worker.
+
+Wiring it requires extending `executePackageMode` to invoke ONLY the worker
+template (it must NOT run the vendored `job-orchestration.schema.ejs.t`, which
+writes into a path package mode deliberately doesn't own) — that touches
+`src/cli/commands/subsystem.ts`, outside this spec's approved file-by-file list.
+Filed as follow-up **issue #517**. The original Verification step 2 ("package mode
+default: `src/worker.ts` emitted") assumed the scaffold runs in package mode; it
+does not — step 2 above is corrected to the vendored subsystems smoke.

--- a/docs/specs/JOB-6.md
+++ b/docs/specs/JOB-6.md
@@ -300,6 +300,37 @@ No Docker required. Hygen invocation tested via baseline fixture in CI.
 - **Does not** modify `src/main.ts` beyond commented block — uncommenting = consumer decision
 - ~~`worker.ts` uses hard-coded `@shared/subsystems/jobs` import path~~ **Resolved by #513.** The worker's `JobWorkerModule` import now routes through the ADR-037 mode-aware resolver (package → `@pattern-stack/codegen/runtime/subsystems/jobs/index`, vendored → `@shared/subsystems/jobs/index`); `AppModule` is imported relatively. (`workerPath`/`mainTsPath` still hard-code `src/`; threading `paths.backend_src` into this resolver remains out of scope — it would move both together.)
 
+## #513 implementation notes (discovered during build)
+
+Two things the #513 design missed, recorded here as post-implementation truth:
+
+1. **`workerForRootOpts` is base64-encoded across the hygen arg boundary.** The
+   forRoot options are a TS object literal (`{ mode: 'standalone', allPools: true }`).
+   Hygen's yargs CLI parser reads the `{ … : … }` syntax as nested object /
+   dot-notation and shreds it — the value reaches `prompt.js` as `{`, rendering
+   `JobWorkerModule.forRoot({)` (`TS1136: Property assignment expected`). The fix:
+   `encodeWorkerForRootOpts` (`src/cli/shared/jobs-scaffold-locals.ts`, applied in
+   `localsToHygenArgs` to the `--workerForRootOpts` value only) ↔
+   `decodeWorkerForRootOpts` (`templates/subsystem/jobs/prompt.js`, with a
+   round-trip guard so a hand-passed plain literal still works). The
+   `jobWorkerModuleImport` specifier has no brace/colon syntax, so it passes through
+   untouched. The resolver's `workerForRootOpts` field stays the plain string the
+   unit tests assert; only the argv crossing is encoded.
+
+2. **Package mode never reaches this scaffold (follow-up: #517).** In
+   `runtime: package` mode (the ADR-037 default), `SubsystemInstallCommand`
+   short-circuits via `executePackageMode` (`src/cli/commands/subsystem.ts:382`) and
+   returns BEFORE `runJobsScaffold` — package mode vendors no files, so the whole
+   hygen scaffold (worker, main-hook, schema template) is skipped. **The worker is
+   therefore never emitted in package mode today.** #513 made the worker
+   package-*correct* (the mode-aware `jobWorkerModuleImport` resolves to the package
+   runtime; the AppModule composition is mode-agnostic) and that branch is covered by
+   unit tests + a direct template render — but it is unit-test-only until the
+   package-mode install path is wired to emit it. Wiring requires extending
+   `executePackageMode` to run ONLY the worker template (NOT the vendored
+   `job-orchestration.schema.ejs.t`, whose target package mode deliberately doesn't
+   own). Tracked in **issue #517**.
+
 ## Open Questions (non-blocking)
 
 - `main-hook.ejs.t` uses `after: "NestFactory.create"` as injection anchor. If consumer uses `NestFactory.createMicroservice` instead, injection silently skips. CLI should print info message when `main.ts` exists but injection result can't be confirmed. Cosmetic; scaffold still functional.

--- a/src/cli/shared/subsystem-barrel-generator.ts
+++ b/src/cli/shared/subsystem-barrel-generator.ts
@@ -342,7 +342,7 @@ const COMPOSERS: Partial<Record<SubsystemName, Composer>> = {
 		const domainOpts = quoteBullmqDomainOpts({ backend, multiTenant, bullExt, drizzleExt });
 		const calls = [`\tJobsDomainModule.forRoot(${domainOpts}),`];
 		// JOB-7: `worker_mode: 'embedded'` runs the worker in-process alongside the
-		// HTTP app. `'standalone'` (default) means the user runs `bun worker.ts`
+		// HTTP app. `'standalone'` (default) means the user runs `bun src/worker.ts`
 		// separately and we don't include JobWorkerModule in AppModule.
 		if (workerMode === 'embedded') {
 			imports.push(


### PR DESCRIPTION
Recovers the post-merge stranded commit from #516: the merge landed `8bec454` while the validator-driven doc fix (`7326ff1`) was pushed minutes later — this cherry-picks it onto main.

Contents (validator findings from the PR #516 report, both verified in code):

1. **Living-docs gap** — both deviations discovered during #513 implementation are now recorded in `.ai-docs/specs/513.md` and `docs/specs/JOB-6.md`:
   - the base64 arg-boundary workaround (`encodeWorkerForRootOpts` ↔ `decodeWorkerForRootOpts`) and why hygen forces it (yargs shreds `{ … }` literals → TS1136);
   - package mode never reaches the jobs scaffold (`executePackageMode` returns before `runJobsScaffold`) — the package-import branch is unit-test-only until #517 wires the install path. Both docs reference #517.
   - corrects the spec's Verification step 2: the load-bearing typecheck gate is `test-smoke-subsystems`, not base `test-smoke`.
2. **Stale comment** — `subsystem-barrel-generator.ts` worker run-command comment now says `bun src/worker.ts`.

Docs + one source comment only; no behavior change. `just test-unit`: 2945 pass / 0 fail.

Refs #513, #516, #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
