### PR TITLE
fix(bridge): audit-tier guard fires only on genuine drift (no false-positive WARN)

### DIFF
--- a/.claude/skills/bridge/SKILL.md
+++ b/.claude/skills/bridge/SKILL.md
@@ -74,11 +74,14 @@ Default configuration gives parallelism, not ordering. For per-aggregate orderin
 
 ### Audit-tier guard (defense-in-depth)
 
-`tier:audit` events (lifecycle / observability — `crm_sync_started`, etc.) are **not bridge-eligible**. The codegen-side validator (AUDIT-2) blocks the registry from listing them as triggers, so the registry is the **primary** enforcement. `BridgeOutboxDrainHook.processEvent` adds a **defense-in-depth** runtime guard at the very top of the method:
+`tier:audit` events (lifecycle / observability — `crm_sync_started`, `connection.created`, etc.) are **not bridge-eligible**. The codegen-side validator (AUDIT-2) blocks the registry from listing them as triggers, so the registry is the **primary** enforcement. `BridgeOutboxDrainHook.processEvent` adds a **defense-in-depth** runtime guard — but the guard runs **after** the registry lookup, and the distinction matters:
 
-- If `event.metadata.tier === 'audit'`, the hook short-circuits, writes no `bridge_delivery` rows, and returns `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }`.
-- A WARN log fires once per `(event_type, process)` via a `Set<string>` (`warnedAuditTypes`) — finer-grained than the once-per-process `warnedNullDirection` flag, so drift in a specific event type surfaces without flooding logs across many types.
-- Reaching the guard is a drift signal: an out-of-band `bridge_trigger` row exists, or there's version skew during deploy. The `auditBlocked` count on `BridgeOutboxDrainResult` rides on every per-event drain return so observability layers can aggregate without a new protocol method.
+- **Audit event WITH a registered trigger** (genuine drift — AUDIT-2 should have prevented it): the hook short-circuits, writes no `bridge_delivery` rows, returns `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }`, and logs a WARN naming the offending trigger id(s). A WARN fires once per `(event_type, process)` via a `Set<string>` (`warnedAuditTypes`). `auditBlocked` rides on every per-event drain return so observability layers can aggregate without a new protocol method.
+- **Audit event with NO trigger** (the common, benign case — a lifecycle event sharing the outbox with domain events): returns all zeros (`auditBlocked: 0`), **silently**. No WARN.
+
+> **Non-obvious rule (do not get this wrong).** The guard's WARN is **not** "an audit event reached the drain." Audit events reach the drain constantly — they share the outbox. The drift signal is specifically *audit-tier event + a trigger registered against it*. Warning on every audit event is a false positive (the bug fixed 2026-06-07; see plan §AUDIT-4 revision note + `ai-docs/specs/2026-06-07-bridge-audit-guard-false-positive.md`). The guard MUST look up triggers before deciding to warn.
+
+> **To make a workflow/directive react to a lifecycle moment** (e.g. "when a connection is created, do X"), **emit a typed domain change-fact — never make the audit lifecycle event bridge-eligible.** Declare a domain-tier change event on the entity's `events:` block (the `message_created` path / EMIT-CHANGES seam, `docs/specs/EMIT-CHANGES-1.md`). That gives the engine a bridge-eligible domain event to bind a trigger to, while the audit tier stays inert. Promoting the audit event would defeat the AUDIT-2 invariant and re-introduce the false-positive class above.
 
 Spec reference: `ai-docs/specs/issue-242/plan.md` §AUDIT-4.
 

--- a/ai-docs/specs/2026-06-07-bridge-audit-guard-false-positive.md
+++ b/ai-docs/specs/2026-06-07-bridge-audit-guard-false-positive.md
@@ -1,0 +1,158 @@
+# Bridge audit-tier guard — fire only on genuine drift Spec
+
+Revises AUDIT-4 (`ai-docs/specs/issue-242/plan.md`). Dogfood discovery from swe-brain.
+
+## Overview
+
+`BridgeOutboxDrainHook.processEvent` emits a false-positive WARN for every
+audit-tier event that flows through the outbox. The warning claims a
+`bridge_trigger` row "exists out-of-band" — a registry/runtime-drift condition it
+never actually checks. Audit-tier lifecycle events (`connection.created`,
+`connection.field_changed`, …) share the outbox with domain events and carry **no**
+triggers; the drain scans every row, hits them, and warns once per type. This
+delivers the fix: the guard fires **only** when an audit event genuinely has a
+registered trigger (the real drift), and is silent for the benign
+shared-outbox case.
+
+## Root cause (confirmed against source)
+
+`runtime/subsystems/bridge/bridge-outbox-drain-hook.ts:90-98`:
+
+```ts
+if (event.metadata?.['tier'] === 'audit') {
+  this.warnAuditBlockedOnce(event);          // fires unconditionally
+  return { delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 };
+}
+const triggers = this.lookupTriggers(event.type);   // L100 — never reached for audit
+```
+
+The guard returns **before** `lookupTriggers` runs, so it cannot know whether a
+trigger exists. Yet `warnAuditBlockedOnce` (L250-258) prints
+`"…a bridge_trigger row exists out-of-band. Investigate registry/runtime drift."`
+— asserting the very fact it skipped checking.
+
+This faithfully implements the **original** AUDIT-4 design
+(`issue-242/plan.md:115`): *"Position the guard at the top of `processEvent`
+(above the existing `lookupTriggers` call)."* That design assumed audit events
+reach the guard only via drift. In practice, audit-tier lifecycle events flow
+through the shared outbox continuously — the benign case the spec assumed away.
+
+## Contract safety
+
+`processEvent`'s return value is **discarded** at
+`runtime/subsystems/events/event-bus.drizzle-backend.ts:635`
+(`await this.bridgeHook.processEvent(event, tx);` — result unused).
+`auditBlocked` has **zero runtime consumers**; it is observability/doc surface
+only (grep confirms: only the protocol doc + an event-bus test stub reference
+it). Changing benign-audit from `auditBlocked:1` to `auditBlocked:0` is safe.
+
+## The fix — reorder so the guard signals genuine drift
+
+In `processEvent`, look up triggers **first**, then branch on audit tier:
+
+- `tier === 'audit'` **and** `triggers.length > 0` → **genuine drift**: an audit
+  event that actually has a registered trigger (codegen-side AUDIT-2 validation
+  should have prevented this). Warn (the message is now *true*) and return
+  `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }`. No fanout
+  rows written. Enrich the WARN with the offending trigger id(s) for debugging.
+- `tier === 'audit'` **and** `triggers.length === 0` → **benign** shared-outbox
+  case. Return all-zeros (`auditBlocked: 0`), **silent**. ← kills the
+  `connection.created` / `connection.field_changed` warning.
+- Non-audit → unchanged.
+
+**Rejected alternative:** filtering `tier='audit'` at the outbox SELECT in the
+event bus. Wrong blast radius — audit events still need the normal drain
+(`processed_at` stamp + subscriber dispatch); only *bridge fanout* must skip
+them. The reorder keeps the change scoped to the one hook.
+
+The per-`(event_type, process)` WARN dedup (`warnedAuditTypes` Set) and the
+once-per-process null-direction warning are preserved.
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `runtime/subsystems/bridge/bridge-outbox-drain-hook.ts` | modify | Reorder: `lookupTriggers` before the audit branch; guard fires only when `triggers.length > 0`; benign audit returns zeros silently; enrich drift WARN with trigger id(s). |
+| `src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts` | modify | Fix the two tests that encode the bug; add the benign-audit regression test. |
+| `runtime/subsystems/bridge/bridge.protocol.ts` | modify | Update `auditBlocked` field doc + `IBridgeOutboxDrainHook` step-0 behaviour doc to the refined semantics. |
+| `ai-docs/specs/issue-242/plan.md` | modify | Dated revision note on AUDIT-4 (decision revisited on grounds that no longer apply). |
+| `.claude/skills/bridge/SKILL.md` | modify | (a) Correct the "Audit-tier guard" section (L75-85) — it encodes the same bug ("at the very top of the method", "reaching the guard is a drift signal: an out-of-band `bridge_trigger` row exists"). (b) Add a non-obvious rule for reacting to lifecycle events. |
+
+## Implementation steps
+
+1. **Hook reorder** (`bridge-outbox-drain-hook.ts`):
+   - Move `const triggers = this.lookupTriggers(event.type)` above the audit
+     branch.
+   - Replace the `tier === 'audit'` early-return with:
+     `if (event.metadata?.['tier'] === 'audit') { if (triggers.length > 0) { this.warnAuditBlockedOnce(event, triggers); return { …, triggerCount: 0, auditBlocked: 1 }; } return { …all zeros }; }`
+   - Keep the existing `triggers.length === 0 → zeros` short-circuit for the
+     non-audit path (now naturally after the audit branch).
+   - Update `warnAuditBlockedOnce(event, triggers)` to include the offending
+     `triggerId`(s) in the message. Update the leading comment block (L85-89) to
+     describe the refined "drift = audit + registered trigger" semantics.
+
+2. **Tests** (`bridge-outbox-drain-hook.spec.ts`):
+   - `'dedups WARN per event type within a single process'` (L376-389) and
+     `'emits a fresh WARN when a different audit event type is seen'` (L391-408):
+     currently construct the hook with an **empty** registry yet assert
+     `auditBlocked:1` + WARN. Rewrite to register a trigger against the audit
+     event type(s) so the drift (and therefore the WARN) is real.
+   - Keep `'blocks fanout when an audit event reaches an out-of-band trigger'`
+     (L343) — already a drift scenario; assert the message now contains the
+     trigger id.
+   - **Add** `'stays silent for an audit event with no registered trigger
+     (benign shared-outbox case)'`: empty registry + audit event → result
+     `{ delivered:0, dedupSkips:0, triggerCount:0, auditBlocked:0 }`, `calls`
+     length 0, `warnSpy` not called. This is the `connection.created` regression
+     guard.
+
+3. **Protocol doc** (`bridge.protocol.ts`): rewrite the `auditBlocked` field
+   comment (~L337-344) and `IBridgeOutboxDrainHook` step 0 (~L379-386) to:
+   guard fires (`auditBlocked:1` + per-type WARN) **only** when an audit event
+   has a registered trigger; benign audit events with no trigger return zeros
+   silently and produce no log.
+
+4. **Spec revision** (`issue-242/plan.md` AUDIT-4): add a dated revision note —
+   the top-of-function guard (L115) produced false positives because audit-tier
+   lifecycle events flow through the shared outbox routinely (benign case the
+   acceptance criteria omitted); guard refined to fire only on
+   `audit + registered trigger`; add the new benign-audit acceptance criterion.
+
+5. **Bridge skill** (`.claude/skills/bridge/SKILL.md`):
+   - Correct the "Audit-tier guard (defense-in-depth)" section (L75-85): it
+     currently states the guard sits "at the very top of the method" (L78) and
+     that "Reaching the guard is a drift signal: an out-of-band `bridge_trigger`
+     row exists" (L81) — both now false. Rewrite to: the guard runs **after**
+     trigger lookup and fires (`auditBlocked:1` + per-type WARN) **only** when an
+     audit event has a registered trigger; benign audit events (the common case
+     — lifecycle events sharing the outbox) return zeros silently.
+   - Add a non-obvious rule (the dogfood lesson): **to make a workflow/directive
+     react to a lifecycle moment (e.g. "a connection was created"), emit a typed
+     domain change-fact** — declare it on the entity `events:` block (the
+     `message_created` path) / EMIT-CHANGES seam — **never make the audit
+     lifecycle event bridge-eligible.** The audit tier stays inert by design;
+     promoting it would defeat the AUDIT-2 invariant and re-introduce exactly the
+     false-positive class this fix removed.
+
+## Forward pointer (not implemented here)
+
+If swe-brain (or any consumer) wants a directive to fire on connection lifecycle,
+the consumer declares a domain change event on its `connection` entity
+(`events:` / EMIT-CHANGES) — a bridge-eligible domain-tier fact distinct from the
+inert `connection.created` audit event. That is the consumer's product decision
+and lives in the consumer repo, not in this codegen fix. Captured as a bridge
+SKILL.md rule so the next person hits the answer, not the rake.
+
+## Acceptance
+
+- Audit event + **registered trigger** → `auditBlocked:1`, no fanout rows, WARN
+  fires once per type, message includes the trigger id.
+- Audit event + **no trigger** → all-zeros, **no WARN**, no inserts.
+- Domain event (valid triggers / no triggers) → unchanged.
+- `just test-unit` green.
+
+## Out of scope
+
+- swe-brain consumer side (stops once codegen is published + consumed).
+- Outbox SELECT changes / event-bus drain changes.
+- Any `IObservability` aggregate read for audit blocks (still AUDIT-6 territory).

--- a/ai-docs/specs/issue-242/plan.md
+++ b/ai-docs/specs/issue-242/plan.md
@@ -111,6 +111,29 @@ This plan takes #219 from "design merged" to "consumers can rely on it." The wor
 
 ### AUDIT-4: Runtime — Bridge dispatcher guard + WARN dedup + return-shape signal
 
+> **Revision (2026-06-07) — guard fires only on genuine drift.** The original
+> design below ("Position the guard at the **top** of `processEvent`, above the
+> `lookupTriggers` call") warned for **every** audit-tier event. That assumed
+> audit events reach the guard only via drift. In dogfood (swe-brain), audit-tier
+> *lifecycle* events (`connection.created`, `connection.field_changed`, …) flow
+> through the shared outbox routinely with **no** triggers — the benign case the
+> acceptance criteria never covered. The unconditional guard turned every such
+> event into a false-positive WARN claiming an out-of-band `bridge_trigger` row
+> it never checked for.
+>
+> **Revised behaviour:** run `lookupTriggers` **first**, then branch on tier.
+> `tier === 'audit'` *and* `triggers.length > 0` → genuine drift: WARN (now a
+> verified claim, naming the offending trigger id) + `auditBlocked: 1`.
+> `tier === 'audit'` *and* no triggers → benign: return zeros, **silent**.
+> The drift signal is preserved; the false positive is gone. The SELECT-level
+> `tier='audit'` filter was rejected — audit events still need the normal drain
+> (`processed_at` + subscriber dispatch); only *bridge fanout* skips them.
+>
+> **Added acceptance:** audit event with **no** registered trigger → all zeros,
+> `auditBlocked: 0`, no WARN, no inserts (the `connection.created` regression
+> guard). See `ai-docs/specs/2026-06-07-bridge-audit-guard-false-positive.md`.
+> The bullets below are the *original* (superseded) design, kept for provenance.
+
 **Scope:** Update bridge outbox drain hook at `runtime/subsystems/bridge/bridge-outbox-drain-hook.ts` (path confirmed; matches dealbrain-v2). The hook already uses a once-per-process WARN dedup pattern (`warnedNullDirection`, L60/L86-97) for null-direction events — extend the same pattern for audit-tier blocks:
 - **Position the guard at the top of `processEvent`** (above the existing `lookupTriggers` call at L72). If `event.metadata?.tier === 'audit'`, return `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }` immediately. The existing trigger-lookup short-circuit at L73-75 (no triggers → return zeros) is the same shape; this just adds an earlier check.
 - **Extend `BridgeOutboxDrainResult` with `auditBlocked: number`** in `runtime/subsystems/bridge/bridge.protocol.ts`. Same idiom as existing `delivered` / `dedupSkips` / `triggerCount`: per-event observability data piggybacked on the return. `0` for non-audit paths, `1` when the guard fires. Update the doc comment on the type to document the field. No in-memory state on the hook; no test-only accessor.

--- a/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
+++ b/runtime/subsystems/bridge/bridge-outbox-drain-hook.ts
@@ -82,22 +82,40 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
     event: DomainEvent,
     tx: DrizzleTransaction,
   ): Promise<BridgeOutboxDrainResult> {
-    // Audit-tier guard (defense-in-depth — AUDIT-4). Audit events are not
-    // bridge-eligible: the codegen-side validator (AUDIT-2) blocks the
-    // registry from listing them as triggers. Reaching this branch means
-    // registry/runtime drift — an out-of-band `bridge_trigger` insert, or
-    // version skew during deploy. Refuse fanout, surface drift via WARN.
+    const triggers = this.lookupTriggers(event.type);
+
+    // Audit-tier guard (defense-in-depth — AUDIT-4). Audit events are
+    // bridge-inert by design: the codegen-side validator (AUDIT-2) blocks the
+    // registry from listing them as triggers, so an audit event should never
+    // have a matched trigger. The guard runs AFTER the lookup so it can tell
+    // apart the two cases that share `tier === 'audit'`:
+    //   - triggers present → genuine registry/runtime drift (an out-of-band
+    //     `bridge_trigger` insert, or version skew during deploy). Refuse
+    //     fanout and surface the drift via WARN — now a verified claim, not a
+    //     guess. (Revises the original top-of-method guard, which warned for
+    //     every audit event: audit-tier lifecycle events like
+    //     `connection.created` routinely share the outbox with domain events,
+    //     so the unconditional warning was a false positive. See
+    //     ai-docs/specs/issue-242/plan.md §AUDIT-4 revision note.)
+    //   - no triggers → the common, benign case. Stay silent; auditBlocked: 0.
     if (event.metadata?.['tier'] === 'audit') {
-      this.warnAuditBlockedOnce(event);
+      if (triggers.length > 0) {
+        this.warnAuditBlockedOnce(event, triggers);
+        return {
+          delivered: 0,
+          dedupSkips: 0,
+          triggerCount: 0,
+          auditBlocked: 1,
+        };
+      }
       return {
         delivered: 0,
         dedupSkips: 0,
         triggerCount: 0,
-        auditBlocked: 1,
+        auditBlocked: 0,
       };
     }
 
-    const triggers = this.lookupTriggers(event.type);
     if (triggers.length === 0) {
       return {
         delivered: 0,
@@ -247,13 +265,18 @@ export class BridgeOutboxDrainHook implements IBridgeOutboxDrainHook {
     };
   }
 
-  private warnAuditBlockedOnce(event: DomainEvent): void {
+  private warnAuditBlockedOnce(
+    event: DomainEvent,
+    triggers: BridgeTriggerEntry[],
+  ): void {
     if (this.warnedAuditTypes.has(event.type)) return;
     this.warnedAuditTypes.add(event.type);
+    const triggerIds = triggers.map((t) => t.triggerId).join(', ');
     this.logger.warn(
       `Bridge guard blocked audit-tier event '${event.type}' (event.id=${event.id}). ` +
-        `Registry says this event is not bridge-eligible; a bridge_trigger row exists ` +
-        `out-of-band. Investigate registry/runtime drift.`,
+        `Audit events are not bridge-eligible, yet the registry has trigger(s) ` +
+        `registered against this type [${triggerIds}] — an out-of-band bridge_trigger ` +
+        `row or version skew. Investigate registry/runtime drift.`,
     );
   }
 

--- a/runtime/subsystems/bridge/bridge.protocol.ts
+++ b/runtime/subsystems/bridge/bridge.protocol.ts
@@ -334,14 +334,16 @@ export type BridgeRegistry = {
  * `triggerCount`: total triggers matched in the registry for this event;
  * `triggerCount === delivered + dedupSkips`.
  *
- * `auditBlocked`: number of events the dispatcher refused to fan out
- * because their `metadata.tier === 'audit'`. Audit-tier events are not
- * bridge-eligible; codegen errors block the registry from listing them
- * as triggers, so a non-zero value here indicates registry/runtime drift
- * (an out-of-band `bridge_trigger` insert, version skew during deploy).
- * Per-event: `0` when the guard does not fire, `1` when it does. Add it
- * to per-batch logging if your drain caller aggregates results. See
- * ai-docs/specs/issue-242/plan.md §AUDIT-4.
+ * `auditBlocked`: number of audit-tier events the dispatcher refused to fan
+ * out *because they had a trigger registered against them*. Audit-tier events
+ * are not bridge-eligible; codegen errors block the registry from listing them
+ * as triggers, so a non-zero value here indicates genuine registry/runtime
+ * drift (an out-of-band `bridge_trigger` insert, version skew during deploy).
+ * A benign audit-tier event — one with no matched trigger, the common case for
+ * lifecycle events sharing the outbox — returns `0` and produces no log.
+ * Per-event: `0` when the guard does not fire (including benign audit events),
+ * `1` when it fires on drift. Add it to per-batch logging if your drain caller
+ * aggregates results. See ai-docs/specs/issue-242/plan.md §AUDIT-4.
  */
 export interface BridgeOutboxDrainResult {
   delivered: number;
@@ -376,13 +378,17 @@ export interface IBridgeOutboxDrainHook {
    * job_run` row pairs for every matched trigger via the supplied `tx`.
    *
    * Behaviour:
-   *   0. **Audit-tier guard (defense-in-depth).** If
-   *      `event.metadata.tier === 'audit'`, returns
+   *   0. **Audit-tier guard (defense-in-depth).** Runs *after* the registry
+   *      lookup (step 1). If `event.metadata.tier === 'audit'` AND a trigger
+   *      is registered against the type (genuine drift — AUDIT-2 should have
+   *      prevented it), returns
    *      `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 1 }`
-   *      immediately and logs a per-`(event_type, process)` WARN. The
-   *      codegen-side validator (AUDIT-2) is the primary enforcement;
-   *      this guard catches out-of-band `bridge_trigger` inserts and
-   *      version skew during deploy. See
+   *      and logs a per-`(event_type, process)` WARN naming the offending
+   *      trigger id(s). If the audit event has *no* matched trigger (the
+   *      common, benign case — lifecycle events sharing the outbox), returns
+   *      all zeros (`auditBlocked: 0`) silently. The codegen-side validator
+   *      (AUDIT-2) is the primary enforcement; this guard catches out-of-band
+   *      `bridge_trigger` inserts and version skew. See
    *      ai-docs/specs/issue-242/plan.md §AUDIT-4.
    *   1. Looks up `bridgeRegistry[event.type]`. No matches → returns
    *      `{ delivered: 0, dedupSkips: 0, triggerCount: 0, auditBlocked: 0 }`;

--- a/src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts
+++ b/src/__tests__/runtime/subsystems/bridge-outbox-drain-hook.spec.ts
@@ -340,6 +340,18 @@ describe('BridgeOutboxDrainHook — audit-tier guard', () => {
     });
   }
 
+  // Drift registry: triggers registered against audit event types. AUDIT-2
+  // codegen validation should make this impossible — these tests simulate the
+  // out-of-band / version-skew drift the runtime guard is defense-in-depth for.
+  const DRIFT_REGISTRY: BridgeRegistry = {
+    crm_sync_started: [
+      { triggerId: 'side_effect_job#0', jobType: 'side_effect_job', map: () => ({}) },
+    ],
+    crm_sync_completed: [
+      { triggerId: 'other_side_effect#0', jobType: 'other_side_effect', map: () => ({}) },
+    ],
+  } as unknown as BridgeRegistry;
+
   it('blocks fanout when an audit event reaches an out-of-band trigger', async () => {
     // Out-of-band: registry has a trigger registered for an audit event
     // type (codegen-side AUDIT-2 should have prevented this — simulating
@@ -370,11 +382,32 @@ describe('BridgeOutboxDrainHook — audit-tier guard', () => {
       "Bridge guard blocked audit-tier event 'crm_sync_started'",
     );
     expect(message).toContain('event.id=audit-evt-1');
+    // The (now verified) drift claim names the offending trigger id.
+    expect(message).toContain('side_effect_job#0');
     expect(message).toContain('Investigate registry/runtime drift.');
   });
 
-  it('dedups WARN per event type within a single process', async () => {
+  it('stays silent for an audit event with no registered trigger (benign shared-outbox case)', async () => {
+    // The common case: an audit-tier lifecycle event (e.g. connection.created)
+    // sharing the outbox with domain events. No trigger → no drift → no WARN.
+    // This is the regression guard for the false-positive class.
     const hook = new BridgeOutboxDrainHook({} as BridgeRegistry);
+    const { tx, calls } = makeTx([]);
+
+    const result = await hook.processEvent(auditEvent(), tx as never);
+
+    expect(result).toEqual({
+      delivered: 0,
+      dedupSkips: 0,
+      triggerCount: 0,
+      auditBlocked: 0,
+    });
+    expect(calls).toHaveLength(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('dedups WARN per event type within a single process', async () => {
+    const hook = new BridgeOutboxDrainHook(DRIFT_REGISTRY);
 
     const a = await hook.processEvent(auditEvent(), makeTx([]).tx as never);
     const b = await hook.processEvent(
@@ -389,7 +422,7 @@ describe('BridgeOutboxDrainHook — audit-tier guard', () => {
   });
 
   it('emits a fresh WARN when a different audit event type is seen', async () => {
-    const hook = new BridgeOutboxDrainHook({} as BridgeRegistry);
+    const hook = new BridgeOutboxDrainHook(DRIFT_REGISTRY);
 
     await hook.processEvent(auditEvent(), makeTx([]).tx as never);
     await hook.processEvent(


### PR DESCRIPTION
## Problem (dogfood — swe-brain)

Running the generated app surfaced a WARN on every audit-tier lifecycle event:

```
WARN [BridgeOutboxDrainHook] Bridge guard blocked audit-tier event
  'connection.created' (event.id=…). Registry says this event is not
  bridge-eligible; a bridge_trigger row exists out-of-band. Investigate
  registry/runtime drift.
```

The guard (`processEvent`, introduced in #264 / #247) returned **before**
`lookupTriggers` ran, so it fired for *every* audit-tier event — then asserted
"a `bridge_trigger` row exists out-of-band," a condition it never checked.
`connection.created` / `connection.field_changed` are audit-tier lifecycle
events that share the outbox with domain events and carry **no** triggers. The
warning was a false positive; nothing was mis-wired.

## Fix

Run `lookupTriggers` first, then branch on tier:

| Case | Before | After |
|------|--------|-------|
| audit + **has** trigger (real drift) | WARN + `auditBlocked:1` | WARN (now *true*, names trigger id) + `auditBlocked:1` |
| audit + **no** trigger (`connection.created`) | ⚠️ false WARN + `auditBlocked:1` | **silent**, all-zeros |
| domain event | unchanged | unchanged |

The audit tier is bridge-inert by invariant (AUDIT-2 blocks audit events from
having triggers), so `audit + no trigger` is the normal state → silence; `audit
+ trigger` is the only real anomaly → the WARN belongs there and its message
becomes verifiable.

**Rejected:** filtering `tier='audit'` at the outbox SELECT — audit events still
need the normal drain (`processed_at` stamp + subscriber dispatch); only bridge
fanout must skip them. `processEvent`'s return is discarded at the drain caller
(`event-bus.drizzle-backend.ts`), so `auditBlocked` is observability/doc only —
no runtime consumer of the changed value.

## Tests

- The two specs that **encoded the bug** (empty registry yet asserting a WARN)
  now use a drift registry where the audit type genuinely has a trigger.
- **New** regression test: audit event + no trigger → all-zeros, no WARN, no
  inserts (the `connection.created` guard).
- `just test-unit` green — **3013 pass, 0 fail**.

## Docs (living-documentation, same PR)

- `bridge.protocol.ts` — `auditBlocked` field + `IBridgeOutboxDrainHook` step-0.
- `ai-docs/specs/issue-242/plan.md` §AUDIT-4 — dated revision note (original
  top-of-method design superseded, kept for provenance).
- `.claude/skills/bridge/SKILL.md` — guard section corrected (it repeated the
  same false premise) **+ a new rule:** to react to a lifecycle moment, emit a
  typed domain change-fact (the `message_created` / EMIT-CHANGES path) — never
  make the audit lifecycle event bridge-eligible.
- New spec `ai-docs/specs/2026-06-07-bridge-audit-guard-false-positive.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
