### PR TITLE
chore(release): 0.27.1 — scheduled-event drain readiness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.1] — 2026-06-07
+
+### Fixed
+
+- **Scheduled-event drain no longer claims future slots early (#533).**
+  `DrizzleEventBus.processBatch()` composed a status-only claim
+  (`status='pending'` [+ pool IN …]) with no readiness predicate, so the 1s
+  fallback poll grabbed the `EventScheduler`'s pre-materialised *next* slot
+  (`occurred_at = slotStart`, in the future) on the very next cycle and stamped
+  `processed_at = now()` — contradicting `materializeScheduledEvent`'s own
+  contract ("a future slot is claimed by polling once `occurred_at` passes").
+  Symptoms: event-log rows reading "N minutes from now" yet already
+  `status:processed`, and schedule-driven triggers firing up to one interval
+  ahead of their slot. Fix: add `occurred_at <= now` to the claim WHERE (both
+  the pooled and pool-less branches). Normal events publish with
+  `occurred_at = now()`, so the gate is transparent to them.
+
+## [0.27.0] — 2026-06-07
+
+### Added
+
+- **Pagination by default (#532): `Page<T>` list emit + `store.<entity>.useData()`.**
+  See PR #532. (CHANGELOG entry backfilled in 0.27.1.)
+
 ## [0.26.1] — 2026-06-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Why

#533 (the `occurred_at <= now` claim gate) merged on top of the already-published `0.27.0` **without a version bump**, so the CI publish step's registry guard skipped it (`0.27.0` already on npm). The fix is on `main` but not on npm.

This bumps `package.json` → `0.27.1` so the merge auto-publishes the fix.

## Changes

- `package.json`: `0.27.0` → `0.27.1`.
- `CHANGELOG.md`: `0.27.1` entry for the drain readiness gate (#533), plus a backfilled `0.27.0` entry (the #532 pagination release shipped without one — the log top was `0.26.1` while npm was `0.27.0`).

No code changes.

## After merge

`0.27.1` publishes to npm → swe-brain consumes (bump pin → regen → biome ×2). Future scheduler slots then sit `pending` until due instead of being claimed early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)