### PR TITLE
test(smoke): exercise jobs emitter end-to-end in smoke-integration (Part B #9, RFC-0005)

### DIFF
--- a/test/fixtures/integration-patterns/definitions/jobs/contact_sync.yaml
+++ b/test/fixtures/integration-patterns/definitions/jobs/contact_sync.yaml
@@ -1,0 +1,23 @@
+# Smoke-integration jobs fixture (RFC-0005 #9). Exercises the jobs emitter
+# end-to-end through the real `entity new` pipeline so the emitted src/jobs/**
+# tree is tsc-compiled.
+#
+# A schedule arm (job-owned cadence — the emitter generates its own
+# `contact_sync__sched` event, so no pre-existing event is referenced and bridge
+# validation can't trip) over a poll arm. The arm domain is a label; the embedded
+# DetectionConfig is emitted as a literal — the handler compiles independently of
+# whether the smoke project happens to have a matching entity.
+type: contact_sync
+pool: integration
+retry: { attempts: 3, backoff: exponential, baseMs: 1000 }
+triggers:
+  - schedule: { every: 15m, align: true }
+arms:
+  - kind: poll
+    domain: contact
+    read:
+      mode: poll
+      poll:
+        cursor: { kind: systemModstamp, field: SystemModstamp }
+      mapping:
+        - { source: id, target: external_id }

--- a/test/smoke-integration/run.ts
+++ b/test/smoke-integration/run.ts
@@ -266,6 +266,12 @@ async function main(): Promise<number> {
 			path.join(FIXTURE_ROOT, 'providers'),
 			path.join(tmpDir, 'definitions/providers'),
 		);
+		// Jobs definitions (RFC-0005 #7) — copied into the default `definitions/jobs/`
+		// so the jobs emitter runs and its src/jobs/** handler tree gets tsc-compiled.
+		const jobsFixtureDir = path.join(FIXTURE_ROOT, 'jobs');
+		if (fs.existsSync(jobsFixtureDir)) {
+			copyDir(jobsFixtureDir, path.join(tmpDir, 'definitions/jobs'));
+		}
 
 		// 7. Author-owned provider client + OAuth stubs (consumer-owned, committed
 		//    under stubs/ — not codegen's job to emit).
@@ -313,8 +319,12 @@ async function main(): Promise<number> {
 		const integErrors = allErrorLines.filter((l) =>
 			/(^|[\s(])src[/\\]integrations[/\\]/.test(l),
 		);
+		// RFC-0005 #9: the emitted src/jobs/** handler tree is in scope too.
+		const jobErrors = allErrorLines.filter((l) =>
+			/(^|[\s(])src[/\\]jobs[/\\]/.test(l),
+		);
 		const otherErrors = allErrorLines.filter(
-			(l) => !/(^|[\s(])src[/\\]integrations[/\\]/.test(l),
+			(l) => !/(^|[\s(])src[/\\](integrations|jobs)[/\\]/.test(l),
 		);
 
 		// Out-of-scope errors (e.g. src/shared/subsystems/events/generated/bus.ts —
@@ -335,6 +345,31 @@ async function main(): Promise<number> {
 			exitCode = 1;
 		} else {
 			log('tsc OK — src/integrations/** compiles clean against in-repo runtime + surfaces');
+		}
+
+		// RFC-0005 #9 — the emitted jobs handler tree must compile too.
+		const jobsRoot = path.join(tmpDir, 'src/jobs');
+		const jobFiles = fs.existsSync(jobsRoot)
+			? execSync(`find src/jobs -type f -name '*.ts'`, { cwd: tmpDir })
+					.toString()
+					.split('\n')
+					.filter(Boolean)
+			: [];
+		log(`src/jobs: ${jobFiles.length} .ts files`);
+		if (fs.existsSync(jobsFixtureDir) && jobFiles.length === 0) {
+			throw new Error(
+				'no files under src/jobs/** — the jobs emitter did not run despite a ' +
+					'definitions/jobs/ fixture being present. This test would pass vacuously.',
+			);
+		}
+		if (jobErrors.length > 0) {
+			logError(
+				`${jobErrors.length} tsc error(s) in src/jobs/** (the emitted jobs tree did NOT compile):`,
+			);
+			for (const l of jobErrors) console.error(l);
+			exitCode = 1;
+		} else if (jobFiles.length > 0) {
+			log('tsc OK — src/jobs/** compiles clean against in-repo runtime');
 		}
 	} catch (err: unknown) {
 		logError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## What

Closes the codegen-side verification loop for Part B (breakdown #9) — the jobs emitter now runs **end-to-end through the real `entity new` pipeline** in the smoke-integration harness, and the emitted `src/jobs/**` tree is tsc-compiled against the in-repo runtime. Stacked on #545.

## Changes

- **Fixture** `definitions/jobs/contact_sync.yaml` — a `schedule` arm (job-owned cadence; the emitter generates its own `contact_sync__sched` event, so no pre-existing event is referenced and bridge validation can't trip) over a poll arm.
- **`run.ts`** — copies `definitions/jobs/` into the temp project, adds a `src/jobs` sanity check (fail-vacuously guard), and extends the tsc failure scope to `src/jobs/**`.

## Verified (`smoke-integration PASS`)

- The emitter emits 1 `@generated` base + 1 emit-once scaffold.
- The scheduled event merges into the event registry (**3 → 4 events**).
- The emit-once subclass is **preserved across the two-pass generation** (pass 1 writes, pass 2 keeps — `0 scaffold(s) written, 1 kept`).
- `src/jobs/** compiles clean against in-repo runtime`.

## On #8

The cross-ref validator is **largely absorbed**: event-arm `event` cross-ref is already enforced by the bridge generator's `validateAgainstEventRegistry` on the declarative `extraTriggers`, and the cadence drift-check is gone (fork 2). No separate #8 PR needed unless we want an `arm.domain → entity` check.

## Stack / next

Part B codegen side is now **built + verified end-to-end**: #542 (schema+loader+fork2) → #544 (emitter) → #545 (wiring) → this (#9 smoke). Remaining is **#10 — the release** (`just bump` → npm), which is gated on human go (immutable publish; swe-brain dogfoods the published tarball).

> ⚠️ `main` advanced to **v0.28.0** ("trigger-catalog metadata on event definitions", #547) via a parallel agent while this stack was in flight — the stack will need a rebase onto new main before merge, and that work touches event definitions (possible overlap with the `ScheduleSchema` export / event-codegen changes here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
