### PR TITLE
fix(frontend-emit): guard createLookups().hydrate() against per-mount full-fetch

### DIFF
--- a/src/emitters/frontend/emit-store.ts
+++ b/src/emitters/frontend/emit-store.ts
@@ -396,20 +396,40 @@ ${lookupBuildAsyncFields}
  */
 export function createLookups() {
 \tlet cache: EntityLookups | null = null;
+\t// Run-once guard for \`hydrate()\`. The store runtime calls hydrate from a
+\t// per-mount useEffect with NO dedup, so without this every EntityList/useData
+\t// mount (x2 under React StrictMode) kicks off another full buildLookupsAsync()
+\t// — a listAll() of every entity. On a large table (tens of thousands of rows)
+\t// that slurps the whole table N times concurrently and can OOM the renderer.
+\t// The guard collapses all callers onto a single hydration: cache the resolved
+\t// set, and dedupe concurrent callers onto one in-flight promise. \`clear()\`
+\t// forces a refresh. NOTE: this caps the damage but does not make full-fetching
+\t// a huge table cheap — lazy/on-demand FK resolution is the deeper fix.
+\tlet inFlight: Promise<EntityLookups> | null = null;
 \treturn {
 \t\tbuild: (): EntityLookups => {
 \t\t\tcache = buildLookups();
 \t\t\treturn cache;
 \t\t},
 \t\thydrate: async (): Promise<EntityLookups> => {
-\t\t\tcache = await buildLookupsAsync();
-\t\t\treturn cache;
+\t\t\tif (cache) return cache;
+\t\t\tif (inFlight) return inFlight;
+\t\t\tinFlight = buildLookupsAsync()
+\t\t\t\t.then((result) => {
+\t\t\t\t\tcache = result;
+\t\t\t\t\treturn result;
+\t\t\t\t})
+\t\t\t\t.finally(() => {
+\t\t\t\t\tinFlight = null;
+\t\t\t\t});
+\t\t\treturn inFlight;
 \t\t},
 \t\tget current(): EntityLookups | null {
 \t\t\treturn cache;
 \t\t},
 \t\tclear: (): void => {
 \t\t\tcache = null;
+\t\t\tinFlight = null;
 \t\t},
 \t};
 }

--- a/test/frontend-golden/snapshot/store/lookups.ts
+++ b/test/frontend-golden/snapshot/store/lookups.ts
@@ -56,20 +56,40 @@ export async function buildLookupsAsync(): Promise<EntityLookups> {
  */
 export function createLookups() {
 	let cache: EntityLookups | null = null;
+	// Run-once guard for `hydrate()`. The store runtime calls hydrate from a
+	// per-mount useEffect with NO dedup, so without this every EntityList/useData
+	// mount (x2 under React StrictMode) kicks off another full buildLookupsAsync()
+	// — a listAll() of every entity. On a large table (tens of thousands of rows)
+	// that slurps the whole table N times concurrently and can OOM the renderer.
+	// The guard collapses all callers onto a single hydration: cache the resolved
+	// set, and dedupe concurrent callers onto one in-flight promise. `clear()`
+	// forces a refresh. NOTE: this caps the damage but does not make full-fetching
+	// a huge table cheap — lazy/on-demand FK resolution is the deeper fix.
+	let inFlight: Promise<EntityLookups> | null = null;
 	return {
 		build: (): EntityLookups => {
 			cache = buildLookups();
 			return cache;
 		},
 		hydrate: async (): Promise<EntityLookups> => {
-			cache = await buildLookupsAsync();
-			return cache;
+			if (cache) return cache;
+			if (inFlight) return inFlight;
+			inFlight = buildLookupsAsync()
+				.then((result) => {
+					cache = result;
+					return result;
+				})
+				.finally(() => {
+					inFlight = null;
+				});
+			return inFlight;
 		},
 		get current(): EntityLookups | null {
 			return cache;
 		},
 		clear: (): void => {
 			cache = null;
+			inFlight = null;
 		},
 	};
 }


### PR DESCRIPTION
## What

Guards the emitted `createLookups().hydrate()` against a per-mount full-fetch storm.

## The bug (found dogfooding in swe-brain)

The emitted store runtime calls the lookups engine's `hydrate()` from a per-mount `useEffect` with **no dedup**, so every `EntityList`/`useData` mount (×2 under React StrictMode) kicks off another full `buildLookupsAsync()` — a `listAll()` paging through *every* entity. On a large consumer table (swe-brain's ~21k-row `emails`) that slurps the whole table N× concurrently → renderer OOM (periodic sad-tab on every surface). Diagnosed via a CDP heap probe: ~700 MB / 3s growth, DOM flat, zero console errors.

## The fix

Emit `createLookups().hydrate()` with a **run-once guard**: cache the resolved set + dedupe concurrent callers onto one in-flight promise; `clear()` refreshes.

Caps the ×N pile-up. Does **not** make full-fetching a huge table cheap — that's the lazy/on-demand FK resolution (or the Electric scoped-shape migration) follow-on. This is the floor that stops the crash.

## Tests
- Golden snapshot regenerated (`UPDATE_FRONTEND_GOLDEN=1`)
- `golden-tree.test.ts` ✓ (12/12) · `emit-store.test.ts` ✓ (28/28)
- Pre-existing `junction.ts` / `barrel-generator.ts` typecheck errors on `main` are unrelated (different files; this PR touches only `emit-store.ts` + the snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
