### PR TITLE
ci: bump node20-deprecated GitHub Actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload test artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-gen-output
           path: test/gen/
@@ -66,7 +66,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
@@ -74,7 +74,7 @@ jobs:
           bun-version: 1.3.x
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 


### PR DESCRIPTION
## Why

GitHub force-migrates Node 20 JS actions to Node 24 on **2026-06-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The 2026-06-14 `main` CI run surfaced the deprecation annotation:

> Node.js 20 actions are deprecated … actions/checkout@v4, actions/setup-node@v4 …

## What

Bump all first-party node20 actions in `ci.yml` to v5 (node24):

- `actions/checkout@v4` → `@v5` (test + publish jobs)
- `actions/setup-node@v4` → `@v5` (publish job)
- `actions/upload-artifact@v4` → `@v5` — same node20 class; its step is `if: failure()` so it wasn't in the annotation, but it hits the same deadline

Left unchanged: `oven-sh/setup-bun@v2` and `taiki-e/install-action@v2` — not flagged (composite / already current).

No behavior change — `node-version: 24` input in the publish job is unchanged; only the action runtimes move to node24.

The sibling `post-publish-smoke.yml` gets the same bump on its own branch (PR #271).