### PR TITLE
fix(clean-lite-ps): belongs_to FK inherits the field's required + index (v0.28.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/clean-lite-ps/entity-fk-template.test.ts
+++ b/src/__tests__/clean-lite-ps/entity-fk-template.test.ts
@@ -345,6 +345,159 @@ describe('external_id_tracking unique index emission', () => {
   });
 });
 
+// ============================================================================
+// belongs_to FK column inherits the underlying field's required + index
+//
+// When the FK column is ALSO declared as a `fields:` entry (e.g.
+// `conversation_id: { type: uuid, required: true, index: true }`), the
+// relationship moves that column out of clpProcessedFields into clpBelongsTo.
+// The belongs_to column must still inherit the field's `required` (→ .notNull())
+// and `index: true` (→ a `<table>_<col>_idx` index) — otherwise both are
+// silently dropped. The .references() FK and relations() block stay intact.
+// ============================================================================
+
+// Fixture: message with conversation_id declared as a required, indexed field
+// AND as a belongs_to relationship (no nullable on the relationship).
+const messageDefinitionFieldBackedFk = {
+  entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
+  fields: {
+    body: { type: 'string', required: true },
+    conversation_id: { type: 'uuid', required: true, index: true },
+  },
+  relationships: {
+    conversation: {
+      type: 'belongs_to',
+      target: 'conversation',
+      foreign_key: 'conversation_id',
+      on_delete: 'cascade',
+    },
+  },
+  behaviors: [],
+};
+
+describe('belongs_to FK inherits field required + index (#34 follow-on)', () => {
+  it('emits .notNull() for a required:true field-backed FK (no rel.nullable)', () => {
+    const locals = buildCleanLitePsLocals(messageDefinitionFieldBackedFk, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(output).toContain(
+      "conversationId: uuid('conversation_id').notNull().references(() => conversations.id, { onDelete: 'cascade' })",
+    );
+  });
+
+  it('derives nullable:false on the clpBelongsTo entry from the field required flag', () => {
+    const locals = buildCleanLitePsLocals(messageDefinitionFieldBackedFk, EMPTY_BASE_LOCALS);
+    const rel = (locals.clpBelongsTo as any[]).find((r: any) => r.field === 'conversation_id');
+
+    expect(rel).toBeDefined();
+    expect(rel!.nullable).toBe(false);
+    expect(rel!.hasIndex).toBe(true);
+  });
+
+  it('emits a <table>_<col>_idx index for the field-backed FK', () => {
+    const locals = buildCleanLitePsLocals(messageDefinitionFieldBackedFk, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(output).toContain("index('messages_conversation_id_idx').on(t.conversationId)");
+    // index() must be imported from drizzle-orm/pg-core
+    expect(locals.clpDrizzleImports).toContain('index');
+    expect(output).toContain('index,');
+  });
+
+  it('still emits the .references() FK and the relations() block', () => {
+    const locals = buildCleanLitePsLocals(messageDefinitionFieldBackedFk, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    // .references() DB FK preserved
+    expect(output).toContain(".references(() => conversations.id, { onDelete: 'cascade' })");
+    // relations() one() block preserved
+    expect(output).toContain('export const messagesRelations = relations(messages');
+    expect(output).toContain('conversation: one(conversations, {');
+    expect(output).toContain('fields: [messages.conversationId],');
+  });
+
+  it('does NOT emit the FK column twice (it stays out of clpProcessedFields)', () => {
+    const locals = buildCleanLitePsLocals(messageDefinitionFieldBackedFk, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    // Exactly one `conversation_id` column definition (from the belongs_to loop).
+    const occurrences = output.split("uuid('conversation_id')").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('an explicit rel.nullable:true overrides the field required flag (no .notNull())', () => {
+    const override = {
+      ...messageDefinitionFieldBackedFk,
+      relationships: {
+        conversation: {
+          type: 'belongs_to',
+          target: 'conversation',
+          foreign_key: 'conversation_id',
+          nullable: true,
+          on_delete: 'cascade',
+        },
+      },
+    };
+    const locals = buildCleanLitePsLocals(override, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    expect(output).toContain("conversationId: uuid('conversation_id').references(");
+    expect(output).not.toContain("conversationId: uuid('conversation_id').notNull()");
+  });
+
+  it('emits the index for a nullable indexed FK (index independent of nullability)', () => {
+    const nullableIndexed = {
+      entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
+      fields: {
+        body: { type: 'string', required: true },
+        conversation_id: { type: 'uuid', index: true },
+      },
+      relationships: {
+        conversation: {
+          type: 'belongs_to',
+          target: 'conversation',
+          foreign_key: 'conversation_id',
+          on_delete: 'cascade',
+        },
+      },
+      behaviors: [],
+    };
+    const locals = buildCleanLitePsLocals(nullableIndexed, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    // nullable (no .notNull()) but indexed
+    expect(output).toContain("conversationId: uuid('conversation_id').references(");
+    expect(output).not.toContain("conversationId: uuid('conversation_id').notNull()");
+    expect(output).toContain("index('messages_conversation_id_idx').on(t.conversationId)");
+  });
+
+  it('does NOT emit an index when the field-backed FK has no index:true', () => {
+    const noIndex = {
+      entity: { name: 'message', plural: 'messages', table: 'messages', pattern: 'Base' },
+      fields: {
+        body: { type: 'string', required: true },
+        conversation_id: { type: 'uuid', required: true },
+      },
+      relationships: {
+        conversation: {
+          type: 'belongs_to',
+          target: 'conversation',
+          foreign_key: 'conversation_id',
+          on_delete: 'cascade',
+        },
+      },
+      behaviors: [],
+    };
+    const locals = buildCleanLitePsLocals(noIndex, EMPTY_BASE_LOCALS);
+    const output = render(locals as Record<string, unknown>);
+
+    // required → notNull, but no index
+    expect(output).toContain("conversationId: uuid('conversation_id').notNull().references(");
+    expect(output).not.toContain('_idx');
+    expect(locals.clpDrizzleImports).not.toContain('index');
+  });
+});
+
 describe('prompt-extension processBelongsTo on_delete propagation', () => {
   it('includes onDelete in clpBelongsTo entries', () => {
     const locals = buildCleanLitePsLocals(messageDefinitionCascade, EMPTY_BASE_LOCALS);

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -441,8 +441,17 @@ function processHasMany(relationships, parentEntityNamePlural, fs, path, srcRoot
 
 /**
  * Process belongs_to relationships into BelongsToRelation[]
+ *
+ * `fields` is the raw `fields:` map (snake_case keyed). When the FK column is
+ * ALSO declared as a field (e.g. `conversation_id: { type: uuid, required:
+ * true, index: true }`), the belongs_to column must inherit that field's
+ * `required`/`nullable` (→ `.notNull()`) and `index: true` (→ a single-column
+ * index). The relationship moves the column out of `clpProcessedFields`, so
+ * those declarations would otherwise be silently dropped. An explicit
+ * `nullable:` on the relationship still wins (back-compat for fixtures that set
+ * it directly on the relation).
  */
-function processBelongsTo(relationships, parentEntityNamePlural) {
+function processBelongsTo(relationships, parentEntityNamePlural, fields = {}) {
   if (!relationships) return [];
 
   const result = [];
@@ -452,7 +461,27 @@ function processBelongsTo(relationships, parentEntityNamePlural) {
 
     const target = rel.target;
     const field = rel.foreign_key;
-    const nullable = rel.nullable ?? true;
+    // Inherit nullability from the underlying field declaration when present.
+    // Precedence: explicit relationship `nullable:` → field `required`/`nullable`
+    // → default nullable (true). A `required: true` field is NOT NULL.
+    const fieldDef = fields[field];
+    let nullable;
+    if (rel.nullable !== undefined && rel.nullable !== null) {
+      nullable = rel.nullable;
+    } else if (fieldDef) {
+      if (fieldDef.required === true) {
+        nullable = false;
+      } else if (fieldDef.nullable !== undefined && fieldDef.nullable !== null) {
+        nullable = fieldDef.nullable;
+      } else {
+        nullable = true;
+      }
+    } else {
+      nullable = true;
+    }
+    // Carry the field's `index: true` so the table-constraints builder can emit
+    // the same single-column index a non-FK field would get.
+    const hasIndex = fieldDef?.index === true;
     const relatedPlural = pluralize(target);
     const isSelfFk = relatedPlural === parentEntityNamePlural;
 
@@ -483,6 +512,7 @@ function processBelongsTo(relationships, parentEntityNamePlural) {
       relatedTable: relatedPlural,
       relatedPlural,
       nullable,
+      hasIndex,
       importPath: `../${relatedPlural}/${target}.entity`,
       relationKey,
       isSelfFk,
@@ -1198,8 +1228,10 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const hasOrderedQuery = processedQueries.some((q) => q.hasOrder);
   const hasViaQuery = processedQueries.some((q) => q.hasVia);
 
-  // Process belongs_to relationships
-  const belongsTo = processBelongsTo(relationships, entityNamePlural);
+  // Process belongs_to relationships. Pass the raw fields map so a FK column
+  // also declared as a field inherits its `required`/`nullable` (→ .notNull())
+  // and `index: true` (→ a single-column index emitted below).
+  const belongsTo = processBelongsTo(relationships, entityNamePlural, fields);
 
   // Process has_many relationships (CGP-358b)
   const hasMany = processHasMany(relationships, entityNamePlural, fs, path, srcRoot);
@@ -1250,10 +1282,23 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // Composite unique indexes (#356).
   const uniqueIndexExpressions = processUniqueIndexes(definition.unique_indexes, entityNamePlural);
 
-  // pgTable extra-config callback entries, in emission order: single-column
-  // indexes, composite unique indexes, then the external_id_tracking unique
-  // index (the ON CONFLICT target integrationUpsert relies on).
+  // belongs_to FK columns that declared `index: true` on their underlying
+  // field. The FK column lives in clpBelongsTo (not clpProcessedFields), so
+  // processFieldFeatures never sees it — emit its index here using the same
+  // `<table>_<col>_idx` naming a non-FK indexed field gets.
+  const belongsToIndexExpressions = belongsTo
+    .filter((rel) => rel.hasIndex)
+    .map((rel) => ({
+      comment: null,
+      expr: `index('${entityNamePlural}_${rel.field}_idx').on(t.${rel.camelField})`,
+    }));
+
+  // pgTable extra-config callback entries, in emission order: belongs_to FK
+  // indexes, single-column field indexes, composite unique indexes, then the
+  // external_id_tracking unique index (the ON CONFLICT target integrationUpsert
+  // relies on).
   const clpTableConstraints = [
+    ...belongsToIndexExpressions,
     ...fieldFeatures.indexExpressions,
     ...uniqueIndexExpressions,
   ];
@@ -1286,7 +1331,9 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   // field declares `index: true` or the entity declares `unique_indexes:`
   // (external_id_tracking adds `uniqueIndex` on its own flag below).
   const extraDrizzleImports = [];
-  if (fieldFeatures.indexExpressions.length > 0) extraDrizzleImports.push('index');
+  if (fieldFeatures.indexExpressions.length > 0 || belongsToIndexExpressions.length > 0) {
+    extraDrizzleImports.push('index');
+  }
   if (uniqueIndexExpressions.length > 0) extraDrizzleImports.push('uniqueIndex');
   const drizzleEntityImports = collectDrizzleImports(processedFields, belongsTo, hasTimestamps, hasSoftDelete, hasExternalIdTracking, hasMany, extraDrizzleImports);
   // Whether relations() import is needed (CGP-358b: also trigger on has_many)


### PR DESCRIPTION
## What

When a `clean-lite-ps` entity declares a `relationships: <name>: { type: belongs_to, foreign_key: <field> }` on a field that is *also* declared `required: true, index: true`, the emitted FK column silently **dropped `.notNull()` and the index**.

Root cause: the relationship moves the FK column out of `clpProcessedFields` (into `clpBelongsTo`), and `processBelongsTo` derived `nullable` solely from the relationship's own `nullable:` key (defaulting truthy) and never consulted the field — so `processFieldFeatures` (which builds the index) never saw the column either.

## Fix (`templates/entity/new/clean-lite-ps/prompt-extension.js`)

- `processBelongsTo` now takes the raw `fields` map. Nullability precedence: explicit relationship `nullable:` → field `required`/`nullable` (a `required: true` field ⇒ `.notNull()`) → default `true`. Existing fixtures that set `nullable:` on the relationship are byte-identical (zero baseline drift).
- The field's `index: true` is carried (`hasIndex`) and emitted via a new `belongsToIndexExpressions`, using the same `<table>_<col>_idx` naming a non-FK indexed field gets.
- The `.references(… { onDelete })` DB FK and the `relations()` block are **unchanged** (this fix is notNull + index only).

## Verification

- +8 targeted tests (28 pass in `entity-fk-template.test.ts`); full unit suite **3098 pass / 0 fail**; `test-all` green (baseline no drift, smokes `tsc OK`).
- **Proven against a real consumer (swe-brain)** via `bun link`: `interaction_party.person_id` now emits `.notNull().references(...)` + `interaction_parties_person_id_idx` + the `relations()` block — exactly the join graph query-surface's `buildRegistry` needs (ADR-0027).

No blast radius beyond clean-lite-ps (`processBelongsTo` is profile-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)