### PR TITLE
feat(frontend): entity-level frontend-exclude knob (entity.frontend: false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] — 2026-06-22
+
+### Added
+
+- **Entity-level frontend-exclude knob: `entity.frontend: false`.** An entity may
+  now declare `frontend: false` (inside the `entity:` block, sibling to `sync:` /
+  `surface:` / `context:`) to emit **NO frontend artifacts** while leaving backend
+  generation completely unaffected. Defaults to `true` — absent ⇒ current
+  behavior, fully backwards-compatible. When `false`, the whole-set frontend
+  emitter (ADR-038) produces no `api`/`collections`/`entities`/`fields` files for
+  the entity, no `store/index.ts` entry, no full-fetch `listAll()` call in the
+  store hydration (`resolvers.ts` / `lookups.ts`), no resolver/lookup entry, and
+  no dangling import referencing it. Filtered at the single emit chokepoint
+  (`loadFrontendEmitContext` — the entity set + parsed map are both filtered
+  before the context is built), so every downstream per-entity emitter sees only
+  the kept set. Backend emitters never read this path.
+
+  Use case: a consumer (swe-brain) has SECRET entities (`auth_session`,
+  `user_credential`, `password_reset`, `email_verification`) whose backend routes
+  are deliberately blocked, but codegen still emitted frontend artifacts + a
+  full-fetch `listAll()` for them, so the frontend eager-fetched them on app load →
+  404 spam against the blocked routes. `frontend: false` keeps those entities dark
+  in the frontend while still generating their backend, killing the 404 spam.
+
 ## [0.28.3] — 2026-06-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pattern-stack/codegen",
-  "version": "0.28.3",
+  "version": "0.29.0",
   "description": "Entity-driven code generation for full-stack TypeScript applications",
   "license": "MIT",
   "type": "module",

--- a/src/__tests__/emitters/frontend/_helpers.ts
+++ b/src/__tests__/emitters/frontend/_helpers.ts
@@ -26,6 +26,7 @@ export function entry(
 	name: string,
 	plural: string,
 	sync: 'api' | 'electric' | null = null,
+	frontend = true,
 ): EntityRegistryEntry {
 	return {
 		name,
@@ -36,6 +37,7 @@ export function entry(
 		camelName: camelCase(name),
 		pluralCamelName: camelCase(plural),
 		sync,
+		frontend,
 	};
 }
 

--- a/src/__tests__/emitters/frontend/load-context.test.ts
+++ b/src/__tests__/emitters/frontend/load-context.test.ts
@@ -9,12 +9,19 @@
  *     skip, and the outDir resolution from `locations.frontendGenerated`.
  */
 
-import { describe, expect, it } from 'bun:test';
-import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import {
 	loadFrontendEmitContext,
 	mapFrontendEmitConfig,
 } from '../../../emitters/frontend/load-context';
+import {
+	buildStoreIndexFile,
+	buildResolversFile,
+	lookupFullFetchNames,
+} from '../../../emitters/frontend/emit-store';
 
 // A focused, intentional entity set (explicit-plural `person` + FK-consumer
 // `user`) — the same fixtures the golden-tree emitter snapshot uses. Avoids the
@@ -198,5 +205,89 @@ describe('loadFrontendEmitContext — zero entities skips', () => {
 		const r = loadFrontendEmitContext(empty, {}, { entitiesDir: empty });
 		expect(r.skip).toBeDefined();
 		expect(r.ctx).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// entity.frontend: false — per-entity frontend-exclude knob
+// ---------------------------------------------------------------------------
+
+describe('loadFrontendEmitContext — entity.frontend:false excludes from the emit set', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'frontend-exclude-'));
+		// A normal entity (frontend emitted by default) ...
+		writeFileSync(
+			join(dir, 'deal.yaml'),
+			`entity:
+  name: deal
+  plural: deals
+  table: deals
+fields:
+  name: { type: string, required: true, max_length: 200 }
+`,
+			'utf-8',
+		);
+		// ... and a route-blocked SECRET entity that opts OUT of the frontend.
+		writeFileSync(
+			join(dir, 'auth_session.yaml'),
+			`entity:
+  name: auth_session
+  plural: auth_sessions
+  table: auth_sessions
+  frontend: false
+fields:
+  token: { type: string, required: true, max_length: 200 }
+`,
+			'utf-8',
+		);
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('drops the frontend:false entity from the emit set but keeps the normal one', () => {
+		const r = loadFrontendEmitContext(dir, {}, { entitiesDir: dir });
+		expect(r.skip).toBeUndefined();
+		if (r.skip !== undefined) return;
+
+		const names = r.ctx.entities.map((e) => e.name);
+		expect(names).toContain('deal');
+		expect(names).not.toContain('auth_session');
+		// the parsed map is filtered to the kept set too (no incidental lookups)
+		expect(r.ctx.parsed.has('deal')).toBe(true);
+		expect(r.ctx.parsed.has('auth_session')).toBe(false);
+	});
+
+	it('produces no store entry / full-fetch / resolver entry for the excluded entity', () => {
+		const r = loadFrontendEmitContext(dir, {}, { entitiesDir: dir });
+		if (r.skip !== undefined) throw new Error(r.skip);
+
+		// The excluded entity must not appear in the store full-fetch/lookup set ...
+		const fullFetch = lookupFullFetchNames(r.ctx);
+		expect(fullFetch.has('deal')).toBe(true);
+		expect(fullFetch.has('auth_session')).toBe(false);
+
+		// ... nor anywhere in the generated store index or resolvers (no dangling
+		// import, no `authSessions:` entry, no `authSessionApi.listAll()` call).
+		const storeIndex = buildStoreIndexFile(r.ctx);
+		const resolvers = buildResolversFile(r.ctx);
+		expect(storeIndex).toContain('deals:');
+		expect(storeIndex).not.toContain('authSession');
+		expect(resolvers).not.toContain('authSession');
+		// deal IS full-fetched (no unbounded text column) so its listAll() is present —
+		// proving the resolver wiring works while the excluded entity is fully absent.
+		expect(resolvers).toContain('dealApi.listAll()');
+	});
+
+	it('a normal entity is still fully wired when a sibling is excluded', () => {
+		const r = loadFrontendEmitContext(dir, {}, { entitiesDir: dir });
+		if (r.skip !== undefined) throw new Error(r.skip);
+		const storeIndex = buildStoreIndexFile(r.ctx);
+		// deal's hooks/collection/fields are imported and registered by plural.
+		expect(storeIndex).toContain("import { dealHooks } from '../entities/deal';");
+		expect(storeIndex).toContain('deals: dealHooks,');
 	});
 });

--- a/src/emitters/frontend/load-context.ts
+++ b/src/emitters/frontend/load-context.ts
@@ -202,7 +202,18 @@ export function loadFrontendEmitContext(
 		path.resolve(cwd, config.paths?.entities_dir ?? 'entities');
 
 	const { registry } = loadEntityRegistry(entitiesDir);
-	const entities: EntityRegistryEntry[] = sortEntities([...registry.values()]);
+
+	// FRONTEND-EXCLUDE chokepoint: drop entities that opted out (`entity.frontend:
+	// false`) BEFORE building the context. Every downstream emitter (api,
+	// collections, entities, fields, store index/resolvers/lookups/module-index,
+	// root barrel) iterates `ctx.entities`, so filtering here is the single point
+	// that removes all their per-entity files, the store entry, the full-fetch
+	// `listAll()` call, the resolver/lookup entries, AND every import that would
+	// otherwise reference the dropped entity. Backend emission never reads this
+	// path, so it is unaffected. Default `frontend: true` ⇒ no behavior change.
+	const entities: EntityRegistryEntry[] = sortEntities(
+		[...registry.values()].filter((e) => e.frontend !== false),
+	);
 
 	if (entities.length === 0) {
 		return {
@@ -210,7 +221,13 @@ export function loadFrontendEmitContext(
 		};
 	}
 
-	const parsedList = loadEntities(entitiesDir).entities;
+	// The parsed map is filtered to the kept set too, so emitters that look up
+	// `ctx.parsed.get(name)` (field metadata, FK resolvers) never see an excluded
+	// entity even incidentally.
+	const kept = new Set(entities.map((e) => e.name));
+	const parsedList = loadEntities(entitiesDir).entities.filter((p) =>
+		kept.has(p.name),
+	);
 	const parsed: Map<string, ParsedEntity> = new Map(
 		parsedList.map((p) => [p.name, p]),
 	);

--- a/src/parser/entity-registry.ts
+++ b/src/parser/entity-registry.ts
@@ -27,6 +27,7 @@ export interface EntityRegistryEntry {
 	camelName: string; // 'dealState'
 	pluralCamelName: string;
 	sync: 'api' | 'electric' | null; // null → inherit global frontend.sync.mode
+	frontend: boolean; // entity.frontend — false ⇒ excluded from all frontend emit (backend unaffected)
 }
 
 export interface LoadEntityRegistryResult {
@@ -114,6 +115,9 @@ export function loadEntityRegistry(entitiesDir: string): LoadEntityRegistryResul
 			camelName: camelCase(entity.name),
 			pluralCamelName: camelCase(entity.plural),
 			sync: entity.sync ?? null,
+			// `entity.frontend` carries a Zod `.default(true)`, so a validated
+			// definition always has it; `?? true` guards an unvalidated/partial entity.
+			frontend: entity.frontend ?? true,
 		});
 	}
 

--- a/src/schema/entity-definition.schema.json
+++ b/src/schema/entity-definition.schema.json
@@ -54,6 +54,10 @@
               "trpc"
             ]
           }
+        },
+        "frontend": {
+          "description": "Emit frontend artifacts for this entity (default true). Set false to keep the entity dark in the frontend (no api/collections/entities/fields, no store entry, no full-fetch listAll) while still generating its backend.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -293,6 +297,29 @@
               "name"
             ]
           }
+        ]
+      }
+    },
+    "unique_indexes": {
+      "description": "Composite (multi-column) unique indexes",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Columns the composite unique constraint spans (2+)"
+          },
+          "name": {
+            "description": "Index name (default <table>_<col1>_<col2>_uniq)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "fields"
         ]
       }
     }

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -545,6 +545,25 @@ const EntityConfigSchema = z
     // docs/specs/2026-06-04-frontend-pipeline-rebuild.md OQ-6.
     // Sibling to `surface:`/`context:`; lives inside the `entity:` block.
     sync: z.enum(['api', 'electric']).optional(),
+
+    // Per-entity FRONTEND opt-out. When `false`, the whole-set frontend emitter
+    // (ADR-038) emits NO frontend artifacts for this entity — no api/collections/
+    // entities/fields files, no store index/resolver/lookup entry, no full-fetch
+    // `listAll()` call, and no dangling import referencing it. Backend generation
+    // (domain/application/infrastructure/presentation + Drizzle schema) is
+    // UNAFFECTED. Defaults to `true` (absent ⇒ current behavior: frontend emitted).
+    //
+    // Use case: an entity whose backend routes are deliberately blocked (e.g.
+    // auth_session / user_credential / password_reset / email_verification). The
+    // frontend would otherwise generate a store entry + a full-fetch `listAll()`
+    // in store hydration and eager-fetch the entity on load → 404 spam against the
+    // blocked routes. Setting `frontend: false` keeps the entity dark in the
+    // frontend while still generating its backend.
+    //
+    // Filtered at the single frontend-emit chokepoint (loadFrontendEmitContext) so
+    // every downstream emitter sees only the kept set. Sibling to `sync:`/
+    // `surface:`/`context:`; lives inside the `entity:` block.
+    frontend: z.boolean().optional().default(true),
   })
   .strict()
   .refine((d) => !(d.pattern && d.patterns), {

--- a/src/schema/generate-json-schema.ts
+++ b/src/schema/generate-json-schema.ts
@@ -82,6 +82,9 @@ const EntityConfigSchema = z.object({
   expose: z.array(z.enum(["repository", "rest", "trpc"])).optional().describe(
     "Which layers to generate"
   ),
+  frontend: z.boolean().optional().describe(
+    "Emit frontend artifacts for this entity (default true). Set false to keep the entity dark in the frontend (no api/collections/entities/fields, no store entry, no full-fetch listAll) while still generating its backend."
+  ),
 });
 
 const EntityDefinitionSchema = z.object({


### PR DESCRIPTION
## What
Adds an entity-level opt-out — `entity.frontend: false` (inside the `entity:` block, sibling to `sync:`/`surface:`/`context:`, **defaults to `true`**) — that emits **no frontend artifacts** for an entity while leaving backend generation completely unaffected.

When `false`: no `api`/`collections`/`entities`/`fields` files, no `store/index.ts` entry, no full-fetch `listAll()` in store hydration (`resolvers.ts`/`lookups.ts`), no resolver/lookup entry, no dangling import. Filtered at a **single chokepoint** — `loadFrontendEmitContext` filters both the entity set and the parsed map before the context is built — so every downstream emitter sees only the kept set. Backend emitters never read this path.

## Why
Consumer (swe-brain) has SECRET entities — `auth_session`, `user_credential`, `password_reset`, `email_verification` — whose backend routes are deliberately blocked, but codegen still emitted frontend artifacts + a full-fetch `listAll()`, so the frontend eager-fetched them on load → **404 spam** against the blocked routes. There was no way to keep an entity dark in the frontend while generating its backend. This adds it.

## Changes
- `schema/entity-definition.schema.ts` — `frontend: z.boolean().optional().default(true)` on the strict `EntityConfigSchema`
- `schema/generate-json-schema.ts` + regenerated `entity-definition.schema.json` (also corrects pre-existing `unique_indexes` drift in the committed JSON)
- `parser/entity-registry.ts` — `frontend` on `EntityRegistryEntry`
- `emitters/frontend/load-context.ts` — the chokepoint filter
- tests: `__tests__/emitters/frontend/load-context.test.ts` (excluded entity absent from emit set, store index, lookups, resolvers; normal sibling stays fully wired)
- `package.json` 0.28.3 → **0.29.0** (minor, additive) + CHANGELOG

## Compatibility & verification
Backwards-compatible by construction (`.default(true)` → absent flag = current behavior). Unit suite green: **3102 pass / 0 fail / 3 skip**. The one failing test in the *full* run (`DrizzleEventBus.listEvents (real Postgres) > filters by tenantId`) is **pre-existing** — confirmed failing identically on clean `main` (events subsystem, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)