### PR TITLE
feat(emit): wire jobs emitter into entity-new gen-walk (Part B #7b, RFC-0005)

### DIFF
--- a/src/__tests__/cli/emit-jobs.test.ts
+++ b/src/__tests__/cli/emit-jobs.test.ts
@@ -1,0 +1,72 @@
+/**
+ * emitJobHandlers write-orchestration tests (RFC-0005, breakdown #7b).
+ *
+ * Verifies the file layout + the seam-split write semantics: the @generated base
+ * reflows on every run (byte-idempotent), and the emit-once subclass is written
+ * once then skipped (author edits survive regen).
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFileSync as read } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { JobDefinitionSchema, type JobDefinition } from '../../schema/job-definition.schema';
+import { emitJobHandlers } from '../../cli/shared/emit-jobs';
+
+const FIXTURE_DIR = resolve(__dirname, '../../../test/fixtures/jobs');
+const loadJob = (name: string): JobDefinition =>
+	JobDefinitionSchema.parse(parseYaml(read(resolve(FIXTURE_DIR, name), 'utf8')));
+
+const drivePoll = loadJob('drive_poll.yaml');
+const reconcilePoll = loadJob('reconcile_poll.yaml');
+
+const tmpDirs: string[] = [];
+function tmpJobsDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'emit-jobs-'));
+	tmpDirs.push(dir);
+	return dir;
+}
+afterEach(() => {
+	while (tmpDirs.length) {
+		const d = tmpDirs.pop();
+		if (d) rmSync(d, { recursive: true, force: true });
+	}
+});
+
+describe('emitJobHandlers', () => {
+	it('writes a @generated base + an emit-once subclass per job', () => {
+		const dir = tmpJobsDir();
+		const res = emitJobHandlers({ jobs: [drivePoll, reconcilePoll], jobsHandlersDir: dir });
+		expect(res.basesWritten).toHaveLength(2);
+		expect(res.scaffoldsWritten).toHaveLength(2);
+		expect(res.scaffoldsSkipped).toEqual([]);
+		expect(existsSync(join(dir, 'drive_poll.job.generated.ts'))).toBe(true);
+		expect(existsSync(join(dir, 'drive_poll.job.ts'))).toBe(true);
+		expect(readFileSync(join(dir, 'drive_poll.job.generated.ts'), 'utf8')).toContain('@generated');
+	});
+
+	it('reflows the base but PRESERVES author edits to the subclass on re-emit', () => {
+		const dir = tmpJobsDir();
+		emitJobHandlers({ jobs: [drivePoll], jobsHandlersDir: dir });
+		const subPath = join(dir, 'drive_poll.job.ts');
+		// Simulate an author edit to the emit-once subclass.
+		writeFileSync(subPath, '// AUTHOR EDIT — do not clobber\n', 'utf8');
+
+		const res2 = emitJobHandlers({ jobs: [drivePoll], jobsHandlersDir: dir });
+		// The subclass is skipped (author edit survives); the base reflows.
+		expect(res2.scaffoldsSkipped).toEqual([subPath]);
+		expect(res2.scaffoldsWritten).toEqual([]);
+		expect(readFileSync(subPath, 'utf8')).toBe('// AUTHOR EDIT — do not clobber\n');
+		expect(readFileSync(join(dir, 'drive_poll.job.generated.ts'), 'utf8')).toContain('DrivePollJobBase');
+	});
+
+	it('dryRun computes paths without writing', () => {
+		const dir = tmpJobsDir();
+		const res = emitJobHandlers({ jobs: [drivePoll], jobsHandlersDir: dir, dryRun: true });
+		expect(res.basesWritten).toHaveLength(1);
+		expect(existsSync(join(dir, 'drive_poll.job.generated.ts'))).toBe(false);
+	});
+});

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -57,6 +57,13 @@ import { findYamlFiles } from '../../utils/find-yaml-files.js';
 import type { AnalysisIssue } from '../../analyzer/types.js';
 import { resolveSubsystemsRoot } from '../shared/subsystems-path.js';
 import { resolveEventsDir } from '../shared/events-path.js';
+import { resolveJobsDir } from '../shared/jobs-path.js';
+import { loadJobs } from '../../parser/load-jobs.js';
+import {
+	buildJobBridgeTriggers,
+	buildJobScheduledEvents,
+} from '../shared/job-emission-generator.js';
+import { emitJobHandlers } from '../shared/emit-jobs.js';
 
 import { theme } from '../ui/theme.js';
 import { icons } from '../ui/icons.js';
@@ -484,6 +491,32 @@ export class EntityNewCommand extends Command {
 			}
 		};
 
+		// Job definitions (RFC-0005 #7) — loaded ONCE, early, so their derived
+		// artifacts feed the event + bridge codegen in the SAME pass: each
+		// `schedule` arm desugars to a job-private scheduled event merged into the
+		// event registry, and every trigger becomes a declarative bridge mapping.
+		// The handler files themselves are emitted later (post-assembly). Because
+		// the bridge/schedule contributions come from the LOADED defs (not the
+		// emitted files), there is no two-pass ordering hazard. Opt-in: no
+		// `definitions/jobs/` ⇒ empty (warn-only), exactly like providers.
+		const jobsDir = resolveJobsDir(ctx);
+		const jobLoad = loadJobs(jobsDir);
+		if (!isJsonMode()) {
+			for (const issue of jobLoad.issues) {
+				if (issue.severity === 'error') {
+					printError(
+						`jobs: ${issue.message}${issue.path ? ` (${issue.path})` : ''}`,
+					);
+				}
+			}
+		}
+		const jobScheduledEvents = jobLoad.jobs.flatMap((j) =>
+			buildJobScheduledEvents(j),
+		);
+		const jobBridgeTriggers = jobLoad.jobs.flatMap((j) =>
+			buildJobBridgeTriggers(j, path.join(jobsDir, `${j.type}.yaml`)),
+		);
+
 		if (this.dryRun) {
 			const barrelPlan = await regenerateBarrels({
 				ctx,
@@ -505,6 +538,7 @@ export class EntityNewCommand extends Command {
 				eventsDir,
 				outputDir: eventCodegenOutputDir,
 				mode: runtimeMode,
+				extraSugarEvents: jobScheduledEvents,
 				dryRun: true,
 			});
 
@@ -514,6 +548,7 @@ export class EntityNewCommand extends Command {
 				outputDir: bridgeRegistryOutputDir,
 				mode: runtimeMode,
 				bridgeInstalled: bridgeInstalledForRegistry,
+				extraTriggers: jobBridgeTriggers,
 				dryRun: true,
 			});
 
@@ -720,6 +755,7 @@ export class EntityNewCommand extends Command {
 				eventsDir,
 				outputDir: eventCodegenOutputDir,
 				mode: runtimeMode,
+				extraSugarEvents: jobScheduledEvents,
 			});
 			if (!isJsonMode()) {
 				for (const issue of eventCodegenResult.issues) {
@@ -748,6 +784,7 @@ export class EntityNewCommand extends Command {
 				outputDir: bridgeRegistryOutputDir,
 				mode: runtimeMode,
 				bridgeInstalled: bridgeInstalledForRegistry,
+				extraTriggers: jobBridgeTriggers,
 			});
 			if (bridgeRegistryResult.skipped && !isJsonMode()) {
 				printInfo(
@@ -949,6 +986,35 @@ export class EntityNewCommand extends Command {
 			const msg = err instanceof Error ? err.message : String(err);
 			if (!isJsonMode()) {
 				printWarning(`adapter codegen failed — ${msg}`);
+			}
+		}
+
+		// Jobs handler emission (RFC-0005 #7). Runs LAST among the integration
+		// steps: the per-arm `runArm*` seam wires the assembly's
+		// ExecuteIntegrationUseCase, so the assemblies must exist first. The
+		// scheduled-event + bridge-trigger contributions already rode the event /
+		// bridge codegen above (from the early `jobLoad`); this step only writes the
+		// `@generated` base (reflow) + emit-once subclass per job into
+		// `<backend_src>/jobs/`. Same warn-but-don't-fail contract as siblings.
+		try {
+			if (jobLoad.jobs.length > 0) {
+				const jobEmit = emitJobHandlers({
+					jobs: jobLoad.jobs,
+					jobsHandlersDir: bridgeHandlersDir,
+					mode: runtimeMode,
+				});
+				if (!isJsonMode()) {
+					printInfo(
+						`jobs: emitted ${jobEmit.basesWritten.length} handler base(s); ` +
+							`${jobEmit.scaffoldsWritten.length} scaffold(s) written, ` +
+							`${jobEmit.scaffoldsSkipped.length} kept`,
+					);
+				}
+			}
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (!isJsonMode()) {
+				printWarning(`jobs codegen failed — ${msg}`);
 			}
 		}
 

--- a/src/cli/shared/emit-jobs.ts
+++ b/src/cli/shared/emit-jobs.ts
@@ -1,0 +1,87 @@
+/**
+ * Jobs emission write-orchestration (RFC-0005, breakdown #7b).
+ *
+ * Wraps the pure `generateJobHandler{Base,Subclass}` emitters with the file
+ * layout + emit-once write logic — exactly as `emitAdapters` wraps the pure sink
+ * generators. Per job, into `<backend_src>/jobs/`:
+ *   - `<type>.job.generated.ts` — `@generated`, written via `writeIfChanged`
+ *     (byte-idempotent; reflows on every run).
+ *   - `<type>.job.ts` — emit-once: written only when absent (`existsSync`-skip),
+ *     so author edits survive regen.
+ *
+ * The flat `<backend_src>/jobs/` layout is load-bearing: it is the same dir the
+ * bridge-registry generator scans. Job triggers reach the bridge DECLARATIVELY
+ * (RFC-0005 fork 1), so the emitted `@JobHandler` carries no `triggers` and the
+ * scan never double-registers them.
+ */
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { RuntimeMode } from "./runtime-import";
+import type { JobDefinition } from "../../schema/job-definition.schema";
+import {
+	generateJobHandlerBase,
+	generateJobHandlerSubclass,
+} from "./job-emission-generator";
+
+export interface EmitJobsOptions {
+	/** Validated job definitions (from `loadJobs`). */
+	jobs: JobDefinition[];
+	/** Absolute path to the handlers dir (`<cwd>/<backend_src>/jobs`). */
+	jobsHandlersDir: string;
+	/** Runtime mode (ADR-037). Default `package`. */
+	mode?: RuntimeMode;
+	/** If true, compute paths but don't write. */
+	dryRun?: boolean;
+}
+
+export interface EmitJobsResult {
+	/** `@generated` base file paths (always reflowed). */
+	basesWritten: string[];
+	/** Emit-once subclass paths written this run (were absent). */
+	scaffoldsWritten: string[];
+	/** Emit-once subclass paths skipped (already present). */
+	scaffoldsSkipped: string[];
+}
+
+/** Byte-idempotent write — skips the disk write when content is unchanged. */
+function writeIfChanged(outPath: string, content: string): void {
+	if (existsSync(outPath) && statSync(outPath).isFile() && readFileSync(outPath, "utf-8") === content) {
+		return;
+	}
+	mkdirSync(dirname(outPath), { recursive: true });
+	writeFileSync(outPath, content);
+}
+
+function writeFresh(outPath: string, content: string): void {
+	mkdirSync(dirname(outPath), { recursive: true });
+	writeFileSync(outPath, content);
+}
+
+export function emitJobHandlers(opts: EmitJobsOptions): EmitJobsResult {
+	const mode = opts.mode ?? "package";
+	const result: EmitJobsResult = {
+		basesWritten: [],
+		scaffoldsWritten: [],
+		scaffoldsSkipped: [],
+	};
+
+	for (const job of opts.jobs) {
+		const basePath = join(opts.jobsHandlersDir, `${job.type}.job.generated.ts`);
+		const subPath = join(opts.jobsHandlersDir, `${job.type}.job.ts`);
+
+		// @generated base — always reflow.
+		if (!opts.dryRun) writeIfChanged(basePath, generateJobHandlerBase({ job, mode }));
+		result.basesWritten.push(basePath);
+
+		// Emit-once subclass — write only when absent.
+		if (existsSync(subPath)) {
+			result.scaffoldsSkipped.push(subPath);
+		} else {
+			if (!opts.dryRun) writeFresh(subPath, generateJobHandlerSubclass({ job, mode }));
+			result.scaffoldsWritten.push(subPath);
+		}
+	}
+
+	return result;
+}


### PR DESCRIPTION
## What

Wires the #7a jobs emitter into the `entity new` gen-walk — makes it functional end-to-end (Part B, breakdown #7b). Stacked on #544.

## `emit-jobs.ts` (write orchestration)

Wraps the pure `generateJobHandler{Base,Subclass}` with the file layout + emit-once write logic, exactly as `emitAdapters` wraps the sink generators. Per job into `<backend_src>/jobs/`:
- `<type>.job.generated.ts` — `@generated`, `writeIfChanged` (byte-idempotent reflow).
- `<type>.job.ts` — emit-once: written only when absent (author edits survive regen).

## `entity.ts` gen-walk wiring

- **Loads jobs ONCE, early** (`resolveJobsDir` + `loadJobs`), surfacing error issues; opt-in (no `definitions/jobs` ⇒ empty, warn-only, like providers).
- **Threads the derived artifacts** — scheduled events (per `schedule` arm) → `generateEventCodegen` `extraSugarEvents`; bridge triggers (per trigger) → `generateBridgeRegistry` `extraTriggers` — at **both** the real and dry-run call sites.
- **No two-pass ordering hazard:** the bridge/event contributions come from the *loaded* defs, so the registries get them in the same pass even though the handler files emit later.
- **Emits handler files LAST** among the integration steps (after assembly — the per-arm seam wires the assembly's `ExecuteIntegrationUseCase`). Warn-but-don't-fail, like every sibling.

## Verification

- emit-jobs unit tests: reflow, **emit-once author-edit survival**, dryRun.
- tsc clean; **`just test-smoke-integration` PASS** — the entity.ts change does not regress the real integration `entity new` flow.
- 1031 cli/parser/schema tests green.

## Next

**#9** — extend the smoke harness with a `definitions/jobs/*.yaml` fixture (schedule arm + a poll arm over an existing entity, so bridge validation passes) and add `src/jobs/**` to the failure scope, exercising the jobs emitter end-to-end through the real pipeline. **#8** — the cross-ref validator (event-arm events must exist; schedule arms generate their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
