### PR TITLE
fix(emit): frontend lookups/resolver OOM guard — don't full-fetch heavy non-target entities (v0.27.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.3] — 2026-06-13
+
+### Fixed
+
+- **Frontend lookups/resolver hydration no longer full-fetches every entity —
+  the LANDMINE-1 OOM guard.** `buildLookupsAsync` (store/lookups.ts) and
+  `hydrateResolverCache` (store/resolvers.ts) paged the COMPLETE table of *every*
+  entity via `api.listAll()` on the first `useData()` mount of *any* route, to
+  populate cross-entity FK-resolution maps. On a large content table this is
+  catastrophic: a swe-brain mailbox of 21,648 emails × ~33 KB `bodyHtml` pulled
+  ~700 MB into the renderer and the browser silently OOM-killed the tab — on
+  every route, including ones that never read email. Dogfood discovery from
+  swe-brain. Fix: full-fetch an entity only if it is a **lookup target** (some
+  `belongs_to` resolves it by id → it backs a FieldMeta `reference`) **or** it
+  has no unbounded text column; heavy, non-target entities (a `text` field, or a
+  `string` with no `max_length`) are seeded from current collection state
+  instead — nothing resolves them by id, so the current page is all any consumer
+  can use. `api` imports for skipped entities are dropped so none dangle. See
+  `lookupFullFetchNames` in `emit-store.ts`. Known edge: an entity consumed as a
+  lookup ONLY via hand-authored `lookups.<plural>` access (not a FieldMeta
+  reference) that *also* has an unbounded string column would be skipped — give
+  it a bounded `max_length` or declare the FK so it registers as a target.
+
 ## [0.27.2] — 2026-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/emitters/frontend/emit-store.test.ts
+++ b/src/__tests__/emitters/frontend/emit-store.test.ts
@@ -47,6 +47,29 @@ function personTaskCtx() {
 	return { person, task, c: ctx([person, task], {}, parsed) };
 }
 
+/**
+ * Heavy entity `note` (unbounded `body` text), NOT a reference target → it is
+ * seeded from collection state and never full-fetched (the LANDMINE-1 OOM guard).
+ * `person` (referenced by `note.author_id`) stays a full-fetch lookup target.
+ */
+function heavyNoteCtx() {
+	const person = entry('person', 'people');
+	const note = entry('note', 'notes');
+	const parsed = parsedMap(
+		parsedEntity(person),
+		parsedEntity(note, {
+			fields: new Map([
+				['body', field('body', { type: 'text' })],
+				['author_id', field('author_id', { foreignKey: { table: 'people', column: 'id' } })],
+			]),
+			relationships: new Map([
+				['author', relationship('author', { target: 'person', foreignKey: 'author_id' })],
+			]),
+		}),
+	);
+	return { person, note, c: ctx([person, note], {}, parsed) };
+}
+
 describe('emit-store — createStore (store/index.ts)', () => {
 	it('keys entities + collections by PLURAL, not table', () => {
 		// table diverges from plural on purpose.
@@ -125,6 +148,18 @@ describe('emit-store — resolvers (store/resolvers.ts)', () => {
 		expect(out).toContain("import { personApi } from '../api/person';");
 	});
 
+	it('skips the full-fetch for heavy non-target entities (LANDMINE-1 OOM guard)', () => {
+		const { c } = heavyNoteCtx();
+		const out = buildResolversFile(c);
+		// person is a lookup target → still paged into the resolver cache.
+		expect(out).toContain('personApi.listAll().then((rows) => {');
+		expect(out).toContain("import { personApi } from '../api/person';");
+		// note is heavy (unbounded body) and nothing resolves it by id → NOT paged;
+		// its resolver falls back to collection state, and no api import dangles.
+		expect(out).not.toContain('noteApi.listAll(');
+		expect(out).not.toContain('import { noteApi }');
+	});
+
 	it('resolvableRels resolves target naming from the registry', () => {
 		const { task, c } = personTaskCtx();
 		const rels = resolvableRels(task, c);
@@ -199,6 +234,19 @@ describe('emit-store — lookups (store/lookups.ts)', () => {
 		expect(out).toContain('personApi.listAll(),');
 		expect(out).toContain('hydrate: async (): Promise<EntityLookups> => {');
 		expect(out).toContain("import { personApi } from '../api/person';");
+	});
+
+	it('skips the full-fetch for heavy non-target entities (LANDMINE-1 OOM guard)', () => {
+		const { c } = heavyNoteCtx();
+		const out = buildLookupsFile(c);
+		// person stays a full-fetch lookup target.
+		expect(out).toContain('personApi.listAll(),');
+		expect(out).toContain("import { personApi } from '../api/person';");
+		// note is seeded from collection state in the async builder too — never
+		// listAll'd, and no api import dangles for it.
+		expect(out).not.toContain('noteApi.listAll(');
+		expect(out).not.toContain('import { noteApi }');
+		expect(out).toContain('Array.from(noteCollection.state.values())');
 	});
 });
 

--- a/src/emitters/frontend/emit-store.ts
+++ b/src/emitters/frontend/emit-store.ts
@@ -85,6 +85,42 @@ function fkField(rel: ParsedRelationship): string {
 }
 
 /**
+ * Entities to FULL-FETCH (`api.listAll()` → the whole table) when hydrating the
+ * cross-entity lookup maps and the resolver cache.
+ *
+ * Full-fetching EVERY entity on the first `useData` mount is the LANDMINE-1 trap:
+ * a large table with an unbounded text/body column (e.g. tens of thousands of
+ * emails × `bodyHtml`) pulls hundreds of MB into the renderer and OOM-kills it,
+ * on every route — even ones that never read it.
+ *
+ * Rule: full-fetch an entity only if it is a LOOKUP TARGET (some belongs_to
+ * resolves it by id → it backs a FieldMeta `reference`) OR it has no unbounded
+ * text column (cheap to page). Heavy, non-target entities are seeded from current
+ * collection state instead — nothing resolves them by id, so the current page is
+ * all any consumer can use. "Heavy" = a `text` field, or a `string` field with no
+ * `max_length` (emitted as unbounded TEXT).
+ */
+export function lookupFullFetchNames(ctx: FrontendEmitContext): Set<string> {
+	const referenceTargets = new Set<string>();
+	for (const e of ctx.entities) {
+		for (const r of resolvableRels(e, ctx)) referenceTargets.add(r.target.name);
+	}
+	const out = new Set<string>();
+	for (const e of ctx.entities) {
+		const parsed = ctx.parsed.get(e.name);
+		const hasUnboundedText = parsed
+			? Array.from(parsed.fields.values()).some(
+					(f) =>
+						f.type === 'text' ||
+						(f.type === 'string' && f.constraints.maxLength === undefined),
+				)
+			: false;
+		if (referenceTargets.has(e.name) || !hasUnboundedText) out.add(e.name);
+	}
+	return out;
+}
+
+/**
  * `store/index.ts` — `createStore({ entities, collections, fields, lookups })`
  * over the full set, keyed by plural. Imports each entity's hooks + collection +
  * generated FieldMeta, and wires the lookups engine. The `fields` + `lookups`
@@ -170,14 +206,19 @@ export type AppStore = typeof store;
  */
 export function buildResolversFile(ctx: FrontendEmitContext): string {
 	const entities = sortEntities(ctx.entities);
+	// Only lookup-target / light entities are full-fetched (LANDMINE-1 guard); the
+	// rest fall back to collection state, so they need no `api` import here.
+	const fullFetch = lookupFullFetchNames(ctx);
+	const fetched = entities.filter((e) => fullFetch.has(e.name));
 
-	// One collection + one api + one type import per entity. FK targets are always
-	// in the same registry set, so a self-referential FK never produces a second
-	// import. The api import backs the full-fetch escape hatch (LANDMINE 1).
+	// One collection + one type import per entity. FK targets are always in the
+	// same registry set, so a self-referential FK never produces a second import.
+	// The api import backs the full-fetch escape hatch (LANDMINE 1) — emitted only
+	// for the entities actually full-fetched below.
 	const collectionImports = entities
 		.map((e) => `import { ${e.camelName}Collection } from '../collections/${e.name}';`)
 		.join('\n');
-	const apiImports = entities
+	const apiImports = fetched
 		.map((e) => `import { ${e.camelName}Api } from '../api/${e.name}';`)
 		.join('\n');
 	const typeImports = entities
@@ -213,7 +254,11 @@ export function buildResolversFile(ctx: FrontendEmitContext): string {
 	const hydrationCacheFields = entities
 		.map((e) => `\t${e.camelName}: new Map<string, ${e.className}>(),`)
 		.join('\n');
-	const hydrationCalls = entities
+	// Full-fetch only lookup-target / light entities. Heavy non-targets (e.g. a
+	// 21k-row emails table with bodyHtml) keep their empty cache map and resolve
+	// from collection state — nothing resolves them by id, so off-page coverage is
+	// never needed. This is the LANDMINE-1 OOM guard (see lookupFullFetchNames).
+	const hydrationCalls = fetched
 		.map(
 			(e) => `\t\t${e.camelName}Api.listAll().then((rows) => {
 \t\t\thydrationCache.${e.camelName} = new Map(rows.map((r) => [r.id as string, r]));
@@ -319,10 +364,15 @@ ${refsSection}`;
 export function buildLookupsFile(ctx: FrontendEmitContext): string {
 	const entities = sortEntities(ctx.entities);
 
+	// Only lookup-target / light entities are full-fetched (LANDMINE-1 guard); the
+	// rest fall back to collection state, so they need no `api` import here.
+	const fullFetch = lookupFullFetchNames(ctx);
+	const fetched = entities.filter((e) => fullFetch.has(e.name));
+
 	const collectionImports = entities
 		.map((e) => `import { ${e.camelName}Collection } from '../collections/${e.name}';`)
 		.join('\n');
-	const apiImports = entities
+	const apiImports = fetched
 		.map((e) => `import { ${e.camelName}Api } from '../api/${e.name}';`)
 		.join('\n');
 	const typeImports = entities
@@ -333,30 +383,38 @@ export function buildLookupsFile(ctx: FrontendEmitContext): string {
 		.map((e) => `\t${e.plural}: Map<string, ${e.className}>;`)
 		.join('\n');
 
-	const lookupBuild = entities
-		.map(
-			(e) => `\t\t${e.plural}: new Map(
+	// One id→entity map for an entity, built from current collection state.
+	const collectionStateMap = (e: EntityRegistryEntry): string => `\t\t${e.plural}: new Map(
 \t\t\tArray.from(${e.camelName}Collection.state.values()).map((item) => [
 \t\t\t\t(item as ${e.className}).id as string,
 \t\t\t\titem as ${e.className},
 \t\t\t]),
-\t\t),`,
-		)
-		.join('\n');
+\t\t),`;
 
-	// Full-fetch variant (LANDMINE 1): build each lookup from the COMPLETE set via
-	// `api.listAll()` rather than current collection state. Used when a lookup must
-	// cover off-page rows (pagination-by-default leaves the collection holding only
-	// the current page). Fetches all entities in parallel.
-	const lookupBuildAsyncDecls = entities
+	const lookupBuild = entities.map(collectionStateMap).join('\n');
+
+	// Full-fetch variant (LANDMINE 1): build lookup-target / light entities from the
+	// COMPLETE set via `api.listAll()` (covers off-page rows under pagination-by-
+	// default); heavy non-target entities (e.g. a 21k-row emails table × bodyHtml)
+	// are seeded from current collection state instead — full-fetching them pulled
+	// hundreds of MB into the renderer and OOM-killed it. See lookupFullFetchNames.
+	const lookupBuildAsyncDecls = fetched
 		.map((e) => `\t\t${e.camelName}Api.listAll(),`)
 		.join('\n');
+	const fetchedIndex = new Map(fetched.map((e, i) => [e.name, i]));
 	const lookupBuildAsyncFields = entities
-		.map(
-			(e, i) =>
-				`\t\t${e.plural}: new Map(rows[${i}].map((r) => [r.id as string, r as ${e.className}])),`,
-		)
+		.map((e) => {
+			const i = fetchedIndex.get(e.name);
+			return i === undefined
+				? collectionStateMap(e)
+				: `\t\t${e.plural}: new Map(rows[${i}].map((r) => [r.id as string, r as ${e.className}])),`;
+		})
 		.join('\n');
+	// Degenerate set (no full-fetch target): keep the fn valid + await-clean.
+	const lookupBuildAsyncBody =
+		fetched.length > 0
+			? `\tconst rows = await Promise.all([\n${lookupBuildAsyncDecls}\n\t]);\n\treturn {\n${lookupBuildAsyncFields}\n\t};`
+			: `\tawait Promise.resolve();\n\treturn {\n${lookupBuildAsyncFields}\n\t};`;
 
 	const body = `${collectionImports}
 ${apiImports}
@@ -381,12 +439,7 @@ ${lookupBuild}
  * may not be on the current page.
  */
 export async function buildLookupsAsync(): Promise<EntityLookups> {
-\tconst rows = await Promise.all([
-${lookupBuildAsyncDecls}
-\t]);
-\treturn {
-${lookupBuildAsyncFields}
-\t};
+${lookupBuildAsyncBody}
 }
 
 /**


### PR DESCRIPTION
## Problem (dogfood discovery from swe-brain)

The generated frontend store hydrates cross-entity FK-resolution maps by paging the **complete table of every entity** via `api.listAll()` on the first `useData()` mount of **any** route:

- `buildLookupsAsync` (`store/lookups.ts`) — consumed by `useData().lookups`
- `hydrateResolverCache` (`store/resolvers.ts`) — the latent twin

On a large content table this OOM-kills the renderer. In swe-brain: a mailbox of **21,648 emails × ~33 KB `bodyHtml`** → ~700 MB pulled into the tab, which the browser **silently kills** (~12–14 s in) — on **every** route, including `/connections` and `/people` that never read email. No JS exception, no overlay — the classic OOM signature.

## Fix

Gate the full-fetch (`lookupFullFetchNames` in `emit-store.ts`). An entity is full-fetched **only if**:

- it is a **lookup target** — some `belongs_to` resolves it by id, so it backs a FieldMeta `reference`, **or**
- it has **no unbounded text column** (cheap to page).

"Heavy" = a `text` field, or a `string` field with no `max_length` (emitted as unbounded TEXT). Heavy, non-target entities are **seeded from current collection state** instead — nothing resolves them by id, so the current page is all any consumer can use. `api` imports for skipped entities are dropped so none dangle.

Applied to **both** `buildLookupsAsync` and `hydrateResolverCache` (same landmine; the resolver twin is currently unwired in swe-brain but would re-introduce the OOM if wired).

### On swe-brain's entity set
- **Full-fetched** (unchanged): `people`, `connections`, `role_templates`, `channels`, `meetings`, … (lookup targets or light).
- **Now seeded from collection state**: `emails`, `messages`, `transcripts`, `documents`, `conversations`, `observations` (heavy + nothing resolves them by id).

Verified live: renderer survives 32 s+, `GET /emails` drops from **~83 → 0**, traffic **~350 MB → ~1.1 MB**, `/connections`+`/people` still render.

### Known edge
An entity consumed as a lookup **only** via hand-authored `lookups.<plural>` access (not a FieldMeta reference) that *also* has an unbounded string column would be skipped. Mitigation: give it a bounded `max_length`, or declare the FK so it registers as a target. (Doesn't affect swe-brain — `people` has no unbounded field.)

## Tests
- 2 new `emit-store` gate tests (heavy non-target seeded from state, not `listAll`'d; no dangling `api` import). **427/427** frontend-emitter tests pass; package typecheck clean.

## Release
- Bumped `0.27.2 → 0.27.3` + CHANGELOG. Consumers (swe-brain) bump the pin + regen to replace the in-tree stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)