### PR TITLE
feat(emit): activate the jobs emitter on main — wire gen-walk + smoke (Part B #7b+#9, RFC-0005)

### DIFF
--- a/src/__tests__/cli/emit-jobs.test.ts
+++ b/src/__tests__/cli/emit-jobs.test.ts
@@ -1,0 +1,72 @@
+/**
+ * emitJobHandlers write-orchestration tests (RFC-0005, breakdown #7b).
+ *
+ * Verifies the file layout + the seam-split write semantics: the @generated base
+ * reflows on every run (byte-idempotent), and the emit-once subclass is written
+ * once then skipped (author edits survive regen).
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFileSync as read } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { JobDefinitionSchema, type JobDefinition } from '../../schema/job-definition.schema';
+import { emitJobHandlers } from '../../cli/shared/emit-jobs';
+
+const FIXTURE_DIR = resolve(__dirname, '../../../test/fixtures/jobs');
+const loadJob = (name: string): JobDefinition =>
+	JobDefinitionSchema.parse(parseYaml(read(resolve(FIXTURE_DIR, name), 'utf8')));
+
+const drivePoll = loadJob('drive_poll.yaml');
+const reconcilePoll = loadJob('reconcile_poll.yaml');
+
+const tmpDirs: string[] = [];
+function tmpJobsDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'emit-jobs-'));
+	tmpDirs.push(dir);
+	return dir;
+}
+afterEach(() => {
+	while (tmpDirs.length) {
+		const d = tmpDirs.pop();
+		if (d) rmSync(d, { recursive: true, force: true });
+	}
+});
+
+describe('emitJobHandlers', () => {
+	it('writes a @generated base + an emit-once subclass per job', () => {
+		const dir = tmpJobsDir();
+		const res = emitJobHandlers({ jobs: [drivePoll, reconcilePoll], jobsHandlersDir: dir });
+		expect(res.basesWritten).toHaveLength(2);
+		expect(res.scaffoldsWritten).toHaveLength(2);
+		expect(res.scaffoldsSkipped).toEqual([]);
+		expect(existsSync(join(dir, 'drive_poll.job.generated.ts'))).toBe(true);
+		expect(existsSync(join(dir, 'drive_poll.job.ts'))).toBe(true);
+		expect(readFileSync(join(dir, 'drive_poll.job.generated.ts'), 'utf8')).toContain('@generated');
+	});
+
+	it('reflows the base but PRESERVES author edits to the subclass on re-emit', () => {
+		const dir = tmpJobsDir();
+		emitJobHandlers({ jobs: [drivePoll], jobsHandlersDir: dir });
+		const subPath = join(dir, 'drive_poll.job.ts');
+		// Simulate an author edit to the emit-once subclass.
+		writeFileSync(subPath, '// AUTHOR EDIT — do not clobber\n', 'utf8');
+
+		const res2 = emitJobHandlers({ jobs: [drivePoll], jobsHandlersDir: dir });
+		// The subclass is skipped (author edit survives); the base reflows.
+		expect(res2.scaffoldsSkipped).toEqual([subPath]);
+		expect(res2.scaffoldsWritten).toEqual([]);
+		expect(readFileSync(subPath, 'utf8')).toBe('// AUTHOR EDIT — do not clobber\n');
+		expect(readFileSync(join(dir, 'drive_poll.job.generated.ts'), 'utf8')).toContain('DrivePollJobBase');
+	});
+
+	it('dryRun computes paths without writing', () => {
+		const dir = tmpJobsDir();
+		const res = emitJobHandlers({ jobs: [drivePoll], jobsHandlersDir: dir, dryRun: true });
+		expect(res.basesWritten).toHaveLength(1);
+		expect(existsSync(join(dir, 'drive_poll.job.generated.ts'))).toBe(false);
+	});
+});

--- a/src/cli/commands/entity.ts
+++ b/src/cli/commands/entity.ts
@@ -57,6 +57,13 @@ import { findYamlFiles } from '../../utils/find-yaml-files.js';
 import type { AnalysisIssue } from '../../analyzer/types.js';
 import { resolveSubsystemsRoot } from '../shared/subsystems-path.js';
 import { resolveEventsDir } from '../shared/events-path.js';
+import { resolveJobsDir } from '../shared/jobs-path.js';
+import { loadJobs } from '../../parser/load-jobs.js';
+import {
+	buildJobBridgeTriggers,
+	buildJobScheduledEvents,
+} from '../shared/job-emission-generator.js';
+import { emitJobHandlers } from '../shared/emit-jobs.js';
 
 import { theme } from '../ui/theme.js';
 import { icons } from '../ui/icons.js';
@@ -484,6 +491,32 @@ export class EntityNewCommand extends Command {
 			}
 		};
 
+		// Job definitions (RFC-0005 #7) — loaded ONCE, early, so their derived
+		// artifacts feed the event + bridge codegen in the SAME pass: each
+		// `schedule` arm desugars to a job-private scheduled event merged into the
+		// event registry, and every trigger becomes a declarative bridge mapping.
+		// The handler files themselves are emitted later (post-assembly). Because
+		// the bridge/schedule contributions come from the LOADED defs (not the
+		// emitted files), there is no two-pass ordering hazard. Opt-in: no
+		// `definitions/jobs/` ⇒ empty (warn-only), exactly like providers.
+		const jobsDir = resolveJobsDir(ctx);
+		const jobLoad = loadJobs(jobsDir);
+		if (!isJsonMode()) {
+			for (const issue of jobLoad.issues) {
+				if (issue.severity === 'error') {
+					printError(
+						`jobs: ${issue.message}${issue.path ? ` (${issue.path})` : ''}`,
+					);
+				}
+			}
+		}
+		const jobScheduledEvents = jobLoad.jobs.flatMap((j) =>
+			buildJobScheduledEvents(j),
+		);
+		const jobBridgeTriggers = jobLoad.jobs.flatMap((j) =>
+			buildJobBridgeTriggers(j, path.join(jobsDir, `${j.type}.yaml`)),
+		);
+
 		if (this.dryRun) {
 			const barrelPlan = await regenerateBarrels({
 				ctx,
@@ -505,6 +538,7 @@ export class EntityNewCommand extends Command {
 				eventsDir,
 				outputDir: eventCodegenOutputDir,
 				mode: runtimeMode,
+				extraSugarEvents: jobScheduledEvents,
 				dryRun: true,
 			});
 
@@ -514,6 +548,7 @@ export class EntityNewCommand extends Command {
 				outputDir: bridgeRegistryOutputDir,
 				mode: runtimeMode,
 				bridgeInstalled: bridgeInstalledForRegistry,
+				extraTriggers: jobBridgeTriggers,
 				dryRun: true,
 			});
 
@@ -720,6 +755,7 @@ export class EntityNewCommand extends Command {
 				eventsDir,
 				outputDir: eventCodegenOutputDir,
 				mode: runtimeMode,
+				extraSugarEvents: jobScheduledEvents,
 			});
 			if (!isJsonMode()) {
 				for (const issue of eventCodegenResult.issues) {
@@ -748,6 +784,7 @@ export class EntityNewCommand extends Command {
 				outputDir: bridgeRegistryOutputDir,
 				mode: runtimeMode,
 				bridgeInstalled: bridgeInstalledForRegistry,
+				extraTriggers: jobBridgeTriggers,
 			});
 			if (bridgeRegistryResult.skipped && !isJsonMode()) {
 				printInfo(
@@ -949,6 +986,35 @@ export class EntityNewCommand extends Command {
 			const msg = err instanceof Error ? err.message : String(err);
 			if (!isJsonMode()) {
 				printWarning(`adapter codegen failed — ${msg}`);
+			}
+		}
+
+		// Jobs handler emission (RFC-0005 #7). Runs LAST among the integration
+		// steps: the per-arm `runArm*` seam wires the assembly's
+		// ExecuteIntegrationUseCase, so the assemblies must exist first. The
+		// scheduled-event + bridge-trigger contributions already rode the event /
+		// bridge codegen above (from the early `jobLoad`); this step only writes the
+		// `@generated` base (reflow) + emit-once subclass per job into
+		// `<backend_src>/jobs/`. Same warn-but-don't-fail contract as siblings.
+		try {
+			if (jobLoad.jobs.length > 0) {
+				const jobEmit = emitJobHandlers({
+					jobs: jobLoad.jobs,
+					jobsHandlersDir: bridgeHandlersDir,
+					mode: runtimeMode,
+				});
+				if (!isJsonMode()) {
+					printInfo(
+						`jobs: emitted ${jobEmit.basesWritten.length} handler base(s); ` +
+							`${jobEmit.scaffoldsWritten.length} scaffold(s) written, ` +
+							`${jobEmit.scaffoldsSkipped.length} kept`,
+					);
+				}
+			}
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (!isJsonMode()) {
+				printWarning(`jobs codegen failed — ${msg}`);
 			}
 		}
 

--- a/src/cli/shared/emit-jobs.ts
+++ b/src/cli/shared/emit-jobs.ts
@@ -1,0 +1,87 @@
+/**
+ * Jobs emission write-orchestration (RFC-0005, breakdown #7b).
+ *
+ * Wraps the pure `generateJobHandler{Base,Subclass}` emitters with the file
+ * layout + emit-once write logic — exactly as `emitAdapters` wraps the pure sink
+ * generators. Per job, into `<backend_src>/jobs/`:
+ *   - `<type>.job.generated.ts` — `@generated`, written via `writeIfChanged`
+ *     (byte-idempotent; reflows on every run).
+ *   - `<type>.job.ts` — emit-once: written only when absent (`existsSync`-skip),
+ *     so author edits survive regen.
+ *
+ * The flat `<backend_src>/jobs/` layout is load-bearing: it is the same dir the
+ * bridge-registry generator scans. Job triggers reach the bridge DECLARATIVELY
+ * (RFC-0005 fork 1), so the emitted `@JobHandler` carries no `triggers` and the
+ * scan never double-registers them.
+ */
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { RuntimeMode } from "./runtime-import";
+import type { JobDefinition } from "../../schema/job-definition.schema";
+import {
+	generateJobHandlerBase,
+	generateJobHandlerSubclass,
+} from "./job-emission-generator";
+
+export interface EmitJobsOptions {
+	/** Validated job definitions (from `loadJobs`). */
+	jobs: JobDefinition[];
+	/** Absolute path to the handlers dir (`<cwd>/<backend_src>/jobs`). */
+	jobsHandlersDir: string;
+	/** Runtime mode (ADR-037). Default `package`. */
+	mode?: RuntimeMode;
+	/** If true, compute paths but don't write. */
+	dryRun?: boolean;
+}
+
+export interface EmitJobsResult {
+	/** `@generated` base file paths (always reflowed). */
+	basesWritten: string[];
+	/** Emit-once subclass paths written this run (were absent). */
+	scaffoldsWritten: string[];
+	/** Emit-once subclass paths skipped (already present). */
+	scaffoldsSkipped: string[];
+}
+
+/** Byte-idempotent write — skips the disk write when content is unchanged. */
+function writeIfChanged(outPath: string, content: string): void {
+	if (existsSync(outPath) && statSync(outPath).isFile() && readFileSync(outPath, "utf-8") === content) {
+		return;
+	}
+	mkdirSync(dirname(outPath), { recursive: true });
+	writeFileSync(outPath, content);
+}
+
+function writeFresh(outPath: string, content: string): void {
+	mkdirSync(dirname(outPath), { recursive: true });
+	writeFileSync(outPath, content);
+}
+
+export function emitJobHandlers(opts: EmitJobsOptions): EmitJobsResult {
+	const mode = opts.mode ?? "package";
+	const result: EmitJobsResult = {
+		basesWritten: [],
+		scaffoldsWritten: [],
+		scaffoldsSkipped: [],
+	};
+
+	for (const job of opts.jobs) {
+		const basePath = join(opts.jobsHandlersDir, `${job.type}.job.generated.ts`);
+		const subPath = join(opts.jobsHandlersDir, `${job.type}.job.ts`);
+
+		// @generated base — always reflow.
+		if (!opts.dryRun) writeIfChanged(basePath, generateJobHandlerBase({ job, mode }));
+		result.basesWritten.push(basePath);
+
+		// Emit-once subclass — write only when absent.
+		if (existsSync(subPath)) {
+			result.scaffoldsSkipped.push(subPath);
+		} else {
+			if (!opts.dryRun) writeFresh(subPath, generateJobHandlerSubclass({ job, mode }));
+			result.scaffoldsWritten.push(subPath);
+		}
+	}
+
+	return result;
+}

--- a/test/fixtures/integration-patterns/definitions/jobs/contact_sync.yaml
+++ b/test/fixtures/integration-patterns/definitions/jobs/contact_sync.yaml
@@ -1,0 +1,23 @@
+# Smoke-integration jobs fixture (RFC-0005 #9). Exercises the jobs emitter
+# end-to-end through the real `entity new` pipeline so the emitted src/jobs/**
+# tree is tsc-compiled.
+#
+# A schedule arm (job-owned cadence — the emitter generates its own
+# `contact_sync__sched` event, so no pre-existing event is referenced and bridge
+# validation can't trip) over a poll arm. The arm domain is a label; the embedded
+# DetectionConfig is emitted as a literal — the handler compiles independently of
+# whether the smoke project happens to have a matching entity.
+type: contact_sync
+pool: integration
+retry: { attempts: 3, backoff: exponential, baseMs: 1000 }
+triggers:
+  - schedule: { every: 15m, align: true }
+arms:
+  - kind: poll
+    domain: contact
+    read:
+      mode: poll
+      poll:
+        cursor: { kind: systemModstamp, field: SystemModstamp }
+      mapping:
+        - { source: id, target: external_id }

--- a/test/smoke-integration/run.ts
+++ b/test/smoke-integration/run.ts
@@ -266,6 +266,12 @@ async function main(): Promise<number> {
 			path.join(FIXTURE_ROOT, 'providers'),
 			path.join(tmpDir, 'definitions/providers'),
 		);
+		// Jobs definitions (RFC-0005 #7) — copied into the default `definitions/jobs/`
+		// so the jobs emitter runs and its src/jobs/** handler tree gets tsc-compiled.
+		const jobsFixtureDir = path.join(FIXTURE_ROOT, 'jobs');
+		if (fs.existsSync(jobsFixtureDir)) {
+			copyDir(jobsFixtureDir, path.join(tmpDir, 'definitions/jobs'));
+		}
 
 		// 7. Author-owned provider client + OAuth stubs (consumer-owned, committed
 		//    under stubs/ — not codegen's job to emit).
@@ -313,8 +319,12 @@ async function main(): Promise<number> {
 		const integErrors = allErrorLines.filter((l) =>
 			/(^|[\s(])src[/\\]integrations[/\\]/.test(l),
 		);
+		// RFC-0005 #9: the emitted src/jobs/** handler tree is in scope too.
+		const jobErrors = allErrorLines.filter((l) =>
+			/(^|[\s(])src[/\\]jobs[/\\]/.test(l),
+		);
 		const otherErrors = allErrorLines.filter(
-			(l) => !/(^|[\s(])src[/\\]integrations[/\\]/.test(l),
+			(l) => !/(^|[\s(])src[/\\](integrations|jobs)[/\\]/.test(l),
 		);
 
 		// Out-of-scope errors (e.g. src/shared/subsystems/events/generated/bus.ts —
@@ -335,6 +345,31 @@ async function main(): Promise<number> {
 			exitCode = 1;
 		} else {
 			log('tsc OK — src/integrations/** compiles clean against in-repo runtime + surfaces');
+		}
+
+		// RFC-0005 #9 — the emitted jobs handler tree must compile too.
+		const jobsRoot = path.join(tmpDir, 'src/jobs');
+		const jobFiles = fs.existsSync(jobsRoot)
+			? execSync(`find src/jobs -type f -name '*.ts'`, { cwd: tmpDir })
+					.toString()
+					.split('\n')
+					.filter(Boolean)
+			: [];
+		log(`src/jobs: ${jobFiles.length} .ts files`);
+		if (fs.existsSync(jobsFixtureDir) && jobFiles.length === 0) {
+			throw new Error(
+				'no files under src/jobs/** — the jobs emitter did not run despite a ' +
+					'definitions/jobs/ fixture being present. This test would pass vacuously.',
+			);
+		}
+		if (jobErrors.length > 0) {
+			logError(
+				`${jobErrors.length} tsc error(s) in src/jobs/** (the emitted jobs tree did NOT compile):`,
+			);
+			for (const l of jobErrors) console.error(l);
+			exitCode = 1;
+		} else if (jobFiles.length > 0) {
+			log('tsc OK — src/jobs/** compiles clean against in-repo runtime');
 		}
 	} catch (err: unknown) {
 		logError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## What

**Activates the jobs definition-kind emitter on main.** A stacked-merge race landed the emitter machinery (#7a — `job-emission-generator.ts` + the bridge `extraTriggers` / event `extraSugarEvents` seams) into main as part of #542, and it shipped in **v0.28.0** — but the **gen-walk wiring (#7b) and smoke gate (#9) never reached main**. So on v0.28.0 the emitter exists but is **inert**: nothing in `entity new` invokes it. This PR re-applies #7b + #9 directly onto current main.

## Contents (cherry-picked clean onto main)

- **#7b wiring** — `emit-jobs.ts` (the write-orchestration: `@generated` base via `writeIfChanged`, emit-once subclass via `existsSync`-skip) + entity.ts gen-walk wiring (early `loadJobs`; threads scheduled events + bridge triggers into event/bridge codegen at the real + dry-run call sites; emits handler files post-assembly).
- **#9 smoke** — `definitions/jobs/contact_sync.yaml` fixture + `run.ts` extension (copies the jobs dir, adds the `src/jobs` sanity guard, extends the tsc failure scope to `src/jobs/**`).

## Verified on top of current main (v0.28.0 + #547 trigger-catalog)

- 125 unit tests (emit-jobs, job-emission, bridge, event-codegen) — coherent with the v0.28.0 trigger-catalog changes.
- tsc clean.
- **`just test-smoke-integration` PASS** — the emitter runs through the real pipeline: emits 1 base + 1 emit-once scaffold, merges the `contact_sync__sched` event (3→4), the scaffold survives the two-pass generation, and `src/jobs/**` compiles clean. My seams coexist with #547's `trigger:` block (disjoint surfaces).

## Notes

- Supersedes the now-stale stack PRs #545 (#7b) / #548 (#9), whose bases became dead-ends after the squash-merge cascade.
- After this lands, a follow-up patch release publishes the activated emitter so swe-brain can dogfood it (Part B #10/#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
