### PR TITLE
fix(events): gate scheduled-event drain on occurred_at <= now

### DIFF
--- a/runtime/subsystems/events/event-bus.drizzle-backend.ts
+++ b/runtime/subsystems/events/event-bus.drizzle-backend.ts
@@ -30,7 +30,7 @@
  */
 import { randomUUID } from 'node:crypto';
 import { Injectable, OnModuleDestroy, OnModuleInit, Inject, Logger, Optional } from '@nestjs/common';
-import { eq, and, inArray, asc, desc, gte, lt, or, sql, type SQL } from 'drizzle-orm';
+import { eq, and, inArray, asc, desc, gte, lt, lte, or, sql, type SQL } from 'drizzle-orm';
 import type {
   DomainEvent,
   DrizzleTransaction,
@@ -584,10 +584,22 @@ export class DrizzleEventBus implements IEventBus, IEventReadPort, OnModuleInit,
   private async processBatch(): Promise<void> {
     const pools = this.opts.pools;
 
-    // Build WHERE: status='pending' [AND pool IN (...)]
+    // Build WHERE: status='pending' AND occurred_at <= now [AND pool IN (...)].
+    //
+    // The readiness gate (`occurred_at <= now`) is what makes a scheduler-
+    // materialised *future* slot wait. The EventScheduler pre-inserts the next
+    // slot with `occurred_at = slotStart` in the future and deliberately does
+    // NOT NOTIFY-wake the drainer for it (see materializeScheduledEvent: a
+    // future slot is claimed by polling once its `occurred_at` passes). Without
+    // this predicate the claim is status-only, so the very next poll grabs the
+    // future-dated row and stamps `processed_at = now()` early — surfacing rows
+    // that read "N minutes from now" yet are already processed, and firing
+    // scheduled triggers up to one interval ahead of their slot. Normal events
+    // publish with `occurred_at = now()`, so the gate is transparent to them.
+    const ready = lte(domainEvents.occurredAt, new Date());
     const whereClause: SQL<unknown> = pools && pools.length > 0
-      ? (and(eq(domainEvents.status, 'pending'), inArray(domainEvents.pool, pools)) as SQL<unknown>)
-      : eq(domainEvents.status, 'pending');
+      ? (and(eq(domainEvents.status, 'pending'), ready, inArray(domainEvents.pool, pools)) as SQL<unknown>)
+      : (and(eq(domainEvents.status, 'pending'), ready) as SQL<unknown>);
 
     // Claim a batch with FOR UPDATE SKIP LOCKED so multiple pollers don't
     // double-dispatch. The lock is released when the outer transaction

--- a/src/__tests__/runtime/subsystems/event-bus.spec.ts
+++ b/src/__tests__/runtime/subsystems/event-bus.spec.ts
@@ -701,12 +701,14 @@ describe('DrizzleEventBus', () => {
 
       expect(selectBuilder.where).toHaveBeenCalledTimes(1);
       const tokens = flatten(selectState.whereArg);
-      // Both the status predicate and the inArray(pool, ...) fragment
-      // should be present in the composed WHERE.
+      // The status predicate, the inArray(pool, ...) fragment, and the
+      // occurred_at readiness gate should all be present in the composed WHERE.
       expect(tokens).toContain('col:pool');
       expect(tokens).toContain('events_change');
       expect(tokens).toContain('col:status');
       expect(tokens).toContain('pending');
+      // Readiness gate: occurred_at <= now keeps future scheduler slots unclaimed.
+      expect(tokens).toContain('col:occurred_at');
       // The FOR UPDATE SKIP LOCKED modifier was applied to the claim.
       expect(selectBuilder.for).toHaveBeenCalledWith('update', { skipLocked: true });
     });
@@ -719,9 +721,11 @@ describe('DrizzleEventBus', () => {
 
       expect(selectBuilder.where).toHaveBeenCalledTimes(1);
       const tokens = flatten(selectState.whereArg);
-      // Only the status='pending' predicate; no pool reference.
+      // The status='pending' predicate and the occurred_at readiness gate, but
+      // no pool reference.
       expect(tokens).toContain('col:status');
       expect(tokens).toContain('pending');
+      expect(tokens).toContain('col:occurred_at');
       expect(tokens).not.toContain('col:pool');
     });
 
@@ -734,6 +738,39 @@ describe('DrizzleEventBus', () => {
       expect(selectBuilder.where).toHaveBeenCalledTimes(1);
       const tokens = flatten(selectState.whereArg);
       expect(tokens).not.toContain('col:pool');
+    });
+
+    it('gates the claim on occurred_at <= now so future scheduler slots are not claimed early', async () => {
+      // Collect Date leaves from the SQL AST — the readiness bound is the only
+      // Date param in the claim WHERE (status/pool params are strings).
+      function findDates(node: unknown, out: Date[] = [], seen = new Set<unknown>()): Date[] {
+        if (node instanceof Date) {
+          out.push(node);
+          return out;
+        }
+        if (node === null || typeof node !== 'object' || seen.has(node)) return out;
+        seen.add(node);
+        const values = Array.isArray(node) ? node : Object.values(node as Record<string, unknown>);
+        for (const v of values) findDates(v, out, seen);
+        return out;
+      }
+
+      const { db, selectState } = makeMockDb();
+      const bus = new DrizzleEventBus(db as never, { backend: 'drizzle' });
+
+      const before = Date.now();
+      await bus.drainOnce();
+      const after = Date.now();
+
+      // The WHERE references occurred_at (the readiness gate) — distinct from
+      // the orderBy(occurred_at), which is captured separately as orderByArg.
+      expect(flatten(selectState.whereArg)).toContain('col:occurred_at');
+      // …and the bound is "now", stamped at claim time (not a fixed/past value),
+      // so the gate tracks wall-clock forward across poll cycles.
+      const dates = findDates(selectState.whereArg);
+      expect(dates.length).toBe(1);
+      expect(dates[0]!.getTime()).toBeGreaterThanOrEqual(before);
+      expect(dates[0]!.getTime()).toBeLessThanOrEqual(after);
     });
   });
 


### PR DESCRIPTION
## Problem

A consumer (swe-brain) noticed its event-log firehose showing rows like `reconcile_due` / `watch_renewal_due` / `schedule_tick_due` with a **future** "WHEN" (`36m from now`) yet **`status: processed`** — both at once, which is nonsensical.

Root cause is in the drainer's claim query. `EventScheduler.materializeTick()` pre-inserts the *next* slot with `occurred_at = slotStart` in the future, and `materializeScheduledEvent()` deliberately does **not** NOTIFY-wake the drainer for a future slot — its own doc says:

> a future slot is claimed by polling once `occurred_at` passes.

But `processBatch()` composed a **status-only** claim:

```ts
const whereClause = pools?.length
  ? and(eq(status,'pending'), inArray(pool, pools))
  : eq(status,'pending');
```

No `occurred_at <= now` predicate. So the 1s fallback poll grabbed the future-dated pending row on the very next cycle and stamped `processed_at = now()`. Two visible symptoms:

1. **Future-dated rows show `processed`** in the event log (the report above).
2. **Schedule-driven triggers fire up to one interval early** — the pre-materialised next slot runs at materialisation time, not at its boundary. (Slot-keyed `ON CONFLICT DO NOTHING` still guarantees one fire per slot, so chains don't double-run or die — they're just phase-shifted early.)

## Fix

Add the readiness gate the contract already promised, to both WHERE branches:

```ts
const ready = lte(domainEvents.occurredAt, new Date());
const whereClause = pools?.length
  ? and(eq(status,'pending'), ready, inArray(pool, pools))
  : and(eq(status,'pending'), ready);
```

- Future slots stay `pending` until their boundary, then the 1s fallback poll claims them within ~1s of becoming due — exactly the documented intent.
- Normal events publish with `occurred_at = now()`, so the gate is transparent to them.
- Claim-time `new Date()` matches the wall-clock already used at the `processed_at` stamp and the NOTIFY-wake decision in `materializeScheduledEvent` — same clock domain, no app/DB skew introduced.

## Tests

- Extended the existing `processBatch — pool filter plumbed into WHERE` specs to assert `col:occurred_at` appears in the claim WHERE in **both** the pooled and pool-less branches.
- Added a focused spec asserting the gate binds a single Date param stamped at claim time (`before ≤ bound ≤ after`).
- Full unit suite green: **3015 pass / 0 fail** (`just test-unit`).

> Note: `bun run typecheck` reports 3 pre-existing errors in `src/cli/{commands/junction.ts,shared/barrel-generator.ts}` on `main` — unrelated to this change and not gated by CI (`test-all` runs `test-unit`, not the `tsconfig.build.json` typecheck; `tsup`/esbuild builds don't full-typecheck). The runtime file in this PR typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)