### PR TITLE
fix(frontend-emit): belongs_to FieldMeta keys on the FK column, not the property (v0.28.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.3] — 2026-06-21
+
+### Fixed
+
+- **`belongs_to` relationships no longer emit an invalid `FieldMeta` relation
+  key in the generated frontend `fields/<entity>.ts` (TS2820).** The frontend
+  fields emitter rendered a belongs_to relation row keyed on, and with `field:`
+  set to, the relationship's PROPERTY name (e.g. `person: { field: 'person' }`).
+  The generated db-entity / output-DTO type carries the FK COLUMN (`personId`)
+  but never a resolved relation object, so `field: 'person'` is not assignable
+  to `keyof T` — **TS2820** ("Type '"person"' is not assignable to … Did you
+  mean '"personId"'?"). It also emitted TWO rows for one FK (the field-derived
+  column row + the phantom relation row), and the runtime `ReferenceCell` reads
+  the cell value as the lookup id — which only exists on the FK column. The
+  relation row now surfaces ON its FK column: keyed on `personId`, `field:
+  'personId'`, enriched to `type: 'entity'` + `reference: '<targetPlural>'`,
+  superseding the plain field-derived row (one row, valid `keyof T`). This is
+  the frontend mirror of the 0.28.2 backend FK fix (#553); discovered building a
+  real consumer (swe-brain `interaction_party`).
+
+## [0.28.2] — 2026-06-20
+
+### Fixed
+
+- **`clean-lite-ps` `belongs_to` FK columns inherit the underlying field's
+  `required` + `index`.** When a FK column is also declared as a `fields:` entry
+  (`required: true, index: true`) and moved into a `belongs_to`, the emitted
+  column silently dropped `.notNull()` and the index. The belongs_to column now
+  inherits the field's nullability (`required: true` ⇒ `.notNull()`) and
+  `index: true` (a `<table>_<col>_idx`); the `.references()` DB FK and the
+  `relations()` block are unchanged (#553).
+
 ## [0.28.1] — 2026-06-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/emitters/frontend/emit-fields.test.ts
+++ b/src/__tests__/emitters/frontend/emit-fields.test.ts
@@ -172,12 +172,19 @@ describe('emit-fields — entity metadata file', () => {
 		expect(out).toContain("defaultSort: { field: 'createdAt', direction: 'desc' as const }");
 	});
 
-	it('emits belongs_to relation row with registry plural reference', () => {
+	it('emits belongs_to relation row keyed on the FK column with registry plural reference', () => {
 		const { deal, c } = dealCtx();
 		const out = buildEntityFieldsFile(deal, c);
-		expect(out).toContain('account: {');
+		// The relation row keys on, and `field`s on, the FK COLUMN (accountId) —
+		// a real key of Deal — NOT the relationship property name (account),
+		// which the output DTO does not carry (that would be TS2820).
+		expect(out).toContain('accountId: {');
+		expect(out).toContain("field: 'accountId',");
 		expect(out).toContain("type: 'entity' as FieldType,");
 		expect(out).toContain("reference: 'accounts',");
+		// No phantom `account` property key / field.
+		expect(out).not.toContain('\taccount: {');
+		expect(out).not.toContain("field: 'account',");
 	});
 
 	it('emits createdAt/updatedAt rows when timestamps behavior is set', () => {
@@ -214,6 +221,75 @@ describe('emit-fields — entity metadata file', () => {
 		// read is never gated.
 		expect(offOut).toContain('list: true,');
 		expect(offOut).toContain('get: true,');
+	});
+});
+
+// ============================================================================
+// belongs_to relation row is keyed on the FK column, never the property name
+//
+// The generated db-entity / output-DTO type carries the FK column (e.g.
+// `personId`) but NOT a resolved relation object (`person`). Emitting
+// `person: { field: 'person', ... }` is therefore a TS2820 (`'person'` is not
+// assignable to `keyof T`). The relation must surface ON its FK column —
+// enriching that one row to `type: 'entity'` + `reference: '<plural>'`,
+// superseding the plain field-derived row so there is no duplicate key.
+//
+// Mirrors the backend fix (codegen #553) where the FK column inherits the
+// relationship's intent. Surfaced downstream by swe-brain interaction_party.
+// ============================================================================
+
+describe('emit-fields — belongs_to relation row keys on the FK column (TS2820)', () => {
+	// swe-brain shape: a plain `uuid` FK column declared in `fields:` with the FK
+	// expressed ONLY via the relationship (no `foreign_key` on the field itself,
+	// so its field-derived row would be a bare `type: text`).
+	function interactionPartyCtx() {
+		const ip = entry('interaction_party', 'interaction_parties');
+		const person = entry('person', 'people');
+		const parsed = parsedMap(
+			parsedEntity(person),
+			parsedEntity(ip, {
+				behaviors: ['timestamps'],
+				fields: new Map([
+					['person_id', field('person_id', { type: 'uuid', required: true, index: true })],
+				]),
+				relationships: new Map([
+					['person', relationship('person', { target: 'person', foreignKey: 'person_id' })],
+				]),
+			}),
+		);
+		return { ip, c: ctx([person, ip], {}, parsed) };
+	}
+
+	it('keys the relation row on the FK column (personId), not the property name (person)', () => {
+		const { ip, c } = interactionPartyCtx();
+		const out = buildEntityFieldsFile(ip, c);
+		expect(out).toContain('personId: {');
+		expect(out).toContain("field: 'personId',");
+		expect(out).toContain("type: 'entity' as FieldType,");
+		expect(out).toContain("reference: 'people',");
+	});
+
+	it('never emits a phantom `person` property key / field (the TS2820 source)', () => {
+		const { ip, c } = interactionPartyCtx();
+		const out = buildEntityFieldsFile(ip, c);
+		expect(out).not.toContain('\tperson: {');
+		expect(out).not.toContain("field: 'person',");
+	});
+
+	it('emits the FK column exactly once (relation row supersedes the field row)', () => {
+		const { ip, c } = interactionPartyCtx();
+		const out = buildEntityFieldsFile(ip, c);
+		// Exactly one `personId: {` map key — no duplicate-key collision.
+		expect(out.split('personId: {').length - 1).toBe(1);
+		// The bare field-derived row (type: text) is gone — replaced by the entity row.
+		expect(out).not.toContain("field: 'personId',\n\t\tlabel: 'Person Id',");
+	});
+
+	it('preserves the FK column in primaryFields (required FK ⇒ primary)', () => {
+		const { ip, c } = interactionPartyCtx();
+		const out = buildEntityFieldsFile(ip, c);
+		// person_id is required → primary; the key survives the relation rewrite.
+		expect(out).toContain("primaryFields: [\n\t\t'personId',\n\t],");
 	});
 });
 

--- a/src/emitters/frontend/emit-fields.ts
+++ b/src/emitters/frontend/emit-fields.ts
@@ -228,13 +228,29 @@ export function buildEntityFieldsFile(
 	const ts = hasTimestamps(parsed);
 	const sd = hasSoftDelete(parsed);
 
-	// FieldMeta map entries: fields, then belongs_to relation rows, then the
-	// behavior-contributed rows (timestamps, soft_delete).
-	const fieldEntries = fields.map(renderFieldMeta);
+	// A belongs_to relation row is keyed on, and references, the FK COLUMN
+	// (`fieldNameCamel`, e.g. `personId`) — never the relationship's property
+	// name (`person`). The generated DB-entity / output-DTO type carries the FK
+	// column but NOT a resolved relation object, so `field: 'person'` is a
+	// TS2820 ("'person' not assignable to keyof T") and the ReferenceCell needs
+	// the id value anyway. This mirrors the backend fix where the FK column
+	// inherits the relationship's intent (codegen #553): the relation surfaces
+	// ON its FK column, enriching that one row to `type: 'entity'` + the target
+	// reference, rather than emitting a phantom property. The enriched relation
+	// row therefore SUPERSEDES the plain field-derived row for the same column —
+	// emit it once, keyed on the FK column, so there is no duplicate key.
+	const relFkColumns = new Set(rels.map((r) => r.fieldNameCamel));
+
+	// FieldMeta map entries: fields (minus FK columns a relation enriches), then
+	// belongs_to relation rows, then the behavior-contributed rows (timestamps,
+	// soft_delete).
+	const fieldEntries = fields
+		.filter((f) => !relFkColumns.has(f.field))
+		.map(renderFieldMeta);
 
 	const relEntries = rels.map(
-		(r) => `\t${r.propertyName}: {
-\t\tfield: '${r.propertyName}',
+		(r) => `\t${r.fieldNameCamel}: {
+\t\tfield: '${r.fieldNameCamel}',
 \t\tlabel: '${humanizeClass(r.target.className)}',
 \t\ttype: 'entity' as FieldType,
 \t\timportance: 'secondary' as FieldImportance,

--- a/test/frontend-golden/snapshot/fields/user.ts
+++ b/test/frontend-golden/snapshot/fields/user.ts
@@ -18,13 +18,6 @@ export const userFields: Record<string, FieldMeta<User>> = {
 		type: 'email' as FieldType,
 		importance: 'primary' as FieldImportance,
 	},
-	personId: {
-		field: 'personId',
-		label: 'Person Id',
-		type: 'reference' as FieldType,
-		importance: 'secondary' as FieldImportance,
-		reference: 'persons',
-	},
 	externalId: {
 		field: 'externalId',
 		label: 'External Id',
@@ -39,8 +32,8 @@ export const userFields: Record<string, FieldMeta<User>> = {
 		importance: 'secondary' as FieldImportance,
 		group: 'external_sync',
 	},
-	person: {
-		field: 'person',
+	personId: {
+		field: 'personId',
 		label: 'Person',
 		type: 'entity' as FieldType,
 		importance: 'secondary' as FieldImportance,


### PR DESCRIPTION
## What

The frontend fields emitter (`src/emitters/frontend/emit-fields.ts`) emitted an
invalid `FieldMeta` relation key for every `belongs_to` relationship, producing a
**TS2820** in the generated `fields/<entity>.ts`.

For `relationships: person belongs_to person (foreign_key: person_id)` it emitted:

```ts
// BEFORE (broken)
personId: {                       // plain field-derived row (type: reference)
  field: 'personId', label: 'Person Id', type: 'reference' as FieldType, ...
},
person: {                         // phantom relation row
  field: 'person',                // <-- TS2820: 'person' is not a key of T
  label: 'Person', type: 'entity' as FieldType, reference: 'people',
},
```

The generated db-entity / output-DTO type `T` carries the **FK column**
(`personId`) but never a resolved relation object (`person`), so
`field: 'person'` is not assignable to `field: keyof T & string`:

```
error TS2820: Type '"person"' is not assignable to type
'"id" | "personId" | "interactionType"'. Did you mean '"personId"'?
```

(The compiler's own suggestion — `'personId'` — is exactly what this PR emits.)

Two further problems: it emitted **two rows for one FK**, and the runtime
`ReferenceCell` reads the cell value as the lookup id — which only exists on the
FK column, never on a phantom `person` property.

## Fix

The belongs_to relation row now surfaces **on its FK column**: keyed on
`personId`, `field: 'personId'`, enriched to `type: 'entity'` +
`reference: '<targetPlural>'`, and it **supersedes** the plain field-derived row
for that column (one row, valid `keyof T`, id-bearing):

```ts
// AFTER (fixed)
personId: {
  field: 'personId',              // valid keyof T
  label: 'Person', type: 'entity' as FieldType, reference: 'people',
},
```

Concretely: `relEntries` key on `r.fieldNameCamel` instead of `r.propertyName`,
and field rows whose camel name a relation enriches are filtered out (dedupe).

## Analogy to #553

This is the **frontend mirror** of the 0.28.2 backend FK fix (#553). Same root
shape: where #553 made the backend FK *column* inherit the relationship's intent
(`.notNull()` + index, leaving `.references()` / `relations()` untouched), this
makes the frontend relation *FieldMeta* live on the FK column rather than a
phantom property. Surfaced downstream building a real consumer — swe-brain
`interaction_party` gaining `relationships: person belongs_to` (the same entity
that motivated #553).

## Verification

- **TS2820 reproduced** against a real type, before and after:
  - old emitted `userFields` map ⇒ `error TS2820: Type '"person"' is not
    assignable … Did you mean '"personId"'?`
  - fixed map ⇒ `tsc --noEmit --strict` exit 0.
- **Golden tree regenerated** — `test/frontend-golden/snapshot/fields/user.ts`
  collapses the phantom `person` + duplicate `personId` into one enriched
  `personId` row; the store/resolvers/collections tree is unchanged (the
  `WithResolved`/resolver layer correctly keeps the resolved `person` property —
  it adds that field to its own type).
- **+4 targeted tests** (FK-column keying, no phantom `person` key/field, single
  FK row / no duplicate-key collision, `primaryFields` preservation); the
  existing deal relation-row test tightened to assert the FK-column key.
- Frontend emitter suite: **431 pass / 0 fail**. Relationship smoke (scaffold +
  generate + `tsc --noEmit` over the generated tree): **`tsc OK` / smoke PASS**.
- Out of scope (pre-existing on clean `main`, confirmed via stash): 7
  `schema-v2.test.ts` failures + 4 `junction`/`jobs-path` typecheck errors —
  none in `emitters/frontend`.

## Downstream

Patch release **0.28.3** (`package.json` + CHANGELOG bumped). swe-brain must
consume 0.28.3 to drop its manual workaround (it currently deletes the broken
`person` relation row by hand after regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSTdcfG1FdchmAYT5biVSS
