### PR TITLE
feat(auth-guard): per-entity api:false HTTP-surface suppression (ADR-043, PR4)

### DIFF
--- a/docs/adrs/ADR-043-data-plane-authentication-guard.md
+++ b/docs/adrs/ADR-043-data-plane-authentication-guard.md
@@ -177,11 +177,12 @@ Add to `EntityDefinitionSchema` (`src/schema/entity-definition.schema.ts`, along
 api: z.boolean().optional().default(true),
 ```
 
-When `api: false`:
+When `api: false`, the **entire HTTP surface** is suppressed — not just the REST `@Controller`. Resolved during implementation: `api: false` semantically means "no network data plane," so it turns off **REST + Electric + tRPC** together (equivalent to `expose: ['repository']`), while the entity / repository / service / use-cases stay generated and in-process reachable. The two pipelines reach this differently:
 
-- The controller template (`controller.ejs.t` in both pipelines) and the NestJS route registration are skipped — the `entity new` post-step gates the controller emission on `api !== false`.
-- The module still binds the service/use-cases (in-process reachability is unchanged); only the `@Controller` and its routes are absent.
-- This is route *emission*, not auth — an `api: false` entity is invisible to HTTP regardless of guard state, which is the correct posture for material that should never traverse the data plane. It composes with §1–§4: a secret entity has no route to guard, and a guarded route is the floor for everything that does emit.
+- **Clean (backend):** `exposeRest` / `exposeElectric` / `exposeTrpc` are AND-ed with `entity.api !== false` in `prompt.js`. The controller `to:` (gated on `exposeRest || exposeElectric`), the core module's controller import + `controllers: [...]`, and the tRPC module/router (gated on `exposeTrpc`) all already key off those flags, so flipping them off suppresses emission *and* wiring with no per-template change. (One gotcha handled: the clean path injects *stub* CLP locals so CLP template bodies render before their `to:null` guard skips the write — `clpApiEnabled: true` had to be added to that stub.)
+- **Clean-Lite-PS:** a `clpApiEnabled` local (`definition.api !== false`) gates the controller + search-controller `skip_if`, and the module template's controller/search-controller import + `controllers: [...]` array (`<% if (clpApiEnabled) %>`).
+
+This is route *emission*, not auth — an `api: false` entity is invisible to HTTP regardless of guard state, the correct posture for material that should never traverse the data plane. It composes with §1–§4: a secret entity has no route to guard, and a guarded route is the floor for everything that does emit.
 
 ### 7. Auto-wire the boundary + guard at install (complete ADR-0002's deferral)
 

--- a/src/__tests__/clean-lite-ps/write-templates.test.ts
+++ b/src/__tests__/clean-lite-ps/write-templates.test.ts
@@ -272,3 +272,29 @@ describe('clean-lite-ps write templates — module rendering', () => {
     expect(output).not.toContain('DeleteContactUseCase');
   });
 });
+
+describe('clean-lite-ps api:false HTTP-surface suppression (ADR-043 §6)', () => {
+  it('clpApiEnabled defaults true and flips false when api: false', () => {
+    expect(buildCleanLitePsLocals(baseEntity, {}).clpApiEnabled).toBe(true);
+    expect(
+      buildCleanLitePsLocals({ ...baseEntity, api: false }, {}).clpApiEnabled,
+    ).toBe(false);
+  });
+
+  it('module omits the controller import + registration when api: false', () => {
+    const locals = buildCleanLitePsLocals({ ...baseEntity, api: false }, {});
+    const output = render('module.ejs.t', locals);
+    // No controller import, empty controllers array — but service + repository stay.
+    expect(output).not.toContain("from './contact.controller'");
+    expect(output).toContain('controllers: [],');
+    expect(output).toContain('ContactService');
+    expect(output).toContain('ContactRepository');
+  });
+
+  it('module wires the controller normally when api is enabled (default)', () => {
+    const locals = buildCleanLitePsLocals(baseEntity, {});
+    const output = render('module.ejs.t', locals);
+    expect(output).toContain("import { ContactController } from './contact.controller';");
+    expect(output).toContain('controllers: [ContactController]');
+  });
+});

--- a/src/__tests__/schema/schema-v2.test.ts
+++ b/src/__tests__/schema/schema-v2.test.ts
@@ -37,6 +37,16 @@ describe('pattern / patterns / config', () => {
 		}
 	});
 
+	it('defaults `api` to true and accepts an explicit false (ADR-043 §6)', () => {
+		const dflt = EntityDefinitionSchema.safeParse({ ...base });
+		expect(dflt.success).toBe(true);
+		if (dflt.success) expect(dflt.data.api).toBe(true);
+
+		const off = EntityDefinitionSchema.safeParse({ ...base, api: false });
+		expect(off.success).toBe(true);
+		if (off.success) expect(off.data.api).toBe(false);
+	});
+
 	it('accepts a `patterns:` array for multi-pattern composition', () => {
 		const result = EntityDefinitionSchema.safeParse({
 			...base,

--- a/src/schema/entity-definition.schema.ts
+++ b/src/schema/entity-definition.schema.ts
@@ -838,6 +838,17 @@ export const EntityDefinitionSchema = z
     // Per-entity generation toggles (e.g. disable write-side emission)
     generate: GenerateConfigSchema.optional(),
 
+    // HTTP surface emission (ADR-043 §6, #557). When `false`, codegen emits NO
+    // HTTP-facing surface for this entity — no REST controller, no Electric
+    // controller, no tRPC router, and no routes. The entity, repository,
+    // service, and use-cases are still generated, so the entity stays reachable
+    // IN-PROCESS (other modules can inject its service) — it simply has no
+    // data-plane presence. The correct posture for secret entities (credentials,
+    // internal join tables) that must never traverse HTTP, rather than emitting
+    // a route that is merely guarded. The backend analogue of the frontend
+    // exclude knob (#556). Defaults to `true`.
+    api: z.boolean().optional().default(true),
+
     // EAV (entity-attribute-value) dual-write + paired reads (ADR-13).
     // When `true`, codegen emits:
     //   - FindXWithFieldsUseCase + ListXWithFieldsUseCase (paired reads)

--- a/templates/entity/new/clean-lite-ps/controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/controller.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.controller : null %>"
-skip_if: "<%= typeof clpOutputPaths === 'undefined' %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' || clpApiEnabled === false %>"
 force: true
 ---
 <%- typeof generatedBanner !== 'undefined' ? generatedBanner : '' %>

--- a/templates/entity/new/clean-lite-ps/module.ejs.t
+++ b/templates/entity/new/clean-lite-ps/module.ejs.t
@@ -38,7 +38,9 @@ import { <%= eavDefinitionPluralPascal %>Module } from '../<%= eavDefinitionEnti
 
 import { <%= classNames.repository %> } from './<%= entityName %>.repository';
 import { <%= classNames.service %> } from './<%= entityName %>.service';
+<% if (clpApiEnabled) { -%>
 import { <%= classNames.controller %> } from './<%= entityName %>.controller';
+<% } -%>
 // OPENAPI-2: Zod schemas registered with OpenApiRegistry at module init.
 import { <%= classNames.createSchema %> } from './dto/create-<%= entityName %>.dto';
 import { <%= classNames.updateSchema %> } from './dto/update-<%= entityName %>.dto';
@@ -59,7 +61,9 @@ import { declarativeQueryClasses } from './use-cases/declarative-queries';
 <% } -%>
 <% if (hasSearchQuery) { -%>
 import { <%= searchQuery.useCaseClassName %> } from './use-cases/search-<%= entityNamePlural %>.use-case';
+<% if (clpApiEnabled) { -%>
 import { <%= classNames.searchController %> } from './<%= entityName %>-search.controller';
+<% } -%>
 <% } -%>
 
 @Module({
@@ -77,7 +81,7 @@ import { <%= classNames.searchController %> } from './<%= entityName %>-search.c
     // <%= rel.relatedEntityPascal %>sModule,
 <%_ }) _%>
   ],
-  controllers: [<%= classNames.controller %><% if (hasSearchQuery) { %>, <%= classNames.searchController %><% } %>],
+  controllers: [<% if (clpApiEnabled) { %><%= classNames.controller %><% if (hasSearchQuery) { %>, <%= classNames.searchController %><% } %><% } %>],
   providers: [
     <%= classNames.repository %>,
     <%= classNames.service %>,

--- a/templates/entity/new/clean-lite-ps/prompt-extension.js
+++ b/templates/entity/new/clean-lite-ps/prompt-extension.js
@@ -1082,6 +1082,10 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
   const relationships = definition.relationships || {};
   const behaviors = definition.behaviors || [];
   const queriesBlock = definition.queries || null;
+  // ADR-043 §6: `api: false` suppresses the HTTP surface (controller + search
+  // controller + their module wiring) while keeping the entity/repository/
+  // service/use-cases in-process reachable. Defaults to true.
+  const clpApiEnabled = definition.api !== false;
 
   // Source root — resolved in priority order:
   //   1. baseLocals.srcRoot (e.g. set explicitly by tests or callers)
@@ -1508,6 +1512,9 @@ export function buildCleanLitePsLocals(definition, baseLocals) {
     entityNamePascal,
     entityNamePlural,
     entityNamePluralPascal,
+
+    // ADR-043 §6: HTTP surface gate (controller + search controller + wiring)
+    clpApiEnabled,
 
     // EVT-7 emits locals (null-safe defaults if baseLocals didn't provide them)
     hasEmits,

--- a/templates/entity/new/clean-lite-ps/search-controller.ejs.t
+++ b/templates/entity/new/clean-lite-ps/search-controller.ejs.t
@@ -1,6 +1,6 @@
 ---
 to: "<%= typeof clpOutputPaths !== 'undefined' ? clpOutputPaths.searchController : null %>"
-skip_if: "<%= typeof clpOutputPaths === 'undefined' || !clpOutputPaths.searchController %>"
+skip_if: "<%= typeof clpOutputPaths === 'undefined' || !clpOutputPaths.searchController || clpApiEnabled === false %>"
 force: true
 ---
 <%- typeof generatedBanner !== 'undefined' ? generatedBanner : '' %>

--- a/templates/entity/new/prompt.js
+++ b/templates/entity/new/prompt.js
@@ -1569,20 +1569,23 @@ export default {
       hasTemporalValidity: resolvedBehaviors.hasTemporalValidity,
       repositoryBehaviorConfig: resolvedBehaviors.repositoryConfig,
 
-      // Expose configuration (which layers to generate)
+      // Expose configuration (which layers to generate).
+      // ADR-043 §6: `api: false` suppresses the ENTIRE HTTP surface (REST +
+      // Electric + tRPC) — equivalent to repository-only — while leaving the
+      // entity/repository/service/use-cases in-process reachable.
       expose: entity.expose || ["repository", "rest", "trpc"],
       exposeRepository: (
         entity.expose || ["repository", "rest", "trpc"]
       ).includes("repository"),
-      exposeRest: (entity.expose || ["repository", "rest", "trpc"]).includes(
-        "rest",
-      ),
-      exposeTrpc: (entity.expose || ["repository", "rest", "trpc"]).includes(
-        "trpc",
-      ),
-      exposeElectric: (
-        entity.expose || ["repository", "rest", "trpc"]
-      ).includes("electric"),
+      exposeRest:
+        entity.api !== false &&
+        (entity.expose || ["repository", "rest", "trpc"]).includes("rest"),
+      exposeTrpc:
+        entity.api !== false &&
+        (entity.expose || ["repository", "rest", "trpc"]).includes("trpc"),
+      exposeElectric:
+        entity.api !== false &&
+        (entity.expose || ["repository", "rest", "trpc"]).includes("electric"),
 
       // Electric SQL where clause (derived from entity FK fields)
       electricWhereColumn,
@@ -1670,6 +1673,10 @@ export default {
       Object.assign(locals, {
         clpOutputPaths: undefined,
         clpImports: undefined,
+        // ADR-043 §6: stub so CLP template bodies referencing clpApiEnabled
+        // render without crashing on the clean-architecture path (the to: guard
+        // still skips the actual write).
+        clpApiEnabled: true,
         entityName: _n,
         entityNamePlural: _p,
         entityNamePascal: _n,


### PR DESCRIPTION
Per-entity `api: false` opt-out (ADR-043 §6, #557 proposal #3). Stacked on #564. Closes #561. The backend analogue of the frontend-exclude knob (#556).

## Changes
- **Schema:** top-level `api: z.boolean().optional().default(true)` on `EntityDefinitionSchema`.
- **`api: false` suppresses the ENTIRE HTTP surface** (REST + Electric + tRPC) — semantically "no network data plane" — while entity/repository/service/use-cases stay generated and **in-process reachable**:
  - **Clean:** `exposeRest`/`exposeElectric`/`exposeTrpc` AND-ed with `entity.api !== false`; controller `to:`, core-module wiring, and tRPC module already key off those flags. (Stub CLP locals gained `clpApiEnabled: true` so clean-path bodies render before their `to:null` skip.)
  - **Clean-Lite-PS:** a `clpApiEnabled` local gates the controller + search-controller `skip_if` and the module's controller import + `controllers: []` array.

## Acceptance criteria
- [x] An `api: false` entity emits no controller/routes but stays in-process reachable (verified e2e: `controllers: []`, service/repository/module/use-cases present).
- [x] Nothing references the absent controller (module import gated).
- [x] Baselines unchanged (default `api: true` is byte-identical) + tests added (schema default/override, `clpApiEnabled`, module wiring).
- [x] Typecheck + `test-all` green.

## Gates
test-unit (3122), test-baseline (no drift), test-smoke (+junction, +subsystems) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfzdkZ7ywnceGK8SEBn3XZ