### PR TITLE
feat(parser): definitions/jobs loader — loadJobs + resolveJobsDir (Part B #6, RFC-0005)

### DIFF
--- a/docs/rfcs/RFC-0005-job-definition-kind.md
+++ b/docs/rfcs/RFC-0005-job-definition-kind.md
@@ -1,6 +1,6 @@
 # RFC-0005 — Jobs definition kind: `JobDefinitionSchema` + emitter (Part B)
 
-**Status:** Draft — schema (#5) landed; loader/emitter/validator (#6–#8) pending
+**Status:** Draft — schema (#5) + loader (#6) landed; emitter/validator (#7–#8) pending
 **Date:** 2026-06-14
 **Owner:** Doug
 **Related:** swe-brain **ADR-0018** (the A→B decision record + the three shapes — *this RFC is the codegen-side byte contract for it*); ADR-039 (time as an event source — cadence lives on the event YAML `schedule:`); ADR-033/033.1 (`detection:` config + `DetectionConfigSchema`, embedded here verbatim); ADR-023 (event→job bridge — the `event` trigger arm); RFC-0003 (`historyId`/`syncToken` cursors); `runtime/subsystems/jobs/job-handler.base.ts` (`JobHandlerMeta` — the 8 fields surfaced); codegen #458/#414/#457 (the soft-ordered registry follow-ups). Grounding: `.ai-docs/research/jobs-kind-design-brief.md` (the 10-agent grounding brief; §3 is the schema this RFC freezes).
@@ -85,7 +85,7 @@ The brief §3 was a paper sketch; authoring against the real runtime types surfa
 | # | Item | Status |
 |---|---|---|
 | 5 | `src/schema/job-definition.schema.ts` (fresh, imports DetectionConfig) + unit tests + living-docs fix to `detection-config.schema.ts` header | **landed (this RFC)** |
-| 6 | `definitions/jobs/` loader + `detectYamlType` 'jobs' branch + parser registry | pending |
+| 6 | `definitions/jobs/` loader (`loadJobs` + `loadJobFromYaml`) + `resolveJobsDir` (`paths.jobs_dir`, fallback `definitions/jobs`) + parser export. **Correction:** NO `detectYamlType` branch — that discriminator is for the entity-family files (entity/relationship/junction) in the entities dir; events and jobs both carry a top-level `type:` and load by **directory** (`loadEvents`/`loadJobs`), never through `detectYamlType`. Enforces filename↔`type` + duplicate-type, mirroring `loadEvents`. No cross-ref (triggers→events is #8). | **landed** |
 | 7 | Jobs emitter (`src/emitters/` or `src/cli/shared/`) + `entity new` post-step; define generated-skeleton vs AST-scanned-`@JobHandler` coexistence | pending |
 | 8 | D4 cross-ref validator: `triggers[].event` → generated `eventRegistry`; Option-D cadence drift check; update ADR-039 + events skill same PR | pending |
 | 9 | `just test-smoke-integration` green for the jobs emitter (must tsc-compile the emitted tree) | pending |

--- a/src/__tests__/parser/load-jobs.test.ts
+++ b/src/__tests__/parser/load-jobs.test.ts
@@ -1,0 +1,128 @@
+/**
+ * loadJobs() unit tests (RFC-0005, breakdown #6).
+ *
+ * Happy path runs against the real RFC-0005 §3 fixtures; error cases use
+ * throwaway temp dirs so the fixtures dir stays clean. Mirrors the loadEvents
+ * loader contract: never throws, accumulates AnalysisIssues, enforces
+ * filename↔type and duplicate-type.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import { loadJobs } from '../../parser/load-jobs';
+
+const FIXTURE_DIR = resolve(__dirname, '../../../test/fixtures/jobs');
+
+const VALID_POLL_JOB = (type: string) => `
+type: ${type}
+pool: integration
+arms:
+  - kind: poll
+    domain: document
+    read:
+      mode: poll
+      poll:
+        cursor: { kind: timestamp, field: updated_at }
+      mapping:
+        - { source: id, target: external_id }
+`;
+
+const tmpDirs: string[] = [];
+function makeJobsDir(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), 'jobs-loader-'));
+	tmpDirs.push(dir);
+	for (const [name, content] of Object.entries(files)) {
+		writeFileSync(join(dir, name), content, 'utf8');
+	}
+	return dir;
+}
+
+afterEach(() => {
+	while (tmpDirs.length) {
+		const dir = tmpDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+// ----------------------------------------------------------------------------
+// Happy path — the three §3 fixtures
+// ----------------------------------------------------------------------------
+
+describe('loadJobs — RFC-0005 §3 fixtures', () => {
+	it('loads all three fixtures with zero error issues', () => {
+		const { jobs, issues } = loadJobs(FIXTURE_DIR);
+		expect(jobs.map((j) => j.type).sort()).toEqual([
+			'drive_poll',
+			'inbound_sync',
+			'reconcile_poll',
+		]);
+		expect(issues.filter((i) => i.severity === 'error')).toEqual([]);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Directory edge cases — opt-in, never throws
+// ----------------------------------------------------------------------------
+
+describe('loadJobs — directory edge cases', () => {
+	it('warns (does not throw) on a nonexistent directory', () => {
+		const { jobs, issues } = loadJobs('/no/such/jobs/dir');
+		expect(jobs).toEqual([]);
+		expect(issues.some((i) => i.severity === 'warning' && i.type === 'no_jobs_dir')).toBe(true);
+	});
+
+	it('warns on an empty directory', () => {
+		const dir = makeJobsDir({});
+		const { jobs, issues } = loadJobs(dir);
+		expect(jobs).toEqual([]);
+		expect(issues.some((i) => i.severity === 'warning' && i.type === 'no_files')).toBe(true);
+	});
+});
+
+// ----------------------------------------------------------------------------
+// Per-file errors — accumulate, no short-circuit
+// ----------------------------------------------------------------------------
+
+describe('loadJobs — per-file errors', () => {
+	it('errors on a filename ↔ type mismatch', () => {
+		const dir = makeJobsDir({ 'drive_poll.yaml': VALID_POLL_JOB('something_else') });
+		const { jobs, issues } = loadJobs(dir);
+		expect(jobs).toEqual([]);
+		expect(issues.some((i) => i.type === 'job_filename_mismatch')).toBe(true);
+	});
+
+	it('errors on a duplicate job type (.yaml + .yml twins)', () => {
+		const dir = makeJobsDir({
+			'drive_poll.yaml': VALID_POLL_JOB('drive_poll'),
+			'drive_poll.yml': VALID_POLL_JOB('drive_poll'),
+		});
+		const { issues } = loadJobs(dir);
+		expect(issues.some((i) => i.type === 'duplicate_job_type')).toBe(true);
+	});
+
+	it('surfaces schema validation errors (bad arm kind) as error issues', () => {
+		const dir = makeJobsDir({
+			'broken.yaml': `
+type: broken
+arms:
+  - kind: streaming
+    domain: document
+`,
+		});
+		const { jobs, issues } = loadJobs(dir);
+		expect(jobs).toEqual([]);
+		expect(issues.some((i) => i.severity === 'error' && i.type === 'schema_error')).toBe(true);
+	});
+
+	it('does not short-circuit — a good file still loads alongside a bad one', () => {
+		const dir = makeJobsDir({
+			'drive_poll.yaml': VALID_POLL_JOB('drive_poll'),
+			'broken.yaml': 'type: broken\narms: []\n',
+		});
+		const { jobs, issues } = loadJobs(dir);
+		expect(jobs.map((j) => j.type)).toEqual(['drive_poll']);
+		expect(issues.some((i) => i.severity === 'error')).toBe(true);
+	});
+});

--- a/src/cli/shared/jobs-path.ts
+++ b/src/cli/shared/jobs-path.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared resolver for the jobs definition source directory.
+ *
+ * This is the directory codegen reads `definitions/jobs/*.yaml` from when
+ * loading job definitions (RFC-0005). Jobs are opt-in like providers — a
+ * project without this directory is valid (the loader returns a non-fatal
+ * warning and an empty list).
+ *
+ * Resolution order:
+ *   1. `paths.jobs_dir` in `codegen.config.yaml`
+ *   2. `<cwd>/definitions/jobs` fallback (matches the `definitions/providers`
+ *      convention; distinct from the bare `events/` legacy path).
+ */
+import path from 'node:path';
+
+import type { CodegenConfig, Context } from './context.js';
+
+const FALLBACK = 'definitions/jobs';
+
+export function resolveJobsDirFromConfig(
+	cwd: string,
+	config: CodegenConfig | null,
+): string {
+	const configured = config?.paths?.jobs_dir;
+	if (typeof configured === 'string' && configured.length > 0) {
+		return path.resolve(cwd, configured);
+	}
+	return path.resolve(cwd, FALLBACK);
+}
+
+export function resolveJobsDir(ctx: Context): string {
+	return resolveJobsDirFromConfig(ctx.cwd, ctx.config);
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -38,3 +38,12 @@ export {
 	type ProviderLoadResult,
 	type ProviderLoadError,
 } from '../utils/yaml-loader';
+
+export { loadJobs, type LoadJobsResult } from './load-jobs';
+
+export {
+	loadJobFromYaml,
+	type LoadJobResult,
+	type JobLoadResult,
+	type JobLoadError,
+} from '../utils/yaml-loader';

--- a/src/parser/load-jobs.ts
+++ b/src/parser/load-jobs.ts
@@ -1,0 +1,152 @@
+/**
+ * Job Definition Loader (RFC-0005, breakdown #6)
+ *
+ * Loads and parses all job YAML files from a directory (default
+ * `definitions/jobs/`). Enforces filename ↔ `type` consistency and rejects
+ * duplicate job types. Returns a {@link LoadJobsResult} that collects all
+ * issues (never throws), matching the `loadEvents()` / `loadEntities()`
+ * contract used elsewhere in the parser layer.
+ *
+ * Deliberately does NOT cross-validate `triggers[].event` against the event
+ * registry, nor arm `domain` against entities — those gen-time cross-refs are
+ * the cross-ref validator's job (breakdown #8). This loader is shape + filename
+ * + uniqueness only; #7 (the emitter) consumes the validated `JobDefinition[]`.
+ */
+
+import { basename, resolve } from 'node:path';
+import { findYamlFiles } from '../utils/find-yaml-files';
+import type { AnalysisIssue } from '../analyzer/types';
+import type { JobDefinition } from '../schema/job-definition.schema';
+import {
+	loadJobFromYaml,
+	type JobLoadError,
+	type LoadJobResult,
+} from '../utils/yaml-loader';
+
+export interface LoadJobsResult {
+	jobs: JobDefinition[];
+	issues: AnalysisIssue[];
+}
+
+/**
+ * Convert a job-load error result into one or more {@link AnalysisIssue}s.
+ * Mirrors `loadErrorToIssue` in `load-events.ts` so CLI renderers treat both
+ * loaders' output uniformly.
+ */
+function loadErrorToIssue(error: JobLoadError): AnalysisIssue[] {
+	const issues: AnalysisIssue[] = [];
+
+	issues.push({
+		severity: 'error',
+		type: 'parse_error',
+		message: error.error,
+		path: error.filePath,
+	});
+
+	if (error.details) {
+		for (const detail of error.details) {
+			issues.push({
+				severity: 'error',
+				type: 'schema_error',
+				message: detail,
+				path: error.filePath,
+			});
+		}
+	}
+
+	return issues;
+}
+
+/**
+ * Strip `.yaml` / `.yml` from a filename.
+ */
+function stripYamlExt(file: string): string {
+	const base = basename(file);
+	if (base.endsWith('.yaml')) return base.slice(0, -'.yaml'.length);
+	if (base.endsWith('.yml')) return base.slice(0, -'.yml'.length);
+	return base;
+}
+
+/**
+ * Load all job YAML files from a directory.
+ *
+ * - Nonexistent directory → non-fatal warning, returns empty list (jobs are
+ *   opt-in, like providers — a project without `definitions/jobs/` is valid).
+ * - Empty directory → warning, returns empty list.
+ * - Per-file errors (YAML syntax, schema, filename mismatch, duplicate type)
+ *   accumulate into {@link AnalysisIssue}s; no short-circuit.
+ * - Never throws. Generator callers abort on `issues.some(i => i.severity === 'error')`.
+ */
+export function loadJobs(jobsDir: string): LoadJobsResult {
+	const jobs: JobDefinition[] = [];
+	const issues: AnalysisIssue[] = [];
+
+	const resolvedDir = resolve(jobsDir);
+
+	let files: string[];
+	try {
+		files = findYamlFiles(resolvedDir);
+	} catch {
+		issues.push({
+			severity: 'warning',
+			type: 'no_jobs_dir',
+			message: `No jobs directory found at: ${resolvedDir}`,
+			path: resolvedDir,
+		});
+		return { jobs, issues };
+	}
+
+	if (files.length === 0) {
+		issues.push({
+			severity: 'warning',
+			type: 'no_files',
+			message: `No job YAML files found in directory: ${resolvedDir}`,
+			path: resolvedDir,
+		});
+		return { jobs, issues };
+	}
+
+	const seenTypes = new Map<string, string>(); // type → filePath of first definition
+
+	for (const filePath of files) {
+		const result: LoadJobResult = loadJobFromYaml(filePath);
+
+		if (!result.success) {
+			issues.push(...loadErrorToIssue(result));
+			continue;
+		}
+
+		const { definition } = result;
+		const baseName = stripYamlExt(filePath);
+
+		// Filename ↔ type match. The job type IS the @JobHandler('<type>')
+		// registry key; a drift between filename and type is a silent footgun.
+		if (baseName !== definition.type) {
+			issues.push({
+				severity: 'error',
+				type: 'job_filename_mismatch',
+				message: `Job file '${baseName}' must contain 'type: ${baseName}' (found 'type: ${definition.type}')`,
+				path: filePath,
+				suggestion: `Rename the file to '${definition.type}.yaml' or fix the 'type' field to '${baseName}'`,
+			});
+			continue;
+		}
+
+		// Duplicate type detection (belt-and-braces — filename match usually
+		// prevents this, but defend against symlinks / .yml vs .yaml twins).
+		if (seenTypes.has(definition.type)) {
+			issues.push({
+				severity: 'error',
+				type: 'duplicate_job_type',
+				message: `Duplicate job type '${definition.type}' (already declared in ${seenTypes.get(definition.type)})`,
+				path: filePath,
+			});
+			continue;
+		}
+
+		seenTypes.set(definition.type, filePath);
+		jobs.push(definition);
+	}
+
+	return { jobs, issues };
+}

--- a/src/schema/codegen-config.schema.ts
+++ b/src/schema/codegen-config.schema.ts
@@ -80,6 +80,7 @@ export type GenerateConfig = z.infer<typeof GenerateConfigSchema>;
 export const PathsConfigSchema = z
   .object({
     events_dir: z.string().optional(),
+    jobs_dir: z.string().optional(),
     generated: z.string().default("src/generated"),
   })
   .passthrough();

--- a/src/utils/yaml-loader.ts
+++ b/src/utils/yaml-loader.ts
@@ -21,6 +21,10 @@ import {
 	type ProviderDefinition,
 	ProviderDefinitionSchema,
 } from '../schema/provider-definition.schema';
+import {
+	type JobDefinition,
+	JobDefinitionSchema,
+} from '../schema/job-definition.schema';
 
 export interface LoadResult {
 	success: true;
@@ -300,6 +304,82 @@ export function loadEventFromYaml(filePath: string): LoadEventResult {
 	}
 
 	const result = EventDefinitionSchema.safeParse(parsed);
+	if (!result.success) {
+		return {
+			success: false,
+			error: `Validation failed for ${filePath}`,
+			details: formatZodErrors(result.error),
+			filePath,
+		};
+	}
+
+	return {
+		success: true,
+		definition: result.data,
+		filePath,
+	};
+}
+
+// ============================================================================
+// Job Definition YAML Loading (RFC-0005, breakdown #6)
+// ============================================================================
+
+export interface JobLoadResult {
+	success: true;
+	definition: JobDefinition;
+	filePath: string;
+}
+
+export interface JobLoadError {
+	success: false;
+	error: string;
+	details?: string[];
+	filePath: string;
+}
+
+export type LoadJobResult = JobLoadResult | JobLoadError;
+
+/**
+ * Load and validate a single job definition from a YAML file.
+ *
+ * Mirrors {@link loadEventFromYaml}: existence check → readFileSync →
+ * parseYaml → `JobDefinitionSchema.safeParse`. Returns a discriminated result;
+ * callers (`loadJobs`) aggregate into `AnalysisIssue`s rather than throw.
+ */
+export function loadJobFromYaml(filePath: string): LoadJobResult {
+	if (!existsSync(filePath)) {
+		return {
+			success: false,
+			error: `File not found: ${filePath}`,
+			filePath,
+		};
+	}
+
+	let content: string;
+	try {
+		content = readFileSync(filePath, 'utf-8');
+	} catch (err) {
+		return {
+			success: false,
+			error: `Failed to read file: ${filePath}`,
+			details: [err instanceof Error ? err.message : String(err)],
+			filePath,
+		};
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = parseYaml(content);
+	} catch (err) {
+		return {
+			success: false,
+			error: `Invalid YAML syntax in ${filePath}`,
+			details: [err instanceof Error ? err.message : String(err)],
+			filePath,
+		};
+	}
+
+	const result = JobDefinitionSchema.safeParse(parsed);
 	if (!result.success) {
 		return {
 			success: false,


### PR DESCRIPTION
## What

Second unit of the **codegen jobs definition kind** (Part B, breakdown #6) — the directory-based loader that turns `definitions/jobs/*.yaml` into validated `JobDefinition[]`. Stacked on #542 (#5, the schema).

## Surface

- **`loadJobFromYaml`** (`yaml-loader.ts`) — mirrors `loadEventFromYaml`: existence → read → `parseYaml` → `JobDefinitionSchema.safeParse` → discriminated result.
- **`loadJobs`** (`parser/load-jobs.ts`) — mirrors `loadEvents`: `findYamlFiles`, **filename ↔ `type`** enforcement (the type IS the `@JobHandler('<type>')` registry key), duplicate-type detection, `AnalysisIssue` accumulation, never throws. Opt-in dir (warning when absent, like providers).
- **`resolveJobsDir`** (`cli/shared/jobs-path.ts`) — `paths.jobs_dir`, fallback `definitions/jobs` (the `definitions/` convention).
- `paths.jobs_dir` added to `PathsConfigSchema`; loader exported from the parser barrel.

## Correction to the brief's #6 (living-docs, recorded in RFC-0005)

**No `detectYamlType` branch.** That discriminator is for the entity-family files (entity/relationship/junction) in the *entities* directory; events and jobs both carry a top-level `type:` and load by **directory**, never through `detectYamlType`.

## Scope boundary

No cross-ref (`triggers[].event` → events, arm `domain` → entities) — that's the **#8** validator. The **#7** emitter consumes the validated `JobDefinition[]`.

## Tests

7 loader cases: 3 §3 fixtures happy path + filename mismatch, duplicate type, schema error, no-short-circuit, missing/empty dir. All green; tsc clean; no regressions in the parser suite (64 pass).

## Next

#7 — the jobs emitter (generated `@JobHandler` skeleton) + `entity new` post-step. This is the meaty "L" (the schedule-arm → scheduled-event + bridge-trigger wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
