### PR TITLE
feat(runtime): compact console logger + LOG_LEVEL threshold (runtime/shared/logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.0] — 2026-06-07
+
+### Added
+
+- **Runtime: compact console logger + `LOG_LEVEL` threshold
+  (`runtime/shared/logging`).** A proven swe-brain (second-dogfood) consumer
+  pattern lifted into the runtime, importable as
+  `@pattern-stack/codegen/runtime/shared/logging`. `CompactConsoleLogger` drops
+  Nest's ~55-char `[Nest] <pid>  - <full locale date>   LEVEL [Context]`
+  preamble (which wraps 2–3× in split-pane dev TUIs) — emitting
+  `12:48:42   LOG [Context] message` — and `createAppLogger(threshold?)` gives
+  consumers the log-level knob the generated entrypoints never wired: a single
+  `LOG_LEVEL` env threshold (`verbose < debug < log < warn < error < fatal`,
+  default `log`) that enables that level and above, with an explicit-override arg
+  that wins over the env (CLI tools pass `'warn'` to stay quiet). Hand it to
+  `NestFactory.create(AppModule, { logger: createAppLogger() })`. See
+  `docs/CONSUMER-SETUP.md` §Application logger. (The generated worker template
+  doesn't auto-wire it yet — follow-up.)
+
 ## [0.25.0] — 2026-06-07
 
 ### Fixed

--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -443,6 +443,63 @@ if (config.openapi?.enabled) {
 }
 ```
 
+## Application logger
+
+`@pattern-stack/codegen/runtime/shared/logging` ships a compact console logger
+plus a `LOG_LEVEL` threshold knob. It replaces Nest's default
+`ConsoleLogger`, whose preamble — `[Nest] <pid>  - <full locale date>   LEVEL
+[Context]` (~55 chars) — wraps 2–3× in split-pane dev TUIs (process-compose,
+tmux), and gives consumers a log-level dial they otherwise lack (the generated
+entrypoints pass no `logger:`, so every subsystem `debug` line — e.g.
+EventScheduler's per-slot `materialised …` — always prints).
+
+`CompactConsoleLogger` drops the `[Nest] <pid>  - ` prefix (a supervisor pane
+header already names the process) and shortens the timestamp to `HH:mm:ss`:
+
+```
+12:48:42   LOG [EventScheduler] materialised 2 slot(s)
+```
+
+Hand it to `NestFactory` in your entrypoint:
+
+```ts
+// src/main.ts
+import { createAppLogger } from '@pattern-stack/codegen/runtime/shared/logging';
+
+const app = await NestFactory.create(AppModule, { logger: createAppLogger() });
+```
+
+```ts
+// src/worker.ts (standalone worker)
+const app = await NestFactory.createApplicationContext(WorkerAppModule, {
+  logger: createAppLogger(),
+});
+```
+
+### `LOG_LEVEL` threshold
+
+A single severity threshold enables that level and everything above it
+(`verbose < debug < log < warn < error < fatal`); the default is `log`.
+
+| `LOG_LEVEL` | Enabled levels |
+|---|---|
+| _(unset)_ / `log` | `log`, `warn`, `error`, `fatal` |
+| `debug` | `debug` and above |
+| `verbose` | everything |
+| `warn` | `warn`, `error`, `fatal` |
+
+Unknown values warn once and fall back to `log`. `createAppLogger(threshold?)`
+takes an explicit override that wins over the env var — CLI tools pass `'warn'`
+to stay quiet regardless of the ambient `LOG_LEVEL`:
+
+```ts
+const logger = createAppLogger('warn'); // ignores LOG_LEVEL
+```
+
+> The generated entrypoints don't yet wire this automatically — pass
+> `createAppLogger()` yourself in `main.ts` / `worker.ts` (a future codegen
+> release will scaffold it into the worker template).
+
 ## `codegen.config.yaml`
 
 Minimum viable config for a backend-only clean-lite-ps project:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",
@@ -34,6 +34,10 @@
     "./runtime/shared/openapi": {
       "types": "./dist/runtime/shared/openapi/index.d.ts",
       "default": "./dist/runtime/shared/openapi/index.js"
+    },
+    "./runtime/shared/logging": {
+      "types": "./dist/runtime/shared/logging/index.d.ts",
+      "default": "./dist/runtime/shared/logging/index.js"
     },
     "./runtime/*": {
       "types": "./dist/runtime/*.d.ts",

--- a/runtime/shared/logging/compact-console-logger.ts
+++ b/runtime/shared/logging/compact-console-logger.ts
@@ -1,0 +1,102 @@
+/**
+ * Compact console logger + `LOG_LEVEL` threshold.
+ *
+ * Nest's default `ConsoleLogger` preamble —
+ *   `[Nest] <pid>  - <full locale date>   LEVEL [Context] <message>`
+ * — is ~55 chars before the message. In a split-pane dev TUI (process-compose,
+ * tmux) every line wraps 2–3×, drowning the actual content. And the generated
+ * entrypoints pass no `logger:` option, so consumers have no log-level knob:
+ * every subsystem `debug` line (e.g. EventScheduler's per-slot `materialised …`)
+ * always prints.
+ *
+ * This module is the proven swe-brain (second-dogfood) consumer pattern lifted
+ * into the runtime so consumers stop rebuilding it by hand:
+ *
+ *   - `CompactConsoleLogger` — drops the `[Nest] <pid>  - ` prefix (a supervisor
+ *     pane header already names the process) and shortens the timestamp to
+ *     `HH:mm:ss`.
+ *   - `parseLogLevels` / the `LOG_LEVEL` env convention — a single severity
+ *     threshold enables that level and everything above it.
+ *   - `createAppLogger` — the factory the entrypoints hand to `NestFactory`.
+ */
+import { ConsoleLogger, type LogLevel } from '@nestjs/common';
+
+/** Severity-ordered (lowest → highest); a threshold enables its suffix. */
+const LEVELS: LogLevel[] = ['verbose', 'debug', 'log', 'warn', 'error', 'fatal'];
+const DEFAULT_THRESHOLD: LogLevel = 'log';
+
+const TIME = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+/**
+ * Resolve a `LOG_LEVEL` threshold into the enabled-levels array Nest's
+ * `logLevels` option expects.
+ *
+ * `LOG_LEVEL=debug` → `['debug','log','warn','error','fatal']`. Unknown input
+ * warns and falls back to the default (`'log'` and above).
+ */
+export function parseLogLevels(threshold = process.env.LOG_LEVEL): LogLevel[] {
+  const idx = LEVELS.indexOf(
+    (threshold ?? DEFAULT_THRESHOLD).toLowerCase() as LogLevel,
+  );
+  if (idx === -1) {
+    console.warn(
+      `[logging] unknown LOG_LEVEL '${threshold}' — defaulting to '${DEFAULT_THRESHOLD}'`,
+    );
+    return LEVELS.slice(LEVELS.indexOf(DEFAULT_THRESHOLD));
+  }
+  return LEVELS.slice(idx);
+}
+
+/**
+ * A `ConsoleLogger` with a compact one-line format tuned for split-pane TUIs.
+ */
+export class CompactConsoleLogger extends ConsoleLogger {
+  /** Drop `[Nest] <pid>  - ` — a supervisor pane header already identifies the process. */
+  protected override formatPid(_pid: number): string {
+    return '';
+  }
+
+  /** `12:48:42`, not `06/07/2026, 12:48:42 PM`. */
+  protected override getTimestamp(): string {
+    return TIME.format(Date.now());
+  }
+
+  protected override formatMessage(
+    logLevel: LogLevel,
+    message: unknown,
+    _pidMessage: string,
+    _formattedLogLevel: string,
+    contextMessage: string,
+    timestampDiff: string,
+  ): string {
+    const output = this.stringifyMessage(message, logLevel);
+    // padStart(5) (vs Nest's 7) aligns LOG/WARN/DEBUG/ERROR; `verbose` may jitter.
+    const level = this.colorize(
+      logLevel.toUpperCase().padStart(5, ' '),
+      logLevel,
+    );
+    return `${this.getTimestamp()} ${level} ${contextMessage}${output}${timestampDiff}\n`;
+  }
+}
+
+/**
+ * Build the app-wide logger that entrypoints hand to `NestFactory`.
+ *
+ * @param threshold explicit `LOG_LEVEL` override. CLI tools that must stay quiet
+ *   regardless of the ambient env pass e.g. `'warn'`. When omitted, the
+ *   `LOG_LEVEL` env var (then the `'log'` default) wins.
+ *
+ * @example
+ *   const app = await NestFactory.create(AppModule, { logger: createAppLogger() });
+ */
+export function createAppLogger(threshold?: LogLevel): CompactConsoleLogger {
+  return new CompactConsoleLogger('', {
+    logLevels: parseLogLevels(threshold ?? process.env.LOG_LEVEL),
+    timestamp: true,
+  });
+}

--- a/runtime/shared/logging/index.ts
+++ b/runtime/shared/logging/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Logging shared subsystem — public API.
+ *
+ * Imported by consumers as `@pattern-stack/codegen/runtime/shared/logging`.
+ */
+export {
+  CompactConsoleLogger,
+  createAppLogger,
+  parseLogLevels,
+} from './compact-console-logger';

--- a/src/__tests__/runtime/shared/logging.spec.ts
+++ b/src/__tests__/runtime/shared/logging.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * CompactConsoleLogger + LOG_LEVEL threshold unit tests.
+ *
+ * Covers:
+ *   - parseLogLevels: default → log-and-above; explicit thresholds; garbage
+ *     input falls back to the default with a warning.
+ *   - CompactConsoleLogger format: no `[Nest]`/pid prefix, HH:mm:ss timestamp,
+ *     5-wide level padding, context preserved.
+ *   - level suppression: a `debug` line is dropped at the default threshold.
+ */
+import { describe, it, expect, mock, afterEach, beforeEach } from 'bun:test';
+import type { LogLevel } from '@nestjs/common';
+
+import {
+  parseLogLevels,
+  createAppLogger,
+  CompactConsoleLogger,
+} from '../../../../runtime/shared/logging';
+
+/** Strip ANSI color escapes so format assertions are color-config-independent. */
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+const stripAnsi = (s: string): string => s.replace(ANSI, '');
+
+describe('parseLogLevels', () => {
+  it("defaults to 'log' and above when LOG_LEVEL is unset", () => {
+    expect(parseLogLevels(undefined)).toEqual(['log', 'warn', 'error', 'fatal']);
+  });
+
+  it('enables the threshold level and everything above it', () => {
+    expect(parseLogLevels('debug')).toEqual([
+      'debug',
+      'log',
+      'warn',
+      'error',
+      'fatal',
+    ]);
+    expect(parseLogLevels('verbose')).toEqual([
+      'verbose',
+      'debug',
+      'log',
+      'warn',
+      'error',
+      'fatal',
+    ]);
+    expect(parseLogLevels('warn')).toEqual(['warn', 'error', 'fatal']);
+    expect(parseLogLevels('error')).toEqual(['error', 'fatal']);
+    expect(parseLogLevels('fatal')).toEqual(['fatal']);
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseLogLevels('DEBUG')).toEqual(parseLogLevels('debug'));
+    expect(parseLogLevels('Warn')).toEqual(parseLogLevels('warn'));
+  });
+
+  it('falls back to the default with a warning on garbage input', () => {
+    const warn = mock(() => undefined);
+    const original = console.warn;
+    console.warn = warn as unknown as typeof console.warn;
+    try {
+      const levels = parseLogLevels('shout');
+      expect(levels).toEqual(['log', 'warn', 'error', 'fatal']);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0] ?? '')).toContain('shout');
+      expect(String(warn.mock.calls[0]?.[0] ?? '')).toContain("defaulting to 'log'");
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  it('reads process.env.LOG_LEVEL when no arg is given', () => {
+    const prev = process.env.LOG_LEVEL;
+    process.env.LOG_LEVEL = 'error';
+    try {
+      expect(parseLogLevels()).toEqual(['error', 'fatal']);
+    } finally {
+      if (prev === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = prev;
+    }
+  });
+});
+
+/** Exposes the protected formatMessage for direct format assertions. */
+class TestLogger extends CompactConsoleLogger {
+  public format(
+    level: LogLevel,
+    message: unknown,
+    contextMessage: string,
+  ): string {
+    // pidMessage / formattedLogLevel are unused by the override; pass blanks.
+    return (
+      this as unknown as {
+        formatMessage(
+          l: LogLevel,
+          m: unknown,
+          p: string,
+          f: string,
+          c: string,
+          t: string,
+        ): string;
+      }
+    ).formatMessage(level, message, '', '', contextMessage, '');
+  }
+}
+
+describe('CompactConsoleLogger format', () => {
+  it('drops the [Nest] <pid> - preamble', () => {
+    const line = stripAnsi(new TestLogger().format('log', 'hello', '[Boot] '));
+    expect(line).not.toContain('[Nest]');
+    // No process-id digits run before the timestamp.
+    expect(line.startsWith('[Nest]')).toBe(false);
+  });
+
+  it('uses an HH:mm:ss timestamp, not a full locale date', () => {
+    const line = stripAnsi(new TestLogger().format('log', 'hello', ''));
+    // Leads with HH:mm:ss (24-hour).
+    expect(line).toMatch(/^\d{2}:\d{2}:\d{2} /);
+    // None of the locale-date artifacts Nest's default prints.
+    expect(line).not.toContain('AM');
+    expect(line).not.toContain('PM');
+    expect(line).not.toMatch(/\d{2}\/\d{2}\/\d{4}/);
+  });
+
+  it('pads the level to 5 chars and preserves context + message', () => {
+    const line = stripAnsi(new TestLogger().format('log', 'hello world', '[Boot] '));
+    // `LOG` padded to width 5 → two leading spaces.
+    expect(line).toContain('  LOG ');
+    expect(line).toContain('[Boot] ');
+    expect(line).toContain('hello world');
+    // Single trailing newline.
+    expect(line.endsWith('\n')).toBe(true);
+  });
+
+  it('keeps wider levels unpadded-beyond-content (WARN/ERROR are 5 chars)', () => {
+    expect(stripAnsi(new TestLogger().format('warn', 'x', ''))).toContain('WARN ');
+    expect(stripAnsi(new TestLogger().format('error', 'x', ''))).toContain('ERROR ');
+    expect(stripAnsi(new TestLogger().format('debug', 'x', ''))).toContain('DEBUG ');
+  });
+});
+
+describe('createAppLogger — level suppression', () => {
+  let stdout: ReturnType<typeof mock>;
+  let originalWrite: typeof process.stdout.write;
+
+  beforeEach(() => {
+    originalWrite = process.stdout.write.bind(process.stdout);
+    stdout = mock(() => true);
+    process.stdout.write = stdout as unknown as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  it('suppresses debug at the default (log) threshold', () => {
+    const logger = createAppLogger(); // default → log and above
+    logger.debug('should-be-suppressed', 'Ctx');
+    logger.log('should-print', 'Ctx');
+
+    const written = stdout.mock.calls.map((c) => stripAnsi(String(c[0]))).join('');
+    expect(written).not.toContain('should-be-suppressed');
+    expect(written).toContain('should-print');
+  });
+
+  it('emits debug when the explicit threshold is debug', () => {
+    const logger = createAppLogger('debug');
+    logger.debug('now-visible', 'Ctx');
+
+    const written = stdout.mock.calls.map((c) => stripAnsi(String(c[0]))).join('');
+    expect(written).toContain('now-visible');
+  });
+
+  it('the explicit threshold overrides the env var', () => {
+    const prev = process.env.LOG_LEVEL;
+    process.env.LOG_LEVEL = 'debug'; // env would enable debug…
+    try {
+      const logger = createAppLogger('warn'); // …but the explicit arg wins.
+      logger.debug('env-says-debug', 'Ctx');
+      logger.log('still-quiet', 'Ctx');
+      logger.warn('this-prints', 'Ctx');
+
+      const written = stdout.mock.calls
+        .map((c) => stripAnsi(String(c[0])))
+        .join('');
+      expect(written).not.toContain('env-says-debug');
+      expect(written).not.toContain('still-quiet');
+      expect(written).toContain('this-prints');
+    } finally {
+      if (prev === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = prev;
+    }
+  });
+});


### PR DESCRIPTION
Lifts the proven **swe-brain** (second-dogfood) consumer logging pattern into the runtime as `runtime/shared/logging`, importable as `@pattern-stack/codegen/runtime/shared/logging` (exports-map subpath following `runtime/shared/openapi`).

## Motivation

Nest's default `ConsoleLogger` preamble — `[Nest] <pid>  - <full locale date>   LEVEL [Context]` (~55 chars before the message) — wraps 2–3× in split-pane dev TUIs (process-compose, tmux), drowning the actual content. And the generated entrypoints pass no `logger:` option, so consumers have **no log-level knob**: every subsystem `debug` line (e.g. EventScheduler's per-slot `materialised …`) always prints. Every consumer rebuilds this by hand — it belongs in the runtime.

## What's added

`@pattern-stack/codegen/runtime/shared/logging`:

- **`CompactConsoleLogger`** — drops the `[Nest] <pid>  - ` prefix (a supervisor pane header already names the process) and shortens the timestamp to `HH:mm:ss`. Output: `12:48:42   LOG [EventScheduler] materialised 2 slot(s)`.
- **`parseLogLevels` + the `LOG_LEVEL` env convention** — a single severity threshold (`verbose < debug < log < warn < error < fatal`, default `log`) enables that level and everything above; unknown input warns once and falls back.
- **`createAppLogger(threshold?)`** — the factory entrypoints hand to `NestFactory`. The explicit override wins over the env var (CLI tools pass `'warn'` to stay quiet regardless of ambient `LOG_LEVEL`).

```ts
const app = await NestFactory.create(AppModule, { logger: createAppLogger() });
```

## Tests

`src/__tests__/runtime/shared/logging.spec.ts`:
- `parseLogLevels`: default → log-and-above; explicit thresholds; case-insensitivity; garbage input → default + warning; reads `process.env.LOG_LEVEL`.
- format: no `[Nest]`/pid preamble, `HH:mm:ss` timestamp shape (no AM/PM, no locale date), 5-wide level padding, context + message preserved, single trailing newline.
- level suppression: `debug` dropped at the default threshold; visible at `debug`; the explicit arg overrides the env.

Full CI gate (`just test-all`) green locally; the module builds to `dist/runtime/shared/logging/` so the exports subpath resolves.

## Docs

`docs/CONSUMER-SETUP.md` → new **§Application logger**: what it does, the `LOG_LEVEL` threshold table, and the `NestFactory.create(AppModule, { logger: createAppLogger() })` example.

## Deliberately out of scope (follow-up)

Auto-wiring `createAppLogger()` into the generated worker entrypoint (`templates/subsystem/jobs/worker.ejs.t`) is **skipped** to keep this PR tight — that template just landed in the worker-scaffold train (#513/#516/#517) and is snapshot-tested by `jobs-scaffold-locals.test.ts` / `subsystem.test.ts` / the subsystems smoke. Threading the logger import through it (and updating those snapshots) is a clean standalone follow-up.

## Release

Rebased onto main after #524 (the lifecycle-events fix) landed as 0.25.0 — this is now **`0.25.0 → 0.26.0`** + CHANGELOG entry (merge to main auto-publishes to npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)