### PR TITLE
fix(runtime): lifecycle-events — revive audit trail + emitSafely logs the cause via Nest Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] — 2026-06-07
+
+### Fixed
+
+- **Lifecycle events: revive the audit trail + diagnosable emit failures.** The
+  `BaseService` lifecycle/change event path (`runtime/base-classes/lifecycle-events.ts`)
+  predates the AUDIT tier + routing schema (ADR-039) and was never migrated:
+  `buildLifecycleEvent` / `buildChangeEvents` stamped no `tier`, so
+  `toInsertValues` defaulted the row to `tier='domain'` with NULL `pool` /
+  `direction` — which violates the `domain_events_tier_routing_check` CHECK
+  (`tier='audit' ⇔ pool IS NULL AND direction IS NULL`). Result: **every**
+  `BaseService` create/update/delete in every consumer paid a rejected INSERT and
+  silently lost its lifecycle audit trail. The builders now stamp `tier: 'audit'`
+  (lifecycle/change events are exactly audit-tier semantics — untyped audit
+  records, never bridge-routed); the rows land and surface under the
+  observability viewer's audit-tier toggle, and the bridge guard keeps them out
+  of job routing. Discovered by the swe-brain dogfood (2× `failed to emit 3
+  event(s)` per dispatcher fire — the 3 being the `[updated, field_changed,
+  field_changed]` `publishMany` batch from `BaseService.update`).
+- **Lifecycle events: `emitSafely` logs the cause via the Nest Logger.** The
+  fire-and-forget catch was a bare `catch {}` that swallowed the error and
+  printed `failed to emit N event(s)` via raw `console.warn` — bypassing the Nest
+  `Logger` (so consumers configuring `app.useLogger` / factory `logger:` could
+  neither format nor filter it) with zero diagnosability. Now logs via a
+  module-level `Logger('LifecycleEvents')` at `warn` level including the event
+  count, the distinct event types, and the error message; the stack follows at
+  `debug`. Never-throw semantics preserved.
+
 ## [0.24.0] — 2026-06-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/runtime/base-classes/lifecycle-events.ts
+++ b/runtime/base-classes/lifecycle-events.ts
@@ -23,7 +23,16 @@
  */
 
 import { randomUUID } from 'crypto';
+import { Logger } from '@nestjs/common';
 import type { IEventBus, DomainEvent } from '../subsystems/events/event-bus.protocol';
+
+/**
+ * Module-level logger for fire-and-forget emission failures. Routed through the
+ * Nest `Logger` (not bare `console`) so consumers configuring `app.useLogger`
+ * or the factory `logger:` option can format and filter it like any other
+ * framework log line.
+ */
+const logger = new Logger('LifecycleEvents');
 
 // ============================================================================
 // Event categories (subset of pattern-stack's EventCategory)
@@ -99,7 +108,17 @@ export function buildLifecycleEvent(
 		aggregateType: entityName,
 		payload: snapshot ? { snapshot } : {},
 		occurredAt: new Date(),
-		metadata: { category: 'lifecycle' as EventCategory },
+		// AUDIT tier: lifecycle/change events are untyped audit-trail records —
+		// never bridge-routed, no pool/direction. The `domain_events`
+		// `domain_events_tier_routing_check` CHECK requires `tier='audit' ⇔
+		// (pool IS NULL AND direction IS NULL)`; the DEFAULT `tier='domain'`
+		// (applied by toInsertValues when absent) requires non-null routing
+		// fields, so an un-tiered lifecycle row violates the constraint and the
+		// INSERT is rejected — silently, pre-fix, by emitSafely's catch. Stamp
+		// `tier:'audit'` so these rows land (and surface under the
+		// observability viewer's audit-tier toggle). The bridge guard keeps
+		// audit-tier events out of job routing.
+		metadata: { category: 'lifecycle' as EventCategory, tier: 'audit' },
 	};
 }
 
@@ -119,7 +138,9 @@ export function buildChangeEvents(
 			newValue: c.newValue,
 		},
 		occurredAt: new Date(),
-		metadata: { category: 'change' as EventCategory },
+		// AUDIT tier — see buildLifecycleEvent. Change events are audit-trail
+		// records; tier:'audit' satisfies the tier-routing CHECK constraint.
+		metadata: { category: 'change' as EventCategory, tier: 'audit' },
 	}));
 }
 
@@ -144,9 +165,21 @@ export async function emitSafely(
 		} else {
 			await eventBus.publishMany(events);
 		}
-	} catch {
-		// Log but never fail the CRUD operation.
-		// In production, this would use a structured logger.
-		console.warn(`[lifecycle-events] failed to emit ${events.length} event(s)`);
+	} catch (err) {
+		// Never fail the CRUD operation — but surface the cause. The bare
+		// `catch` that used to live here swallowed the error entirely, so a
+		// failing bus printed `failed to emit N event(s)` with zero
+		// diagnosability. Route through the Nest Logger (not bare console) at
+		// warn level, including the distinct event types and the error message;
+		// the stack follows at debug so it's available without noising the
+		// default-threshold output.
+		const message = err instanceof Error ? err.message : String(err);
+		const types = [...new Set(events.map((e) => e.type))].join(', ');
+		logger.warn(
+			`failed to emit ${events.length} event(s) [${types}]: ${message}`,
+		);
+		if (err instanceof Error && err.stack) {
+			logger.debug(err.stack);
+		}
 	}
 }

--- a/src/__tests__/runtime/base-classes/lifecycle-events.spec.ts
+++ b/src/__tests__/runtime/base-classes/lifecycle-events.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * emitSafely unit tests.
+ *
+ * emitSafely is fire-and-forget: a throwing bus must NEVER propagate (it would
+ * fail the host CRUD operation). Before this fix the failure was swallowed by a
+ * bare `catch` and printed via `console.warn` with no cause — these tests lock
+ * in the never-throw contract AND that the cause + the distinct event types now
+ * reach the Nest Logger.
+ */
+import { describe, it, expect, mock, spyOn, afterEach } from 'bun:test';
+import { Logger } from '@nestjs/common';
+
+import {
+  emitSafely,
+  buildLifecycleEvent,
+  buildChangeEvents,
+} from '../../../../runtime/base-classes/lifecycle-events';
+import type {
+  IEventBus,
+  DomainEvent,
+} from '../../../../runtime/subsystems/events/event-bus.protocol';
+
+function makeEvent(type: string): DomainEvent {
+  return {
+    id: `id-${type}`,
+    type,
+    aggregateId: 'agg-1',
+    aggregateType: 'widget',
+    payload: {},
+    occurredAt: new Date(),
+  };
+}
+
+function makeBus(overrides: Partial<IEventBus> = {}): IEventBus {
+  return {
+    publish: mock(async () => undefined),
+    publishMany: mock(async () => undefined),
+    subscribe: mock(() => () => undefined),
+    ...overrides,
+  } as unknown as IEventBus;
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('emitSafely', () => {
+  it('is a no-op when no bus is provided', async () => {
+    // No throw, nothing to assert beyond completion.
+    await emitSafely(undefined, [makeEvent('widget.created')]);
+  });
+
+  it('is a no-op when the event list is empty', async () => {
+    const bus = makeBus();
+    await emitSafely(bus, []);
+    expect(bus.publish).not.toHaveBeenCalled();
+    expect(bus.publishMany).not.toHaveBeenCalled();
+  });
+
+  it('publishes a single event via publish()', async () => {
+    const bus = makeBus();
+    const ev = makeEvent('widget.created');
+    await emitSafely(bus, [ev]);
+    expect(bus.publish).toHaveBeenCalledTimes(1);
+    expect(bus.publish).toHaveBeenCalledWith(ev);
+    expect(bus.publishMany).not.toHaveBeenCalled();
+  });
+
+  it('publishes multiple events via publishMany()', async () => {
+    const bus = makeBus();
+    const events = [makeEvent('widget.created'), makeEvent('widget.field_changed')];
+    await emitSafely(bus, events);
+    expect(bus.publishMany).toHaveBeenCalledTimes(1);
+    expect(bus.publishMany).toHaveBeenCalledWith(events);
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  it('does NOT throw when a single-event publish rejects', async () => {
+    const warn = spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    const bus = makeBus({
+      publish: mock(async () => {
+        throw new Error('bus is down');
+      }),
+    });
+
+    // Must resolve, not reject.
+    await emitSafely(bus, [makeEvent('widget.created')]);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const line = String(warn.mock.calls[0]?.[0] ?? '');
+    expect(line).toContain('bus is down'); // the cause
+    expect(line).toContain('widget.created'); // the event type
+    expect(line).toContain('1 event(s)');
+  });
+
+  it('logs the cause and the distinct event types when publishMany rejects', async () => {
+    const warn = spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const debug = spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    const cause = new Error('publishMany exploded');
+    const bus = makeBus({
+      publishMany: mock(async () => {
+        throw cause;
+      }),
+    });
+
+    // Three events, two distinct types — the log must dedupe the types.
+    const events = [
+      makeEvent('widget.created'),
+      makeEvent('widget.field_changed'),
+      makeEvent('widget.field_changed'),
+    ];
+
+    await emitSafely(bus, events); // never-throw
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const line = String(warn.mock.calls[0]?.[0] ?? '');
+    expect(line).toContain('publishMany exploded');
+    expect(line).toContain('3 event(s)');
+    expect(line).toContain('widget.created');
+    expect(line).toContain('widget.field_changed');
+    // Distinct, not repeated: exactly one occurrence of the duplicated type.
+    expect(line.match(/widget\.field_changed/g)).toHaveLength(1);
+
+    // Stack surfaced at debug level (available, not noisy at default threshold).
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(String(debug.mock.calls[0]?.[0] ?? '')).toContain(
+      'publishMany exploded',
+    );
+  });
+
+  it('tolerates a non-Error throw without propagating', async () => {
+    const warn = spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    const debug = spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+    const bus = makeBus({
+      publish: mock(async () => {
+        throw 'string failure';
+      }),
+    });
+
+    await emitSafely(bus, [makeEvent('widget.created')]);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0] ?? '')).toContain('string failure');
+    // No Error ⇒ no stack ⇒ no debug follow-up.
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  // The original silent failure: `domain_events_tier_routing_check` rejects a
+  // domain-tier row with NULL pool/direction. With builders now stamping
+  // `tier:'audit'`, such rows are constraint-legal — but emitSafely must STILL
+  // swallow any genuine bus error. This bus mirrors the DB check.
+  it('never throws even when the bus enforces the tier-routing invariant', async () => {
+    spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+    // Reproduce `domain_events_tier_routing_check`: tier:'audit' ⇔ pool/direction null.
+    const enforcingPublish = (event: DomainEvent) => {
+      const meta = event.metadata ?? {};
+      const tier = (meta['tier'] as string | undefined) ?? 'domain';
+      const routingNull = meta['pool'] == null && meta['direction'] == null;
+      if ((tier === 'audit') !== routingNull) {
+        throw new Error(
+          'new row for relation "domain_events" violates check constraint ' +
+            '"domain_events_tier_routing_check"',
+        );
+      }
+    };
+    const bus = makeBus({
+      publish: mock(async (e: DomainEvent) => enforcingPublish(e)),
+      publishMany: mock(async (es: DomainEvent[]) => es.forEach(enforcingPublish)),
+    });
+
+    // The builder output (audit-tier) passes the enforcing bus — no throw, no log.
+    const warnSpy = spyOn(Logger.prototype, 'warn');
+    await emitSafely(bus, [buildLifecycleEvent('widget', 'updated', 'agg-1')]);
+    await emitSafely(bus, buildChangeEvents('widget', 'agg-1', [
+      { field: 'name', oldValue: 'a', newValue: 'b' },
+    ]));
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // An un-tiered (domain) row with null routing trips the constraint — but
+    // emitSafely still resolves, never rejecting the host CRUD op.
+    const domainTierRow: DomainEvent = {
+      ...makeEvent('widget.updated'),
+      metadata: { category: 'lifecycle' },
+    };
+    await emitSafely(bus, [domainTierRow]); // must NOT reject
+  });
+});
+
+describe('event builders — AUDIT tier stamping', () => {
+  it('buildLifecycleEvent stamps tier:audit (constraint-legal: no pool/direction)', () => {
+    const ev = buildLifecycleEvent('widget', 'created', 'agg-1', { name: 'x' });
+    expect(ev.type).toBe('widget.created');
+    expect(ev.metadata?.['tier']).toBe('audit');
+    expect(ev.metadata?.['category']).toBe('lifecycle');
+    // Audit branch of the CHECK: pool/direction must be absent (→ NULL).
+    expect(ev.metadata?.['pool']).toBeUndefined();
+    expect(ev.metadata?.['direction']).toBeUndefined();
+  });
+
+  it('buildChangeEvents stamps tier:audit on every change event', () => {
+    const events = buildChangeEvents('widget', 'agg-1', [
+      { field: 'name', oldValue: 'a', newValue: 'b' },
+      { field: 'size', oldValue: 1, newValue: 2 },
+    ]);
+    expect(events).toHaveLength(2);
+    for (const ev of events) {
+      expect(ev.type).toBe('widget.field_changed');
+      expect(ev.metadata?.['tier']).toBe('audit');
+      expect(ev.metadata?.['category']).toBe('change');
+      expect(ev.metadata?.['pool']).toBeUndefined();
+      expect(ev.metadata?.['direction']).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Two coupled fixes to `runtime/base-classes/lifecycle-events.ts`, both surfaced live by the **swe-brain** dogfood (the second-dogfood consumer): `[lifecycle-events] failed to emit 3 event(s)` printing twice per worker dispatcher fire, with zero diagnosability.

## Root cause — lifecycle audit trail was silently dead

The `BaseService` lifecycle/change event path predates the AUDIT tier + routing schema (ADR-039) and was never migrated. `buildLifecycleEvent` / `buildChangeEvents` stamped only `metadata.category`, no `tier`. So `toInsertValues` (`runtime/subsystems/events/event-bus.drizzle-backend.ts`) read `metadata.tier ?? 'domain'`, `metadata.pool ?? null`, `metadata.direction ?? null` and wrote a row with `tier='domain', pool=NULL, direction=NULL`.

That violates the storage-boundary CHECK:

```
domain_events_tier_routing_check:
  tier IN ('domain','audit') AND ((tier = 'audit') = (pool IS NULL AND direction IS NULL))
```

Domain-tier rows MUST carry pool+direction; audit-tier rows must have both NULL. The lifecycle row had neither tier set nor routing fields, so:

```
new row for relation "domain_events" violates check constraint "domain_events_tier_routing_check"
```

…on **every** `BaseService` create/update/delete, in **every** consumer. The bare `catch` swallowed it, so the entire lifecycle/change audit trail was silently lost framework-wide.

**Fix:** the builders now stamp `tier: 'audit'`. Lifecycle/change events are exactly audit-tier semantics — untyped audit-trail records, never bridge-routed, no pool/direction. This satisfies the constraint's audit branch, revives the trail (rows now land and show under the observability viewer's audit-tier toggle), and the existing bridge guard (`bridge-outbox-drain-hook.ts` — `metadata.tier === 'audit'` ⇒ refuse fanout) correctly keeps them out of job routing. These events use the raw `EVENT_BUS` (`DrizzleEventBus`) publish path, not `TypedEventBus`, so no registry Zod refinement re-validates them.

## emitSafely — log the cause via the Nest Logger

The fire-and-forget catch was `catch {}` → `console.warn(\`...failed to emit N event(s)\`)`. That bypassed the Nest `Logger` entirely (consumers configuring `app.useLogger` / the factory `logger:` option could neither format nor filter it) and discarded the error cause.

Now logs via a module-level `Logger('LifecycleEvents')` at `warn` level, including the event count, the **distinct** event types, and the error message; the stack follows at `debug`. Never-throw semantics preserved.

Observed impact (swe-brain): the `3` in `failed to emit 3 event(s)` was the `[updated, field_changed, field_changed]` `publishMany` batch from a `BaseService.update`.

## Tests

`src/__tests__/runtime/base-classes/lifecycle-events.spec.ts`:
- builders stamp `tier:'audit'` and leave pool/direction absent (constraint-legal);
- `emitSafely` never throws even against a bus that enforces the tier-routing invariant (mirrors `domain_events_tier_routing_check`);
- the warn log carries the cause + the distinct event types; the stack lands at debug; non-`Error` throws are tolerated.

Full CI gate (`just test-all`) green locally.

## Release

`0.24.0 → 0.25.0` + CHANGELOG entry (merge to main auto-publishes to npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)