### PR TITLE
docs(jobs-kind): design brief + handoff for sync-job primitives → codegen jobs-definition-kind

### DIFF
--- a/.ai-docs/research/jobs-kind-design-brief.md
+++ b/.ai-docs/research/jobs-kind-design-brief.md
@@ -1,0 +1,276 @@
+# Sync-Job Primitives: A→B Consolidated Design Brief
+
+> Produced by the `jobs-kind-design-grounding` workflow (10 agents, 2026-06-13) grounding
+> the request `.ai-docs/requests/job-primitives-and-codegen-jobs-kind.md` (swe-brain worktree).
+>
+> **A** = swe-brain (`/Users/dug/Projects/swe-brain/swe-brain`) — hand-built sync-job primitives.
+> **B** = codegen-patterns (`/Users/dug/Projects/codegen-patterns`) — the future jobs definition kind + emitter that lifts A's shape.
+> **Load-bearing contract:** a per-adapter sync-profile object (A config) **IS** a `JobDefinitionSchema` instance (B schema). A authors YAML; B compiles it.
+
+---
+
+## 1. Anchor verification verdict
+
+Overall confidence: **HIGH.** 28 of 31 anchors confirmed. The research is sound and the plan holds. Three anchors drifted/refuted, and a handful of surprises matter — but **none invalidates a single design decision**; two of them actively *sharpen* the recommendations (the dedupKey/differ seam-split, and the inbound-sync cadence premise).
+
+| Anchor | Cited | Verdict | What actually is | Plan impact |
+|---|---|---|---|---|
+| DetectionConfig discriminated on mode, per-mode cursor strategy, **`dedupKey`**, filters, mapping | `detection-config.schema.ts` | **DRIFTED** | Discriminant `mode` ✓; cursor union has **6** members (systemModstamp/replayId/timestamp/eventId/historyId/syncToken), not 4; **no `dedupKey` field exists at all** — it's a runtime `Change<T>` property derived from `webhook.eventIdField`/poll cursor. Header doc @17 is stale ("four shapes"). | **Reinforces D2 + D3.** Confirms dedupe lives on the *change source*, not config or differ. No field to lift into JobDefinitionSchema. |
+| `inbound-sync` has a schedule cadence (implied: all 4 sync jobs scheduled) | (premise) | **REFUTED** | `inbound-sync` is **webhook-doorbell-driven, zero cadence**. Only reconcile-poll (1h), google-reconcile (1h), drive-poll (15m/+webhook) are scheduled. | **Reinforces D4.** A job has **0/1/N** triggers — cadence cannot live on the job. `triggers` must be a *list*. |
+| `historyId`/`syncToken` cursor strategies; stale "four shapes" comment | `detection-config.schema.ts:17` | **DRIFTED (doc)** | Code has 6 cursor strategies; header comment lists 4. RFC-0003 added historyId+syncToken without updating the doc. | **Same-PR living-docs fix** when B touches the file. |
+
+**Surprises that change nothing but belong in the ADR:**
+- `JobHandlerMeta` has **8** fields, not 6 — claim omitted `scope` and `replayFrom`. The schema must surface all of them.
+- `ScheduleSchema` is **duration/slot-based** (`every`/`align`/`catchUp`/`maxCatchUpSlots`), **no cron, no timezone**. Any text saying "cron" is wrong.
+- The handlers are **composites of shapes**, not one-shape-each (reconcile-poll = PollSync channel-refresh sub-phase + ReconcileSync message sub-phase). Forces the multi-arm schema in §3.
+- A **per-entity differ rebind already exists** at the DI layer (`INTEGRATION_FIELD_DIFFER`), so D2's "defer" has an escape hatch today with zero new surface.
+- CDC is **provenance, not a mode** (`mode:'poll'` + `poll.provenance:'cdc'`). The `action:'cdc'` on the run input is a different axis.
+- Codegen's ONLY `@JobHandler` touch is the **bridge-registry generator**, which scans authored `.ts` via the TS AST — *not* a jobs YAML loader. The jobs YAML gap is architectural intent, not oversight.
+
+---
+
+## 2. Resolved design decisions
+
+| # | Decision | Call | Conf. | One-line rationale | Schema implication |
+|---|---|---|---|---|---|
+| **D1** | RealtimeSync = peer primitive vs webhook-drain mode | **Drain MODE** over the existing `webhook` change-source — **not** a 3rd primitive | High | `buildChangeSource` already has `poll\|webhook`; `WebhookChangeSource` is passive; claim/ack lives in the job handler; a single "realtime" run already mixes webhook + poll sources | **No new mode.** `DetectionConfigSchema` stays `discriminatedUnion('mode',[Poll,Webhook])`. Realtime arms reuse `mode:'webhook'`. |
+| **D2** | Add per-run `differOverride` to `ExecuteIntegrationInput`? | **DEFER** (option c) | High | Dedupe/window lives on the *source* (`sourceOverride`), not the differ; the one cross-cutting need (`deletedAt`) is solved globally via `differ.unignore`; per-entity DI rebind covers the rest | **No change** to input type or schema. Fallback: add `differOverride?: IFieldDiffer<T>` mirroring `sourceOverride` only if a per-run need is proven. |
+| **D3** | Adopt `DetectionConfigSchema` as profile backbone, or fresh? | **FRESH `JobDefinitionSchema`**, `DetectionConfig` **composed in per-arm** as read leaf | High | 0 of 8 requested profile fields exist in DetectionConfig; it's a single-source detection leaf (ADR-033) while a job is a multi-arm composite; W3 derivation-profile is the proven catalog-by-code + instances-by-data template | **Net-new** `src/schema/job-definition.schema.ts` + `definitions/jobs/` loader + emitter. `DetectionConfigSchema` **imported, not modified**. |
+| **D4** | Where cadence lives | **Event-YAML `schedule:` wins** (ADR-039). **Option D**: profile carries an *optional read-only* `cadence` annotation codegen validates (drift-errors) vs the referenced event | High | Cadence is a property of the time-*event*, not the job; job→cadence is **0/1/N**; scheduler reads `eventRegistry`, never job defs | **No authoritative cadence field.** Profile references cadence via `triggers[].event`. Option D adds optional derived `cadence` + gen-time drift validator. |
+| **D5** | How `inbound-sync` gets `(provider,domain)→use-case` | **Hand-build a throwaway LOCAL registry in A now** (option a); #458 is **not** a B blocker | High | Inputs already hand-injected; #458 is under-specified and entangled with #414/#457; the local registry *is the spec* for #458 | **None for B.** ~30-line A-side Nest provider. #458 stays a later additive emitter. |
+
+### Decision interactions
+- **D1 ↔ D3 (two discriminated unions at two altitudes).** Arm-kind `poll|reconcile|realtime` lives at the **job-arm** altitude *above* the `mode: poll|webhook` discriminator inside the embedded `DetectionConfig` leaf. A realtime arm carries `kind: realtime` *and* an embedded `read.mode: webhook`.
+- **D2 ↔ D3 (one seam-split, two sides).** No `dedupKey` in config + global differ ⇒ `dedupe.unignore` on the profile is a **differ knob** (maps to `integration.differ.unignore`), not a DetectionConfig field and not a per-run differ. Cursor stays inside `DetectionConfig.poll.cursor` (6-member union).
+- **D3 ↔ D4 (cadence is a reference, not a field).** Fresh schema gains `triggers[].event`; D4 forbids an authoritative cadence field. Consistent only because the schema is multi-arm with a trigger *list* — which the refuted inbound-sync premise independently forces.
+- **D5 stands apart.** Touches no schema, gates nothing in B. Local registry must key by `(provider, domain)` from day one so #458 inherits the composite key (avoids the #414 entity-only-keying trap).
+
+---
+
+## 3. Proposed `JobDefinitionSchema` (B) / sync-profile shape (A)
+
+**The single most important artifact.** It reconciles all five decisions: two-altitude discriminated unions (D1+D3), embedded `DetectionConfig` leaf (D2+D3), trigger-list-not-cadence-field with optional drift-checked annotation (D4), zero registry surface (D5).
+
+### Structural contract (annotated)
+
+```
+JobDefinition (top level)
+├─ type            string           # job-type literal == @JobHandler('<type>')
+├─ pool            string?          # JobHandlerMeta.pool — execution lane
+├─ lane            string?          # logical lane (maps to pool config)
+├─ scope           ScopeRef?        # JobHandlerMeta.scope  (DON'T omit — anchor surprise)
+├─ retry           RetryPolicy?     # JobHandlerMeta.retry
+├─ concurrency     ConcurrencyPolicy?
+├─ timeoutMs       number?
+├─ replayFrom      'scratch'|'last_step'|'last_checkpoint'?   # (DON'T omit — anchor surprise)
+├─ dedupe          { unignore: string[] }?   # D2: DIFFER knob, NOT DetectionConfig, NOT per-run
+│                                            #     maps to integration.differ.unignore
+├─ triggers        Trigger[]        # D4: 0/1/N. The ONLY cadence linkage. NOT a cadence field.
+│   └─ Trigger: { event: string,            # cross-ref'd vs generated eventRegistry at gen time
+│                 cadence?: CadenceAnnotation }   # D4 Option D: OPTIONAL, READ-ONLY, drift-validated
+│        CadenceAnnotation = { every: string, align?: bool }  # mirror of event schedule:, NON-authoritative
+└─ arms            Arm[]            # D1+D3: the multi-arm composite. discriminated on `kind`.
+    └─ Arm = discriminatedUnion('kind', [PollArm, ReconcileArm, RealtimeArm])
+
+PollArm:        { kind:'poll',      domain, read: DetectionConfig }            # read.mode:'poll', cursor ADVANCES
+ReconcileArm:   { kind:'reconcile', domain, window: { hours: number },        # windowed sourceOverride
+                  read: DetectionConfig, cursorWithheld: true }               #   cursor WITHHELD, tombstone-infer
+RealtimeArm:    { kind:'realtime',  domain, staging: { table, pushAccelerate? },
+                  read: DetectionConfig }                                     # read.mode:'webhook', claim/ack drain
+
+DetectionConfig (IMPORTED from runtime/subsystems/integration/detection-config.schema.ts — REUSED, NOT redefined)
+  = discriminatedUnion('mode', [PollMode, WebhookMode])   # UNTOUCHED, ADR-033 intact
+```
+
+### Annotated YAML — `poll` case (`drive-poll`)
+
+```yaml
+# definitions/jobs/drive-poll.yaml
+type: drive-poll
+pool: integration
+triggers:
+  - event: document_poll_due          # → ScheduleSchema every:15m on the event YAML (authoritative)
+    cadence: { every: 15m, align: true }   # D4 Option D: READ-ONLY mirror; codegen drift-errors if ≠ event
+  - event: document_sync_due          # webhook doorbell — NO cadence (0/1/N triggers, anchor-confirmed)
+arms:
+  - kind: poll                        # D1: PollSync usage-shape over the `poll` change-source mode
+    domain: document
+    read:                             # D3: embedded DetectionConfig leaf — REUSED, not redefined
+      mode: poll
+      poll:
+        cursor: { kind: systemModstamp }   # 6-member union (drift: not 4)
+      mapping: [{ source: id, target: external_id }]
+      filters: []
+```
+
+### Annotated YAML — `reconcile` case (`reconcile-poll`, composite)
+
+```yaml
+# definitions/jobs/reconcile-poll.yaml
+type: reconcile-poll
+pool: integration
+dedupe:
+  unignore: [deletedAt]               # D2: differ knob (== integration.differ.unignore), NOT per-run
+triggers:
+  - event: reconcile_due
+    cadence: { every: 1h, align: true }    # D4: drift-validated mirror of reconcile_due.yaml schedule
+arms:
+  - kind: poll                        # composite arm #1: channel_refresh sub-phase (cursor advances)
+    domain: channel
+    read:
+      mode: poll
+      poll: { cursor: { kind: timestamp } }
+      mapping: [{ source: id, target: external_id }]
+  - kind: reconcile                   # composite arm #2: message_reconcile (windowed, cursor withheld)
+    domain: message
+    window: { hours: 24 }             # runtime windowStart = now − window; selects windowed sourceOverride
+    cursorWithheld: true              # never regress the watermark (tombstone-inference source)
+    read:
+      mode: poll
+      poll: { cursor: { kind: timestamp } }
+      mapping: [{ source: ts, target: external_id }]
+```
+
+### Annotated YAML — `realtime` case (`inbound-sync`, drain mode, NO cadence)
+
+```yaml
+# definitions/jobs/inbound-sync.yaml
+type: inbound-sync
+pool: integration
+# NO triggers cadence — webhook-doorbell-driven (anchor REFUTED the "scheduled" premise)
+triggers:
+  - event: message_received           # webhook doorbells; none carry schedule:
+  - event: reaction_added
+  - event: mail_sync_due
+  - event: transcript_ready
+arms:
+  - kind: realtime                    # D1: webhook-DRAIN mode (NOT a peer primitive)
+    domain: message
+    staging:
+      table: slack_message_staging    # consumer-owned staging table (package refuses to own it)
+      pushAccelerate: true
+    read:
+      mode: webhook                   # D1: realtime REUSES mode:'webhook' — no new mode/case/subclass
+      webhook: { eventIdField: client_msg_id }
+      mapping: [{ source: externalId, target: external_id }]
+  - kind: realtime
+    domain: reaction
+    staging: { table: slack_reaction_staging }
+    read:
+      mode: webhook
+      webhook: { eventIdField: event_id }
+      mapping: [{ source: externalId, target: external_id }]
+  - kind: poll                        # Google doorbell arm: action:'webhook' but NO sourceOverride —
+    domain: email                     #   DI-bound adapter walks the historyId cursor. Proves a single
+    read:                             #   "realtime" run mixes webhook + poll → realtime can't be one primitive.
+      mode: poll
+      poll: { cursor: { kind: historyId } }   # 6-member union member added in RFC-0003
+      mapping: [{ source: id, target: external_id }]
+```
+
+**Negative space that proves the decisions:**
+- No third mode/arm-source primitive for realtime (**D1**).
+- No `differOverride`, no per-run differ; `dedupe.unignore` is the only differ touchpoint, job-wide (**D2**).
+- No widening of `DetectionConfigSchema` — imported verbatim (**D3**).
+- No authoritative `schedule`/`every`/`cron` at job top level; cadence is a *reference* + optional drift-checked mirror (**D4**).
+- No `(provider,domain)→use-case` registry surface — A-side throwaway (**D5**).
+
+---
+
+## 4. Dependency-ordered work breakdown (PR-sized)
+
+Order: lock shared schema/ADR → build & behaviour-verify A primitives → B lifts the shape → npm auto-deploy gate → swe-brain dogfoods B (deletes hand-built primitives).
+
+| # | [repo] Title | Scope | dependsOn | Size |
+|---|---|---|---|---|
+| **1** | [swe-brain] ADR-0018: sync-job primitives — 3 shapes, A→B contract | Lock taxonomy (Poll/Reconcile/Realtime as usage-shapes over poll/webhook modes), composition table, resolutions to D1–D5. Skeleton in §5. | — | M |
+| **2** | [codegen] Lock `JobDefinitionSchema` shape + A→B contract doc | Agree §3 schema *on paper* (no emitter): arm-kind over source-mode, embedded DetectionConfig leaf, trigger-list, dedupe knob. RFC/spec only — the byte contract A builds against. | 1 | M |
+| **3** | [swe-brain] D5: local `(provider,domain)→use-case` registry (THROWAWAY) | ~30-line Nest provider injecting the 8 use-case tokens; refactor `InboundSyncJobHandler` to `registry.get(provider,domain)`; keyed `(provider,domain)` to dodge #414. | — (independent) | S |
+| **4** | [swe-brain] Behaviour-baseline the 4 sync handlers (golden tests) | Capture observable behaviour (cursor advance/withhold, tombstone counts, claim/ack drain, dual-trigger, no-cadence) as golden assertions **before** migration. The parity oracle for the B-lift. | 1, 3 | M |
+| **5** | [codegen] Author `src/schema/job-definition.schema.ts` (fresh, imports DetectionConfig) | The Zod schema from §3. No loader/emitter yet — schema + unit tests against the 3 §3 YAML examples. Fix the stale `detection-config.schema.ts:17` header (living-docs). | 2 | M |
+| **6** | [codegen] `definitions/jobs/` loader + `detectYamlType` 'jobs' branch | `loadJobs` in `yaml-loader.ts`; add `jobs` branch to `detectYamlType` (526–547); parser registry entry. Closes half the GAP. | 5 | M |
+| **7** | [codegen] Job-handler emitter under `src/emitters/` + `entity new` post-step | Emit generated handler skeleton (arms → sourceOverride wiring, embedded DetectionConfig → change-source construction); wire `jobs` post-step in `entity.ts`. Define generated-skeleton vs AST-scanned authored `@JobHandler` coexistence. | 6 | L |
+| **8** | [codegen] D4 cross-ref validator: `triggers[].event` → `eventRegistry`; Option-D cadence drift check | Reuse the bridge-registry generator's event-validation. Add optional read-only `cadence` + drift error. Update ADR-039 + events skill same PR. | 7 | M |
+| **9** | [codegen] `just test-smoke-integration` green for the jobs emitter | Emitted-output-shape change MUST tsc-compile the emitted tree (project-memory gate). Gates the emitter PRs before release. | 7, 8 | M |
+| **10** | 🚦 **[codegen] RELEASE GATE — `just bump` + main→npm auto-deploy of the jobs emitter** | **Explicit gated step.** Merging the bump to `main` auto-publishes. swe-brain consumes the *published* tarball, so the B-lift (#11) cannot start until the emitter is live on npm. Run `just test-post-publish` first; published versions are immutable. | 7, 8, 9 | S |
+| **11** | [swe-brain] Author `definitions/jobs/*.yaml` for the 4 sync handlers (dogfood B) | Write the 4 profiles per §3 against the **published** codegen; generate; verify against #4 golden baseline. Migration is serialization, not redesign. | 4, 10 | L |
+| **12** | [swe-brain] Delete A's hand-built primitives; collapse to generated wiring | Remove the copy-pasted shell (env-disable gate, connection resolve, re-declared `PhaseSummary` ×4); per-arm `sourceOverride` selection moves into generated arms. Behaviour-parity vs #4 must be green. | 11 | M |
+| **13** | [codegen] **#458** — per-surface runtime `(provider,entity)→use-case` registry emitter | **SOFT-ordered, NOT a B blocker (D5).** After the dogfood; co-resolve #414 (composite key) + #457 (inbound event contract). Acceptance = #14. | 11 (soft) | L |
+| **14** | [swe-brain] Delete the throwaway local registry; collapse 8 injections to `registry.get(...)` | #458's acceptance test: local registry removed, handler calls generated registry, smoke green. | 3, 13 | S |
+
+**Critical-path note:** #10 is the only hard cross-repo serialization point — A's dogfood (#11) is gated on the npm publish, not on a checkout. After the §3 schema is locked on paper (#2), **A-build (#3,#4) and B-build (#5–#9) parallelize.** #13/#458 is explicitly *off* B's critical path.
+
+---
+
+## 5. ADR-0018 outline (swe-brain)
+
+```
+# ADR-0018: Sync-Job Primitives and the A→B Codegen Contract
+
+## Status
+Proposed — 2026-06-13. Supersedes the ad-hoc copy-pasted sync-handler shell.
+
+## Context
+- Four hand-authored sync JobHandlers (inbound-sync, reconcile-poll, google-reconcile,
+  drive-poll) share a copy-pasted shell + a re-declared PhaseSummary struct ×4.
+- Each handler is a COMPOSITE of source-usage shapes layered over the two change-source
+  modes the codegen package owns (poll | webhook, switched in buildChangeSource).
+- Jobs are code-first (@JobHandler self-registration); codegen has NO jobs YAML kind today
+  (the verified GAP). Goal: lift the per-adapter sync profile into a codegen JobDefinition.
+
+## The three shapes (usage-shapes, NOT three primitives — see D1)
+| Shape        | Source behaviour                          | Cursor      | Mode     |
+|--------------|-------------------------------------------|-------------|----------|
+| PollSync     | DI-bound adapter walks delta              | ADVANCES    | poll     |
+| ReconcileSync| windowed sourceOverride (now−window),     | WITHHELD    | poll     |
+|              |   tombstone inference                     |             |          |
+| RealtimeSync | webhook-staging sourceOverride, claim/ack | n/a (drain) | webhook  |
+
+## Per-adapter composition table (handlers are composites)
+| Handler          | Arms                                              | Cadence                  |
+|------------------|---------------------------------------------------|--------------------------|
+| drive-poll       | poll(document)                                    | 15m + webhook doorbell   |
+| reconcile-poll   | poll(channel) + reconcile(message)                | 1h                       |
+| google-reconcile | poll(mail) + poll(calendar) + reconcile(transcript)| 1h                      |
+| inbound-sync     | realtime(message) + realtime(reaction) + poll(google)| NONE (webhook doorbells)|
+
+## The A→B contract
+- A per-adapter sync-profile object IS a B JobDefinitionSchema instance.
+- A authors definitions/jobs/*.yaml; B (codegen) compiles them to handler skeletons.
+- Cadence is NOT in the profile — it lives on the event YAML schedule: block (ADR-039);
+  the profile references it via triggers[].event (+ optional drift-checked mirror).
+- DetectionConfig is COMPOSED IN per read-arm (reused leaf), never adopted as backbone.
+
+## Decisions (D1–D5)
+- D1 — RealtimeSync is a webhook-DRAIN MODE, not a peer primitive.
+- D2 — DEFER differOverride; global differ.unignore + per-entity DI rebind suffice.
+- D3 — FRESH JobDefinitionSchema; compose DetectionConfig per-arm.
+- D4 — Cadence stays on the event YAML (Option D drift-checked mirror).
+- D5 — Throwaway local (provider,domain)→use-case registry now; #458 soft/later.
+
+## Consequences
+- New codegen surface: job-definition.schema.ts + definitions/jobs/ loader + emitter + post-step.
+- DetectionConfigSchema and the entity detection: block UNTOUCHED (ADR-033 intact).
+- swe-brain's no-detection stance preserved (adopts a JOB profile, not the detection contract).
+- Living-docs: fix detection-config.schema.ts:17 ("four shapes"→six); ADR-039 + events skill
+  note cadence is event-owned.
+
+## References
+- ADR-039 (time as an event source), ADR-033 (narrow DetectionConfig), ADR-023 (bridge),
+  ADR-0016 (surface gate), #458/#414/#457, RFC-0003 (historyId/syncToken cursors).
+```
+
+---
+
+## 6. Risks and watch-items
+
+| Risk | Severity | Watch-item / mitigation |
+|---|---|---|
+| **Behaviour-parity drift in the A-lift** (composite handlers: cursor advance vs *withheld*, tombstone inference, claim/ack drain) | **High** | Land golden-baseline tests (#4) **before** migration; B-lift (#11/#12) diffs against them. `cursorWithheld` on the ReconcileArm is the highest-value invariant — a regressed watermark silently re-processes. |
+| **npm auto-deploy coupling** (B-lift consumes the *published* tarball; main→npm is immutable) | **High** | Item #10 is an explicit gate. Run `just test-post-publish` + `just publish-ci --dry-run` first. Don't start #11 until the emitter version is live. A bad publish can't be unpublished — only superseded. |
+| **Schema churn between A-build and B-lift** | **Medium** | Lock §3 on paper first (#2) and treat as the byte contract. Key the local registry `(provider,domain)` from day one. Freeze §3 before #11. |
+| **Stale-doc landmines** (DetectionConfig "four"→six; ScheduleSchema is duration-based not cron; JobHandlerMeta 8 fields) | **Medium** | Any ADR/schema text saying "cron"/"timezone" is wrong. Surface all 8 JobHandlerMeta fields. Fix `detection-config.schema.ts:17` in the same PR (#5). |
+| **inbound-sync premise REFUTED** (zero cadence; drive-poll dual triggers) | **Medium** | Schema MUST model `triggers` as a 0/1/N list, never a single cadence field. |
+| **D1 realtime under-specification** (no single named codegen artifact; claim/ack stays hand-authored) | **Low** | Accept "realtime" is a usage pattern, not a 1:1 emitter output. Keep the staging table consumer-owned. |
+| **Emitter/AST-seam coexistence** (generated skeleton vs bridge-registry's AST scan of authored `@JobHandler`) | **Medium** | #7 must define coexistence; the flat `jobs/` layout is load-bearing (generator scans only `<backend_src>/jobs`). Don't break the event→job bridge harvest. |
+| **#458 entanglement leaking onto B's path** | **Low** (mitigated by D5) | Hold the line: #13/#458 is soft-ordered. The local registry (#3) *is* the spec. |

--- a/.ai-docs/research/jobs-kind-grounding.workflow.js
+++ b/.ai-docs/research/jobs-kind-grounding.workflow.js
@@ -1,0 +1,218 @@
+export const meta = {
+  name: 'jobs-kind-design-grounding',
+  description: 'Verify the sync-job-primitives request anchors across swe-brain and codegen-patterns, then ground the 5 open design decisions and propose a PR-sized work breakdown',
+  phases: [
+    { title: 'Verify', detail: 'confirm cited file:line anchors in both repos' },
+    { title: 'Decide', detail: 'one agent per open design decision, grounded in verified facts' },
+    { title: 'Synthesize', detail: 'consolidated design brief and dependency-ordered work breakdown' },
+  ],
+}
+
+const SWE = '/Users/dug/Projects/swe-brain/swe-brain'
+const CG = '/Users/dug/Projects/codegen-patterns'
+
+const ANCHOR_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['cluster', 'anchors', 'summary'],
+  properties: {
+    cluster: { type: 'string' },
+    anchors: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['claim', 'citedLocation', 'verdict', 'actualLocation', 'evidence'],
+        properties: {
+          claim: { type: 'string', description: 'the assertion, in one line' },
+          citedLocation: { type: 'string', description: 'file:line as cited' },
+          verdict: { type: 'string', enum: ['confirmed', 'drifted', 'refuted', 'not-found'] },
+          actualLocation: { type: 'string', description: 'where the substance actually lives now (file:line), or n/a' },
+          evidence: { type: 'string', description: 'short quote or paraphrase of what is actually there' },
+        },
+      },
+    },
+    surprises: { type: 'array', items: { type: 'string' }, description: 'anything found that contradicts or complicates the request' },
+    summary: { type: 'string' },
+  },
+}
+
+const DECISION_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['decision', 'recommendation', 'confidence', 'rationale', 'options', 'schemaImplication', 'affects'],
+  properties: {
+    decision: { type: 'string' },
+    recommendation: { type: 'string', description: 'the concrete call to make' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    rationale: { type: 'string' },
+    options: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['option', 'pros', 'cons'],
+        properties: { option: { type: 'string' }, pros: { type: 'string' }, cons: { type: 'string' } },
+      },
+    },
+    schemaImplication: { type: 'string', description: 'effect on the JobDefinitionSchema (A config equals B schema)' },
+    affects: { type: 'object', additionalProperties: false, required: ['sweBrain', 'codegen'], properties: { sweBrain: { type: 'string' }, codegen: { type: 'string' } } },
+    openItems: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+phase('Verify')
+
+const verifiers = [
+  {
+    cluster: 'codegen-integration',
+    prompt:
+`You are verifying file:line anchors in the codegen-patterns repo at ${CG}. For EACH claim below, open the cited file (line numbers may have drifted — read plus/minus 50 lines and search the file for the substance), and report verdict: confirmed (substance present, maybe moved), drifted (present but materially different/moved far), refuted (contradicted), not-found.
+
+Claims to verify (cluster: integration orchestrator + source builder + detection + the differ/input seams):
+1. execute-integration.use-case.ts:113 — ExecuteIntegrationUseCase.execute() IS the single generic pull/diff/upsert/audit/cursor loop reused across every (provider, mode, entity).
+2. build-change-source.ts:23 — buildChangeSource(cfg, fetch, middlewares) switches on cfg.mode of poll or webhook (and CDC-as-provenance). Report the exact mode enum it accepts.
+3. detection-config.schema.ts — DetectionConfigSchema is discriminated on mode, with per-mode cursor strategy (systemModstamp/replayId/timestamp/historyId/syncToken/and so on), dedupKey, filters, mapping. Report the actual discriminant, the cursor strategy union, and the top-level fields.
+4. ExecuteIntegrationInput — it carries a per-run sourceOverride but NO differOverride. CRITICAL: find where ExecuteIntegrationInput is DEFINED (which file), and state definitively whether it is package-owned (codegen runtime, i.e. under ${CG}/runtime) vs app-owned. This determines whether adding differOverride is a codegen change.
+5. The dedupe/update policy is a SINGLE GLOBAL DeepEqualDiffer wired from codegen.config integration.differ.unignore. Confirm the differ is injected globally (one instance), not per-run. Report the DI token and where the global instance is constructed in runtime.
+
+Report via the schema. Use cluster equal to codegen-integration.`,
+  },
+  {
+    cluster: 'codegen-jobs-events-parser',
+    prompt:
+`You are verifying file:line anchors in the codegen-patterns repo at ${CG}. For EACH claim, open the cited file (line numbers may have drifted — read plus/minus 50 lines / search for substance) and report verdict.
+
+Claims (cluster: jobs base + boot upsert + event schedule + parser gap):
+1. job-handler.base.ts:114-128 — JobHandlerMeta shape includes pool, retry, concurrency, dedupe, timeoutMs, triggers. Report the ACTUAL full field list of JobHandlerMeta.
+2. job-handler.base.ts:203-234 — JobHandler classes self-register into an in-code registry at class-load time. Report the registry mechanism.
+3. job-worker.module.ts:191-212 — at boot, JobHandler classes are upserted into job rows from the in-code registry (NOT DB-seeded). Confirm.
+4. event-definition.schema.ts:154-174 — there is a schedule block in the event-definition schema. Report its fields (cron/cadence/interval, timezone, and so on).
+5. event-scheduler.ts — EventScheduler materializes scheduled ticks idempotently (not seeded). Confirm the idempotency mechanism.
+6. THE GAP: codegen loads ONLY entities, events, providers, relationships, junctions. There is NO jobs definition kind, NO definitions/jobs/ loader, NO job-handler emitter. Verify by reading src/parser/load-entities.ts, src/parser/load-events.ts (around line 88), and the gen-walk discovery in src/cli/commands/entity.ts (around line 169). Confirm definitively that no jobs kind exists and report exactly what kinds the gen-walk discovers.
+
+Report via schema. cluster equal to codegen-jobs-events-parser.`,
+  },
+  {
+    cluster: 'swe-brain-sync-handlers',
+    prompt:
+`You are verifying file:line anchors in the swe-brain repo at ${SWE}. The relevant handlers live in ${SWE}/apps/backend/src/jobs/. For EACH claim, open the file (lines may have drifted) and report verdict.
+
+Claims (cluster: the four sync handlers + duplicated shell + registry flag + global differ):
+1. Four sync JobHandler classes exist: inbound-sync, reconcile-poll, google-reconcile, drive-poll (files: inbound-sync.job-handler.ts, reconcile-poll.job-handler.ts, google-reconcile.job-handler.ts, drive-poll.job-handler.ts).
+2. The COPY-PASTED shell across the four is: env-disable gate, then connection resolve, then ADR-0016 surface gate, then per-domain execute(), then a re-declared PhaseSummary struct. Confirm a PhaseSummary struct is re-declared in reconcile-poll (around line 84), google-reconcile (around line 110), drive-poll (around line 103). Quote each PhaseSummary declaration so we can judge how identical they are.
+3. THE THREE SHAPES — read how each handler calls ExecuteIntegrationUseCase.execute():
+   - PollSync: NO sourceOverride, cursor ADVANCES (drive-poll; mail/calendar arms of google-reconcile; Google arms of inbound-sync).
+   - ReconcileSync: windowed sourceOverride (now minus window) + tombstone inference, cursor WITHHELD (reconcile-poll; transcript arm of google-reconcile).
+   - RealtimeSync: webhook-staging sourceOverride + claim/ack drain loop (Slack message/reaction arms of inbound-sync).
+   Confirm each shape by quoting the relevant execute()-call sites. This is the load-bearing taxonomy claim — scrutinize it.
+4. inbound-sync.job-handler.ts:45-49 and :318-322 + inbound-jobs.module.ts:18-24 — the code hand-injects named (provider,domain) use-case tokens and flags the future codegen #458 (provider,domain)->use-case registry collapse. Confirm.
+5. apps/backend/src/generated/subsystems.ts:27 — the global DeepEqualDiffer is constructed there from integration.differ.unignore of [deletedAt]. Confirm.
+
+Report via schema. cluster equal to swe-brain-sync-handlers.`,
+  },
+  {
+    cluster: 'swe-brain-scope-cadence-priorart',
+    prompt:
+`You are verifying claims in the swe-brain repo at ${SWE}. Report verdicts.
+
+Claims (cluster: out-of-scope handlers + cadence home + context layout + prior art):
+1. FOUR non-sync handlers are correctly OUT of scope because they are NOT IChangeSource-driven. Confirm by reading each:
+   - watch-renewal.job-handler.ts — direct repo sweep, no change-source.
+   - trigger-runner.job-handler.ts + schedule-dispatcher.job-handler.ts — the Predicate/Directive seam; look at ${SWE}/apps/backend/src/triggers/execute.ts.
+   - transcript-extraction.job-handler.ts — thin reflex over ExtractObservationsUseCase.
+2. CADENCE HOME TODAY: where do the cadences (cron/interval) for the four sync jobs actually live right now? Search ${SWE}/apps/backend (or wherever definitions/events/** lives — find it) for schedule YAML blocks tied to these jobs. Report the exact files and cadence values for inbound-sync / reconcile-poll / google-reconcile / drive-poll.
+3. CONTEXT LAYOUT: is apps/backend/src/jobs/ organized by bounded context today (messaging/mail/calendar/transcript/document subfolders) or FLAT? The request proposes moving to per-context subfolders — report current reality.
+4. PRIOR ART for D3: the request mentions that W3 extraction already uses declarative derivation profiles for chunking. Find this in swe-brain (search for derivation profile / chunking / W3 / extraction config). Summarize the profile pattern — is it a YAML/object-driven config that could be a template for the job-profile schema?
+5. The request says system JobHandler jobs are upserted at boot (no DB seeding) and the ONLY magic seeding (seed-schedules.ts / seed-directives.ts) is for user automations (out of scope). Find seed-schedules.ts / seed-directives.ts and confirm they seed user automations, not system jobs.
+
+Report via schema. cluster equal to swe-brain-scope-cadence-priorart.`,
+  },
+]
+
+const facts = await parallel(
+  verifiers.map((v) => () => agent(v.prompt, { label: 'verify:' + v.cluster, phase: 'Verify', schema: ANCHOR_SCHEMA }))
+)
+const verified = facts.filter(Boolean)
+const factsDigest = JSON.stringify(verified, null, 1)
+log('Verification complete: ' + verified.length + ' clusters. Grounding the 5 design decisions...')
+
+phase('Decide')
+
+const decisions = [
+  {
+    key: 'D1-realtime-peer-vs-mode',
+    prompt:
+`Open design decision 1: Is RealtimeSync a PEER primitive (3 peers: Poll/Reconcile/Realtime) or a webhook-DRAIN MODE on top of Poll/Reconcile (2 primitives + a mode)? RealtimeSync is the only one with a claim/ack loop over a webhook-staging table.
+Read ${CG}/runtime/subsystems/integration/build-change-source.ts (the mode switch of poll or webhook) and the swe-brain Slack realtime arm in ${SWE}/apps/backend/src/jobs/inbound-sync.job-handler.ts. Consider that build-change-source ALREADY has a webhook mode — does realtime collapse into webhook-mode-plus-drain, making it a mode not a peer? Recommend.`,
+  },
+  {
+    key: 'D2-differ-override',
+    prompt:
+`Open design decision 2: Add a per-run differOverride on ExecuteIntegrationInput (mirroring sourceOverride) so ReconcileSync can carry a configurable dedupe/update strategy — OR is the single global unignore policy enough for now? KEY FACT from verification: whether ExecuteIntegrationInput is package-owned (codegen runtime) decides if this is a codegen change that B must subsume. Read ${CG}/runtime/subsystems/integration/execute-integration.use-case.ts and the input type definition, plus ${CG}/runtime/subsystems/integration/detection-config.schema.ts (does per-mode dedupKey already cover the need?). Recommend, and state clearly whether differOverride should be: (a) an A-side app seam first then lifted, (b) a codegen change from the start, or (c) deferred (global unignore suffices).`,
+  },
+  {
+    key: 'D3-detection-adopt-vs-fresh',
+    prompt:
+`Open design decision 3: Should B per-adapter job profile ADOPT codegen existing detection config (DetectionConfigSchema) as its dedupe/cursor/window/filters/mapping backbone, or roll a FRESH profile shape? swe-brain deliberately avoids detection today. Read ${CG}/runtime/subsystems/integration/detection-config.schema.ts fully and assess coverage vs the request profile fields (cadence, window, dedupe.unignore, pool, lane, stagingSource/pushSource, pushAccelerate). Also weigh the W3 declarative derivation profiles prior art surfaced in verification. Recommend: reuse DetectionConfigSchema (composed into JobDefinitionSchema), extend it, or fresh — with the schema-shape consequence.`,
+  },
+  {
+    key: 'D4-cadence-home',
+    prompt:
+`Open design decision 4: Where does cadence live — the existing event-YAML schedule block (status quo, codegen EventScheduler materializes ticks), or INSIDE the job profile (one declaration per job)? The request recommends the profile. Read ${CG}/src/schema/event-definition.schema.ts (schedule block) and ${CG}/runtime/subsystems/events/event-scheduler.ts, and consider verification finding on where swe-brain cadences live today. One source must win. Recommend, and specify how the job profile would express cadence and how it wires to EventScheduler (does the job emitter ALSO emit a schedule event, or does the scheduler learn to read job definitions?).`,
+  },
+  {
+    key: 'D5-registry-source',
+    prompt:
+`Open design decision 5: The generic handler needs a (provider,domain)->use-case lookup. Wait for codegen #458 to ship that registry, or hand-build a small LOCAL registry in swe-brain (A) now? Read the swe-brain hand-injected tokens in ${SWE}/apps/backend/src/jobs/inbound-jobs.module.ts and inbound-sync.job-handler.ts, and check codegen-patterns issue #458 framing (the assembly use-case registry). Recommend the sequencing: does A build a throwaway local registry now (deleted when #458 lands), or should #458 be pulled forward as a B dependency? Note the dependency edge for the work breakdown.`,
+  },
+]
+
+const resolved = await parallel(
+  decisions.map((d) => () =>
+    agent(d.prompt + '\n\n--- VERIFIED FACTS (JSON, use these; do not re-derive) ---\n' + factsDigest, {
+      label: 'decide:' + d.key,
+      phase: 'Decide',
+      schema: DECISION_SCHEMA,
+    })
+  )
+)
+const resolvedDecisions = resolved.filter(Boolean)
+log('Decisions grounded: ' + resolvedDecisions.length + '/5. Synthesizing design brief + work breakdown...')
+
+phase('Synthesize')
+
+const synthesisPrompt =
+`You are the synthesis lead. You have (1) verified anchor facts and (2) five grounded design-decision recommendations for a cross-repo feature: sync-job primitives (Part A, swe-brain at ${SWE}) lifted into a codegen jobs definition kind plus emitter (Part B, codegen-patterns at ${CG}). The load-bearing constraint: A per-adapter sync-profile object IS B JobDefinitionSchema (A config equals B schema).
+
+Produce a SINGLE consolidated design brief in Markdown with these sections:
+
+## 1. Anchor verification verdict
+A compact table of any DRIFTED / REFUTED / NOT-FOUND anchors (skip the plainly-confirmed ones, but state the overall confidence: did the request research hold up?). Flag anything that changes the plan.
+
+## 2. Resolved design decisions
+For each of the 5 decisions: the recommended call, confidence, one-line rationale, and the resulting schema implication. Where two decisions interact (for example D1 mode-vs-peer changes the schema primitive field; D3 detection-adoption changes the dedupe/cursor fields), say so.
+
+## 3. Proposed JobDefinitionSchema (B) / sync-profile shape (A)
+A concrete draft of the YAML schema that satisfies the A-to-B contract, reconciling all 5 resolved decisions. Show it as an annotated YAML example covering poll / reconcile / realtime cases. This is the single most important artifact — it is the thing A builds against and B compiles.
+
+## 4. Dependency-ordered work breakdown (PR-sized)
+A numbered list of PR-sized issues spanning BOTH repos. For each: [repo] title — one-line scope — dependsOn (issue numbers in this list) — rough size (S/M/L). Order so that: shared schema/ADR is locked first; A primitives plus profiles are built and behaviour-verified; then B lifts the shape; then swe-brain dogfoods B (deletes A hand-built primitives, re-expresses as YAML). Call out the codegen-patterns main-to-npm auto-deploy coordination step explicitly as its own gated item. Note where codegen #458 (D5) sits in the order.
+
+## 5. ADR outline
+A skeleton for the swe-brain ADR-0018+ (the three shapes, the per-adapter composition table, the A-to-B contract, and the resolutions to the 5 decisions).
+
+## 6. Risks and watch-items
+Top risks (behaviour-parity verification for A; npm-deploy coupling; schema churn between A-build and B-lift; anything verification surfaced as a surprise).
+
+Be concrete and decisive — this brief feeds an SDLC plan. Do not hedge with could-go-either-way; make the call and note the fallback.
+
+--- VERIFIED FACTS (JSON) ---
+${factsDigest}
+
+--- RESOLVED DECISIONS (JSON) ---
+${JSON.stringify(resolvedDecisions, null, 1)}`
+
+const brief = await agent(synthesisPrompt, { label: 'synthesize:brief', phase: 'Synthesize' })
+
+return { brief, verified, resolvedDecisions }

--- a/.ai-docs/research/jobs-kind-handoff.md
+++ b/.ai-docs/research/jobs-kind-handoff.md
@@ -1,0 +1,73 @@
+# Handoff — Sync-Job Primitives (A) → codegen jobs-definition-kind (B)
+
+**Session:** 2026-06-13/14. **Author:** Claude (codegen-patterns session).
+**Status:** design grounded + locked; **no implementation started by me.**
+
+## TL;DR verified state (re-swept 2026-06-14, both repos, all refs + PRs + worktrees)
+- **Part B (codegen jobs-definition-kind): does not exist anywhere.** Pickaxe across all
+  branches + full history for `JobDefinitionSchema` / `definitions/jobs` / `loadJobs` /
+  `job-handler-emission` = **zero**. No branch, no PR. **Never started.**
+- **Part A (swe-brain primitives): ~60% done, UNCOMMITTED WIP, a day stale.** Lives only in
+  the `velvet-snuggling-yeti` worktree as untracked `apps/backend/src/jobs/sync/` +
+  3 modified handlers. Not on any ref. **At risk** — see the velvet handoff note.
+- **ADR-0018:** referenced in the Part-A code comments everywhere, but **the doc does not exist.**
+
+## Artifacts produced this session (saved, untracked)
+- `.ai-docs/research/jobs-kind-design-brief.md` — the full design brief: anchor verification
+  (28/31 confirmed, HIGH confidence), resolved D1–D5, the proposed `JobDefinitionSchema`,
+  PR-sized work breakdown, ADR-0018 outline, risks. **This is the live plan.**
+- `.ai-docs/research/jobs-kind-grounding.workflow.js` — the 10-agent grounding workflow
+  (re-runnable / resumable).
+- `.ai-docs/requests/job-primitives-and-codegen-jobs-kind.md` (in the velvet worktree) — the
+  original request that kicked this off.
+
+## Decisions LOCKED with Doug this session (override the brief where noted)
+- **Cadence = owned by the JOB** (overrides the brief's D4 "event-owned" recommendation).
+  Doug: "job declares its own cadence; I'm not setting up timers then attaching jobs."
+  The in-flight Part A already implements exactly this (`SyncJobProfile.cadence: '1h'` +
+  `realizedBy: <event>` + a drift-guard; Part B's emitter later generates the event FROM
+  `cadence` and `realizedBy` drops). Firing mechanism stays "app-level, align thereafter."
+- **Realtime = NOT a peer primitive** (D1 confirmed). It's the existing `webhook` change-source
+  mode + a claim/ack drain loop in the handler. Part A defers it entirely to a future
+  `realtime-drain.ts`; `inbound-sync` is untouched. `kind: realtime` stays a schema label only.
+- **`differOverride` = DEFER** (D2). Global `differ.unignore` + per-entity DI rebind suffice.
+- **Local `(provider,domain)→use-case` registry now; codegen #458 is NOT a B blocker** (D5).
+- **Piggyback A into B** (Doug): design the YAML directly for B; swe-brain is the first
+  consumer. Drops the throwaway "hand-build 3 generic primitives then delete" phase. Behaviour
+  oracle is still *today's* 4 handlers.
+
+## OPEN question Doug did NOT resolve (resolve before Part B schema freeze)
+**Cadence shape: single-string vs trigger-list.** Part A models cadence as one
+`cadence: '1h'` string per job — clean for the 3 heal jobs, but the grounding found
+`inbound-sync` has **zero** cadence and `drive-poll` has **cadence + a webhook doorbell**.
+Recommended resolution (mine): model `triggers` as a **list** with a `schedule` arm + an
+`event` arm (Doug's own "ScheduleTrigger" idea), with a single `cadence` as sugar over one
+schedule-trigger. Handles 0/1/N without a special case. Surface this in ADR-0018.
+
+## Next actions (ordered)
+**Part B (codegen — this repo), per the brief §4:**
+1. Write **ADR-0018** (or its codegen-side spec) locking the schema on paper — the A↔B byte
+   contract. Fold in cadence-on-job + the trigger-list resolution above.
+2. `src/schema/job-definition.schema.ts` — fresh Zod schema; imports `DetectionConfig`
+   per-arm (do NOT modify detection-config; fix its stale `:17` "four shapes" header in the
+   same PR). Two discriminated unions at two altitudes: arm-`kind` (poll|reconcile|realtime)
+   over source-`mode` (poll|webhook). Surface all 8 `JobHandlerMeta` fields.
+3. `src/parser/load-jobs.ts` + `detectYamlType` 'jobs' branch (`yaml-loader.ts` ~526-547).
+4. `src/cli/shared/job-handler-emission-generator.ts` — seam-split emitter (`@generated` base
+   + emit-once subclass), mirroring `sink-emission-generator.ts`. Wire a `jobs` post-step in
+   `src/cli/commands/entity.ts`.
+5. `just test-smoke-integration` MUST tsc-compile the emitted tree (project gate).
+6. 🚦 RELEASE GATE: merging codegen `main` auto-publishes to npm (immutable). Run
+   `just test-post-publish` first. swe-brain's B-dogfood consumes the *published* tarball.
+
+**Part A (swe-brain — the velvet agent):** finish 3 remaining profiles
+(`drive-poll`/`reconcile-poll`/`inbound-sync`), the realtime-drain shape, ADR-0018, and
+**commit the WIP first** (see velvet note).
+
+## Key risks
+- **At-risk WIP** — Part A is uncommitted in a worktree, a day stale. Commit/branch before anything else.
+- **npm auto-deploy coupling** — the one hard cross-repo serialization point (B publish → A regen).
+- **Behaviour parity** — baseline today's 4 handlers (esp. `cursorWithheld` on reconcile arms;
+  a regressed watermark silently re-processes) before the B-lift.
+- **Emitter/AST-seam coexistence** — generated handler skeleton vs the bridge-registry
+  generator's AST scan of authored `@JobHandler` in `<backend>/jobs`. Don't break the bridge harvest.


### PR DESCRIPTION
Docs-only. Lands the grounded design for the **sync-job primitives (A) → codegen jobs-definition-kind (B)** feature so it lives on `main` instead of a stranded local branch.

- `jobs-kind-design-brief.md` — anchor verification (28/31 confirmed), resolved D1–D5, proposed `JobDefinitionSchema`, PR-sized work breakdown, ADR-0018 outline.
- `jobs-kind-handoff.md` — next actions + locked decisions (cadence-on-job, realtime-as-drain, defer differOverride, local registry, piggyback A into B).
- `jobs-kind-grounding.workflow.js` — the 10-agent grounding workflow (re-runnable).

**Status captured:** Part B (codegen jobs-definition-kind) is unstarted; Part A (swe-brain primitives) is uncommitted WIP in the velvet-snuggling-yeti worktree. No code change — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
