### PR TITLE
chore(release): 0.27.2 — bridge audit-tier guard false-positive fix (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.2] — 2026-06-08
+
+### Fixed
+
+- **Bridge audit-tier guard no longer emits a false-positive WARN on every
+  audit event (#535).** `BridgeOutboxDrainHook.processEvent` ran its audit-tier
+  guard *before* the trigger lookup, so it fired — and logged a WARN — for every
+  `tier:audit` event, while asserting "a `bridge_trigger` row exists out-of-band"
+  (a registry/runtime-drift claim it never actually checked). Audit-tier
+  lifecycle events (`connection.created`, `connection.field_changed`, …) share
+  the outbox with domain events and carry no triggers, so the warning fired on
+  ordinary, correct operation. Dogfood discovery from swe-brain. Fix: look up
+  triggers first, then branch — `tier:audit` **with** a registered trigger is
+  genuine drift (WARN, now naming the offending trigger id, + `auditBlocked:1`,
+  no fanout); `tier:audit` with **no** trigger is the benign shared-outbox case
+  (returns zeros, silent). The SELECT-level `tier='audit'` filter was rejected:
+  audit events still need the normal drain (`processed_at` stamp + subscriber
+  dispatch); only bridge fanout skips them. Revises the original AUDIT-4
+  top-of-method guard (`ai-docs/specs/issue-242/plan.md` §AUDIT-4 revision note).
+  To make a workflow react to a lifecycle moment, emit a typed domain
+  change-fact — do not make the audit event bridge-eligible (new bridge skill
+  rule).
+
 ## [0.27.1] — 2026-06-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Release 0.27.2

Publishes the #535 fix (merged to `main` as `de24148`).

**Merging this version bump triggers the CI publish job** (tarball smoke gate →
publish-if-version-not-on-npm, per package). `0.27.1 → 0.27.2`.

### Contents

- **fix(bridge): audit-tier guard fires only on genuine drift (#535).** The
  outbox drain guard warned on *every* `tier:audit` event, falsely claiming an
  out-of-band `bridge_trigger` row. Now it warns/blocks only when an audit event
  actually has a registered trigger (genuine drift); benign audit lifecycle
  events sharing the outbox (`connection.created`, `connection.field_changed`)
  return zeros silently.

Once this publishes, swe-brain bumps its `@pattern-stack/codegen` dep to make the
`connection.created` / `connection.field_changed` warnings disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
