### PR TITLE
fix(generators): namespace pg enums by entity + dedupe belongs_to/unique-FK query collision (v0.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.1] — 2026-06-20
+
+### Fixed
+
+- **pg enum types are now namespaced by ENTITY, not just the field — no more
+  cross-entity collisions.** The entity generators (both `clean-lite-ps`, the
+  `codegen init` default, and the legacy `backend` clean-architecture pipeline)
+  derived an enum field's exported const AND its Postgres TYPE name from the
+  FIELD name alone. Two entities that each declared an enum field with the same
+  name (e.g. `role`, `status`, `agg`, `additivity`) therefore generated the SAME
+  `export const roleEnum = pgEnum('role', …)` in two files — a duplicate barrel
+  export (**TS2308** "has already exported a member named 'roleEnum'") and a
+  duplicate `CREATE TYPE role` at the DB level (a real migration conflict).
+  Discovered building a real NestJS + Drizzle consumer app (`field_config` and
+  `canonical_field` both declaring `role`). The const and pg type name are now
+  namespaced by entity — pg type `field_config_role`, export `fieldConfigRoleEnum`
+  — matching the convention the junction generator already used. The COLUMN name
+  is unchanged (still the bare snake field name), so the generated table shape and
+  `InferSelectModel` types are identical; only the type/const identifiers move.
+- **`belongs_to` + an explicit unique FK `queries:` entry no longer emit a
+  duplicate method.** An entity with BOTH a `belongs_to` on a column AND an
+  explicit `queries: [{ by: [that_fk_column], unique: true }]` emitted
+  `findByFieldDefinitionId` TWICE — once from the declarative-query generator
+  (single-row return) and once from the `belongs_to` FK-traversal generator
+  (array return) → **TS2393** "Duplicate function implementation." CGP-358 already
+  resolved the *non-unique* case (the FK method, which accepts `opts`, is a
+  superset, so the plain declarative impl is skipped); the unique/via/select case
+  was the gap. Now a unique/via/select declarative query is treated as the more
+  specific intent and WINS — the colliding FK-traversal method is skipped. Fixed
+  in all three repository templates (clean-lite-ps + backend base-class + backend
+  inline). Exactly one method emits in every case.
+
 ## [0.28.0] — 2026-06-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/clean-lite-ps/entity-column-features.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-column-features.test.ts
@@ -68,7 +68,9 @@ describe('column defaults (#345)', () => {
   it('emits .default(literal) on an enum column', () => {
     const { output } = render(definition);
     expect(output).toContain(".default('created')");
-    expect(output).toContain("stateEnum('state').notNull().default('created')");
+    // The enum const is namespaced by entity (conversation_state) — the column
+    // name stays the bare field name.
+    expect(output).toContain("conversationStateEnum('state').notNull().default('created')");
   });
 
   it('emits a bare numeric default on an integer column', () => {

--- a/src/__tests__/clean-lite-ps/entity-enum-template.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-enum-template.test.ts
@@ -50,10 +50,17 @@ const integrationDefinition = {
 };
 
 describe('clean-lite-ps entity template — pgEnum emission', () => {
-  it('exposes clpEnumFields with enumName, dbName, and choices', () => {
+  it('exposes clpEnumFields with entity-namespaced enumName, dbName, and choices', () => {
     const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS) as any;
+    // Both the exported const (enumName) and the pg TYPE name (dbName) are
+    // namespaced by entity so a same-named enum field on another entity can't
+    // collide (TS2308 / duplicate CREATE TYPE).
     expect(locals.clpEnumFields).toEqual([
-      { enumName: 'statusEnum', dbName: 'status', choices: ['active', 'paused', 'disabled'] },
+      {
+        enumName: 'integrationStatusEnum',
+        dbName: 'integration_status',
+        choices: ['active', 'paused', 'disabled'],
+      },
     ]);
   });
 
@@ -62,10 +69,11 @@ describe('clean-lite-ps entity template — pgEnum emission', () => {
     expect(locals.clpDrizzleImports).toContain('pgEnum');
   });
 
-  it('produces a drizzleChain referencing the enum declaration, not text()', () => {
+  it('produces a drizzleChain referencing the namespaced enum const, not text()', () => {
     const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS) as any;
     const statusField = locals.clpProcessedFields.find((f: any) => f.name === 'status');
-    expect(statusField.drizzleChain).toBe("statusEnum('status').notNull()");
+    // The const is namespaced; the COLUMN name stays the bare field name.
+    expect(statusField.drizzleChain).toBe("integrationStatusEnum('status').notNull()");
     expect(statusField.tsType).toBe("'active' | 'paused' | 'disabled'");
   });
 
@@ -73,12 +81,12 @@ describe('clean-lite-ps entity template — pgEnum emission', () => {
     const locals = buildCleanLitePsLocals(integrationDefinition, EMPTY_BASE_LOCALS);
     const out = render(locals as Record<string, unknown>);
 
-    // Top-of-file declaration
+    // Top-of-file declaration — const + pg TYPE name both namespaced by entity.
     expect(out).toContain(
-      "export const statusEnum = pgEnum('status', ['active', 'paused', 'disabled']);",
+      "export const integrationStatusEnum = pgEnum('integration_status', ['active', 'paused', 'disabled']);",
     );
-    // Column reference inside pgTable block
-    expect(out).toContain("status: statusEnum('status').notNull()");
+    // Column reference inside pgTable block — namespaced const, bare column name.
+    expect(out).toContain("status: integrationStatusEnum('status').notNull()");
     // No text() fallback for the enum column
     expect(out).not.toMatch(/status: text\('status'\)/);
     // pgEnum import present
@@ -102,5 +110,57 @@ describe('clean-lite-ps entity template — pgEnum emission', () => {
     const locals = buildCleanLitePsLocals(noEnum, EMPTY_BASE_LOCALS) as any;
     expect(locals.clpEnumFields).toEqual([]);
     expect(locals.clpDrizzleImports).not.toContain('pgEnum');
+  });
+});
+
+describe('clean-lite-ps entity template — enum namespacing across entities (no collision)', () => {
+  // Regression: two entities that each declare an enum field with the SAME name
+  // (`role`) must produce DISTINCT enum consts AND distinct pg type names.
+  // Pre-fix both emitted `export const roleEnum = pgEnum('role', …)`, which is a
+  // duplicate barrel export (TS2308) and a duplicate `CREATE TYPE role` at the
+  // DB level (a real migration conflict). Hit building a real consumer app.
+  const fieldConfig = {
+    entity: { name: 'field_config', plural: 'field_configs', table: 'field_configs', pattern: 'Base' },
+    fields: { role: { type: 'enum', choices: ['a', 'b'], required: true } },
+    relationships: {},
+    behaviors: [],
+  };
+  const canonicalField = {
+    entity: { name: 'canonical_field', plural: 'canonical_fields', table: 'canonical_fields', pattern: 'Base' },
+    fields: { role: { type: 'enum', choices: ['a', 'b'], required: true } },
+    relationships: {},
+    behaviors: [],
+  };
+
+  it('namespaces the enum const + pg type name by entity', () => {
+    const a = buildCleanLitePsLocals(fieldConfig, EMPTY_BASE_LOCALS) as any;
+    const b = buildCleanLitePsLocals(canonicalField, EMPTY_BASE_LOCALS) as any;
+
+    expect(a.clpEnumFields).toEqual([
+      { enumName: 'fieldConfigRoleEnum', dbName: 'field_config_role', choices: ['a', 'b'] },
+    ]);
+    expect(b.clpEnumFields).toEqual([
+      { enumName: 'canonicalFieldRoleEnum', dbName: 'canonical_field_role', choices: ['a', 'b'] },
+    ]);
+
+    // Distinct const names → no duplicate barrel export (TS2308).
+    expect(a.clpEnumFields[0].enumName).not.toBe(b.clpEnumFields[0].enumName);
+    // Distinct pg type names → no duplicate CREATE TYPE.
+    expect(a.clpEnumFields[0].dbName).not.toBe(b.clpEnumFields[0].dbName);
+  });
+
+  it('emits distinct pgEnum declarations + column references in the rendered files', () => {
+    const aOut = render(buildCleanLitePsLocals(fieldConfig, EMPTY_BASE_LOCALS) as Record<string, unknown>);
+    const bOut = render(buildCleanLitePsLocals(canonicalField, EMPTY_BASE_LOCALS) as Record<string, unknown>);
+
+    expect(aOut).toContain("export const fieldConfigRoleEnum = pgEnum('field_config_role', ['a', 'b']);");
+    expect(aOut).toContain("role: fieldConfigRoleEnum('role').notNull()");
+
+    expect(bOut).toContain("export const canonicalFieldRoleEnum = pgEnum('canonical_field_role', ['a', 'b']);");
+    expect(bOut).toContain("role: canonicalFieldRoleEnum('role').notNull()");
+
+    // Neither file emits the bare, un-namespaced const that previously collided.
+    expect(aOut).not.toContain("export const roleEnum = pgEnum('role'");
+    expect(bOut).not.toContain("export const roleEnum = pgEnum('role'");
   });
 });

--- a/src/__tests__/clean-lite-ps/repository-template.test.ts
+++ b/src/__tests__/clean-lite-ps/repository-template.test.ts
@@ -200,3 +200,78 @@ describe('clean-lite-ps repository template — declarative queries use baseQuer
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 });
+
+describe('clean-lite-ps repository template — belongs_to + explicit FK query collision (TS2393)', () => {
+  // Regression: an entity with BOTH a `belongs_to` on a column AND an explicit
+  // `queries: [{ by: [that_fk_column], unique: true }]` previously emitted
+  // `findByFieldDefinitionId` TWICE — once from the declarative-query generator
+  // (single-row return) and once from the belongs_to FK-traversal generator
+  // (array return) → "Duplicate function implementation" (TS2393). Exactly one
+  // method must emit; the explicit declarative query is the more specific intent.
+  const collisionEntity = {
+    entity: {
+      name: 'field_config',
+      plural: 'field_configs',
+      table: 'field_configs',
+      pattern: 'Base',
+    },
+    fields: { value: { type: 'string', required: true } },
+    relationships: {
+      field_definition: {
+        type: 'belongs_to',
+        target: 'field_definition',
+        foreign_key: 'field_definition_id',
+      },
+    },
+    queries: [{ by: ['field_definition_id'], unique: true }],
+    behaviors: [],
+  };
+
+  const countMethodDefs = (out: string, method: string): number =>
+    (out.match(new RegExp(`async ${method}\\(`, 'g')) ?? []).length;
+
+  it('emits findByFieldDefinitionId exactly ONCE when belongs_to + unique query collide', () => {
+    const locals = buildCleanLitePsLocals(collisionEntity, {});
+    const output = renderRepository(locals);
+
+    expect(countMethodDefs(output, 'findByFieldDefinitionId')).toBe(1);
+  });
+
+  it('keeps the declarative (unique, single-row) method and drops the FK-traversal array method', () => {
+    const locals = buildCleanLitePsLocals(collisionEntity, {});
+    const output = renderRepository(locals);
+
+    // The surviving method is the unique declarative one — single-row return.
+    expect(output).toContain(
+      'async findByFieldDefinitionId(fieldDefinitionId: string): Promise<FieldConfig | null>',
+    );
+    // The FK-traversal array variant must NOT also be emitted.
+    expect(output).not.toContain(
+      'async findByFieldDefinitionId(id: string, opts?: { cursor?: string; limit?: number })',
+    );
+  });
+
+  it('still emits the FK-traversal method when there is NO colliding declarative query (CGP-358 unchanged)', () => {
+    // A non-unique declarative query on the same column → FK method wins
+    // (CGP-358), declarative impl is skipped; either way exactly one method.
+    const nonUnique = {
+      ...collisionEntity,
+      queries: [{ by: ['field_definition_id'] }],
+    };
+    const output = renderRepository(buildCleanLitePsLocals(nonUnique, {}));
+    expect(countMethodDefs(output, 'findByFieldDefinitionId')).toBe(1);
+    // The FK-traversal (opts) variant is the survivor here.
+    expect(output).toContain(
+      'async findByFieldDefinitionId(id: string, opts?: { cursor?: string; limit?: number })',
+    );
+  });
+
+  it('emits the FK-traversal method when there are no declarative queries at all', () => {
+    const noQueries = { ...collisionEntity, queries: undefined as unknown as [] };
+    const output = renderRepository(buildCleanLitePsLocals(noQueries, {}));
+    expect(countMethodDefs(output, 'findByFieldDefinitionId')).toBe(1);
+    expect(output).toContain(
+      'async findByFieldDefinitionId(id: string, opts?: { cursor?: string; limit?: number })',
+    );
+  });
+});

--- a/templates/entity/new/backend/database/repository.ejs.t
+++ b/templates/entity/new/backend/database/repository.ejs.t
@@ -52,8 +52,20 @@ export class <%= className %>Repository
 // covers the same method name (simple single-FK, non-unique, non-via, non-select).
 // The declarative use-case class still works because opts is optional.
 const _fkMethodNames = new Set(belongsToRelations.map(rel => `findBy${rel.foreignKeyPascal}`));
+// Inverse guard: a unique/via/select declarative query is the more specific
+// intent (single-row / junction / projection) and WINS over a same-named FK
+// method; emitting both is a duplicate function implementation (TS2393). Skip
+// the FK method when such a declarative query already owns its name.
+const _emittedDqNames = new Set(
+	(typeof processedQueries !== 'undefined' ? processedQueries : [])
+		.filter((q) => q.isUnique || q.hasVia || q.hasSelect)
+		.map((q) => q.methodName),
+);
+const _emittedFkRels = belongsToRelations.filter(
+	(rel) => !_emittedDqNames.has(`findBy${rel.foreignKeyPascal}`),
+);
 _%>
-<% belongsToRelations.forEach((rel) => { -%>
+<% _emittedFkRels.forEach((rel) => { -%>
 
 	async findBy<%= rel.foreignKeyPascal %>(id: string, opts?: { cursor?: string; limit?: number }): Promise<<%= className %>[]> {
 		let q = this.baseQuery()
@@ -275,8 +287,19 @@ export class <%= className %>Repository implements I<%= className %>Repository {
 // CGP-358: FK methods with opts take priority over same-named declarative query impl.
 // Always emit FK methods with opts; skip declarative body when FK covers it.
 const _fkMethodNamesInline = new Set(belongsToRelations.map(rel => `findBy${rel.foreignKeyPascal}`));
+// Inverse guard (see base_class strategy above): a unique/via/select declarative
+// query wins over a same-named FK method, so skip the FK method to avoid a
+// duplicate function implementation (TS2393).
+const _emittedDqNamesInline = new Set(
+	(typeof processedQueries !== 'undefined' ? processedQueries : [])
+		.filter((q) => q.isUnique || q.hasVia || q.hasSelect)
+		.map((q) => q.methodName),
+);
+const _emittedFkRelsInline = belongsToRelations.filter(
+	(rel) => !_emittedDqNamesInline.has(`findBy${rel.foreignKeyPascal}`),
+);
 _%>
-<% belongsToRelations.forEach((rel) => { -%>
+<% _emittedFkRelsInline.forEach((rel) => { -%>
 
 	async findBy<%= rel.foreignKeyPascal %>(id: string, opts?: { cursor?: string; limit?: number }): Promise<<%= className %>[]> {
 		let q = this.baseQuery()

--- a/templates/entity/new/backend/database/schema.ejs.t
+++ b/templates/entity/new/backend/database/schema.ejs.t
@@ -66,9 +66,11 @@ import { entityTypeEnum } from './entity-types.schema';
 <% } -%>
 <% if (enumFields.length > 0 && isPostgres) { -%>
 
-// Enum definitions (Postgres only)
+// Enum definitions (Postgres only). The pg TYPE name is namespaced by entity
+// (`enumDbName`, e.g. `opportunity_status`) so same-named enum fields on
+// different entities don't emit a duplicate `CREATE TYPE`.
 <% enumFields.forEach((field) => { -%>
-export const <%= field.enumName %> = pgEnum('<%= field.name %>', [<%- field.choices.map(c => `'${c}'`).join(', ') %>]);
+export const <%= field.enumName %> = pgEnum('<%= field.enumDbName || field.name %>', [<%- field.choices.map(c => `'${c}'`).join(', ') %>]);
 <% }) -%>
 <% } -%>
 <%

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -302,9 +302,17 @@ function renderColumnDefault(value, drizzleType) {
 }
 
 /**
- * Process entity fields into ProcessedField[]
+ * Process entity fields into ProcessedField[].
+ *
+ * `entityName` (snake_case) namespaces enum-typed fields so two entities that
+ * each declare an enum field with the SAME name (e.g. `role`, `status`) don't
+ * collide. Without it the pg type name AND the exported const were derived from
+ * the field name alone, so a second entity with the same enum field produced a
+ * duplicate `export const roleEnum` (TS2308) and a duplicate `CREATE TYPE role`
+ * at the DB level (a real migration conflict). Namespacing yields
+ * `field_config_role` (pg type) / `fieldConfigRoleEnum` (export) instead.
  */
-function processFields(fields) {
+function processFields(fields, entityName = '') {
   const processed = [];
 
   for (const [fieldName, field] of Object.entries(fields)) {
@@ -325,7 +333,14 @@ function processFields(fields) {
     const drizzleType = hasChoices
       ? 'enum'
       : (DRIZZLE_TYPE_MAP[type] || 'text');
-    const enumName = hasChoices ? camelCase(fieldName) + 'Enum' : null;
+    // Namespace the enum const + pg type name by entity so same-named enum
+    // fields on different entities don't collide (TS2308 / duplicate CREATE TYPE).
+    // The COLUMN name keeps the bare snake field name (`role`); only the const
+    // (`fieldConfigRoleEnum`) and pg type (`field_config_role`) are namespaced.
+    const enumDbName = hasChoices
+      ? (entityName ? `${entityName}_${fieldName}` : fieldName)
+      : null;
+    const enumName = hasChoices ? camelCase(enumDbName) + 'Enum' : null;
     const tsType = hasChoices
       ? choices.map((c) => `'${c}'`).join(' | ')
       : (TS_TYPE_MAP[type] || 'unknown');
@@ -350,6 +365,7 @@ function processFields(fields) {
       choices,
       hasChoices,
       enumName,
+      enumDbName,
     });
   }
 
@@ -1133,8 +1149,10 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     typeof patternConfigBlock === 'object' &&
     Object.keys(patternConfigBlock).length > 0;
 
-  // Process entity fields
-  const processedFields = processFields(fields);
+  // Process entity fields. Pass the entity name so enum fields namespace their
+  // pg type + exported const by entity (prevents same-named enum collisions
+  // across entities — TS2308 / duplicate CREATE TYPE).
+  const processedFields = processFields(fields, entityName);
 
   // Behavior flags (re-read from behaviors array for clean-lite-ps use).
   //
@@ -1250,11 +1268,17 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // template can emit `export const xEnum = pgEnum('x', [...])` ahead of
   // the `pgTable(...)` block. Both FK-filtered and unfiltered processing
   // include the same enum fields; they're never FKs.
+  //
+  // `dbName` is the Postgres TYPE name — namespaced by entity
+  // (`field_config_role`) so two entities with a same-named enum field don't
+  // emit duplicate `CREATE TYPE`s. The COLUMN name is still the bare field
+  // name and is carried by the column reference (`f.name`) in the entity
+  // template, not here.
   const clpEnumFields = processedFields
     .filter((f) => f.hasChoices && f.enumName)
     .map((f) => ({
       enumName: f.enumName,
-      dbName: f.name,
+      dbName: f.enumDbName,
       choices: f.choices,
     }));
 

--- a/templates/entity/new/clean-lite-ps/repository.ejs.t
+++ b/templates/entity/new/clean-lite-ps/repository.ejs.t
@@ -13,6 +13,22 @@ const _fkMethodNamesCLP = new Set(_fkMethods.map(rel => {
   const _p = rel.camelField.charAt(0).toUpperCase() + rel.camelField.slice(1);
   return `findBy${_p}`;
 }));
+// A declarative query and an FK-traversal method can resolve to the SAME method
+// name (e.g. `findByFieldDefinitionId` from both a `belongs_to` FK and an
+// explicit `queries: [{ by: [field_definition_id], unique: true }]`). Emitting
+// both is a duplicate function implementation (TS2393). Exactly one wins:
+//   - plain non-unique single-param declarative → FK method wins (it accepts
+//     `opts` and is a superset), the declarative impl is skipped (CGP-358, the
+//     `_skipClpDq` flag below);
+//   - unique / via / select declarative → the declarative is the more specific
+//     intent (single-row return, junction join, projection), so IT wins and the
+//     FK-traversal method is skipped here.
+const _emittedDqNamesCLP = new Set(
+  (typeof processedQueries !== 'undefined' ? processedQueries : [])
+    .filter((q) => q.isUnique || q.hasVia || q.hasSelect)
+    .map((q) => q.methodName),
+);
+const _skipFkMethodCLP = (name) => _emittedDqNamesCLP.has(name);
 const _needsEq = hasDeclarativeQueries || _fkMethods.length > 0;
 _%>
 <% if (_needsEq) { -%>
@@ -174,13 +190,16 @@ _%>
 
   // TODO: Add entity-specific query methods here.
 <% } -%>
-<%_ if (_fkMethods.length > 0) { _%>
+<%_ const _emittedFkMethods = _fkMethods.filter(rel => !_skipFkMethodCLP(`findBy${rel.camelField.charAt(0).toUpperCase() + rel.camelField.slice(1)}`)); _%>
+<%_ if (_emittedFkMethods.length > 0) { _%>
 
   // ═══════════════════════════════════════════════════════════════════════
   // FK traversal methods (from belongs_to relationships — CGP-358b)
   // Called by service-layer composition methods on the inverse (has_many) side.
+  // A FK method whose name collides with a unique/via/select declarative query
+  // is skipped — that declarative query is the more specific intent and wins.
   // ═══════════════════════════════════════════════════════════════════════
-<%_ _fkMethods.forEach(rel => { _%>
+<%_ _emittedFkMethods.forEach(rel => { _%>
 
   async findBy<%= rel.camelField.charAt(0).toUpperCase() + rel.camelField.slice(1) %>(id: string, opts?: { cursor?: string; limit?: number }): Promise<<%= classNames.entity %>[]> {
     let q = this.baseQuery().where(eq(this.table['<%= rel.camelField %>'], id));

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -783,8 +783,16 @@ export default {
         zodType = `z.enum([${choices.map((c) => `'${c}'`).join(", ")}])`;
       }
 
-      // Generate enum name for Drizzle pgEnum (camelCase + 'Enum')
-      const enumName = hasChoices ? camelCase(fieldName) + "Enum" : null;
+      // Generate enum name for Drizzle pgEnum. Namespace the const + pg TYPE
+      // name by entity (`opportunity_status` / `opportunityStatusEnum`) so two
+      // entities that each declare a same-named enum field (e.g. `status`,
+      // `role`) don't emit a duplicate `export const statusEnum` (TS2308) or a
+      // duplicate `CREATE TYPE status` (a migration conflict). The COLUMN name
+      // stays the bare field name — only the type + export are namespaced.
+      const enumDbName = hasChoices
+        ? (name ? `${name}_${fieldName}` : fieldName)
+        : null;
+      const enumName = hasChoices ? camelCase(enumDbName) + "Enum" : null;
 
       // Infer UI metadata with defaults
       const ui_type = inferUiType(fieldName, field);
@@ -815,6 +823,7 @@ export default {
         choicesFrom: field.choices_from,
         hasChoices,
         enumName,
+        enumDbName,
         default: field.default,
         index: field.index ?? false,
         unique: field.unique ?? false,

--- a/test/baseline/packages/api/src/infrastructure/persistence/drizzle/deal-state.schema.ts
+++ b/test/baseline/packages/api/src/infrastructure/persistence/drizzle/deal-state.schema.ts
@@ -15,15 +15,17 @@ import {
 } from 'drizzle-orm/pg-core';
 import { opportunities } from './opportunities.schema';
 
-// Enum definitions (Postgres only)
-export const stateTypeEnum = pgEnum('state_type', ['open', 'won', 'lost', 'stalled']);
+// Enum definitions (Postgres only). The pg TYPE name is namespaced by entity
+// (`enumDbName`, e.g. `opportunity_status`) so same-named enum fields on
+// different entities don't emit a duplicate `CREATE TYPE`.
+export const dealStateStateTypeEnum = pgEnum('deal_state_state_type', ['open', 'won', 'lost', 'stalled']);
 
 export const deal_states = pgTable('deal_states', {
 	id: uuid('id').defaultRandom().primaryKey(),
 	tenantId: uuid('tenant_id'),
 	name: varchar('name', { length: 50 }).notNull(),
 	displayName: varchar('display_name', { length: 100 }).notNull(),
-	stateType: stateTypeEnum('state_type').notNull(),
+	stateType: dealStateStateTypeEnum('state_type').notNull(),
 	sortOrder: integer('sort_order').notNull(),
 	probabilityDefault: integer('probability_default'),
 	color: varchar('color', { length: 20 }),

--- a/test/baseline/packages/api/src/infrastructure/persistence/drizzle/deal.schema.ts
+++ b/test/baseline/packages/api/src/infrastructure/persistence/drizzle/deal.schema.ts
@@ -19,14 +19,16 @@ import {
 import { users } from './users.schema';
 import { accounts } from './accounts.schema';
 
-// Enum definitions (Postgres only)
-export const stageEnum = pgEnum('stage', ['prospecting', 'qualification', 'proposal', 'negotiation', 'closed_won', 'closed_lost']);
+// Enum definitions (Postgres only). The pg TYPE name is namespaced by entity
+// (`enumDbName`, e.g. `opportunity_status`) so same-named enum fields on
+// different entities don't emit a duplicate `CREATE TYPE`.
+export const dealStageEnum = pgEnum('deal_stage', ['prospecting', 'qualification', 'proposal', 'negotiation', 'closed_won', 'closed_lost']);
 
 export const deals = pgTable('deals', {
 	id: uuid('id').defaultRandom().primaryKey(),
 	name: varchar('name', { length: 255 }).notNull(),
 	amount: numeric('amount'),
-	stage: stageEnum('stage').notNull(),
+	stage: dealStageEnum('stage').notNull(),
 	ownerId: uuid('owner_id').notNull().references(() => users.id),
 	accountId: uuid('account_id').notNull().references(() => accounts.id),
 	closeDate: date('close_date', { mode: 'date' }),

--- a/test/smoke/fixtures/canonical_field.yaml
+++ b/test/smoke/fixtures/canonical_field.yaml
@@ -1,0 +1,26 @@
+# Smoke fixture: canonical_field
+# Third entity carrying a same-named `role` enum field (see field_definition /
+# field_config). Confirms the BUG 1 enum-namespacing fix scales past two
+# entities — pre-fix this was the THIRD duplicate `roleEnum` export. Post-fix →
+# `canonicalFieldRoleEnum` / `canonical_field_role`.
+entity:
+  name: canonical_field
+  plural: canonical_fields
+  table: canonical_fields
+  pattern: Base
+  folder_structure: nested
+
+fields:
+  name:
+    type: string
+    required: true
+    max_length: 255
+
+  role:
+    type: enum
+    choices: [reader, writer]
+    required: true
+    default: reader
+
+behaviors:
+  - timestamps

--- a/test/smoke/fixtures/field_config.yaml
+++ b/test/smoke/fixtures/field_config.yaml
@@ -1,0 +1,53 @@
+# Smoke fixture: field_config
+# Reproduces BOTH generator bugs fixed in v0.28.1:
+#
+#   BUG 1 (enum namespacing): declares a `role` enum field — same name as
+#   field_definition.role and canonical_field.role. Pre-fix all three emitted
+#   `export const roleEnum = pgEnum('role', …)` → duplicate barrel export (TS2308)
+#   + duplicate `CREATE TYPE role`. Post-fix → `fieldConfigRoleEnum` /
+#   `field_config_role`.
+#
+#   BUG 2 (belongs_to + explicit unique FK query → duplicate method): has a
+#   belongs_to on field_definition_id AND an explicit `queries: [{ by:
+#   [field_definition_id], unique: true }]`. Pre-fix this emitted
+#   `findByFieldDefinitionId` TWICE (declarative single-row + belongs_to FK array)
+#   → TS2393 "Duplicate function implementation". Post-fix the unique declarative
+#   query wins and the FK-traversal method is skipped → exactly one method.
+entity:
+  name: field_config
+  plural: field_configs
+  table: field_configs
+  pattern: Base
+  folder_structure: nested
+
+fields:
+  field_definition_id:
+    type: uuid
+    required: true
+    index: true
+
+  value:
+    type: string
+    required: true
+    max_length: 255
+
+  role:
+    type: enum
+    choices: [reader, writer]
+    required: true
+    default: reader
+
+behaviors:
+  - timestamps
+
+relationships:
+  field_definition:
+    type: belongs_to
+    target: field_definition
+    foreign_key: field_definition_id
+
+queries:
+  # Explicit unique FK query — collides by name with the belongs_to
+  # findByFieldDefinitionId FK-traversal method (BUG 2 repro).
+  - by: [field_definition_id]
+    unique: true

--- a/test/smoke/fixtures/field_definition.yaml
+++ b/test/smoke/fixtures/field_definition.yaml
@@ -1,0 +1,26 @@
+# Smoke fixture: field_definition
+# Target of field_config's belongs_to. Declares a `role` enum field so that the
+# same-named `role` enum on field_config / canonical_field would COLLIDE pre-fix
+# (duplicate `roleEnum` export → TS2308; duplicate `CREATE TYPE role`). Post-fix
+# each entity's enum is namespaced (`field_definition_role` / `fieldDefinitionRoleEnum`).
+entity:
+  name: field_definition
+  plural: field_definitions
+  table: field_definitions
+  pattern: Base
+  folder_structure: nested
+
+fields:
+  key:
+    type: string
+    required: true
+    max_length: 255
+
+  role:
+    type: enum
+    choices: [system, custom]
+    required: true
+    default: custom
+
+behaviors:
+  - timestamps


### PR DESCRIPTION
## Summary

Two real generator bugs hit building a NestJS + Drizzle consumer app via `codegen init` (clean-lite-ps). Both produced code that **fails `tsc`**. This patch fixes both, bumps the version `0.28.0 → 0.28.1`, and adds regression coverage at the unit, baseline, and end-to-end (smoke) levels.

## BUG 1 — pg enum types named by FIELD, not namespaced by ENTITY → collisions

The entity generators derived an enum field's exported const AND its Postgres TYPE name from the **field name alone**. Two entities that each declare a same-named enum field (`role`, `status`, `agg`, `additivity`, …) both emitted:

```ts
export const roleEnum = pgEnum('role', [...]);
```

→ a duplicate barrel re-export (**TS2308** "has already exported a member named 'roleEnum'") and a duplicate `CREATE TYPE role` at the DB level (a real migration conflict).

**Repro:** `field_config` and `canonical_field` each declaring `role: { type: enum, choices: [...] }` → `codegen entity new --all` → `tsc` fails.

**Fix:** namespace the const AND the pg TYPE name by entity — pg type `field_config_role`, export `fieldConfigRoleEnum` — matching the convention the **junction** generator already used (`opportunity_contact_role` / `opportunityContactRoleEnum`). The **column name is unchanged** (still the bare snake field name), so the generated table shape and `InferSelectModel` types are byte-identical; only the type/const identifiers move. Fixed in `clean-lite-ps` (`prompt-extension.js`) and the legacy `backend` clean-architecture pipeline (`prompt.js` + `schema.ejs.t`).

## BUG 2 — `belongs_to` + an explicit unique FK `queries:` entry → DUPLICATE method

An entity with BOTH a `belongs_to` on a column AND an explicit `queries: [{ by: [that_fk_column], unique: true }]` emitted `findByFieldDefinitionId` **twice** — once from the declarative-query generator (single-row return) and once from the `belongs_to` FK-traversal generator (array return) → **TS2393** "Duplicate function implementation."

CGP-358 already handled the *non-unique* case (the FK method accepts `opts`, so it's a superset and the plain declarative impl is skipped). The **unique / via / select** case was the gap. Now such a declarative query is treated as the more specific intent and **wins** — the colliding FK-traversal method is skipped. Fixed in all three repository templates (clean-lite-ps + backend base-class + backend inline). Exactly one method emits in every case.

## Version bump

`0.28.0 → 0.28.1` (patch, bug fixes) in `package.json`; `CHANGELOG.md` updated with a `## [0.28.1]` `### Fixed` section matching the repo convention.

## Files changed

**Generators (the fix):**
- `templates/entity/new/clean-lite-ps/prompt-extension.js` — entity-namespaced enum const + `enumDbName` (pg type)
- `templates/entity/new/prompt.js` — same for the backend pipeline
- `templates/entity/new/backend/database/schema.ejs.t` — emit namespaced pg type name
- `templates/entity/new/clean-lite-ps/repository.ejs.t` — skip FK method when a unique/via/select declarative query owns the name
- `templates/entity/new/backend/database/repository.ejs.t` — same, in both base-class + inline strategies

**Tests:**
- `src/__tests__/clean-lite-ps/entity-enum-template.test.ts` — namespaced-name expectations + new cross-entity no-collision test
- `src/__tests__/clean-lite-ps/repository-template.test.ts` — new belongs_to + unique-FK collision test (exactly one method; CGP-358 path preserved)
- `src/__tests__/clean-lite-ps/entity-column-features.test.ts` — enum-default expectation updated
- `test/smoke/fixtures/{field_definition,field_config,canonical_field}.yaml` — end-to-end repro of BOTH bugs (init → `entity new --all` → `tsc`)
- `test/baseline/.../deal.schema.ts`, `deal-state.schema.ts` — regenerated for the namespaced enum output

## Verification

- `bun test` (canonical unit suite): **3090 pass / 0 fail**
- `bun test/run-test.ts full` (baseline + generated-output typecheck): **all passed**, generated clean-pipeline output typechecks
- `bun test/smoke/run-smoke.ts`: **smoke PASS** — `tsc OK (consumer-emitted code is syntax-clean)` with all repro fixtures generated (no TS2308, no TS2393)
- `bun run build`: ok
- Pre-existing 4 `tsc` errors (in untouched `junction.ts` / `barrel-generator.ts` / `jobs-path.ts`) are unchanged — this patch introduces zero new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwW41ZZUEhggvj5zDuSV8p