### PR TITLE
fix(clean-lite-ps): expose external_id read-only on the Integrated output DTO

### DIFF
--- a/src/__tests__/clean-lite-ps/dto-template.test.ts
+++ b/src/__tests__/clean-lite-ps/dto-template.test.ts
@@ -118,4 +118,53 @@ describe('clean-lite-ps DTO templates — Zod type leaks (issue #35)', () => {
       expect(output).not.toContain('z.record(');
     });
   });
+
+  describe('external_id on the output DTO (cross-entity join key)', () => {
+    // A Base entity that declares the external_id_tracking behavior directly —
+    // proves the output emission tracks the behavior flag, not the pattern name.
+    const baseSynced = {
+      entity: { name: 'thing', plural: 'things', table: 'things' },
+      fields: { label: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: ['external_id_tracking'],
+    };
+
+    // A plain Base entity — no external-id tracking at all.
+    const plainBase = {
+      entity: { name: 'task', plural: 'tasks', table: 'tasks' },
+      fields: { title: { type: 'string', required: true } },
+      relationships: {},
+      behaviors: [],
+    };
+
+    it('Integrated entity exposes externalId read-only on the output DTO', () => {
+      const locals = buildCleanLitePsLocals(agentDefinition, {});
+      const output = render(OUTPUT_TEMPLATE, locals);
+
+      // external_id is the public cross-entity join key — it must ride the output.
+      expect(output).toMatch(/externalId:\s*z\.string\(\)\.nullable\(\)/);
+    });
+
+    it('external_id_tracking behavior alone (no pattern) still exposes externalId', () => {
+      const locals = buildCleanLitePsLocals(baseSynced, {});
+      const output = render(OUTPUT_TEMPLATE, locals);
+
+      expect(output).toMatch(/externalId:\s*z\.string\(\)\.nullable\(\)/);
+    });
+
+    it('provider / provider_metadata stay internal — never on the output DTO', () => {
+      const locals = buildCleanLitePsLocals(agentDefinition, {});
+      const output = render(OUTPUT_TEMPLATE, locals);
+
+      expect(output).not.toContain('provider:');
+      expect(output).not.toContain('providerMetadata:');
+    });
+
+    it('a plain Base entity emits no externalId on the output DTO', () => {
+      const locals = buildCleanLitePsLocals(plainBase, {});
+      const output = render(OUTPUT_TEMPLATE, locals);
+
+      expect(output).not.toContain('externalId');
+    });
+  });
 });

--- a/templates/entity/new/clean-lite-ps/dto/output.ejs.t
+++ b/templates/entity/new/clean-lite-ps/dto/output.ejs.t
@@ -14,6 +14,12 @@ export const <%= classNames.outputSchema %> = z.object({
 <%_ clpOutputDtoFields.forEach(field => { _%>
   <%= field.camelName %>: <%- field.zodChainOutput %>,
 <%_ }) _%>
+<%_ if (hasExternalIdTracking) { _%>
+  // external_id_tracking behavior — external_id is the public cross-entity join
+  // key (a referenced entity exposes it so consumers can join), so it rides the
+  // output DTO read-only. provider / provider_metadata stay internal.
+  externalId: z.string().nullable(),
+<%_ } _%>
 <%_ if (hasTimestamps) { _%>
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),


### PR DESCRIPTION
## Problem

Entities with the `external_id_tracking` behavior (i.e. `pattern: Integrated`) get `external_id` / `provider` / `provider_metadata` columns injected into the table by the entity template. But the clean-lite-ps **output DTO** excluded all three.

`external_id` is the public cross-entity join key: a referenced entity exposes it so a referencing entity can resolve the relationship. In the swe-brain dogfood, `message.channel_external_id REFERENCES channel.external_id` — yet the channel's *own* `external_id` was absent from `ChannelOutputSchema`, so the frontend could not join a channel to its messages off the API payload.

Concretely, generated `apps/backend/src/modules/channels/dto/channel-output.dto.ts` had `id, userId, kind, name, topic, purpose, isArchived, isExtShared, remoteCreatedAt, createdAt, updatedAt` but no `externalId`.

## Fix

Emit `externalId: z.string().nullable()` on the output DTO when the `external_id_tracking` behavior is present (guarded by the existing `hasExternalIdTracking` local), placed right before the timestamp block to mirror the column order the entity template already hand-emits. `provider` / `provider_metadata` stay excluded — they're genuine internal sync metadata, not a join key.

The previous exclusion lived in `prompt-extension.js`'s `outputDtoSource` filter, but that filter only ever applied to *declared* fields; the behavior columns are hand-emitted by a template guard and were never in `clpOutputDtoFields` at all. So the cleanest fix is a symmetric template guard in `output.ejs.t`, matching how `entity.ejs.t` emits the columns.

## Blast radius

**Purely additive.** Affects only the output DTO of entities with `external_id_tracking` (`pattern: Integrated`) across all consumers:
- A new read-only field appears on the output schema. No existing field is removed, renamed, or retyped.
- Base entities (no external-id tracking) are completely unchanged.
- `provider` / `provider_metadata` remain hidden.
- Backend-arch DTO template (`templates/entity/new/backend/.../dto.ejs.t`) is a separate template and is untouched; the `full` baseline (backend arch) still passes.

A regenerating consumer (e.g. dealbrain) would simply gain `externalId` on each Integrated entity's output schema — a superset of the current payload. No consumer code reads "absence of externalId", so nothing breaks. swe-brain consumes it immediately to wire the channel↔message join.

## Tests

- New cases in `src/__tests__/clean-lite-ps/dto-template.test.ts`:
  - Integrated entity exposes `externalId` read-only on the output DTO
  - `external_id_tracking` behavior alone (no pattern) still exposes it (tracks the behavior flag, not the pattern name)
  - `provider` / `provider_metadata` never appear on the output DTO
  - a plain Base entity emits no `externalId`
- Full clean-lite-ps + patterns + templates unit suites green; `bun run test` (backend baseline) green. (The 7 pre-existing `schema-v2.test.ts` cross-block-validation failures are unrelated — they fail identically on a clean `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)