### PR TITLE
docs(adr): ADR-041 capability composition emission — verified mixin-hybrid

### DIFF
--- a/.ai-docs/research/capability-composition-emission.md
+++ b/.ai-docs/research/capability-composition-emission.md
@@ -1,0 +1,243 @@
+---
+slug: capability-composition-emission
+linear: null
+status: research
+date: 2026-06-15
+related: [subject-lattice-codegen-lift, ADR-031, ADR-032, ADR-041]
+---
+
+# Understanding: how should codegen-patterns emit a single repository/service that carries the behaviour of MULTIPLE composed patterns, given TypeScript single-inheritance?
+
+## Request
+
+The ADR-031 app-defined-patterns system already supports multi-pattern composition at the YAML + validator layer (`patterns: [A, B]`; `src/patterns/validate-composition.ts:49-182` unions implied behaviors and hard-errors on column conflicts). But **emission picks exactly one base class** — the clean-lite-ps resolver takes the base from `patterns[0]` and silently drops every later pattern's `repositoryClass`/`serviceClass`/methods (`templates/entity/new/clean-lite-ps/prompt-extension.js:86-107`). So `patterns: [Integrated, Group, Individual]` validates but cannot emit all three capabilities' methods onto one repository/service. TypeScript single-inheritance is the wall.
+
+This research characterises that limitation precisely across **both** backend pipelines, traces exactly where the second pattern's contributions drop, surveys the composition-emission mechanisms (generated composed-base / TS mixins / config-driven delegate / hybrid) against this repo's actual machinery, and recommends a direction concrete enough to write an ADR from. It does **not** decide the ADR — it lays out the options and the decisions the ADR must make.
+
+## Motivation
+
+ADR-0022's "both, layered" ruling (a subject entity that is `Integrated` *and* a `Group` *and/or* `Individual`) forces this question, but the limitation is **general** to the patterns system, not specific to the subject lattice. Any consumer wanting two capabilities' generated methods on one entity hits it. The prior research (`subject-lattice-codegen-lift.md:50-72`) flagged this as the single biggest design risk gating the whole lift; this artifact is the dedicated decision-prep for that risk so the lift (and any other multi-capability consumer) can proceed.
+
+---
+
+## Current emission trace — where the methods drop, and what data is available
+
+### How a pattern represents its capability (the crux)
+
+A `PatternDefinition` (`src/patterns/pattern-definition.ts:54-119`) carries the base class as a **string constructor name + import path**, never the class itself:
+
+```ts
+// src/patterns/pattern-definition.ts:74-96
+repositoryClass?: string;   // "Constructor name codegen emits in the extends clause"
+serviceClass?: string;
+repositoryImport?: string;  // path alias the consumer's tsconfig resolves
+serviceImport?: string;
+repositoryInheritedMethods?: string[];  // "Documentation-only method-signature strings emitted as comments"
+serviceInheritedMethods?: string[];
+columns?: PatternColumnContribution[];
+impliedBehaviors?: string[];
+configSchema?: ZodSchema<TConfig>;
+```
+
+The doc comment at `:8-11` is explicit about *why* it is a string: `definePattern()` "carries only names + import paths for the classes a generated entity should extend — never the class constructors themselves. This keeps the codegen pipeline free of TS class-evaluation cost and avoids `reflect-metadata`, which lets the Hygen subprocess cheaply rebuild the registry." ADR-031 Alternative 2 (`docs/adrs/ADR-031-app-defined-patterns.md:223-227`) rejected TS-class patterns for the same reason.
+
+**Load-bearing consequence:** the generator does **not** and **cannot** see a pattern's actual methods. `repositoryInheritedMethods` is a free-text comma-joined string emitted as `// comment` lines (see `repository.ejs.t:234-237`), not a structured method list. The real methods live in the opaque runtime base class (e.g. `IntegratedEntityRepository.findByExternalId`, `runtime/base-classes/integrated-entity-repository.ts:33`). The generator knows a pattern's *name, import, columns, behaviors, configSchema* — it does **not** know its method set as machine-readable data. **This single fact constrains every strategy below** (see §Strategy A feasibility).
+
+### Pipeline 1 — clean-lite-ps (the only pipeline that consumes patterns today)
+
+The base class is resolved in `resolvePatternBaseClasses` (`templates/entity/new/clean-lite-ps/prompt-extension.js:86-107`):
+
+```js
+// prompt-extension.js:86-107
+export function resolvePatternBaseClasses(entity) {
+  const name =
+    (typeof entity.pattern === 'string' && entity.pattern) ||
+    (Array.isArray(entity.patterns) && entity.patterns[0]) ||   // <- only [0]
+    'Base';
+  const def = getPattern(name) || getPattern('Base');
+  ...
+  return {
+    patternName: def.name,
+    repositoryBaseClass: def.repositoryClass,   // single string
+    serviceBaseClass: def.serviceClass,         // single string
+    repositoryBaseImport: def.repositoryImport,
+    serviceBaseImport: def.serviceImport,
+    repositoryInheritedMethods: def.repositoryInheritedMethods ?? [],
+    serviceInheritedMethods: def.serviceInheritedMethods ?? [],
+  };
+}
+```
+
+The doc comment at `:76-82` states the drop in plain words: *"`entity.patterns[0]` … the first name drives the base-class choice. Subsequent patterns contribute columns + implied behaviors … but do not change the template's repository/service base class."*
+
+The single resolved name lands in the templates verbatim:
+
+- **Repository** (`templates/entity/new/clean-lite-ps/repository.ejs.t:26,76,82,234`):
+  ```ejs
+  import { <%= repositoryBaseClass %> } from '<%= repositoryBaseImport %>';
+  ...
+  export class <%= classNames.repository %> extends <%= repositoryBaseClass %><<%= classNames.entity %>> {
+  ...
+  // Inherited from <%= repositoryBaseClass %>:
+  <%_ repositoryInheritedMethods.forEach(line => { _%>  //   <%= line %>
+  ```
+- **Service** (`templates/entity/new/clean-lite-ps/service.ejs.t:10,39-41`):
+  ```ejs
+  import { <%= serviceBaseClass %> } from '<%= serviceBaseImport %>';
+  ...
+  export class <%= classNames.service %> extends WithAnalytics(
+    <%= serviceBaseClass %><<%= classNames.repository %>, <%= classNames.entity %>>,
+  ) {
+  ```
+
+**Where exactly the second pattern dies:** at `prompt-extension.js:89` (`entity.patterns[0]`). Patterns `[1..n]` are read *only* by `resolveImpliedBehaviors` (`prompt-extension.js:122-139`, unions `impliedBehaviors`) and by the column-conflict validator. Their `repositoryClass`/`serviceClass`/`*Import`/`*InheritedMethods` are never read. **The full pattern set IS available at this point** — `entity.patterns` is the whole array and `getPattern(name)` resolves each — so a different emission strategy *could* see all contributions. Nothing upstream discards them; the resolver simply indexes `[0]`.
+
+**Already-present mixin precedent:** the service template (`service.ejs.t:39`) ALREADY wraps the base in a mixin application — `extends WithAnalytics(ServiceBase<...>)`. `WithAnalytics` is a real TS mixin (`runtime/base-classes/with-analytics.ts:17-22`, `function WithAnalytics<TBase extends Constructor>(Base)`). So **emitting `extends Mixin(Base<...>)` is a shipped, tested pattern in this pipeline** — strategy B is not greenfield syntax.
+
+### Pipeline 2 — full clean (`templates/entity/new/backend/`, the default)
+
+**The clean pipeline does not consume patterns AT ALL.** Findings:
+
+1. `prompt.js` only computes pattern-derived locals (`repositoryBaseClass`, etc.) inside the `isCleanLitePs` branch (`prompt.js:1643-1651`). In the `clean` branch it injects empty stubs (`prompt.js:1672-1677`): `repositoryBaseClass: ''`, `serviceBaseClass: ''`, `patternName: 'Base'`, `hasPatternConfig: false`. The pattern registry (`ensurePatternsRegistryLoaded`) is loaded only for clean-lite-ps (`prompt.js:1649`).
+2. The clean repository template hardcodes its base: `extends BaseRepository<typeof <%= plural %>, ...>` (`templates/entity/new/backend/database/repository.ejs.t:28-36`). No `repositoryBaseClass` local — `BaseRepository` is a literal in the template.
+3. **There is no service-class template in the clean pipeline at all.** `Grep` for `extends (BaseService|...)` under `templates/entity/new/backend/` returns nothing. The clean pipeline is command/query-per-operation (`BaseFindByIdUseCase`/`BaseListUseCase`, `runtime/base-classes/base-read-use-cases.ts`), not a single service class.
+4. The composition validator emits a `pattern_clean_pipeline_noop` **warning** for any entity declaring `pattern:` under `architecture: clean` (`src/patterns/validate-composition.ts:209-233`).
+
+**So the limitation is asymmetric, not uniform:**
+
+| | clean-lite-ps | clean (default) |
+|---|---|---|
+| Consumes patterns? | Yes | **No** (no-op warning) |
+| Base-class selection | `patterns[0]` → single base (the drop) | Hardcoded `BaseRepository`; no service class |
+| Multi-capability gap | Present — drops `patterns[1..n]` | Present in a deeper sense — **no pattern emission to extend** |
+
+The clean pipeline is *worse*: it has no capability-composition machinery to fix, only an empty seam. Any composition-emission mechanism that targets clean-lite-ps would need a from-scratch port to clean (likely out of scope — ADR-031 `:213` defers clean-pipeline pattern support to "additive Phase 3+"). **The decision below should scope to clean-lite-ps and treat clean as explicitly deferred.**
+
+### What the chosen base class actually requires of the concrete class
+
+Each library base carries its own *required config contract*, which matters for composition (you can't naively stack two bases that each demand a different abstract member):
+
+- `IntegratedEntityRepository` (`runtime/base-classes/integrated-entity-repository.ts:19-28`): `protected abstract readonly integrationConfig: IntegrationUpsertConfig` — concrete repo MUST supply it (emitted from `clpIntegrationConfig`, `repository.ejs.t:107-118`).
+- `ActivityEntityRepository` (`runtime/base-classes/activity-entity-repository.ts:36-69`): reads `protected readonly patternConfig?: ActivityPatternConfig`; subject finders throw if absent (emitted from `config:` via `renderPatternConfigLiteral`, `repository.ejs.t:94-101`).
+
+Both also extend `BaseRepository` (diamond root). A composed base must satisfy *every* composed pattern's abstract members and config hand-off, and resolve the shared `BaseRepository` root once.
+
+---
+
+## Strategy survey — evaluated against this repo's machinery
+
+### (A) Generated composed-base — codegen synthesizes one base class per entity that flattens all patterns' methods
+
+**How it would work here:** for `patterns: [Integrated, Group]`, codegen emits a new file `<entity>.composed-base.ts` defining `class OpportunityComposedBase extends ??? { ... }` that exposes the union of both patterns' methods, and the concrete repo extends *that*.
+
+**FEASIBILITY KILL for the literal "flatten the methods" form:** the generator has **no machine-readable view of a pattern's methods** (see trace above — `repositoryInheritedMethods` is a doc-comment string; the real methods live in opaque runtime classes referenced only by name + import). Codegen **cannot mechanically merge method bodies it cannot see.** To "flatten methods of all composed patterns into one emitted class," codegen would need either (a) the pattern to expose its methods as structured, emittable units (it does not — `PatternDefinition` has no method-body field, by deliberate design to avoid TS-class evaluation, `pattern-definition.ts:8-11`), or (b) to read and parse the runtime base-class source — a non-starter (brittle AST surgery, breaks the package/vendored import model).
+
+**What IS feasible — generated composed-base via mixin *application*, not method-flattening:** codegen can emit a base file that *applies* the patterns as mixins/extends-chains without seeing their bodies:
+```ts
+// opportunity.composed-base.ts  (generated)
+export abstract class OpportunityComposedBase
+  extends GroupCapability(IntegratedEntityRepository<...>) {}
+```
+This collapses to **strategy B's mechanism** (mixins) with a generated wrapper file. The "codegen owns emission so it can merge what hand-written TS can't" advantage is real, but the *thing being merged* is mixin applications, not method bodies — codegen's leverage is that it can compute the correct nesting order and config hand-off, not that it can see inside the bases.
+
+**Cost / interactions:** an extra generated file per multi-pattern entity; the concrete repo `extends <Entity>ComposedBase`. Column union + behavior union already work (validator). Method-name collisions: **invisible to codegen** (it can't see the methods) → surface as TS errors at consumer compile, exactly as the validator already documents (`validate-composition.ts:17-20`: "Method-name conflicts … surface as TypeScript compile errors"). NestJS DI: the composed base is still a single `@Injectable()` concrete class — no `multi:true` problem. **Verdict: viable only as a thin generated wrapper over strategy B; the "flatten methods" framing is infeasible given opaque bases.**
+
+### (B) TS mixins — `Capability(Base)` mixin application, emitted by codegen
+
+**How it would work here:** each composable capability ships as a mixin function `Group<TBase extends Constructor>(Base: TBase)` in `runtime/base-classes/`, exactly like `WithAnalytics` (`with-analytics.ts:17-22`). Codegen emits the nested application in the `extends` clause: `extends Group(Integrated(BaseRepository<...>))` (or via a generated composed-base file, = hybrid with A). One pattern remains the "spine" base (`patterns[0]`), the rest are mixins.
+
+**This is the lowest-syntax-risk option because the pipeline already does it.** `service.ejs.t:39` ships `extends WithAnalytics(<%= serviceBaseClass %><...>)` today, compiled and smoke-tested. Extending the resolver to emit `repositoryMixins: string[]` + `repositoryBaseClass` (spine) is a localized change to `resolvePatternBaseClasses` (`prompt-extension.js:86-107`) + the two `extends` lines in `repository.ejs.t:76/82` and `service.ejs.t:39`.
+
+**Costs / friction:**
+- **Typing.** Mixins return intersection types; deep nesting (`A(B(C(Base)))`) is known to strain TS inference and can produce "type instantiation is excessively deep" with generics. The base classes here are generic (`IntegratedEntityRepository<TEntity, TWrite, TProjection>`) — nesting generic mixins needs care. The existing `WithAnalytics` wraps only a single generic base; 3-deep generic nesting is untested here.
+- **NestJS DI + decorator metadata.** `@Injectable()` is on the concrete class (`repository.ejs.t:74`), not the mixins — fine. But mixin-injected dependencies (e.g. a capability needing its own injected service) can't be constructor-injected through a mixin cleanly without property injection (`@Inject()` on a property, the `WithAnalytics` model — `with-analytics.ts` doc `:11`). Capabilities that need constructor deps would force constructor-signature coordination across the mixin chain — friction. The Activity/Integrated config-hand-off model (property `patternConfig`/`integrationConfig`, not constructor args) sidesteps this and is the safer shape for capabilities.
+- **Abstract-member satisfaction.** If two stacked bases each declare an abstract member, the concrete class must satisfy both — codegen already emits `integrationConfig` and `patternConfig`; a second capability's abstract member would need its own emit hook.
+- **Collision policy.** Same as A — method-name collisions surface as TS errors (the validator's documented stance).
+
+**Verdict: the strongest *mechanism* (proven in-repo), with the generated-composed-base wrapper (A) as the readable packaging. Main risk is generic-mixin typing depth.**
+
+### (C) Config-driven delegate — capabilities as injected/configured delegates, not inheritance (the Activity model generalized)
+
+**What the Activity model actually is (read in full):** `ActivityEntityRepository` (`runtime/base-classes/activity-entity-repository.ts:36-109`) is **NOT a delegate** — it is a config-driven **base class**. Its methods (`findBySubjectId`, etc.) live *on the inherited base*; `patternConfig` only *parameterizes* which column they read (`subjectColumn` getter at `:59-69`). `ActivityEntityService` (`activity-entity-service.ts:19-50`) likewise has the methods on the base and forwards to the repo. So today's "config-driven" pattern is **single-inheritance + runtime config**, not delegation. It does NOT compose two capabilities — it configures one base.
+
+**A true delegate generalization would be:** the concrete repo/service news-up (or injects) a `GroupCapability` helper from `config:`/role-map and exposes its methods by *forwarding*. Methods would be *typed* only if codegen emits explicit forwarder methods (`async members(id) { return this.groupCapability.members(id); }`) — which is exactly how the `queries:` block already emits service pass-throughs (`service.ejs.t:94-99`) and how CGP-358b relationship composition emits forwarders (`service.ejs.t:120-147`). So the **precedent for typed delegation already exists in the service template.**
+
+**Costs / interactions:**
+- **Typed surface requires emitted forwarders.** A delegate gives you runtime behaviour for free but a *typed* method surface only if codegen emits one forwarder per capability method — and codegen doesn't know the method list (opaque base problem again). So either the capability exposes a *fixed, known* method set the template hardcodes forwarders for (like Activity's 4 finders), or the surface is untyped (`this.groupCapability.members(...)` reachable only by knowing the delegate). For a *known, small* capability vocab (the lattice's `members()`/`toShape()`), hardcoded forwarders are tractable — this is the Activity precedent extended.
+- **Discoverability.** Delegated methods don't appear on the class unless forwarded; less discoverable than inherited/mixed methods.
+- **Sidesteps single-inheritance entirely** — the killer advantage. A concrete repo can hold N delegate capabilities with zero inheritance-chain conflict, zero diamond, zero generic-mixin-depth risk. DI is clean: each delegate is an `@Injectable()` or a config-newed helper.
+- **No abstract-member collision, no constructor-chain coordination.** Each delegate manages its own config.
+
+**Verdict: the safest mechanism for *new* capabilities whose method vocab is small and codegen-known (lattice `members`/`toShape`). Weaker for wrapping *existing* opaque bases (`Integrated`) as delegates — you'd still inherit one and delegate the rest.**
+
+### Hybrid — one inherited spine base + others as delegates/mixins
+
+**The shape the evidence points to:** keep `patterns[0]` (or a designated spine) as the inherited base (preserves the Integrated/Activity config-hand-off and the existing `extends <%= repositoryBaseClass %>` line), and compose `patterns[1..n]` as **either** mixins (B, when the capability is a mixin function) **or** typed delegates (C, when the capability has a small known method vocab emitted as forwarders). This matches how the service template *already* layers: `extends WithAnalytics(Base<...>)` (mixin) + `queries:`/CGP-358b forwarders (delegate-style) on the same class.
+
+This is almost certainly the realistic answer because: (1) existing opaque bases like `Integrated` can only be *inherited* (can't be mechanically merged or delegated without a forwarder list codegen doesn't have); (2) new capabilities like `Group`/`Individual` can be authored as mixins or small-vocab delegates from day one. So the ADR likely ratifies: **spine = the one pattern with an abstract-config base (Integrated/Activity); capabilities = mixins or forwarder-delegates layered on top.**
+
+---
+
+## Interaction with the rest of the system
+
+- **`queries:` emission** composes cleanly on top of any strategy — it appends methods to the concrete class body (`repository.ejs.t:146-172`, `service.ejs.t:94-99`) and registers query classes in the module (`prompt-extension.js` module locals). It does not touch the `extends` clause, so it is orthogonal. A composed capability that emits a method of the same name as a query *would* collide — collision policy (below) must cover capability-vs-query, not just capability-vs-capability.
+- **Runtime base-classes (`runtime/base-classes/`)** — strategy B adds mixin-function capabilities here (the `WithAnalytics` neighbourhood, `index.ts:60`); strategy C adds `@Injectable()` delegate helpers; both are package-published + vendored (the `runtimeImport`/`subsystemsImport` machinery in `prompt.js:1407-1417`). Import-specifier wiring already exists for base classes (`prompt-extension.js` rewrites via `rewriteSharedImport`).
+- **Baseline snapshot tests** — CLAUDE.md + memory `project_baseline_clean_arch_only`: baseline covers **clean-arch only**, which does NOT consume patterns. So baseline will NOT catch composition-emission changes. Coverage must come from **clean-lite-ps template-emission tests** (memory) + the smoke/tsc gate.
+- **Smoke / tsc gate** — this is the real safety net. Composed bases must `tsc`-compile in the smoke project (`just test-smoke` / `just test-smoke-integration`, memory `feedback_smoke_integration_gate`). The generic-mixin-depth risk (B) and the abstract-member-satisfaction risk surface *here*, not in unit tests. Any strategy MUST add a multi-pattern fixture to the smoke harness.
+- **Blast radius (smallest first):** (C) typed-delegate forwarders for a *new* small-vocab capability is the most contained — touches only new runtime helpers + new template forwarder blocks, leaves `extends <%= repositoryBaseClass %>` untouched. (B) mixins touch the `extends` line + resolver but reuse the shipped `WithAnalytics` mechanism. (A) literal method-flattening is infeasible (opaque bases). The clean pipeline is out of scope under every option.
+
+---
+
+## Recommendation
+
+**Adopt a hybrid: one inherited spine base + capabilities composed as TS mixins (the `WithAnalytics` mechanism), with a generated per-entity composed-base file as the readable packaging when ≥2 mixins stack.** For *new* lattice capabilities (`Group`/`Individual`) whose method vocab is small and codegen-known, prefer the **typed-delegate-forwarder** shape (strategy C, the Activity/`queries:` precedent) — it sidesteps single-inheritance entirely and is the most contained.
+
+**One-line why:** mixin application is already shipped and tsc-gated in this exact pipeline (`service.ejs.t:39` `extends WithAnalytics(Base<...>)`), so it is the lowest-risk path to "more than one capability's methods on one class," while a spine base preserves the Integrated/Activity abstract-config hand-off that pure delegation can't replicate for the opaque library bases.
+
+**Three reasons it beats the alternatives:**
+1. **The mechanism is proven in-emission, not theoretical** — `WithAnalytics(Base)` compiles in the smoke project today; strategy A's "flatten methods" is *infeasible* because patterns expose bases as opaque string-named imports with no machine-readable method list (`pattern-definition.ts:8-11,74-96`), so codegen literally cannot merge what it cannot see.
+2. **The spine preserves the existing config-hand-off** (`integrationConfig`/`patternConfig` abstract members, `integrated-entity-repository.ts:28`, `activity-entity-repository.ts:42`) that the concrete-class emit already satisfies — pure delegation would orphan those abstract contracts.
+3. **It minimizes blast radius and reuses existing precedents** — typed-delegate forwarders for new capabilities mirror the `queries:` and CGP-358b service pass-throughs already in `service.ejs.t:94-147`; no new emission paradigm.
+
+**Single biggest feasibility risk:** **generic-mixin typing depth.** The library bases are generic (`IntegratedEntityRepository<TEntity, TWrite, TProjection>`), and `WithAnalytics` has only ever wrapped a *single* generic base. Stacking 2-3 generic mixins (`Group(Individual(Integrated<...>))`) is untested here and is exactly the class of thing that produces "type instantiation is excessively deep and possibly infinite" — which would only surface in the smoke/tsc gate, not unit tests. **A spike that tsc-compiles a 3-deep generic-mixin stack in the smoke harness should gate the ADR's acceptance.** If it fails, fall back to the typed-delegate-forwarder shape (C) for everything, accepting that opaque library bases can only be the single inherited spine. **→ Spike run 2026-06-15: PASSED on all axes — see Spike Verdict below; the delegate-only fallback is no longer forced.**
+
+---
+
+## Spike verdict — generic-mixin depth (VERIFIED 2026-06-15)
+
+The gating risk above was tested with a hermetic `tsc` spike (TS **6.0.3**, the repo's compiler — `node_modules/.bin/tsc`, `strict: true`). The spike copies `WithAnalytics`/`Constructor` **verbatim** from `with-analytics.ts:15-22` and faithfully models `BaseRepository<TEntity>` + `IntegratedEntityRepository<TEntity, TWrite, TProj>` (three generics + `protected abstract readonly integrationConfig` + generic-returning `integrationUpsertOne(W): Promise<P>`), then stacks `Group`/`Individual`/`Analytics` capability mixins over it.
+
+**All four sub-risks cleared:**
+
+1. **No "type instantiation excessively deep".** A 4-deep stack `Group(Individual(Analytics(Integrated<E,W,P>)))` compiles in ~0.03s. A controlled depth ladder (0→4) showed zero depth-related degradation. Depth is a **non-risk** on TS 6.0.3.
+2. **Generic method signatures survive the stack.** `integrationUpsertOne({externalId,name}, p)` returns `SubjectProjection` (P), not erased — and a wrong write literal `{wrong:1}` is **rejected** with TS2353, proving `TWrite` did **not** collapse to `any` through the `Constructor<T>` erasure.
+3. **Abstract-member enforcement survives.** A concrete subclass omitting `integrationConfig` errors **TS2515** ("does not implement inherited abstract member integrationConfig") through the full 4-deep real-mixin stack — so codegen's emitted config stays compile-time-required; a hand-edit dropping it is caught.
+4. **Per-capability typed methods compose.** `membersFragment()` and the literal-preserving `toShape('email'): {shape:'email'}` are both present and typed on the leaf.
+
+*Investigation note:* an initial `@ts-expect-error`-based spike gave a false "abstract lost" reading — a directive line-targeting artifact (two directives in one file). A directive-free re-run, plus a depth ladder and a single-variable isolation pass (16+ configs), unanimously confirm enforcement holds. Positive control: an injected `const x: string = 123` correctly errored TS2322, confirming the compiler was actually checking.
+
+**Consequence for the ADR:** the recommended **mixin-hybrid mechanism is verified** — Open Question framing stands, but the mechanism choice is settled (not delegate-only-by-necessity). The smoke harness should still carry a real 3-deep multi-pattern fixture as a regression guard, since the spike *models* rather than *imports* the drizzle-bearing real bases.
+
+---
+
+## Open questions an ADR must answer
+
+1. **Collision policy when two composed capabilities (or a capability + a `queries:` method + a relationship forwarder) emit the same method name.** Today the validator is *silent* on method-name collisions by design (`validate-composition.ts:17-20`) and lets TS catch them at consumer compile. Is that acceptable for composition, or must codegen pre-detect collisions across patterns + queries + relationships and hard-error at generation time (better DX, but requires a codegen-known method vocab per capability — which mixins/opaque-bases don't provide)?
+2. **Ordering / precedence.** In `extends Group(Integrated(Base))`, last-applied wins on name clash. Does declaration order in `patterns: [...]` define mixin nesting order (and thus override precedence)? Is the order deterministic and documented?
+3. **Spine selection — does `patterns[0]` keep a privileged role?** Recommendation keeps the *first abstract-config base* as the inherited spine. Must the spine be `patterns[0]`, or the first pattern with a `repositoryClass`, or explicitly designated (e.g. `spine: Integrated`)? What happens when two patterns both want to be a base (both have `repositoryClass` + abstract config, e.g. `Integrated` + `Activity`)? Today only one can be inherited — the other must become a mixin/delegate, which requires it to ALSO ship in mixin form.
+4. **How does the composed base name itself + where is it emitted?** A generated `<Entity>ComposedBase` file (strategy A packaging) vs inline nested `extends` in the concrete class. File adds an artifact + import; inline keeps it in `repository.ejs.t`/`service.ejs.t` but can get unreadable at 3-deep.
+5. **Migration of existing single-base patterns.** `Integrated`/`Activity` are inheritance bases today. To be composable as non-spine capabilities they must ALSO be authorable as mixins (or expose a forwarder vocab). Does the ADR require every library pattern to ship in both forms, or only new capabilities? (No-backwards-compat rule, CLAUDE.md, means we can restructure them freely.)
+6. **Does this need a new pattern `kind:`?** `PatternKind` is `'domain' | 'orchestration'` (`pattern-definition.ts:47`). A composable *capability* (mixin/delegate that is never a spine base) is arguably a third shape — it has no `repositoryClass` as a base, it has a mixin import + a known method vocab. Should the ADR add `kind: 'capability'` (with a `mixinImport` / `forwarderMethods` field) distinct from `kind: 'domain'` (a spine base)? This cleanly separates "things you extend" from "things you layer."
+7. **Does `Group`/`Individual` need the configSchema → `patternConfig` hand-off, and can a mixin read it?** Activity/Integrated read config via an inherited `protected readonly patternConfig`/`integrationConfig`. A *mixin* can declare a property too (`WithAnalytics` adds `analytics?`), but a *delegate* needs config passed at construction. The ADR must specify how a non-spine capability receives its per-entity config (`config:` block) — property on the mixin, or constructor arg to the delegate.
+8. **Clean-pipeline scope.** Confirm clean stays explicitly out of scope (no pattern consumption today, ADR-031 `:213`), or whether the lattice forces minimum clean support. Recommendation: defer, document as a known asymmetry.
+
+## What I could not determine from the code
+
+- ~~**Whether a 3-deep generic-mixin stack actually tsc-compiles in this repo.**~~ **RESOLVED 2026-06-15** — yes, verified to 4-deep with generics + abstract members intact (see Spike Verdict). The remaining unknown is narrower: the spike models the bases rather than importing the real drizzle-bearing `IntegratedEntityRepository`, so a smoke-harness fixture should confirm against the published types.
+- **Whether the lattice capabilities (`Group`/`Individual`) have a method vocab small enough for forwarder-delegation.** That shape lives in swe-brain ADR-0022 / the dogfood (not re-read here); the prior research (`subject-lattice-codegen-lift.md`) treats `members()`/`to_shape()` as the core vocab, which *is* small — but the exact method set is a dogfood output, not yet pinned.
+
+## Status — decision recorded
+
+**The ADR is written: `docs/adrs/ADR-041-capability-composition-emission.md` (Accepted 2026-06-15).** The gating generic-mixin-depth spike was run and **PASSED** (see Spike Verdict), so ADR-041 codifies the verified mixin-hybrid and settles all eight decisions: spine = config-bearing base (not positional); a new `kind: 'capability'`; generation-time collision detection for known vocabs; new-capabilities-only migration; plus the ordering / composed-base-file / config-hand-off / clean-deferred defaults.
+
+**Next is NOT `/plan` for codegen.** Per swe-brain ADR-0022's build-dogfood-first mandate, the `Group`/`Individual` shapes are proven in the swe-brain dogfood first; the codegen implementation here is mechanical once they land. Implementation-time follow-ups (pin `forwarderMethods` vocab, the 3-capability smoke fixture, `extends?`-chain interaction) are listed in ADR-041 and are not blocking the decision.

--- a/.ai-docs/research/subject-lattice-codegen-lift.md
+++ b/.ai-docs/research/subject-lattice-codegen-lift.md
@@ -1,0 +1,188 @@
+---
+slug: subject-lattice-codegen-lift
+linear: null
+status: research
+date: 2026-06-15
+related: [swe-brain#ADR-0022]
+---
+
+# Understanding: forward-design the codegen-patterns framework lift of swe-brain ADR-0022 §6 (subject people⇄group lattice, role-typed edges, selectors + `to_shape` projections)
+
+> **Scope discipline.** This is read-only forward-design research for the *eventual* framework lift described in ADR-0022 §6. ADR-0022 is **explicitly built dogfood-first in swe-brain**; nothing here is to be implemented in codegen-patterns yet. The job is to map §6's deliverables onto this repo's real seams so a downstream `/plan` can decompose the lift into PR-sized issues once the dogfood proves the shape.
+
+## Request
+
+swe-brain ADR-0022 (`/Users/dug/Projects/swe-brain/swe-brain/.ai-docs/decisions/ADR-0022-subject-lattice-role-edges-selectors.md`, accepted/ratified 2026-06-15) generalizes ADR-0006's subject/interaction seam into a **people⇄group lattice**:
+
+- **`Individual`** (Person leaf) ships `to_shape(need)` + the identity shape.
+- **`Group`** (Org/Account/Team/Channel) yields its members as a **Predicate fragment, not a materialized list** — so a selector over a 5,000-person org compiles to *one* composed query, never an N+1 walk.
+- Each **interaction declares a role map** — `role → (target subject type, cardinality)` edges (core vocab `from/to/cc/bcc/host/invitee/attendee/about/owner`, per-interaction extensible).
+- A field is **either** a scalar leaf (the F1 `FieldType` typed-slot kernel) **or** a role-edge → a **Selector** (the F3 `ChannelSelect` picker, generalized).
+- `to_shape` is a **registered shape catalog contributed by ports** (same catalog-by-code seam as Find-targets / named predicates, ADR-0012), not a god-method.
+- Resolution is **live at dispatch** (option B, rides ADR-0021).
+
+§6 ("Upstream to `codegen-patterns`") asks the framework to, *from the role-map declarations*, emit: role-edge **retrieval fragments**, **selector registration** (Find-target/selector catalog), and the standard **`to_shape` projections**, all **auto-wired onto the ApplicationServices with no hand glue**; and to ship **`Individual`/`Group` as composable entity-family capabilities** "alongside `Activity`/`Integrated`", with the shape registry as a port-contribution seam. Ratified open-Q #4: `Group`-as-family-vs-axis is **"both, layered"** — a codegen-patterns family *capability* that an ADR-0006 subject *composes* (NOT a mutually-exclusive family pick).
+
+## Motivation
+
+ADR-0022's pitch: one primitive (casting a net over the lattice) collapses three surfaces — the composer filter value, the actuator recipient, and the watch-list subscription. The codegen lift is the **second-dogfood repeatability proof** the project exists to produce: a selector/projection primitive general enough to ship in codegen, proven by an unrelated app (swe-brain), is exactly the evidence codegen-patterns is built to generate. Concretely it removes per-interaction hand-wiring of subject-scoping/selectors/projections, the way `queries:` already removed hand-wiring of repository finders.
+
+## The §6 deliverables (what the framework must eventually generate)
+
+1. **`Individual` / `Group` as composable entity-family capabilities** in codegen-patterns — `Individual` ships `to_shape` + identity shape; `Group` ships fragment-retrieval over declared member relations. Must be **composable** (a subject entity that is *also* `Integrated`, *also* a `Group`), per ratified open-Q #4.
+2. **A role-declaration surface in entity YAML** — the carrier for §2's role map (`role → (target subject type, cardinality)`), core vocab + per-interaction extension.
+3. **Emission from those declarations** — role-edge **retrieval fragments** (§4; group membership compiles to ONE composed query / Predicate subtree, never an N+1 walk), **selector registration** (Find-target/selector catalog), and standard **`to_shape` projections**, auto-wired onto the generated ApplicationServices.
+4. **A shape registry** as a port-contribution seam (same catalog-by-code seam as Find-targets / named predicates).
+
+## Domain landscape — repo mapping (the six areas)
+
+### Area 1 — Entity-family seam: composable patterns, but single-base emission
+
+**The families are no longer a mutually-exclusive `family:` pick.** ADR-005's closed `family:` enum was *superseded* by ADR-031's **app-defined patterns** (`docs/adrs/ADR-031-app-defined-patterns.md`; vocabulary note `:10` records the `sync→integration` rename). The library ships five patterns — `Base`/`Integrated`/`Activity`/`Knowledge`/`Metadata` — each a `definePattern({...})` metadata record:
+
+- `src/patterns/library/integrated.pattern.ts:17-35` — `IntegratedPattern`: `repositoryClass: 'IntegratedEntityRepository'`, `serviceClass`, import aliases, `impliedBehaviors: ['external_id_tracking']`.
+- `src/patterns/library/activity.pattern.ts:44-62` — `ActivityPattern`: `extends: ['Base']`, a `configSchema` (`subject`/`subjectColumn`/`occurredAt`) read via `this.patternConfig` at runtime, generic subject-scoped finders (`findBySubjectId`/`findRecentBySubjectId`). **This is the closest existing analog to a `Group`/`Individual` capability** — a config-driven, subject-aware base whose per-entity facts (which FK column is the subject) come from YAML `config:`.
+
+The `PatternDefinition` surface (`src/patterns/pattern-definition.ts:54-119`) carries: `name`, `extends?`, `repositoryClass?`/`serviceClass?` (constructor *names*, never the classes — `:8-11`, `:74-78`), `repositoryImport?`/`serviceImport?`, `columns?` (`PatternColumnContribution`, `:35-40`), `impliedBehaviors?`, `configSchema?` (Zod, validates the per-entity `config:` block). Registration: `src/patterns/registry.ts` — `LIBRARY_PATTERNS` (seeded by the library barrel, `:44`), `APP_PATTERNS` (consumer globs, `:45`), `getPattern()` (`:151-153`).
+
+**The YAML surface already supports composition.** `EntityConfigSchema` (`src/schema/entity-definition.schema.ts:490-499`) has `pattern: z.string().optional()` *and* `patterns: z.array(z.string()).optional()` (mutually exclusive, refined at `:550-552`), plus `config: z.record(...)` keyed by pattern name. ADR-031 §2 (`docs/adrs/ADR-031-app-defined-patterns.md:96-104`) documents `patterns: [CrmEntity, Event]` multi-pattern composition explicitly. The composition validator (`src/patterns/validate-composition.ts:49-182`) walks **all** declared patterns, unions `impliedBehaviors` (silent dedup, `:155-160`), and hard-errors on column-name conflicts between patterns / fields / behaviors (`:139-153`).
+
+**THE GAP — composition is validated, not emitted (the single biggest design risk).** TypeScript has single inheritance, and the emitter honours that: the clean-lite-ps resolver picks **exactly one** base class from the **first** pattern.
+
+```js
+// templates/entity/new/clean-lite-ps/prompt-extension.js:76-82 (doc-comment)
+//   2. `entity.patterns[0]` — multi-pattern case: the first name drives the
+//      base-class choice. Subsequent patterns contribute columns + implied
+//      behaviors (PATTERN-4 composition check) but do not change the
+//      template's repository/service base class.
+```
+
+```js
+// templates/entity/new/clean-lite-ps/prompt-extension.js:86-106 (resolvePatternBaseClasses)
+const name =
+  (typeof entity.pattern === 'string' && entity.pattern) ||
+  (Array.isArray(entity.patterns) && entity.patterns[0]) ||   // <- only [0]
+  'Base';
+const def = getPattern(name) || getPattern('Base');
+return { repositoryBaseClass: def.repositoryClass, serviceBaseClass: def.serviceClass, ... };
+```
+
+So today `patterns: [Integrated, Group]` would: validate column/behavior composition correctly, contribute `Group`'s implied behaviors, but emit a repo that extends **only `IntegratedEntityRepository`** — `Group`'s `repositoryClass`/`serviceClass`/methods would be silently dropped. ADR-0022's "both, layered" (a subject entity that is `Integrated` *and* a `Group` *and/or* `Individual`) **cannot be expressed by the current emission model**. ADR-031 itself notes the `extends` chain is single-depth in Phase 1 (`docs/adrs/ADR-031-app-defined-patterns.md:207`); true multi-capability composition is unbuilt.
+
+This is the load-bearing finding: **the schema/validator layer is composition-ready; the emission layer is not.** The lift needs a real composition mechanism for *behavioural* contributions (methods + base capability), not just *column/behavior* contributions. Candidate shapes the planner must weigh (not decided here): TS mixins (`runtime/base-classes/with-analytics.ts` `WithAnalytics` is the existing in-repo mixin precedent — see `runtime/base-classes/index.ts:60`), a generated composed-base file (`<Entity>Base extends Mix(Integrated, Group)`), or capability-as-delegate (the base news-up a `GroupMembership` helper from `config:` rather than inheriting). The `Activity` pattern's config-driven-delegate shape (`activity.pattern.ts:44-62` reading `this.patternConfig`) is the lowest-friction precedent: `Group`/`Individual` could be **delegate capabilities driven by `config:` + the role map**, *not* base classes at all — sidestepping single-inheritance entirely. Flag for /plan.
+
+### Area 2 — Entity YAML schema: where the role-map lands
+
+Entity blocks live in `src/schema/entity-definition.schema.ts`; the full `EntityDefinitionSchema` is at `:830-1023`. The **declaration→generated** precedents to mirror end-to-end:
+
+- **`queries:`** (`:571-619`, `AnyQueryDeclarationSchema` union of `QueryDeclarationSchema` + `SearchQueryDeclarationSchema`) — the canonical "declarative block → generated repo methods + interface sigs + injectable query classes + module registration". Schema → parsed (`src/analyzer/types.ts:63-70` `ParsedQuery`) → emitted (clean-lite-ps `processQueries` at `prompt-extension.js:698-745`, `processSearchQueries` at `:795`, threaded into template locals at `:1158-1208`). **This is the closest existing precedent for §6's "declaration → generated, auto-wired service surface" and the role-map block should follow its schema→parser→emitter path exactly.**
+- **`integration.sink:` `SinkPolicySchema`** (`:683-689`) + its `superRefine` (`:977-1023`) — the most recent precedent for adding a per-entity declarative sub-block with **cross-field validation** (exclude_fields must be declared copy-through scalars, not FK columns, not `user_id`). The role map will need the same kind of superRefine (e.g. a role's `target` must be a known subject entity; cardinality must be `one`/`many`).
+- **`relationships:`** (`RelationshipSchema`, `:364-390`; `target: z.string()`, `foreign_key`, `type: belongs_to|has_many|has_one`) — the existing typed-edge surface. **The role map is a semantic overlay on relationships**: a role-edge is a relationship *plus* a role label *plus* a target-is-a-subject assertion. The planner should decide whether roles annotate existing `relationships:` entries (e.g. `relationships.from: { ..., role: from }`) or live in a sibling `roles:` block. ADR-0022 §2 frames it as a distinct map ("Each interaction declares its role map"), favouring a sibling block.
+
+**Proposed landing (for /plan to ratify, not a decision):** a sibling `roles:` block on `EntityDefinitionSchema`, e.g.
+
+```yaml
+roles:
+  from:     { target: person,  cardinality: one }
+  to:       { target: subject, cardinality: many }   # subject = lattice node (person|group)
+  cc:       { target: subject, cardinality: many }
+  about:    { target: subject, cardinality: one, optional: true }
+```
+
+Zod shape: `z.record(RoleNameSchema, z.object({ target: z.string(), cardinality: z.enum(['one','many']), optional: z.boolean().optional() }))` where `RoleNameSchema` is the core enum (`from/to/cc/bcc/host/invitee/attendee/about/owner`) *unioned* with a free string for per-interaction extension (mirrors how `FieldTypeSchema` is a closed enum but patterns are open). `ParsedRole` added to `src/analyzer/types.ts` alongside `ParsedQuery`/`ParsedRelationship`. Cross-validation in a `superRefine` (target resolves to a subject-capable entity) and/or in `analyzeDomain()` (`src/patterns/validate-composition.ts` is the model for analyzer-phase validation).
+
+**Note on `entity_ref` / `allowed_types`.** The schema already has a polymorphic-reference type (`entity_ref`, `:33`, requires `allowed_types`, `:271-279`). The lattice's "target: subject (person OR group)" cardinality smells like an `entity_ref` over the subject union — the planner should check whether role-edge targets reuse `entity_ref`/`allowed_types` machinery or introduce a parallel subject-typed reference.
+
+### Area 3 — Emission points: which pipeline owns each §6 output
+
+The repo has **two backend pipelines and TS emitters** (CLAUDE.md "Core Pipeline"): clean-arch (hygen, `templates/entity/new/backend/`), clean-lite-ps (hygen, `templates/entity/new/clean-lite-ps/`, the pipeline that consumes patterns today), and TS emitters (`src/emitters/frontend/`, `src/cli/shared/*-emission-generator.ts` for integration). Mapping each §6 output:
+
+- **Role-edge retrieval fragments (§4).** Backend, **clean-lite-ps pipeline**. They are repository/service methods (`findMembersFragment()` / role-scoped finders) generated from the `roles:` block exactly the way `queries:` generates `findByX()`. Entry point would be a new `processRoles()` alongside `processQueries` (`prompt-extension.js:698`), threaded into the repository/service template locals. The fragment-not-list contract (group membership = a Predicate subtree, ADR-0022 §4) is a **runtime base-class** concern (Area 1's `Group` capability owns the fragment-composition method); the emitter only wires the per-entity role/FK facts into it via `config:`/`patternConfig` (the `Activity` pattern's `findBySubjectId` reading `this.patternConfig` is the exact precedent — `activity.pattern.ts:12-20`).
+
+- **Selector registration (Find-target/selector catalog).** This is a **catalog/registry emission** — see Area 4. Closest pipeline is the **integration TS emitters** (`src/cli/shared/adapter-emission-generator.ts`), which already emit per-surface registries and aggregators. A selector catalog keyed by `(entity, role)` mirrors the `<SURFACE>_ENTITY_SOURCES` registry shape.
+
+- **`to_shape` projections.** The **registry mechanism** is a runtime base-class concern (`Individual` ships it); the **per-entity projection wiring** is emitted. Projections are the outbound dual of the read/projection types already generated by clean-lite-ps `buildIntegrationSurface` (`prompt-extension.js:870-974`, per the assembly-default-sinks research). The emitter generates the *registration* of an entity's identity shape into the catalog; ports contribute additional shapes at runtime (Area 4).
+
+- **Auto-wiring onto ApplicationServices.** clean-lite-ps already auto-registers generated query classes into the NestJS module (the `queries:` precedent — module providers threaded at `prompt-extension.js:1158-1208`). The role-edge fragments + selector classes + projection registrations follow the same module-registration path. The `patternConfig` hand-off (`docs/adrs/ADR-031-app-defined-patterns.md:124-148`: `protected override readonly patternConfig = {...}`) is how per-entity role facts reach the base capability with no hand glue.
+
+**Pipeline caveat:** patterns (and therefore any `Group`/`Individual` capability) are consumed by **clean-lite-ps only** today; the `clean` pipeline ignores `pattern:` and emits a no-op warning (`src/patterns/validate-composition.ts:209-233`, `pattern_clean_pipeline_noop`). The lift targets clean-lite-ps; `clean` support is out of scope unless the planner decides otherwise.
+
+### Area 4 — The catalog-by-code / port-contribution seam: closest existing precedent
+
+ADR-0022 leans on "the same catalog-by-code seam as Find targets / named predicates (ADR-0012)" for both the **shape registry** and **selector registration**. codegen-patterns already emits **two** registry/catalog seams that are near-exact precedents:
+
+1. **The integration `changeSources` registry + surface aggregator (RFC-0001 §3).** Each adapter *contributes* `changeSources: Record<string, IChangeSource<unknown>>` (entity-keyed); the **surface module folds** every adapter's contribution into one `IEntityChangeSourceRegistry` bound under `<SURFACE>_ENTITY_SOURCES`:
+   - `src/cli/shared/adapter-emission-generator.ts:641-663` `generateSurfaceTokens` — emits `<SURFACE>_ADAPTER_CONTRIBUTIONS` + `<SURFACE>_ENTITY_SOURCES` symbol tokens and the `AdapterContribution { provider, sources }` interface.
+   - `:675-720+` `generateSurfaceAggregator` — knowing the full adapter set at emit time, injects each adapter directly and folds `adapter.changeSources` into a `MemoryEntityChangeSourceRegistry` (NestJS has no `multi:true`, so codegen does the fold with full knowledge — `:670-674`). **Two providers serving one entity is a boot error** (one entity → one source, `:673`).
+
+   **This is the closest structural precedent for the shape registry and the selector catalog:** a code-keyed registry, contributions assembled at emit time by a generator that knows the full set, bound under a stable token. The shape registry would be: ports *contribute* shapes (`Record<ShapeCode, Projection>`); a generated aggregator folds them into one `IShapeCatalog` bound under a token; `Individual.to_shape(need)` resolves against it. The selector catalog: `(entity, role)` → selector class, folded the same way.
+
+2. **The orchestration pattern (ADR-032).** `OrchestrationPatternDefinition` (`src/patterns/pattern-definition.ts:228-251`) is *literally* a declarative "catalog-by-code" DI registry: `registry: { keyType, valueType, entries: [{ key, provider }] }` + `coKeyedRegistries` + an optional `dispatcher` with an `assemblySlot` the consumer overrides. Emitted by `src/cli/shared/orchestration-generator.ts`. **If the selector/shape catalog is a port-contributed DI registry, the orchestration-pattern kind is the existing mechanism to emit it** — the planner should evaluate whether the shape registry is a *new* orchestration pattern (`kind: 'orchestration'`) rather than net-new emission code.
+
+3. **Subsystem `forRoot({ backend })` (ADR-008).** The five subsystems (events/jobs/cache/storage/observability) use `DynamicModule.forRoot({ backend })` with `global: true` (CLAUDE.md). This is the *backend-swappable* seam, less directly relevant — the shape registry is contribution-folding (precedent 1), not backend-swapping. But the "core contract + opt-in extensions" rule (CLAUDE.md Operating Principles) maps cleanly: the **core shape catalog** ships the universal identity/Workspace-email shape; **extension shapes** (`SlackTarget`, actuator shapes) are port-contributed opt-ins.
+
+**No existing `to_shape`/selector/projection/role machinery exists in this repo** (grep for `to_shape|Selector|role_map|Individual|Group` returns only incidental hits — job "shape", sink "projection", frontend providers). This is genuinely greenfield codegen against existing *seams*, not an extension of existing selector code.
+
+### Area 5 — The framework/app boundary
+
+The line between what codegen-patterns *generates* and what stays swe-brain *app code*:
+
+| Concern | Framework (codegen generates) | App / swe-brain (stays hand-authored or scaffold-only) |
+|---|---|---|
+| Role map → repo/service methods | **Yes** — `processRoles()` emits role-scoped finders + fragment-retrieval method signatures, auto-wired (the `queries:` precedent). | — |
+| `Group` member-fragment *mechanism* | **Yes** — the `Group` base capability ships `members(): Predicate` composition (cycle-detect + dedup live in the base, ADR-0022 §1). | The **membership source-of-truth is per group type** (ADR-0022 §1 `:29`, ratified Q2). A CRM Account's contacts vs a Slack Channel's participants are *different declared member relations* — the framework generates the fragment *over a declared relation*, but **which relation** is per-entity `config:`/role-map app input. |
+| Selector resolution model (Predicate fragment, ONE composed query) | **Scaffold the catalog + the fragment-retrieval seam.** | The **Predicate-fragment resolution model itself** (RFC-0002 §4) and **dispatch-time live resolution (option B, riding ADR-0021)** are swe-brain runtime concerns. The framework can generate the *selector registration* and the *fragment method*; it cannot own *when* resolution fires (dispatch admission is ADR-0021, swe-brain). |
+| `to_shape` registry *mechanism* | **Yes** — the catalog seam + the universal identity/Workspace-email shape (precedent: surface aggregator fold). | **Port-contributed extension shapes** (`SlackTarget`, actuator shapes) are app/port code registered *into* the catalog. The framework owns the catalog and the universal shape; ports own their shapes. |
+| Cycle-detection / dedup implementation | **Yes** — a base-class algorithm (ADR-0022 "Remaining" `:96`). | — |
+| Dispatch-time membership resolution | **No** — swe-brain (ADR-0021 dispatch admission). Framework only emits the fragment-producing seam the dispatcher calls. | **Yes** — the resolver that fires at dispatch is swe-brain app code. |
+
+**Explicit on the two ADR-0022 claims the prompt flags:**
+- *Membership source-of-truth is per-group-type* → the framework **can only scaffold** this. It generates a uniform `members()`/fragment interface (ADR-0022 §1 "the *interface* is uniform"), but the concrete member relation per group type is declared app input (role map / `config:`), not framework-owned. The framework owns the *shape*, the app owns the *binding*.
+- *Resolution is live-at-dispatch* → **purely swe-brain (ADR-0021)**. The framework generates the selector (the stored net) and the fragment seam; it does *not* own the dispatch-time admission that resolves it. Live resolution "rides ADR-0021's dispatch-side predicate admission" (ADR-0022 §4 `:65`) — ADR-0021 is a swe-brain ADR, not in codegen-patterns.
+
+### Area 6 — Sequencing & risk
+
+ADR-0022 is **explicit**: build in swe-brain dogfood first, lift once proven (`§6 :73`, "built in swe-brain first, but designed so the framework lift is mechanical"). The `job-creator-v0` stack (#250–#256) is the **scalar-leaf floor** being built in swe-brain now (the F1 `FieldType` typed-slot kernel; ADR-0022 §3 "The stack is the leaf half; this ADR is the edge half").
+
+**What must be proven in the dogfood before the codegen lift is safe:**
+1. The **role map declares cleanly** for ≥2 different interaction entities (email, meeting) with the full core vocab including the set-difference roles (`invitee`/`attendee`/`bcc`) — proving the YAML shape before it becomes a Zod schema.
+2. The **`Group` member-fragment** actually composes to one query across ≥2 *different group types* (CRM Account vs Slack Channel) with *different* member relations — proving the "uniform interface, per-type source-of-truth" split is real, not aspirational.
+3. **Nested/transitive group resolution** with cycle-detect + dedup works at unbounded depth terminating at a Person leaf (ratified Q2) — this is the hardest runtime algorithm and must be a proven base-class before it ships as a library capability.
+4. **`to_shape` port-contribution** registers ≥1 non-universal shape (`SlackTarget`) *without a running app* at codegen time — proving the registry seam works the way the surface aggregator does (fold-at-emit), not requiring runtime reflection.
+5. The **composition story** (`Integrated` + `Group` on one subject entity) is exercised — because Area 1's single-base emission gap will surface the moment a real subject entity needs to be both integrated *and* a group.
+
+## Boundaries
+
+**In scope for the eventual lift (what /plan would decompose):**
+- A `roles:` (or equivalent) Zod block on `EntityDefinitionSchema` + parser + analyzer validation (the `queries:`/`SinkPolicy` precedent).
+- `Individual`/`Group` as composable capabilities — **gated on resolving the composition-emission gap (Area 1)**.
+- `processRoles()` emission in clean-lite-ps: role-edge retrieval fragments + auto-wired service surface.
+- A shape registry + selector catalog as a port-contribution seam (the surface-aggregator / orchestration-pattern precedent).
+- The runtime base-class algorithms: fragment composition, cycle-detect, dedup, `to_shape` catalog.
+
+**Adjacent but out of scope (stays swe-brain / separate work):**
+- The Predicate-fragment resolution model (RFC-0002 §4) and dispatch-time live resolution (ADR-0021) — swe-brain runtime.
+- Port-contributed extension shapes (`SlackTarget`, actuator shapes) — app/port code.
+- Per-group-type membership *source-of-truth* bindings — app config.
+- The `clean` (full Clean Architecture) pipeline — patterns are clean-lite-ps-only today.
+- Anything before the swe-brain dogfood proves the five items in Area 6.
+
+## Open questions for /plan
+
+1. **(LOAD-BEARING) How does codegen compose behavioural capabilities under TypeScript single-inheritance?** Today only `patterns[0]` drives the base class (`prompt-extension.js:86-106`); subsequent patterns contribute *columns/behaviors only*, silently dropping their `repositoryClass`/`serviceClass`/methods. ADR-0022's "both, layered" (`Integrated` + `Group` + `Individual` on one subject) **cannot be emitted today**. Options to weigh: (a) TS mixins (`WithAnalytics` precedent, `runtime/base-classes/with-analytics.ts`), (b) a generated composed-base file, (c) **capability-as-config-driven-delegate** (the `Activity` pattern shape — `Group`/`Individual` are NOT base classes, they are delegates the base news-up from `config:`/role-map; sidesteps single-inheritance entirely). This decision gates the whole lift.
+2. **Is the role map per-interaction-entity or global?** ADR-0022 §2 says "each interaction declares its role map" (per-entity). But the role *vocabulary* is shared-core. Does the core vocab live in a global registry (config/codegen) with per-entity extension, or is it purely per-entity YAML? Affects whether there's a `roles` config-level surface or only an entity-level block.
+3. **Does the role-edge target reuse `entity_ref`/`allowed_types`, or a new subject-typed reference?** The lattice's "target: subject (person|group)" cardinality overlaps the existing polymorphic `entity_ref` (`entity-definition.schema.ts:33,271-279`). Reuse vs parallel machinery.
+4. **Is the role map a sibling `roles:` block or an annotation on `relationships:`?** A role-edge is a relationship + role label + subject assertion. ADR-0022 frames it as a distinct map (favouring a sibling block), but `relationships:` already models typed edges (`:364-390`).
+5. **Is the shape/selector registry a new orchestration pattern (`kind: 'orchestration'`) or net-new emission code?** ADR-032's `OrchestrationPatternDefinition` (`pattern-definition.ts:228-251`) is already a declarative port-contributed DI registry + dispatcher. The shape catalog may *be* an orchestration pattern rather than bespoke emission.
+6. **How do `to_shape` ports register shapes without a running app?** The surface aggregator folds contributions *at emit time* with full knowledge of the set (`adapter-emission-generator.ts:675+`). Can the shape catalog be folded the same way (codegen knows the port set), or does it need runtime registration? ADR-0022 wants port-contribution; the framework needs to know whether that's a build-time fold or a runtime DI bind.
+7. **Sequencing vs RFC-0004 / assembly-sinks:** the integration emitters (`src/cli/shared/*-emission-generator.ts`) are slated to move out of `cli/` (memory `project_emitters_misplaced_under_cli`); the selector/shape catalog emission would land in the same neighbourhood. Coordinate placement so the lift doesn't fight the relocation.
+
+## What I could not determine
+
+- **The concrete swe-brain F1/F3/Predicate shapes.** I did not grep the swe-brain repo for the F1 `FieldType`/`accepts()` kernel (PR #4), the F3 `ChannelSelect` picker, or the named-predicate catalog — the codegen-patterns mapping was determinable from ADR-0022 + the distilled memory without them. If /plan needs the *exact* TS shapes the framework must lift (e.g. the `accepts()` discriminant signature, the `ChannelSelect` props), a follow-up read of `/Users/dug/Projects/swe-brain/swe-brain` is warranted. ADR-0022 §3 says `accepts()`'s `scalar`-vs-`ref` discriminant *is* the leaf/edge line — that's the integration point, but I did not verify its concrete signature.
+- **Whether the dogfood has started.** The job-creator-v0 stack status (scalar-leaf floor, #250–#256) is from the memory, not re-verified in swe-brain — the memory says it's "mechanically merge-ready" but the selector/edge half is unbuilt. The five Area-6 proof items are *my* derivation of the dogfood gate, not an ADR-stated checklist.
+- **The exact runtime home for `Individual`/`Group` base capabilities.** They'd live in `runtime/base-classes/` alongside `integrated-entity-{repository,service}.ts`, but whether they're repository-side, service-side, or a standalone capability module depends entirely on Open Question #1's composition resolution.
+
+## Recommended next agent
+
+**`/plan`** — but **gated on the swe-brain dogfood proving the Area-6 items first** (per ADR-0022's explicit build-dogfood-first mandate). The single decision that must precede any decomposition is Open Question #1 (capability composition under single-inheritance); everything else is mechanical once that's settled. If the dogfood is not yet built, the next step is *not* /plan but tracking the swe-brain stack to the point where the role-map + member-fragment + `to_shape` shapes are proven.

--- a/docs/adrs/ADR-041-capability-composition-emission.md
+++ b/docs/adrs/ADR-041-capability-composition-emission.md
@@ -1,0 +1,106 @@
+# ADR-041 — Capability Composition Emission (multi-pattern repositories/services via a spine base + layered capabilities)
+
+**Status:** Accepted
+**Date:** 2026-06-15
+**Owner:** Doug
+**Related:** ADR-031 (App-Defined Patterns — this extends it with a third `pattern:` kind), ADR-032 (Orchestration Patterns — the sibling second kind), ADR-005 (superseded family enum), swe-brain `ADR-0022-subject-lattice-role-edges-selectors` (the driving consumer; this ADR is the codegen-side mechanism its §6 lift depends on)
+**Research:** `.ai-docs/research/capability-composition-emission.md` (strategy survey + the verified generic-mixin-depth spike), `.ai-docs/research/subject-lattice-codegen-lift.md` (the §6 lift this unblocks)
+
+> **Sequencing note.** This ADR settles the *mechanism* for multi-capability emission. It does **not** trigger implementation. Per swe-brain ADR-0022's build-dogfood-first mandate, the subject-lattice capabilities (`Group`/`Individual`) are hand-built in swe-brain first; the codegen lift here is mechanical once their shapes prove out. This decision exists so that lift — and any other multi-capability consumer — has a settled, verified target rather than re-litigating single-inheritance at build time.
+
+## Context
+
+ADR-031 made patterns composable at the **YAML + validator** layer: `patterns: [A, B]` is accepted, `src/patterns/validate-composition.ts` unions implied behaviors and hard-errors on column conflicts. But **emission picks exactly one base class** — the clean-lite-ps resolver takes the base from `patterns[0]` and silently drops every later pattern's `repositoryClass`/`serviceClass`/methods (`templates/entity/new/clean-lite-ps/prompt-extension.js:86-107`, doc-comment `:76-82`). So `patterns: [Integrated, Group, Individual]` *validates* but cannot emit all three capabilities' methods onto one repository/service. TypeScript single-inheritance is the wall.
+
+swe-brain ADR-0022's "both, layered" ruling (a subject entity that is `Integrated` **and** a `Group` **and/or** `Individual`) forces the question, but the gap is **general** to the patterns system — any consumer wanting two capabilities' generated methods on one entity hits it.
+
+Three facts constrain the solution space (full trace in the research artifact):
+
+1. **Patterns expose their base as an opaque string name + import, never the class.** `PatternDefinition` carries `repositoryClass?: string` + `repositoryImport?: string` + a doc-comment-only `repositoryInheritedMethods?: string[]` (`src/patterns/pattern-definition.ts:44-59`). This is deliberate (ADR-031 `:81` — keeps codegen free of TS class-evaluation + `reflect-metadata`). **Consequence: codegen cannot see a pattern's methods, so it cannot mechanically merge method bodies.**
+2. **A mixin mechanism is already shipped and tsc-gated in this exact pipeline.** `service.ejs.t:39` emits `extends WithAnalytics(<ServiceBase><...>)`; `WithAnalytics` is a real TS mixin (`runtime/base-classes/with-analytics.ts:17-22`).
+3. **The gap is asymmetric.** Only **clean-lite-ps** consumes patterns; the **full clean** pipeline ignores them entirely (hardcodes `BaseRepository`, has no service class, emits a `pattern_clean_pipeline_noop` warning — `validate-composition.ts:209-233`).
+
+**Mechanism verified before this decision.** A hermetic `tsc` spike (TS 6.0.3, the repo's compiler) stacked `Group`/`Individual`/`Analytics` capability mixins 4-deep over a faithful `IntegratedEntityRepository<TEntity, TWrite, TProj>` model. Result: no "type instantiation excessively deep" (compiles ~0.03s); generic method signatures survive (`TWrite` rejects wrong input — did not collapse to `any`); the `integrationConfig` **abstract-member contract stays enforced** on the concrete leaf (TS2515 when omitted); per-capability typed methods compose. See the research artifact's **Spike Verdict** section.
+
+## Decision
+
+### 1. Mechanism — a spine base + layered capabilities
+
+A composed entity emits **one inherited spine base** plus **N layered capabilities**, where each capability is either:
+
+- a **TS mixin** applied in the `extends` clause (the shipped `WithAnalytics(Base)` mechanism), or
+- a **typed-delegate forwarder** (the `queries:` / CGP-358b service pass-through precedent, `service.ejs.t:94-147`) for a capability with a small, codegen-known method vocab.
+
+When ≥2 capabilities stack, codegen emits a generated `<Entity>ComposedBase` file applying the mixin chain, and the concrete class extends that (readability over a 3-deep inline `extends`).
+
+**Rejected: "synthesize one base by flattening all patterns' methods" (strategy A).** Infeasible — patterns expose opaque string-named bases with no machine-readable method list (Context #1). Codegen cannot merge method bodies it cannot see. A survives only as mixin-application *packaging*, which is exactly the generated `<Entity>ComposedBase` file above.
+
+### 2. Spine selection — by config-bearing base, not by position (Ruling #1)
+
+The spine is **the one pattern whose base carries an abstract-config contract**: `Integrated` (`protected abstract readonly integrationConfig`, `integrated-entity-repository.ts:28`) or `Activity` (`patternConfig`, `activity-entity-repository.ts:42`). Everything else layers as a capability.
+
+- **Not positional.** `patterns[0]` does **not** get a privileged base role; reordering `patterns:` must not change which class is inherited.
+- **Two config-bearing bases in one entity is a hard validation error**: *"only one inheritable spine base is allowed; express the other capability as `kind: 'capability'`."* (e.g. `patterns: [Integrated, Activity]` fails until one is authored as a capability.)
+- **No config-bearing base** → spine = the default `Base` repository/service; all declared patterns layer as capabilities.
+
+This rule is honest about the actual constraint (only one inheritable base) where positional selection silently hides it.
+
+### 3. A third pattern kind: `kind: 'capability'` (Ruling #2)
+
+`PatternKind` (`pattern-definition.ts:47`, currently `'domain' | 'orchestration'`) gains **`'capability'`**. A capability pattern:
+
+- carries `mixinImport` (the mixin function's import) **and/or** a `forwarderMethods` vocab (the small, known method set it contributes),
+- has **no** `repositoryClass`/`serviceClass`-as-spine (it is layered, never inherited as the base),
+- may still carry `columns`, `impliedBehaviors`, and a `configSchema`.
+
+This cleanly separates **`domain`** ("a base you *extend*") from **`capability`** ("something you *layer*"), and — load-bearing — it gives codegen the **machine-readable method vocab** it otherwise lacks (Context #1), which is what makes Ruling #3 possible.
+
+### 4. Collision policy — detect what we can see, defer the rest to tsc (Ruling #3)
+
+- For **codegen-known vocabs** — a `capability`'s `forwarderMethods`, `queries:` methods, and relationship forwarders — codegen **pre-detects method-name collisions across the composed set and hard-errors at generation time** (better DX than a downstream compile error).
+- For **opaque spine bases** (no visible method list), keep ADR-031's existing stance: name clashes surface as **TypeScript compile errors at consumer build** (`validate-composition.ts:17-20`).
+
+Generation-time detection is only possible *because* Ruling #2 makes capability methods visible; the opaque-base remainder is irreducible and stays a tsc concern.
+
+### 5. Migration scope — new capabilities only, for now (Ruling #4)
+
+Only the **new** lattice capabilities (`Group`/`Individual`) ship in `kind: 'capability'` form initially. `Integrated`/`Activity` remain spine-only inheritance bases. We do **not** dual-author the existing library patterns into both base and mixin forms until a real consumer needs one of them as a *non-spine* capability. (The no-backwards-compat rule lets us restructure freely — YAGNI says don't, yet.)
+
+### 6. Baked defaults (low-controversy; flagged for completeness)
+
+- **Ordering / precedence.** Declaration order in `patterns: [...]` defines mixin nesting (rightmost = outermost). Last-applied wins on an *un-flagged* clash; Ruling #3 hard-errors *known* clashes first, so precedence only resolves genuinely-invisible (opaque-base) overlaps. Order is deterministic and documented.
+- **Composed-base emission.** A generated `<Entity>ComposedBase` file when ≥2 capabilities stack; inline `extends Capability(Spine<...>)` when exactly one capability layers.
+- **Config hand-off for non-spine capabilities.** A **mixin** capability reads its per-entity `config:` via an inherited property (the `WithAnalytics` `analytics?` model — a property the concrete class fills, not a constructor arg). A **delegate** capability receives config at construction. The capability definition declares which.
+- **Clean pipeline.** Explicitly **deferred** — it consumes no patterns today (ADR-031 `:213` defers clean pattern support to "additive Phase 3+"). Documented asymmetry; the subject lattice does not force clean support. Scope all of the above to **clean-lite-ps**.
+
+## Consequences
+
+**Positive.**
+- Composition now both *validates* (ADR-031) **and** *emits*.
+- The mechanism is **verified, not assumed** — the spike clears depth, generic-erasure, and abstract-member-enforcement risks.
+- `kind: 'capability'` separates extend-from-layer and unlocks generation-time collision DX.
+- Minimal blast radius — reuses the shipped `WithAnalytics` mixin and the `queries:`/CGP-358b forwarder precedents; no new emission paradigm.
+- The spine rule states the real single-inheritance constraint instead of hiding it behind `patterns[0]`.
+
+**Cost.**
+- A third `PatternKind` + the `mixinImport`/`forwarderMethods` schema fields.
+- Capability patterns must enumerate `forwarderMethods` — viable only for *small, known* vocabs (the lattice's `members()`/`toShape()` qualify).
+- A generated `<Entity>ComposedBase` file per ≥2-capability entity (extra artifact + import).
+- A multi-pattern smoke fixture is required (see below).
+
+**Testing / safety.**
+- Baseline snapshot tests are **clean-arch-only** and do not consume patterns — they will **not** catch composition-emission changes. Coverage comes from **clean-lite-ps template-emission tests** + the **smoke/tsc gate**.
+- The spike *models* the bases; it does not *import* the drizzle-bearing real classes. A **3-capability smoke fixture that tsc-compiles against the published bases** is the regression guard and must land with the implementation (`just test-smoke-integration`).
+
+## Alternatives considered
+
+- **(A) Generated composed-base by method-flattening** — rejected as infeasible: opaque string-named bases (`pattern-definition.ts:44-59`) give codegen no method list to merge. Survives only as the mixin-application packaging adopted in Decision #1.
+- **(B) Mixins-only** — verified and viable, but forces *every* non-spine capability into mixin form (including any future `Integrated`-as-capability). The hybrid keeps the delegate option for small known vocabs, which is more contained.
+- **(C) Delegate-only** — sidesteps single-inheritance entirely but orphans the spine's abstract-config hand-off (`integrationConfig`/`patternConfig`) and needs an emitted forwarder for *every* method. Reserved as the fallback had the spike failed; the spike passed, so it is not adopted.
+- **Positional spine (`patterns[0]`)** — rejected (Decision #2): silent about the real "only one inheritable base" constraint and fragile under `patterns:` reordering.
+
+## Open follow-ups (implementation-time; not blocking this decision)
+
+1. Pin `Group`/`Individual`'s exact `forwarderMethods` vocab from the swe-brain dogfood (ADR-0022's `members()` / `to_shape()` are the seed).
+2. Land the 3-capability smoke fixture (tsc against the real published bases).
+3. Confirm how ADR-031's single-depth `extends?` chain interacts with capability layering (likely orthogonal — `extends` builds a spine, capabilities layer on top — but verify at build time).


### PR DESCRIPTION
## What

Records **ADR-041 — Capability Composition Emission** (Accepted), the codegen-side decision that unblocks multi-capability entities, plus the two research artifacts behind it.

**Driver:** swe-brain `ADR-0022`'s "both, layered" subject lattice needs an entity that is `Integrated` **and** a `Group`/`Individual`. ADR-031 patterns already compose at the YAML + validator layer (`patterns: [A, B]`), but emission picked one base (`patterns[0]`) and silently dropped the rest's methods — TypeScript single-inheritance. The gap is general to the patterns system, not lattice-specific.

## Decision (six rulings)

1. **Mechanism** — one inherited **spine base** + capabilities **layered** as TS mixins (the shipped `WithAnalytics` mechanism) or typed-delegate forwarders. Method-flattening rejected: patterns expose *opaque* string-named bases, so codegen can't merge methods it can't see.
2. **Spine = the config-bearing base** (`Integrated`/`Activity`), not `patterns[0]`. Two config-bases in one entity → hard validation error.
3. **New `kind: 'capability'`** (3rd `PatternKind`) carrying `mixinImport` + `forwarderMethods` — gives codegen the method vocab it otherwise lacks.
4. **Collision policy** — generation-time hard-error for known vocabs (capabilities + `queries:` + relationships); opaque-base clashes defer to tsc.
5. **Migration** — new capabilities only; `Integrated`/`Activity` stay spine-only (YAGNI).
6. **Defaults** — declaration-order precedence · generated `<Entity>ComposedBase` file at ≥2 stack · property-config for mixins · clean pipeline deferred.

## Verified, not assumed

A hermetic `tsc` spike (TS 6.0.3) stacked capability mixins **4-deep** over a faithful `IntegratedEntityRepository<TEntity, TWrite, TProj>` model. All four sub-risks cleared: no "type instantiation excessively deep" (~0.03s); generics survive (`TWrite` rejects wrong input — no `any` collapse); the `integrationConfig` abstract contract stays enforced on the leaf (TS2515 when omitted); capability methods compose. Details in the research artifact's **Spike Verdict**.

## Scope

**Docs only — no code.** This settles the *mechanism*; it does not trigger implementation. Per ADR-0022's build-dogfood-first mandate, the codegen lift is mechanical once `Group`/`Individual` prove out in swe-brain. Implementation-time follow-ups (pin `forwarderMethods`, a 3-capability smoke fixture, `extends?`-chain interaction) are listed in ADR-041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
