### PR TITLE
fix(sink-emitter): generated bases compile for the relative-path layout — import depth + userId (#528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.1] — 2026-06-07
+
+### Fixed
+
+- **Sink-seam emitter (#491 Shape C): generated `*.sink.generated.ts` bases now
+  compile for the relative-path (swe-brain) layout.** Two defects made every
+  emitted base non-compiling when no tsconfig alias covers the module dir
+  (#528):
+  - **Repo import one level too deep.** The sink base lives at
+    `integrations/<surface>/sinks/` (3 deep under `src/`) but reused the
+    *assembly*-relative `repoImportSpecifier` (computed for
+    `integrations/<surface>/modules/<provider>/`, 4 deep), emitting
+    `../../../../modules/…` — which lands at the repo root, not `src/` (TS2307).
+    The caller now recomputes the specifier relative to the SINK dir from the
+    resolved repo file path (alias-aware via the same `toImportSpecifier`
+    helper, now exported; `EntityModuleLocation` carries `repoFileAbs` /
+    `moduleFileAbs`). Correct prefix: `../../../modules/…`. The assembly import
+    depth is unchanged.
+  - **Bare `userId,` shorthand (TS18004).** `default<E>BuildWrite(record)` is a
+    standalone function with only `record` in scope, but a declared `user_id`
+    field was special-cased as a bare `userId,` shorthand referencing no
+    binding. `userId` is a plain projection field — now emitted as
+    `userId: record.userId`, like every other copy-through field.
+  - Validation: a new compile-level gate
+    (`sink-swe-brain-layout.compile.test.ts`) runs the real emitter into a
+    swe-brain-shaped tree (`integrations/<surface>/sinks/` +
+    `modules/<plural>/<entity>.repository.ts`, no alias) and `tsc --noEmit`s the
+    emitted base — the prior §3b gate missed both (it stubbed the repo import
+    same-dir and used no `user_id` field). Found consuming 0.26.0 in swe-brain
+    (6 bases, 12 errors).
+
 ## [0.26.0] — 2026-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/cli/adapter-emission-generator.test.ts
+++ b/src/__tests__/cli/adapter-emission-generator.test.ts
@@ -447,6 +447,68 @@ describe('E2 — per-entity assembly + sink + integration tokens', () => {
     );
   });
 
+  it('relative-path layout: sink base import depth is one shallower than the assembly (#528)', () => {
+    // swe-brain geometry: NO alias → relative imports. outputRoot is
+    // <backendSrc>/integrations, exactly as the entity command wires it.
+    const backendSrcAbs = join(mkdtempSync(join(tmpdir(), 'cgp-528-')), 'src');
+    const outRoot = join(backendSrcAbs, 'integrations');
+    const res = emitAdapters({
+      providers: [{ definition: loadDef('google.yaml'), filePath: resolve(FIX, 'google.yaml') }],
+      entities: [ASSEMBLY_ENTITIES[0]],
+      outputRoot: outRoot,
+      backendSrcAbs,
+      aliases: {}, // no alias → relative path
+    });
+
+    // Assembly lives at integrations/calendar/modules/google/ (4 deep under src)
+    // → ../../../../modules/... reaches src/modules. Unchanged by this fix.
+    const mod = readFileSync(
+      join(outRoot, 'calendar/modules/google/meeting-integration.module.ts'),
+      'utf-8',
+    );
+    expect(mod).toContain(
+      "import { MeetingRepository } from '../../../../modules/meetings/meeting.repository';",
+    );
+
+    // Sink base lives at integrations/calendar/sinks/ (3 deep under src)
+    // → MUST be ../../../modules/... (one fewer `../`). The bug emitted
+    // ../../../../modules/... here (assembly-relative), landing at the repo root.
+    const base = readFileSync(
+      join(outRoot, 'calendar/sinks/meeting.sink.generated.ts'),
+      'utf-8',
+    );
+    expect(base).toContain(
+      "from '../../../modules/meetings/meeting.repository'",
+    );
+    expect(base).not.toContain('../../../../modules/meetings/meeting.repository');
+
+    // The emit-once subclass shares the sinks/ dir → same depth.
+    const sink = readFileSync(
+      join(outRoot, 'calendar/sinks/meeting.sink.ts'),
+      'utf-8',
+    );
+    expect(sink).toContain("from '../../../modules/meetings/meeting.repository'");
+    expect(sink).not.toContain('../../../../modules/meetings/meeting.repository');
+  });
+
+  it('alias layout: sink base prefers the @modules alias (depth-independent)', () => {
+    const backendSrcAbs = join(mkdtempSync(join(tmpdir(), 'cgp-528-')), 'src');
+    const outRoot = join(backendSrcAbs, 'integrations');
+    const res = emitAdapters({
+      providers: [{ definition: loadDef('google.yaml'), filePath: resolve(FIX, 'google.yaml') }],
+      entities: [ASSEMBLY_ENTITIES[0]],
+      outputRoot: outRoot,
+      backendSrcAbs,
+      aliases: { '@modules': join(backendSrcAbs, 'modules') },
+    });
+    void res;
+    const base = readFileSync(
+      join(outRoot, 'calendar/sinks/meeting.sink.generated.ts'),
+      'utf-8',
+    );
+    expect(base).toContain("from '@modules/meetings/meeting.repository'");
+  });
+
   it('records a non-Integrated surface entity as a skip (read side still emits)', () => {
     const res = runAssembly('/unused');
     expect(res.skippedAssemblies).toHaveLength(1);

--- a/src/__tests__/cli/sink-emission-generator.test.ts
+++ b/src/__tests__/cli/sink-emission-generator.test.ts
@@ -216,13 +216,15 @@ describe("generateSinkBase — userId is a declared copy-through field", () => {
     }),
   );
 
-  it("sources userId from the method param, not the record (bare `userId,`)", () => {
+  it("reads userId from the record like any copy-through field (#528 — bare `userId,` shorthand was TS18004)", () => {
     const buildWrite = out.slice(
       out.indexOf("export function defaultTranscriptBuildWrite("),
       out.indexOf("export function defaultTranscriptToCanonicalView("),
     );
-    expect(buildWrite).toContain("userId,");
-    expect(buildWrite).not.toContain("userId: record.userId");
+    expect(buildWrite).toContain("userId: record.userId,");
+    // The standalone default function has ONLY `record` in scope, so a bare
+    // `userId,` shorthand referenced an undeclared binding → must not be emitted.
+    expect(buildWrite).not.toMatch(/^\s*userId,\s*$/m);
   });
 
   it("still copies the non-userId fields from the record", () => {
@@ -380,13 +382,13 @@ describe("generateSinkBase — FK + json + userId together", () => {
     expect(codeOnly(out)).not.toContain("channelExternalId: record.");
   });
 
-  it("sources userId from the param shorthand", () => {
+  it("reads userId from the record like any copy-through field (#528)", () => {
     const buildWrite = out.slice(
       out.indexOf("export function defaultMessageBuildWrite("),
       out.indexOf("export function defaultMessageToCanonicalView("),
     );
-    expect(buildWrite).toContain("userId,");
-    expect(buildWrite).not.toContain("userId: record.userId");
+    expect(buildWrite).toContain("userId: record.userId,");
+    expect(buildWrite).not.toMatch(/^\s*userId,\s*$/m);
   });
 
   it("has no TODO(author) text", () => {

--- a/src/__tests__/cli/sink-swe-brain-layout.compile.test.ts
+++ b/src/__tests__/cli/sink-swe-brain-layout.compile.test.ts
@@ -1,0 +1,195 @@
+/**
+ * #528 — compile-level proof: the EMITTED sink base typechecks against the
+ * swe-brain directory layout.
+ *
+ * Two defects made every generated `*.sink.generated.ts` base non-compiling
+ * for the swe-brain layout at 0.26.0:
+ *   1. repo import one `../` too deep — `../../../../modules/...` from
+ *      `integrations/<surface>/sinks/` lands at the REPO ROOT, not `src/` (TS2307).
+ *   2. bare `userId,` shorthand in `default<E>BuildWrite(record)` — no `userId`
+ *      binding in scope (TS18004).
+ *
+ * The existing §3b gate (`sink-widened-canonical.gate.test.ts`) missed BOTH: it
+ * rewrites the repo import to a SAME-DIR stub (never exercises depth) and uses a
+ * fixture with no `user_id` field. This test runs the REAL `emitAdapters` so the
+ * actual import path is emitted, builds the swe-brain tree on disk —
+ *   <src>/integrations/<surface>/sinks/<entity>.sink.generated.ts
+ *   <src>/modules/<plural>/<entity>.repository.ts
+ * — and runs `tsc --noEmit` over the whole tree. A regression on either defect
+ * fails the compile.
+ */
+import { describe, it, expect } from 'bun:test';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { emitAdapters } from '../../cli/shared/adapter-emission-generator';
+import { loadProviderFromYaml } from '../../utils/yaml-loader';
+
+const FIX = resolve(import.meta.dir, '../parser/fixtures/providers');
+
+function loadDef(name: string) {
+  const r = loadProviderFromYaml(resolve(FIX, name));
+  if (!r.success) throw new Error(`fixture ${name} failed`);
+  return r.definition;
+}
+
+// A messaging entity declaring a `user_id` field + a belongs_to FK — exercises
+// the copy-through write (incl. userId: record.userId) AND the FK-null seam.
+// google.yaml's `transcript` surface is reused as the provider's surface tag.
+const ENTITY = {
+  entity: {
+    name: 'transcript',
+    surface: 'transcript',
+    pattern: 'Integrated',
+    plural: 'transcripts',
+    context: null,
+  },
+  fields: {
+    user_id: { type: 'string' },
+    title: { type: 'string' },
+  },
+  relationships: {},
+};
+
+// Stub the repo module the emitted base imports (projection + write + repo class).
+// userId + title are on the projection; userId is on the write surface (#528 D2).
+const STUB_REPO_TS = `
+export interface TranscriptIntegrationProjection {
+  id: string;
+  externalId: string;
+  userId: string;
+  title: string;
+}
+export interface TranscriptIntegrationWrite {
+  externalId: string;
+  userId: string;
+  title: string;
+}
+export class TranscriptRepository {
+  async findByExternalIdProjected(_externalId: string, _provider: string): Promise<TranscriptIntegrationProjection | null> {
+    return null;
+  }
+  async integrationUpsertOne(_write: TranscriptIntegrationWrite, _provider: string): Promise<TranscriptIntegrationProjection> {
+    return null as unknown as TranscriptIntegrationProjection;
+  }
+  async softDeleteByExternalId(_externalId: string, _provider: string): Promise<{ id: string } | null> {
+    return null;
+  }
+}
+`;
+
+// Stub IIntegrationSink (the base imports it from @pattern-stack/codegen/subsystems);
+// redirected via a tsconfig paths alias so the temp tsc resolves it locally.
+const STUB_SINK_PROTOCOL_TS = `
+export interface IIntegrationSink<TCanonical> {
+  findByExternalId(userId: string, externalId: string): Promise<TCanonical | null>;
+  upsertByExternalId(userId: string, record: TCanonical, provider: string): Promise<{ id: string; saved: TCanonical }>;
+  softDeleteByExternalId(userId: string, externalId: string): Promise<{ id: string } | null>;
+}
+`;
+
+// Compile ONLY the sink seam (base + subclass) + its real on-disk repo stub +
+// the IIntegrationSink stub. The same `emitAdapters` run also writes the adapter
+// scaffold / assembly modules / tokens (which pull @nestjs/common, Ref, the
+// use-case, etc. — out of scope for #528); narrowing `include` to the seam keeps
+// this a focused compile proof of the two emitter defects (#528), exactly as the
+// §3b gate compiles the base in isolation — but here with the REAL relative
+// import path resolving against the swe-brain module geometry on disk.
+const TSCONFIG = (subsystemsStubAbs: string, includeAbs: string[]) =>
+  JSON.stringify(
+    {
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+        module: 'commonjs',
+        moduleResolution: 'bundler',
+        target: 'es2020',
+        lib: ['es2020'],
+        ignoreDeprecations: '6.0',
+        baseUrl: '.',
+        paths: {
+          '@pattern-stack/codegen/subsystems': [subsystemsStubAbs.replace(/\.ts$/, '')],
+        },
+      },
+      files: includeAbs,
+    },
+    null,
+    2,
+  );
+
+describe('#528 — emitted sink base compiles against the swe-brain layout', () => {
+  // Build <root>/src as the backend src root; outputRoot = <src>/integrations.
+  const root = mkdtempSync(join(tmpdir(), 'cgp-528-compile-'));
+  const srcAbs = join(root, 'src');
+  const outRoot = join(srcAbs, 'integrations');
+
+  // The repo stub at the swe-brain module path: <src>/modules/transcripts/transcript.repository.ts
+  const repoAbs = join(srcAbs, 'modules', 'transcripts', 'transcript.repository.ts');
+  mkdirSync(dirname(repoAbs), { recursive: true });
+  writeFileSync(repoAbs, STUB_REPO_TS);
+
+  // IIntegrationSink stub anywhere under src; aliased into the base's import.
+  const sinkProtoAbs = join(srcAbs, 'stubs', 'sink.protocol.stub.ts');
+  mkdirSync(dirname(sinkProtoAbs), { recursive: true });
+  writeFileSync(sinkProtoAbs, STUB_SINK_PROTOCOL_TS);
+
+  // Run the REAL emitter — package mode emits the @pattern-stack/codegen/subsystems import.
+  const res = emitAdapters({
+    providers: [{ definition: loadDef('google.yaml'), filePath: resolve(FIX, 'google.yaml') }],
+    entities: [ENTITY],
+    outputRoot: outRoot,
+    backendSrcAbs: srcAbs,
+    aliases: {}, // relative-path layout (the failing swe-brain case)
+    mode: 'package',
+  });
+
+  const baseAbs = join(outRoot, 'transcript', 'sinks', 'transcript.sink.generated.ts');
+  const subclassAbs = join(outRoot, 'transcript', 'sinks', 'transcript.sink.ts');
+
+  // Compile the seam (base + subclass) + the real repo stub + the protocol stub.
+  const tsconfigAbs = join(srcAbs, 'tsconfig.seam.json');
+  writeFileSync(
+    tsconfigAbs,
+    TSCONFIG(sinkProtoAbs, [baseAbs, subclassAbs, repoAbs, sinkProtoAbs]),
+  );
+  const tsc = spawnSync('bunx', ['tsc', '--project', tsconfigAbs], {
+    cwd: srcAbs,
+    encoding: 'utf-8',
+    env: { ...process.env },
+  });
+  const tscOut = (tsc.stdout ?? '') + (tsc.stderr ?? '');
+
+  it('emitAdapters wrote the base into integrations/<surface>/sinks/', () => {
+    expect(res.written).toContain(baseAbs);
+  });
+
+  it('D1: the repo import is ../../../modules/... (3 levels, not 4)', () => {
+    const base = readFileSync(baseAbs, 'utf-8');
+    expect(base).toContain("from '../../../modules/transcripts/transcript.repository'");
+    expect(base).not.toContain('../../../../modules/transcripts/transcript.repository');
+  });
+
+  it('D2: the write reads userId from the record (no bare shorthand)', () => {
+    const base = readFileSync(baseAbs, 'utf-8');
+    const writeBlock = base.slice(
+      base.indexOf('export function defaultTranscriptBuildWrite('),
+      base.indexOf('export function defaultTranscriptToCanonicalView('),
+    );
+    expect(writeBlock).toContain('userId: record.userId,');
+    expect(writeBlock).not.toMatch(/^\s*userId,\s*$/m);
+  });
+
+  it('tsc --noEmit exits 0 against the swe-brain layout (both defects fixed)', () => {
+    if ((tsc.status ?? 0) !== 0) {
+      console.error('#528 compile gate tsc output (exit', tsc.status, '):\n', tscOut);
+    }
+    expect(tsc.status).toBe(0);
+  });
+});

--- a/src/cli/shared/adapter-emission-generator.ts
+++ b/src/cli/shared/adapter-emission-generator.ts
@@ -56,6 +56,7 @@ import {
   generateIntegrationAggregator,
   generateIntegrationTokens,
   resolveEntityModuleImports,
+  toImportSpecifier,
   type IntegrationAssemblyEntry,
   type IntegrationTokenEntry,
 } from "./assembly-emission-generator";
@@ -1091,7 +1092,18 @@ export function emitAdapters(opts: EmitAdaptersOptions): EmitAdaptersResult {
         //
         // The adapter scaffold sentinel (adapter-emission-generator.ts:203/562/975-976)
         // is a SEPARATE CONCERN — left untouched here.
-        const sinkInput = buildSinkInput(def!, surface, slugs[0], loc.repoImportSpecifier);
+        // The sink base + subclass live in `integrations/<surface>/sinks/`, NOT
+        // the assembly dir (`…/modules/<provider>/`) — one level shallower. Reusing
+        // `loc.repoImportSpecifier` (assembly-relative) emitted a repo import one
+        // `../` too deep (`../../../../modules/…` → repo root instead of src/). #528.
+        // Recompute the specifier relative to the SINK dir from the resolved repo
+        // file path (alias-aware via the same helper the assembly uses).
+        const sinkRepoImportSpecifier = toImportSpecifier(
+          loc.repoFileAbs,
+          sinksDir,
+          aliases,
+        );
+        const sinkInput = buildSinkInput(def!, surface, slugs[0], sinkRepoImportSpecifier);
         const basePath = join(sinksDir, `${entityName}.sink.generated.ts`);
         const baseContent = generateSinkBase({ ...sinkInput, mode });
         if (!opts.dryRun) writeIfChanged(basePath, baseContent);

--- a/src/cli/shared/assembly-emission-generator.ts
+++ b/src/cli/shared/assembly-emission-generator.ts
@@ -383,10 +383,21 @@ export interface EntityModuleLocation {
   repoClass: string;
   /** `<PluralPascal>Module` class name (`MeetingsModule`). */
   moduleClass: string;
-  /** Import specifier for the repo (alias or relative, no extension). */
+  /** Import specifier for the repo (alias or relative, no extension), computed
+   *  RELATIVE TO THE ASSEMBLY DIR (`integrations/<surface>/modules/<provider>`).
+   *  A consumer emitting into a DIFFERENT directory (e.g. the sink base in
+   *  `integrations/<surface>/sinks/`) must recompute from {@link repoFileAbs}
+   *  with {@link toImportSpecifier} — the relative depth differs (#528). */
   repoImportSpecifier: string;
-  /** Import specifier for the module (alias or relative, no extension). */
+  /** Import specifier for the module (alias or relative, no extension),
+   *  relative to the assembly dir. See {@link repoImportSpecifier}. */
   moduleImportSpecifier: string;
+  /** Absolute path of the repo source file (`…/<plural>/<entity>.repository.ts`).
+   *  Exposed so emitters whose output dir differs from the assembly dir can
+   *  recompute a correct relative specifier (#528). */
+  repoFileAbs: string;
+  /** Absolute path of the module source file (`…/<plural>/<plural>.module.ts`). */
+  moduleFileAbs: string;
 }
 
 export interface ResolveEntityModuleImportsInput {
@@ -417,8 +428,12 @@ function pluralPascalCase(plural: string): string {
 
 /** Express an absolute target file (no extension) as an alias import if any
  *  alias target dir is a prefix, else as a relative import from `fromDirAbs`.
- *  Always emits POSIX separators and strips the `.ts` extension. */
-function toImportSpecifier(
+ *  Always emits POSIX separators and strips the `.ts` extension.
+ *
+ *  Exported (#528) so emitters whose output directory differs from the assembly
+ *  dir — e.g. the sink base in `integrations/<surface>/sinks/` vs the assembly in
+ *  `…/modules/<provider>/` — can recompute the repo import at the correct depth. */
+export function toImportSpecifier(
   targetFileAbs: string,
   fromDirAbs: string,
   aliases: Record<string, string>,
@@ -488,5 +503,7 @@ export function resolveEntityModuleImports(
     moduleClass,
     repoImportSpecifier: toImportSpecifier(repoFileAbs, assemblyDirAbs, input.aliases),
     moduleImportSpecifier: toImportSpecifier(moduleFileAbs, assemblyDirAbs, input.aliases),
+    repoFileAbs,
+    moduleFileAbs,
   };
 }

--- a/src/cli/shared/sink-emission-generator.ts
+++ b/src/cli/shared/sink-emission-generator.ts
@@ -42,8 +42,8 @@
  * Built by explicit field enumeration so it type-checks against `<Entity>IntegrationWrite`
  * with no spread/cast:
  *   - `externalId` — always present.
- *   - copy-through fields (`copyThroughFields` — post-exclusion), one `<f>: record.<f>` each,
- *     EXCEPT `userId` (sourced from the method param — bare `userId,` shorthand).
+ *   - copy-through fields (`copyThroughFields` — post-exclusion), one `<f>: record.<f>` each
+ *     (`userId`, if declared, is just another copy-through field — `record.userId`).
  *   - FK external join-keys — emitted as `<writeKey>: null` + SEAM comment. The
  *     projection-default canonical has no external-key member; null is write-safe (the
  *     repo's `!== null` guard skips it, `integrated-entity-repository.ts:118-120`). Replace
@@ -67,11 +67,13 @@
  *   - External-key reconstruction on the find side (a local `accountId` ≠ `accountExternalId`).
  *   - Dropping local-only projection columns when you widen the canonical.
  *
- * ## `userId` is NOT injected — it is a declared field
+ * ## `userId` is a plain declared field — read from `record`
  *
- * If the entity declares a `user_id` field, `userId` is sourced from the method parameter
- * (the authenticated user), emitted as a bare `userId,` shorthand — matching swe-brain's
- * hand-authored sinks. If NOT declared, the write object omits `userId` entirely.
+ * If the entity declares a `user_id` field, `userId` is on the projection and the write
+ * reads it via `record.userId`, exactly like any other copy-through field. If NOT declared,
+ * the write object omits `userId` entirely. (Pre-#528 emit special-cased it as a bare
+ * `userId,` shorthand — but the standalone `default<E>BuildWrite(record)` has only `record`
+ * in scope, so the shorthand was an undeclared binding → TS18004; the base never compiled.)
  *
  * ## @Injectable() — OMITTED (OQ2 CLOSED, #491)
  *
@@ -81,10 +83,6 @@
  */
 
 import { subsystemsImport, type RuntimeMode } from "./runtime-import";
-
-/** The camelCase name of the user-scoping field — sourced from the sink's
- *  `userId` parameter rather than the canonical record. */
-const USER_ID_FIELD = "userId";
 
 // ============================================================================
 // Input
@@ -230,15 +228,18 @@ function assertIntegrated(input: SinkEmitInput): void {
 // Shared body builders (reused by both emitters)
 // ============================================================================
 
-function buildWriteBodyLines(input: SinkEmitInput, n: SinkNames): string[] {
-  const hasUserIdField = input.copyThroughFields.some(
-    (f) => f.camelName === USER_ID_FIELD,
+function buildWriteBodyLines(input: SinkEmitInput, _n: SinkNames): string[] {
+  // `userId` is a DECLARED copy-through field carried on the projection — it is
+  // read from `record.userId` exactly like every other field. (Earlier emit
+  // special-cased it as a bare `userId,` shorthand "sourced from the method
+  // param" — but `default<E>BuildWrite(record)` is a standalone function with
+  // ONLY `record` in scope, so the shorthand referenced an undeclared binding →
+  // TS18004 and the generated base never compiled. Issue #528.)
+  const copyThroughLines = input.copyThroughFields.map(
+    (f) => `      ${f.camelName}: record.${f.camelName},`,
   );
-  const copyThroughLines = input.copyThroughFields
-    .filter((f) => f.camelName !== USER_ID_FIELD)
-    .map((f) => `      ${f.camelName}: record.${f.camelName},`);
   const fkLines = input.fkExternalKeys.flatMap((fk) => [
-    `      // SEAM (FK external key — null until you widen ${n.projectionType} to carry \`${fk.writeKey}\`):`,
+    `      // SEAM (FK external key — null until you widen ${_n.projectionType} to carry \`${fk.writeKey}\`):`,
     `      // Replace null with record.${fk.writeKey} after widening. Write-safe: repo skips null FKs.`,
     `      ${fk.writeKey}: null,`,
   ]);
@@ -257,11 +258,6 @@ function buildWriteBodyLines(input: SinkEmitInput, n: SinkNames): string[] {
       `      // FK external join-keys (null until canonical widens to carry them):`,
       ...fkLines,
     );
-  }
-  if (hasUserIdField) {
-    // `userId` is sourced from the authenticated-user param, not the vendor
-    // record — matches swe-brain's hand-authored sinks.
-    lines.push(`      userId,`);
   }
   return lines;
 }

--- a/test/integration-emit/assembly-contract.test.ts
+++ b/test/integration-emit/assembly-contract.test.ts
@@ -254,13 +254,13 @@ describe("E4 · sink base file (@generated) assertions — FK belongs_to + user_
     expect(base).not.toContain("TODO(author)");
   });
 
-  test("bare `userId,` ONLY in defaultContactBuildWrite because user_id is declared", () => {
+  test("declared user_id is a plain copy-through — `userId: record.userId` (#528: bare shorthand was TS18004)", () => {
     const buildWriteFn = base.slice(
       base.indexOf("export function defaultContactBuildWrite("),
       base.indexOf("export function defaultContactToCanonicalView("),
     );
-    expect(buildWriteFn).toContain("userId,");
-    expect(buildWriteFn).not.toContain("userId: record.userId");
+    expect(buildWriteFn).toContain("userId: record.userId,");
+    expect(buildWriteFn).not.toMatch(/^\s*userId,\s*$/m);
   });
 
   test("copies the non-FK, non-userId scalar (email) through in defaultContactBuildWrite", () => {


### PR DESCRIPTION
Two defects in the #491 Shape C sink-seam emitter made **every** emitted `*.sink.generated.ts` base non-compiling for the swe-brain (relative-path) layout at 0.26.0 — 12 errors across 6 entities (the bases were excluded from the swe-brain consumption PR because none compiled). Both slipped past CI: the §3b gate (`sink-widened-canonical.gate.test.ts`) stubbed the repo import **same-dir** (so it never exercised depth) with a fixture that has **no `user_id` field**, and the smoke fixtures use tsconfig **aliases** (so the relative-path bug never manifested).

## Defect 1 — repo import one level too deep (TS2307)

The sink base lives at `integrations/<surface>/sinks/` — **3 deep** under `src/`. But the caller reused `loc.repoImportSpecifier`, which `resolveEntityModuleImports` computes relative to the **assembly** dir `integrations/<surface>/modules/<provider>/` — **4 deep**. So it emitted:

```ts
import type { ... } from '../../../../modules/messages/message.repository';
```

…which lands at the **repo root**, not `src/`. Correct from `sinks/` is `../../../`.

**Fix** (root cause, not a hardcoded decrement): the caller now recomputes the specifier **relative to the sink dir** from the resolved repo file path, alias-aware via the same `toImportSpecifier` helper the assembly uses (now exported; `EntityModuleLocation` carries `repoFileAbs` / `moduleFileAbs`). The assembly import depth is unchanged — its test still asserts `../../../../modules/…`. Verified the geometry invariant `outputRoot === backendSrcAbs/integrations` (set in `entity.ts`), so `relative(sinksDir, repoFileAbs)` yields the correct `../../../modules/…`.

## Defect 2 — bare `userId,` shorthand (TS18004)

`default<E>BuildWrite(record)` is a **standalone function with only `record` in scope**, but a declared `user_id` field was special-cased OUT of the copy-through loop and re-added as a bare `userId,` shorthand — referencing a binding that doesn't exist. The stale header claimed `userId` is "sourced from the method param", but the standalone function has no such param.

**Fix:** `userId` is a plain projection field — now emitted as `userId: record.userId`, exactly like every other copy-through field. Removed the dead `USER_ID_FIELD` special-casing and corrected the header docs.

## Corrected emitted output (what a clean regen now looks like)

Import (relative layout):
```ts
import { MessageRepository, type MessageIntegrationProjection, type MessageIntegrationWrite }
  from '../../../modules/messages/message.repository';
```
buildWrite (entity with `user_id` + a belongs_to FK):
```ts
export function defaultMessageBuildWrite(record: MessageIntegrationProjection): MessageIntegrationWrite {
  return {
      externalId: record.externalId,
      // copy-through fields (one line per `fields:` entry):
      userId: record.userId,
      body: record.body,
      // FK external join-keys (null until canonical widens to carry them):
      channelExternalId: null,
  };
}
```

## Validation (the gates the prior tests missed)

- **`sink-swe-brain-layout.compile.test.ts` (NEW)** — runs the real `emitAdapters` into a swe-brain-shaped tree (`integrations/<surface>/sinks/` + `modules/<plural>/<entity>.repository.ts`, **no alias**, a `user_id` field) and `tsc --noEmit`s the emitted base. This is the compile-level proof the §3b gate couldn't give.
- **`adapter-emission-generator.test.ts`** — relative-path geometry: sink base `../../../modules/…` vs assembly `../../../../modules/…`; plus an alias-layout case (depth-independent).
- **Fixed the encoded-bug assertions** in `sink-emission-generator.test.ts` and `test/integration-emit/assembly-contract.test.ts` that previously locked in the bare `userId,` shorthand (per the 0.15.3 mapping.target lesson — a fixture that encodes the bug).

Full CI gate (`just test-all`) green locally; `smoke-integration` (full integration tree + tsc) passes; the snapshot needs no re-baseline (its fixtures use the alias layout + have no `user_id`, so the emitted bytes are unchanged there). The repo's own `tsc -p tsconfig.build.json` has the same 3 pre-existing `src/cli/{junction,barrel-generator}.ts` errors as origin/main — zero new errors in the touched files.

## Release

`0.26.0 → 0.26.1` + CHANGELOG (merge to main auto-publishes to npm).

Validated as the consuming dogfood: **swe-brain** (6 sink bases regenerated at 0.26.0).

Fixes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)